### PR TITLE
Add GitHub Actions workflow for automated releases and npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,174 @@
+name: Release & Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build-ios:
+    name: Build iOS Libraries
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-ios-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-ios-
+
+      - name: Install uniffi-bindgen
+        run: cargo install uniffi --version 0.30.0 --features cli --locked
+
+      - name: Build iOS Libraries
+        working-directory: bindings/react-native
+        run: bash scripts/build-uniffi-ios.sh
+
+      - name: Upload iOS Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-libs
+          path: |
+            bindings/react-native/ios/libs/
+            bindings/react-native/ios/Generated/
+          retention-days: 1
+
+  build-android:
+    name: Build Android Libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r26b
+          add-to-path: true
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-android-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-android-
+
+      - name: Install uniffi-bindgen
+        run: cargo install uniffi --version 0.30.0 --features cli --locked
+
+      - name: Build Android Libraries
+        working-directory: bindings/react-native
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: bash scripts/build-uniffi-android.sh
+
+      - name: Upload Android Native Libs
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-jniLibs
+          path: bindings/react-native/android/src/main/jniLibs/
+          retention-days: 1
+
+      - name: Upload Android Generated Bindings
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-uniffi-bindings
+          path: bindings/react-native/android/src/main/java/uniffi/
+          retention-days: 1
+
+  release:
+    name: Create Release & Publish to npm
+    needs: [build-ios, build-android]
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download iOS Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-libs
+          path: bindings/react-native/ios
+
+      - name: Download Android Native Libs
+        uses: actions/download-artifact@v4
+        with:
+          name: android-jniLibs
+          path: bindings/react-native/android/src/main/jniLibs
+
+      - name: Download Android Generated Bindings
+        uses: actions/download-artifact@v4
+        with:
+          name: android-uniffi-bindings
+          path: bindings/react-native/android/src/main/java/uniffi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Update package.json version
+        working-directory: bindings/react-native
+        run: npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version --allow-same-version
+
+      - name: Install dependencies
+        working-directory: bindings/react-native
+        run: npm ci
+
+      - name: Build TypeScript
+        working-directory: bindings/react-native
+        run: npm run build
+
+      - name: Validate package
+        working-directory: bindings/react-native
+        run: bash scripts/prepare-npm.sh
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to npm
+        working-directory: bindings/react-native
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/bindings/react-native/scripts/build-android.sh
+++ b/bindings/react-native/scripts/build-android.sh
@@ -52,14 +52,27 @@ if [ -z "$ANDROID_NDK_HOME" ] && [ -z "$NDK_HOME" ]; then
   fi
 fi
 
-# Add NDK toolchain to PATH
-NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin"
-if [ ! -d "$NDK_TOOLCHAIN" ]; then
-  # Try alternate path for Apple Silicon
-  NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-aarch64/bin"
-fi
+# Add NDK toolchain to PATH (detect OS)
+OS_NAME="$(uname -s)"
+case "$OS_NAME" in
+  Darwin)
+    ARCH_NAME="$(uname -m)"
+    if [ "$ARCH_NAME" = "arm64" ]; then
+      NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-aarch64/bin"
+    else
+      NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin"
+    fi
+    ;;
+  Linux)
+    NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+    ;;
+  *)
+    echo "Warning: Unsupported OS: $OS_NAME"
+    NDK_TOOLCHAIN=""
+    ;;
+esac
 
-if [ -d "$NDK_TOOLCHAIN" ]; then
+if [ -n "$NDK_TOOLCHAIN" ] && [ -d "$NDK_TOOLCHAIN" ]; then
   export PATH="$NDK_TOOLCHAIN:$PATH"
   echo "Added NDK toolchain to PATH: $NDK_TOOLCHAIN"
 else

--- a/bindings/react-native/scripts/build-uniffi-android.sh
+++ b/bindings/react-native/scripts/build-uniffi-android.sh
@@ -54,14 +54,27 @@ if [ -z "$ANDROID_NDK_HOME" ] && [ -z "$NDK_HOME" ]; then
   fi
 fi
 
-# Add NDK toolchain to PATH
-NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin"
-if [ ! -d "$NDK_TOOLCHAIN" ]; then
-  # Try alternate path for Apple Silicon
-  NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-aarch64/bin"
-fi
+# Add NDK toolchain to PATH (detect OS)
+OS_NAME="$(uname -s)"
+case "$OS_NAME" in
+  Darwin)
+    ARCH_NAME="$(uname -m)"
+    if [ "$ARCH_NAME" = "arm64" ]; then
+      NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-aarch64/bin"
+    else
+      NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin"
+    fi
+    ;;
+  Linux)
+    NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+    ;;
+  *)
+    echo "Warning: Unsupported OS: $OS_NAME"
+    NDK_TOOLCHAIN=""
+    ;;
+esac
 
-if [ -d "$NDK_TOOLCHAIN" ]; then
+if [ -n "$NDK_TOOLCHAIN" ] && [ -d "$NDK_TOOLCHAIN" ]; then
   export PATH="$NDK_TOOLCHAIN:$PATH"
   echo "Added NDK toolchain to PATH: $NDK_TOOLCHAIN"
 else

--- a/bindings/react-native/scripts/prepare-npm.sh
+++ b/bindings/react-native/scripts/prepare-npm.sh
@@ -32,7 +32,7 @@ ANDROID_ABIS=("arm64-v8a" "armeabi-v7a" "x86_64" "x86")
 MISSING_ABIS=()
 
 for abi in "${ANDROID_ABIS[@]}"; do
-  lib_path="$ANDROID_DIR/$abi/liboffline_protocol_uniffi.so"
+  lib_path="$ANDROID_DIR/$abi/libuniffi_offline_protocol.so"
   if [ -f "$lib_path" ]; then
     echo "✅ Android $abi library found"
     echo "   Size: $(du -h "$lib_path" | cut -f1)"


### PR DESCRIPTION
- Add release.yml workflow that triggers on version tags (v*)
- Build iOS libraries on macOS using build-uniffi-ios.sh
- Build Android libraries on Ubuntu using build-uniffi-android.sh
- Install uniffi-bindgen for generating Swift/Kotlin bindings
- Create GitHub release with auto-generated notes
- Publish to npm after successful builds
- Fix build-android.sh and build-uniffi-android.sh for Linux support
- Fix prepare-npm.sh to validate correct library name (libuniffi_offline_protocol.so)