### PR TITLE
fix: DORS transport fallback and transport-agnostic connection requests

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -541,6 +541,57 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun sendConnectionRequest(recipient: String, senderName: String, keyPackage: ReadableArray?, promise: Promise) {
+        try {
+            val proto = protocol ?: throw IllegalStateException("Protocol not initialized")
+            val keyPackageData = if (keyPackage != null) {
+                val data = mutableListOf<UByte>()
+                for (i in 0 until keyPackage.size()) {
+                    data.add(keyPackage.getInt(i).toUByte())
+                }
+                data
+            } else {
+                null
+            }
+            val messageId = proto.sendConnectionRequest(recipient, senderName, keyPackageData)
+            promise.resolve(messageId)
+        } catch (e: Exception) {
+            promise.reject("ERROR_CONNECTION_REQUEST", "Failed to send connection request: ${e.message}", e)
+        }
+    }
+
+    @ReactMethod
+    fun acceptConnectionRequest(recipient: String, accepterName: String, keyPackage: ReadableArray?, promise: Promise) {
+        try {
+            val proto = protocol ?: throw IllegalStateException("Protocol not initialized")
+            val keyPackageData = if (keyPackage != null) {
+                val data = mutableListOf<UByte>()
+                for (i in 0 until keyPackage.size()) {
+                    data.add(keyPackage.getInt(i).toUByte())
+                }
+                data
+            } else {
+                null
+            }
+            val messageId = proto.acceptConnectionRequest(recipient, accepterName, keyPackageData)
+            promise.resolve(messageId)
+        } catch (e: Exception) {
+            promise.reject("ERROR_CONNECTION_REQUEST", "Failed to accept connection request: ${e.message}", e)
+        }
+    }
+
+    @ReactMethod
+    fun rejectConnectionRequest(recipient: String, promise: Promise) {
+        try {
+            val proto = protocol ?: throw IllegalStateException("Protocol not initialized")
+            val messageId = proto.rejectConnectionRequest(recipient)
+            promise.resolve(messageId)
+        } catch (e: Exception) {
+            promise.reject("ERROR_CONNECTION_REQUEST", "Failed to reject connection request: ${e.message}", e)
+        }
+    }
+
+    @ReactMethod
     fun receiveMessage(promise: Promise) {
         val messageJson = protocol?.receiveMessage()
         promise.resolve(messageJson)

--- a/bindings/react-native/ios/OfflineProtocolModule.m
+++ b/bindings/react-native/ios/OfflineProtocolModule.m
@@ -34,6 +34,22 @@ RCT_EXTERN_METHOD(sendMessage:(NSString *)recipient
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(sendConnectionRequest:(NSString *)recipient
+                  senderName:(NSString *)senderName
+                  keyPackage:(NSArray *)keyPackage
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(acceptConnectionRequest:(NSString *)recipient
+                  accepterName:(NSString *)accepterName
+                  keyPackage:(NSArray *)keyPackage
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(rejectConnectionRequest:(NSString *)recipient
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(getTopology:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -593,6 +593,68 @@ class OfflineProtocolModule: RCTEventEmitter {
             rejecter("ERROR_SEND", "Failed to send message: \(error.localizedDescription)", error)
         }
     }
+
+    @objc func sendConnectionRequest(_ recipient: String,
+                                     senderName: String,
+                                     keyPackage: [NSNumber]?,
+                                     resolver: @escaping RCTPromiseResolveBlock,
+                                     rejecter: @escaping RCTPromiseRejectBlock) {
+        do {
+            guard let proto = protocolInstance else {
+                throw NSError(domain: "OfflineProtocol", code: -1,
+                            userInfo: [NSLocalizedDescriptionKey: "Protocol not initialized"])
+            }
+
+            let keyPackageData = keyPackage?.map { UInt8($0.intValue) }
+            let messageId = try proto.sendConnectionRequest(
+                recipient: recipient,
+                senderName: senderName,
+                keyPackage: keyPackageData
+            )
+            resolver(messageId)
+        } catch {
+            rejecter("ERROR_CONNECTION_REQUEST", "Failed to send connection request: \(error.localizedDescription)", error)
+        }
+    }
+
+    @objc func acceptConnectionRequest(_ recipient: String,
+                                       accepterName: String,
+                                       keyPackage: [NSNumber]?,
+                                       resolver: @escaping RCTPromiseResolveBlock,
+                                       rejecter: @escaping RCTPromiseRejectBlock) {
+        do {
+            guard let proto = protocolInstance else {
+                throw NSError(domain: "OfflineProtocol", code: -1,
+                            userInfo: [NSLocalizedDescriptionKey: "Protocol not initialized"])
+            }
+
+            let keyPackageData = keyPackage?.map { UInt8($0.intValue) }
+            let messageId = try proto.acceptConnectionRequest(
+                recipient: recipient,
+                accepterName: accepterName,
+                keyPackage: keyPackageData
+            )
+            resolver(messageId)
+        } catch {
+            rejecter("ERROR_CONNECTION_REQUEST", "Failed to accept connection request: \(error.localizedDescription)", error)
+        }
+    }
+
+    @objc func rejectConnectionRequest(_ recipient: String,
+                                       resolver: @escaping RCTPromiseResolveBlock,
+                                       rejecter: @escaping RCTPromiseRejectBlock) {
+        do {
+            guard let proto = protocolInstance else {
+                throw NSError(domain: "OfflineProtocol", code: -1,
+                            userInfo: [NSLocalizedDescriptionKey: "Protocol not initialized"])
+            }
+
+            let messageId = try proto.rejectConnectionRequest(recipient: recipient)
+            resolver(messageId)
+        } catch {
+            rejecter("ERROR_CONNECTION_REQUEST", "Failed to reject connection request: \(error.localizedDescription)", error)
+        }
+    }
     
     @objc func receiveMessage(_ resolver: @escaping RCTPromiseResolveBlock,
                              rejecter: @escaping RCTPromiseRejectBlock) {

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -8,6 +8,9 @@ import { NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-na
 import type {
   ProtocolConfig,
   SendMessageParams,
+  SendConnectionRequestParams,
+  AcceptConnectionRequestParams,
+  RejectConnectionRequestParams,
   SendFileParams,
   ProtocolEvent,
   EventListener,
@@ -588,6 +591,56 @@ export class OfflineProtocol {
       params.content,
       priority,
       params.replyToMsg ?? null
+    );
+    return messageId;
+  }
+
+  /**
+   * Sends a connection request
+   *
+   * @param params - Connection request parameters
+   * @returns Message ID
+   * @throws Error if request fails to send
+   */
+  async sendConnectionRequest(params: SendConnectionRequestParams): Promise<string> {
+    const messageId = await OfflineProtocolNativeModule.sendConnectionRequest(
+      params.recipient,
+      params.senderName,
+      params.keyPackage ?? null
+    );
+    return messageId;
+  }
+
+  /**
+   * Accepts a connection request
+   *
+   * @param params - Connection acceptance parameters
+   * @returns Message ID
+   * @throws Error if acceptance fails to send
+   */
+  async acceptConnectionRequest(
+    params: AcceptConnectionRequestParams
+  ): Promise<string> {
+    const messageId = await OfflineProtocolNativeModule.acceptConnectionRequest(
+      params.recipient,
+      params.accepterName,
+      params.keyPackage ?? null
+    );
+    return messageId;
+  }
+
+  /**
+   * Rejects a connection request
+   *
+   * @param params - Connection rejection parameters
+   * @returns Message ID
+   * @throws Error if rejection fails to send
+   */
+  async rejectConnectionRequest(
+    params: RejectConnectionRequestParams
+  ): Promise<string> {
+    const messageId = await OfflineProtocolNativeModule.rejectConnectionRequest(
+      params.recipient
     );
     return messageId;
   }

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -270,6 +270,38 @@ export interface SendMessageParams {
 }
 
 /**
+ * Parameters for sending a connection request
+ */
+export interface SendConnectionRequestParams {
+  /** Recipient's user ID */
+  recipient: string;
+  /** Display name of the sender */
+  senderName: string;
+  /** Optional MLS key package bytes */
+  keyPackage?: number[];
+}
+
+/**
+ * Parameters for accepting a connection request
+ */
+export interface AcceptConnectionRequestParams {
+  /** Recipient's user ID */
+  recipient: string;
+  /** Display name of the accepting party */
+  accepterName: string;
+  /** Optional MLS key package bytes */
+  keyPackage?: number[];
+}
+
+/**
+ * Parameters for rejecting a connection request
+ */
+export interface RejectConnectionRequestParams {
+  /** Recipient's user ID */
+  recipient: string;
+}
+
+/**
  * Parameters for sending a file
  */
 export interface SendFileParams {
@@ -462,6 +494,35 @@ export interface SecureSessionFailedEvent extends BaseEvent {
 }
 
 /**
+ * Connection request received event
+ */
+export interface ConnectionRequestReceivedEvent extends BaseEvent {
+  type: 'connection_request_received';
+  sender: string;
+  sender_name: string;
+  timestamp: number;
+  key_package?: number[];
+}
+
+/**
+ * Connection accepted event
+ */
+export interface ConnectionAcceptedEvent extends BaseEvent {
+  type: 'connection_accepted';
+  accepted_by: string;
+  accepted_by_name: string;
+  key_package?: number[];
+}
+
+/**
+ * Connection rejected event
+ */
+export interface ConnectionRejectedEvent extends BaseEvent {
+  type: 'connection_rejected';
+  rejected_by: string;
+}
+
+/**
  * Union type of all events
  */
 export type ProtocolEvent =
@@ -479,7 +540,10 @@ export type ProtocolEvent =
   | FileReceivedEvent
   | DiagnosticEvent
   | SecureSessionEstablishedEvent
-  | SecureSessionFailedEvent;
+  | SecureSessionFailedEvent
+  | ConnectionRequestReceivedEvent
+  | ConnectionAcceptedEvent
+  | ConnectionRejectedEvent;
 
 /**
  * Event listener type

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -511,6 +511,7 @@ export interface ConnectionAcceptedEvent extends BaseEvent {
   type: 'connection_accepted';
   accepted_by: string;
   accepted_by_name: string;
+  timestamp: number;
   key_package?: number[];
 }
 

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -294,6 +294,8 @@ impl TransportSelector {
                     return Some(current);
                 }
 
+                // current_still_available is true here, so current is in available_transports,
+                // which means it was scored in scored_transports — the find always succeeds.
                 if let Some(current_score) = scored_transports
                     .iter()
                     .find(|(t, _)| *t == current)
@@ -302,8 +304,6 @@ impl TransportSelector {
                     if !self.should_switch(current, current_score, best_transport, best_score) {
                         return Some(current);
                     }
-                } else if !self.is_past_cooldown() {
-                    return Some(current);
                 }
             }
             // When current transport is unavailable, fall through to select the

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -285,21 +285,29 @@ impl TransportSelector {
         let best_score = best.1.total;
 
         if let Some(current) = self.current_transport {
-            if current == best_transport {
-                return Some(current);
-            }
+            // If current transport is no longer available, switch immediately
+            // regardless of cooldown or hysteresis (e.g. Internet disconnected).
+            let current_still_available = available_transports.contains_key(&current);
 
-            if let Some(current_score) = scored_transports
-                .iter()
-                .find(|(t, _)| *t == current)
-                .map(|(_, s)| s.total)
-            {
-                if !self.should_switch(current, current_score, best_transport, best_score) {
+            if current_still_available {
+                if current == best_transport {
                     return Some(current);
                 }
-            } else if !self.is_past_cooldown() {
-                return Some(current);
+
+                if let Some(current_score) = scored_transports
+                    .iter()
+                    .find(|(t, _)| *t == current)
+                    .map(|(_, s)| s.total)
+                {
+                    if !self.should_switch(current, current_score, best_transport, best_score) {
+                        return Some(current);
+                    }
+                } else if !self.is_past_cooldown() {
+                    return Some(current);
+                }
             }
+            // When current transport is unavailable, fall through to select the
+            // best available transport without cooldown or hysteresis checks.
         }
 
         // Track switch
@@ -1241,5 +1249,43 @@ mod tests {
 
         let selected = selector.select_transport(&message, &transports).unwrap();
         assert_eq!(selected, TransportType::BLE);
+    }
+
+    #[test]
+    fn test_unavailable_transport_bypasses_cooldown() {
+        let config = DorsConfig {
+            prefer_online: true,
+            switch_cooldown_secs: 60, // Long cooldown
+            ..Default::default()
+        };
+        let mut selector = TransportSelector::with_config(config);
+        let message = create_test_message();
+
+        // First: select Internet while it's available
+        let mut transports_with_internet = HashMap::new();
+        transports_with_internet
+            .insert(TransportType::Internet, create_test_metrics(None, 0.0, 0));
+        transports_with_internet
+            .insert(TransportType::BLE, create_test_metrics(Some(-60), 0.2, 10));
+
+        let selected = selector
+            .select_transport(&message, &transports_with_internet)
+            .unwrap();
+        assert_eq!(selected, TransportType::Internet);
+
+        // Now Internet disconnects (removed from available transports).
+        // Despite the 60s cooldown, DORS must switch to BLE immediately.
+        let mut transports_without_internet = HashMap::new();
+        transports_without_internet
+            .insert(TransportType::BLE, create_test_metrics(Some(-60), 0.2, 10));
+
+        let selected = selector
+            .select_transport(&message, &transports_without_internet)
+            .unwrap();
+        assert_eq!(
+            selected,
+            TransportType::BLE,
+            "DORS must fall back to BLE when Internet is no longer available"
+        );
     }
 }

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -1021,6 +1021,47 @@ impl OfflineProtocol {
     }
 
     // ========================================================================
+    // CONNECTION REQUESTS (TRANSPORT-AGNOSTIC)
+    // ========================================================================
+
+    /// Sends a connection request to another user via any available transport (DORS-routed).
+    pub fn send_connection_request(
+        &self,
+        recipient: String,
+        sender_name: String,
+        key_package: Option<Vec<u8>>,
+    ) -> Result<String, ProtocolError> {
+        let mut protocol = self.inner.lock().unwrap();
+        let message_id = protocol
+            .send_connection_request(&recipient, &sender_name, key_package)
+            .map_err(|e| ProtocolError::SendFailed(e.to_string()))?;
+        Ok(message_id.as_str())
+    }
+
+    /// Accepts a connection request from another user via any available transport (DORS-routed).
+    pub fn accept_connection_request(
+        &self,
+        recipient: String,
+        accepter_name: String,
+        key_package: Option<Vec<u8>>,
+    ) -> Result<String, ProtocolError> {
+        let mut protocol = self.inner.lock().unwrap();
+        let message_id = protocol
+            .accept_connection_request(&recipient, &accepter_name, key_package)
+            .map_err(|e| ProtocolError::SendFailed(e.to_string()))?;
+        Ok(message_id.as_str())
+    }
+
+    /// Rejects a connection request from another user via any available transport (DORS-routed).
+    pub fn reject_connection_request(&self, recipient: String) -> Result<String, ProtocolError> {
+        let mut protocol = self.inner.lock().unwrap();
+        let message_id = protocol
+            .reject_connection_request(&recipient)
+            .map_err(|e| ProtocolError::SendFailed(e.to_string()))?;
+        Ok(message_id.as_str())
+    }
+
+    // ========================================================================
     // BLE TRANSPORT OPERATIONS
     // ========================================================================
 

--- a/crates/offline-protocol-uniffi/src/offline_protocol.udl
+++ b/crates/offline-protocol-uniffi/src/offline_protocol.udl
@@ -346,6 +346,16 @@ interface OfflineProtocol {
     
     string? receive_message();
     
+    // Connection requests (transport-agnostic, routed via DORS)
+    [Throws=ProtocolError]
+    string send_connection_request(string recipient, string sender_name, sequence<u8>? key_package);
+    
+    [Throws=ProtocolError]
+    string accept_connection_request(string recipient, string accepter_name, sequence<u8>? key_package);
+    
+    [Throws=ProtocolError]
+    string reject_connection_request(string recipient);
+    
     // BLE transport operations
     [Throws=ProtocolError]
     void ble_peer_discovered(string peer_id, i16 rssi);

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -213,6 +213,36 @@ pub enum Event {
         /// Reason for the failure.
         reason: String,
     },
+
+    /// A connection request was received from another user.
+    ConnectionRequestReceived {
+        /// User ID of the sender.
+        sender: String,
+        /// Display name of the sender.
+        sender_name: String,
+        /// Timestamp of the request (Unix ms).
+        timestamp: i64,
+        /// MLS key package data (if provided for encrypted session setup).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_package: Option<Vec<u8>>,
+    },
+
+    /// A previously sent connection request was accepted.
+    ConnectionAccepted {
+        /// User ID of the accepting party.
+        accepted_by: String,
+        /// Display name of the accepting party.
+        accepted_by_name: String,
+        /// MLS key package data (if provided for encrypted session setup).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_package: Option<Vec<u8>>,
+    },
+
+    /// A previously sent connection request was rejected.
+    ConnectionRejected {
+        /// User ID of the rejecting party.
+        rejected_by: String,
+    },
 }
 
 impl Event {
@@ -417,6 +447,39 @@ impl Event {
         Self::SecureSessionFailed { peer_id, reason }
     }
 
+    /// Creates a ConnectionRequestReceived event.
+    pub fn connection_request_received(
+        sender: String,
+        sender_name: String,
+        timestamp: i64,
+        key_package: Option<Vec<u8>>,
+    ) -> Self {
+        Self::ConnectionRequestReceived {
+            sender,
+            sender_name,
+            timestamp,
+            key_package,
+        }
+    }
+
+    /// Creates a ConnectionAccepted event.
+    pub fn connection_accepted(
+        accepted_by: String,
+        accepted_by_name: String,
+        key_package: Option<Vec<u8>>,
+    ) -> Self {
+        Self::ConnectionAccepted {
+            accepted_by,
+            accepted_by_name,
+            key_package,
+        }
+    }
+
+    /// Creates a ConnectionRejected event.
+    pub fn connection_rejected(rejected_by: String) -> Self {
+        Self::ConnectionRejected { rejected_by }
+    }
+
     /// Converts the event to JSON.
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
@@ -617,6 +680,32 @@ impl fmt::Debug for Event {
                 .debug_struct("SecureSessionFailed")
                 .field("peer_id", &"[REDACTED]")
                 .field("reason", reason)
+                .finish(),
+            Self::ConnectionRequestReceived {
+                sender: _,
+                sender_name: _,
+                timestamp,
+                key_package,
+            } => f
+                .debug_struct("ConnectionRequestReceived")
+                .field("sender", &"[REDACTED]")
+                .field("sender_name", &"[REDACTED]")
+                .field("timestamp", timestamp)
+                .field("has_key_package", &key_package.is_some())
+                .finish(),
+            Self::ConnectionAccepted {
+                accepted_by: _,
+                accepted_by_name: _,
+                key_package,
+            } => f
+                .debug_struct("ConnectionAccepted")
+                .field("accepted_by", &"[REDACTED]")
+                .field("accepted_by_name", &"[REDACTED]")
+                .field("has_key_package", &key_package.is_some())
+                .finish(),
+            Self::ConnectionRejected { rejected_by: _ } => f
+                .debug_struct("ConnectionRejected")
+                .field("rejected_by", &"[REDACTED]")
                 .finish(),
         }
     }

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -233,6 +233,8 @@ pub enum Event {
         accepted_by: String,
         /// Display name of the accepting party.
         accepted_by_name: String,
+        /// Timestamp of the acceptance (Unix ms).
+        timestamp: i64,
         /// MLS key package data (if provided for encrypted session setup).
         #[serde(skip_serializing_if = "Option::is_none")]
         key_package: Option<Vec<u8>>,
@@ -466,11 +468,13 @@ impl Event {
     pub fn connection_accepted(
         accepted_by: String,
         accepted_by_name: String,
+        timestamp: i64,
         key_package: Option<Vec<u8>>,
     ) -> Self {
         Self::ConnectionAccepted {
             accepted_by,
             accepted_by_name,
+            timestamp,
             key_package,
         }
     }
@@ -696,11 +700,13 @@ impl fmt::Debug for Event {
             Self::ConnectionAccepted {
                 accepted_by: _,
                 accepted_by_name: _,
+                timestamp,
                 key_package,
             } => f
                 .debug_struct("ConnectionAccepted")
                 .field("accepted_by", &"[REDACTED]")
                 .field("accepted_by_name", &"[REDACTED]")
+                .field("timestamp", timestamp)
                 .field("has_key_package", &key_package.is_some())
                 .finish(),
             Self::ConnectionRejected { rejected_by: _ } => f

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -60,12 +60,15 @@ struct ConnectionRequestPayload {
 struct ConnectionAcceptedPayload {
     /// Display name of the accepting party.
     accepted_by_name: String,
+    /// Timestamp of the acceptance (Unix ms).
+    #[serde(default)]
+    timestamp_ms: i64,
     /// Optional MLS key package data for encrypted session setup.
     #[serde(skip_serializing_if = "Option::is_none")]
     key_package: Option<Vec<u8>>,
 }
 
-/// Result of processing an internal MLS message.
+/// Result of processing an internal protocol message.
 enum InternalMessageResult {
     /// Message was consumed internally (don't surface to app).
     Consumed,
@@ -570,6 +573,56 @@ impl OfflineProtocol {
         state.emit_event(Event::message_sent(message));
         drop(state);
         Ok(())
+    }
+
+    /// Sends an internal protocol message (connection requests, etc.) via DORS.
+    ///
+    /// Handles the full send orchestration: state check, deduplication, transport send,
+    /// success/failure handling, and transport switch events. Does NOT emit a
+    /// `MessageSent` event — internal messages are not user-visible content.
+    fn send_internal_message(
+        &mut self,
+        recipient: &str,
+        content: String,
+        priority: MessagePriority,
+    ) -> Result<MessageId> {
+        {
+            let state = lock_shared_state(&self.shared_state)?;
+            if state.state != ProtocolState::Running {
+                return Err(Error::NotStarted);
+            }
+        }
+
+        let message = self.create_message(recipient, content, Some(priority), None)?;
+        let message_id = message.id.clone();
+
+        if self.deduplicator.is_duplicate(&message_id) {
+            return Err(crate::Error::Other("Duplicate message".to_string()));
+        }
+
+        self.deduplicator.mark_seen(message_id.clone());
+
+        let previous_transport = self.transport_manager.current_transport();
+        let send_result = self.transport_manager.send(&message);
+        let current_transport = self.transport_manager.current_transport();
+
+        match send_result {
+            Ok(()) => {
+                self.handle_send_success(&message, current_transport)?;
+            }
+            Err(err) => {
+                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
+                warn!(
+                    message_id = %message.id,
+                    recipient = %recipient,
+                    error = %err,
+                    "Internal message send failed, message deferred"
+                );
+            }
+        }
+
+        self.emit_transport_switch_event(previous_transport, current_transport)?;
+        Ok(message_id)
     }
 
     /// Sends a message.
@@ -1296,13 +1349,6 @@ impl OfflineProtocol {
         sender_name: &str,
         key_package: Option<Vec<u8>>,
     ) -> Result<MessageId> {
-        {
-            let state = lock_shared_state(&self.shared_state)?;
-            if state.state != ProtocolState::Running {
-                return Err(Error::NotStarted);
-            }
-        }
-
         let payload = ConnectionRequestPayload {
             sender_name: sender_name.to_string(),
             timestamp_ms: Utc::now().timestamp_millis(),
@@ -1313,35 +1359,8 @@ impl OfflineProtocol {
             serde_json::to_string(&payload).map_err(|e| Error::Serialization(e.to_string()))?;
         let content = format!("{}{}", internal_prefixes::CONN_REQUEST, serialized);
 
-        let message =
-            self.create_message(recipient, content, Some(MessagePriority::High), None)?;
-        let message_id = message.id.clone();
-
-        if self.deduplicator.is_duplicate(&message_id) {
-            return Err(crate::Error::Other("Duplicate message".to_string()));
-        }
-
-        self.deduplicator.mark_seen(message_id.clone());
-
-        let previous_transport = self.transport_manager.current_transport();
-        let send_result = self.transport_manager.send(&message);
-        let current_transport = self.transport_manager.current_transport();
-
-        match send_result {
-            Ok(()) => {
-                self.handle_send_success(&message, current_transport)?;
-            }
-            Err(err) => {
-                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
-                warn!(
-                    recipient = %recipient,
-                    error = %err,
-                    "Connection request send failed, message deferred"
-                );
-            }
-        }
-
-        self.emit_transport_switch_event(previous_transport, current_transport)?;
+        let message_id =
+            self.send_internal_message(recipient, content, MessagePriority::High)?;
         info!(recipient = %recipient, "Sent connection request");
         Ok(message_id)
     }
@@ -1361,15 +1380,9 @@ impl OfflineProtocol {
         accepter_name: &str,
         key_package: Option<Vec<u8>>,
     ) -> Result<MessageId> {
-        {
-            let state = lock_shared_state(&self.shared_state)?;
-            if state.state != ProtocolState::Running {
-                return Err(Error::NotStarted);
-            }
-        }
-
         let payload = ConnectionAcceptedPayload {
             accepted_by_name: accepter_name.to_string(),
+            timestamp_ms: Utc::now().timestamp_millis(),
             key_package,
         };
 
@@ -1377,35 +1390,8 @@ impl OfflineProtocol {
             serde_json::to_string(&payload).map_err(|e| Error::Serialization(e.to_string()))?;
         let content = format!("{}{}", internal_prefixes::CONN_ACCEPT, serialized);
 
-        let message =
-            self.create_message(recipient, content, Some(MessagePriority::High), None)?;
-        let message_id = message.id.clone();
-
-        if self.deduplicator.is_duplicate(&message_id) {
-            return Err(crate::Error::Other("Duplicate message".to_string()));
-        }
-
-        self.deduplicator.mark_seen(message_id.clone());
-
-        let previous_transport = self.transport_manager.current_transport();
-        let send_result = self.transport_manager.send(&message);
-        let current_transport = self.transport_manager.current_transport();
-
-        match send_result {
-            Ok(()) => {
-                self.handle_send_success(&message, current_transport)?;
-            }
-            Err(err) => {
-                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
-                warn!(
-                    recipient = %recipient,
-                    error = %err,
-                    "Connection accept send failed, message deferred"
-                );
-            }
-        }
-
-        self.emit_transport_switch_event(previous_transport, current_transport)?;
+        let message_id =
+            self.send_internal_message(recipient, content, MessagePriority::High)?;
         info!(recipient = %recipient, "Accepted connection request");
         Ok(message_id)
     }
@@ -1418,44 +1404,10 @@ impl OfflineProtocol {
     ///
     /// * `recipient` - The user ID of the original requester
     pub fn reject_connection_request(&mut self, recipient: &str) -> Result<MessageId> {
-        {
-            let state = lock_shared_state(&self.shared_state)?;
-            if state.state != ProtocolState::Running {
-                return Err(Error::NotStarted);
-            }
-        }
-
         let content = internal_prefixes::CONN_REJECT.to_string();
 
-        let message =
-            self.create_message(recipient, content, Some(MessagePriority::High), None)?;
-        let message_id = message.id.clone();
-
-        if self.deduplicator.is_duplicate(&message_id) {
-            return Err(crate::Error::Other("Duplicate message".to_string()));
-        }
-
-        self.deduplicator.mark_seen(message_id.clone());
-
-        let previous_transport = self.transport_manager.current_transport();
-        let send_result = self.transport_manager.send(&message);
-        let current_transport = self.transport_manager.current_transport();
-
-        match send_result {
-            Ok(()) => {
-                self.handle_send_success(&message, current_transport)?;
-            }
-            Err(err) => {
-                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
-                warn!(
-                    recipient = %recipient,
-                    error = %err,
-                    "Connection reject send failed, message deferred"
-                );
-            }
-        }
-
-        self.emit_transport_switch_event(previous_transport, current_transport)?;
+        let message_id =
+            self.send_internal_message(recipient, content, MessagePriority::High)?;
         info!(recipient = %recipient, "Rejected connection request");
         Ok(message_id)
     }
@@ -1778,6 +1730,7 @@ impl OfflineProtocol {
                     state.emit_event(Event::connection_accepted(
                         sender.to_string(),
                         payload.accepted_by_name,
+                        payload.timestamp_ms,
                         payload.key_package,
                     ));
                 }
@@ -1788,7 +1741,7 @@ impl OfflineProtocol {
         }
 
         // Handle connection rejected messages
-        if content == internal_prefixes::CONN_REJECT {
+        if content.starts_with(internal_prefixes::CONN_REJECT) {
             info!(sender = %sender, "Connection request rejected");
             if let Ok(state) = lock_shared_state(&self.shared_state) {
                 state.emit_event(Event::connection_rejected(sender.to_string()));
@@ -2723,6 +2676,7 @@ mod tests {
 
         let payload = ConnectionAcceptedPayload {
             accepted_by_name: "Bob".to_string(),
+            timestamp_ms: 99999,
             key_package: Some(vec![1, 2, 3, 4]),
         };
         let content = format!(
@@ -2747,10 +2701,12 @@ mod tests {
             Event::ConnectionAccepted {
                 accepted_by,
                 accepted_by_name,
+                timestamp,
                 key_package,
             } => {
                 assert_eq!(accepted_by, "bob");
                 assert_eq!(accepted_by_name, "Bob");
+                assert_eq!(*timestamp, 99999);
                 assert_eq!(key_package.as_ref(), Some(&vec![1, 2, 3, 4]));
             }
             _ => panic!("Wrong event type"),

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use tracing::{debug, error, info, warn};
 
-/// Internal message prefixes for MLS protocol messages.
+/// Internal message prefixes for protocol messages.
 mod internal_prefixes {
     /// Prefix for key package messages.
     pub const KEY_PACKAGE: &str = "__MLS_KEY_PKG__";
@@ -24,6 +24,12 @@ mod internal_prefixes {
     pub const WELCOME: &str = "__MLS_WELCOME__";
     /// Prefix for encrypted messages.
     pub const ENCRYPTED: &str = "__MLS_ENC__";
+    /// Prefix for connection request messages.
+    pub const CONN_REQUEST: &str = "__CONN_REQ__";
+    /// Prefix for connection accepted messages.
+    pub const CONN_ACCEPT: &str = "__CONN_ACC__";
+    /// Prefix for connection rejected messages.
+    pub const CONN_REJECT: &str = "__CONN_REJ__";
 }
 
 /// Payload for key package exchange.
@@ -35,6 +41,28 @@ struct KeyPackagePayload {
     key_package_data: Vec<u8>,
     /// Timestamp of creation.
     timestamp_ms: u64,
+}
+
+/// Payload for a connection request message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ConnectionRequestPayload {
+    /// Display name of the sender.
+    sender_name: String,
+    /// Timestamp of the request (Unix ms).
+    timestamp_ms: i64,
+    /// Optional MLS key package data for encrypted session setup.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key_package: Option<Vec<u8>>,
+}
+
+/// Payload for a connection accepted message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ConnectionAcceptedPayload {
+    /// Display name of the accepting party.
+    accepted_by_name: String,
+    /// Optional MLS key package data for encrypted session setup.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key_package: Option<Vec<u8>>,
 }
 
 /// Result of processing an internal MLS message.
@@ -1253,6 +1281,185 @@ impl OfflineProtocol {
         Ok(message_id)
     }
 
+    /// Sends a connection request to another user via any available transport.
+    ///
+    /// The request is routed through DORS, so it works over Internet, BLE, or WiFi Direct.
+    ///
+    /// # Arguments
+    ///
+    /// * `recipient` - The user ID of the recipient
+    /// * `sender_name` - Display name of the sender
+    /// * `key_package` - Optional MLS key package for encrypted session setup
+    pub fn send_connection_request(
+        &mut self,
+        recipient: &str,
+        sender_name: &str,
+        key_package: Option<Vec<u8>>,
+    ) -> Result<MessageId> {
+        {
+            let state = lock_shared_state(&self.shared_state)?;
+            if state.state != ProtocolState::Running {
+                return Err(Error::NotStarted);
+            }
+        }
+
+        let payload = ConnectionRequestPayload {
+            sender_name: sender_name.to_string(),
+            timestamp_ms: Utc::now().timestamp_millis(),
+            key_package,
+        };
+
+        let serialized =
+            serde_json::to_string(&payload).map_err(|e| Error::Serialization(e.to_string()))?;
+        let content = format!("{}{}", internal_prefixes::CONN_REQUEST, serialized);
+
+        let message =
+            self.create_message(recipient, content, Some(MessagePriority::High), None)?;
+        let message_id = message.id.clone();
+
+        if self.deduplicator.is_duplicate(&message_id) {
+            return Err(crate::Error::Other("Duplicate message".to_string()));
+        }
+
+        self.deduplicator.mark_seen(message_id.clone());
+
+        let previous_transport = self.transport_manager.current_transport();
+        let send_result = self.transport_manager.send(&message);
+        let current_transport = self.transport_manager.current_transport();
+
+        match send_result {
+            Ok(()) => {
+                self.handle_send_success(&message, current_transport)?;
+            }
+            Err(err) => {
+                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
+                warn!(
+                    recipient = %recipient,
+                    error = %err,
+                    "Connection request send failed, message deferred"
+                );
+            }
+        }
+
+        self.emit_transport_switch_event(previous_transport, current_transport)?;
+        info!(recipient = %recipient, "Sent connection request");
+        Ok(message_id)
+    }
+
+    /// Accepts a connection request from another user via any available transport.
+    ///
+    /// The response is routed through DORS, so it works over Internet, BLE, or WiFi Direct.
+    ///
+    /// # Arguments
+    ///
+    /// * `recipient` - The user ID of the original requester
+    /// * `accepter_name` - Display name of the accepting party
+    /// * `key_package` - Optional MLS key package for encrypted session setup
+    pub fn accept_connection_request(
+        &mut self,
+        recipient: &str,
+        accepter_name: &str,
+        key_package: Option<Vec<u8>>,
+    ) -> Result<MessageId> {
+        {
+            let state = lock_shared_state(&self.shared_state)?;
+            if state.state != ProtocolState::Running {
+                return Err(Error::NotStarted);
+            }
+        }
+
+        let payload = ConnectionAcceptedPayload {
+            accepted_by_name: accepter_name.to_string(),
+            key_package,
+        };
+
+        let serialized =
+            serde_json::to_string(&payload).map_err(|e| Error::Serialization(e.to_string()))?;
+        let content = format!("{}{}", internal_prefixes::CONN_ACCEPT, serialized);
+
+        let message =
+            self.create_message(recipient, content, Some(MessagePriority::High), None)?;
+        let message_id = message.id.clone();
+
+        if self.deduplicator.is_duplicate(&message_id) {
+            return Err(crate::Error::Other("Duplicate message".to_string()));
+        }
+
+        self.deduplicator.mark_seen(message_id.clone());
+
+        let previous_transport = self.transport_manager.current_transport();
+        let send_result = self.transport_manager.send(&message);
+        let current_transport = self.transport_manager.current_transport();
+
+        match send_result {
+            Ok(()) => {
+                self.handle_send_success(&message, current_transport)?;
+            }
+            Err(err) => {
+                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
+                warn!(
+                    recipient = %recipient,
+                    error = %err,
+                    "Connection accept send failed, message deferred"
+                );
+            }
+        }
+
+        self.emit_transport_switch_event(previous_transport, current_transport)?;
+        info!(recipient = %recipient, "Accepted connection request");
+        Ok(message_id)
+    }
+
+    /// Rejects a connection request from another user via any available transport.
+    ///
+    /// The response is routed through DORS, so it works over Internet, BLE, or WiFi Direct.
+    ///
+    /// # Arguments
+    ///
+    /// * `recipient` - The user ID of the original requester
+    pub fn reject_connection_request(&mut self, recipient: &str) -> Result<MessageId> {
+        {
+            let state = lock_shared_state(&self.shared_state)?;
+            if state.state != ProtocolState::Running {
+                return Err(Error::NotStarted);
+            }
+        }
+
+        let content = internal_prefixes::CONN_REJECT.to_string();
+
+        let message =
+            self.create_message(recipient, content, Some(MessagePriority::High), None)?;
+        let message_id = message.id.clone();
+
+        if self.deduplicator.is_duplicate(&message_id) {
+            return Err(crate::Error::Other("Duplicate message".to_string()));
+        }
+
+        self.deduplicator.mark_seen(message_id.clone());
+
+        let previous_transport = self.transport_manager.current_transport();
+        let send_result = self.transport_manager.send(&message);
+        let current_transport = self.transport_manager.current_transport();
+
+        match send_result {
+            Ok(()) => {
+                self.handle_send_success(&message, current_transport)?;
+            }
+            Err(err) => {
+                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
+                warn!(
+                    recipient = %recipient,
+                    error = %err,
+                    "Connection reject send failed, message deferred"
+                );
+            }
+        }
+
+        self.emit_transport_switch_event(previous_transport, current_transport)?;
+        info!(recipient = %recipient, "Rejected connection request");
+        Ok(message_id)
+    }
+
     /// Receives the next available message.
     ///
     /// # Returns
@@ -1541,6 +1748,52 @@ impl OfflineProtocol {
                     }
                 }
             }
+        }
+
+        // Handle connection request messages
+        if content.starts_with(internal_prefixes::CONN_REQUEST) {
+            let data = &content[internal_prefixes::CONN_REQUEST.len()..];
+            if let Ok(payload) = serde_json::from_str::<ConnectionRequestPayload>(data) {
+                info!(sender = %sender, sender_name = %payload.sender_name, "Received connection request");
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::connection_request_received(
+                        sender.to_string(),
+                        payload.sender_name,
+                        payload.timestamp_ms,
+                        payload.key_package,
+                    ));
+                }
+            } else {
+                warn!(sender = %sender, "Failed to parse connection request payload");
+            }
+            return Some(InternalMessageResult::Consumed);
+        }
+
+        // Handle connection accepted messages
+        if content.starts_with(internal_prefixes::CONN_ACCEPT) {
+            let data = &content[internal_prefixes::CONN_ACCEPT.len()..];
+            if let Ok(payload) = serde_json::from_str::<ConnectionAcceptedPayload>(data) {
+                info!(sender = %sender, accepted_by_name = %payload.accepted_by_name, "Connection request accepted");
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::connection_accepted(
+                        sender.to_string(),
+                        payload.accepted_by_name,
+                        payload.key_package,
+                    ));
+                }
+            } else {
+                warn!(sender = %sender, "Failed to parse connection accepted payload");
+            }
+            return Some(InternalMessageResult::Consumed);
+        }
+
+        // Handle connection rejected messages
+        if content == internal_prefixes::CONN_REJECT {
+            info!(sender = %sender, "Connection request rejected");
+            if let Ok(state) = lock_shared_state(&self.shared_state) {
+                state.emit_event(Event::connection_rejected(sender.to_string()));
+            }
+            return Some(InternalMessageResult::Consumed);
         }
 
         None // Not an internal message
@@ -2009,6 +2262,7 @@ impl OfflineProtocol {
 mod tests {
     use super::*;
     use offline_protocol_transport::{mock::MockTransport, Transport, TransportType};
+    use std::sync::{Arc, Mutex};
     use std::thread;
     use std::time::Duration;
 
@@ -2362,6 +2616,9 @@ mod tests {
         assert_eq!(internal_prefixes::KEY_PACKAGE, "__MLS_KEY_PKG__");
         assert_eq!(internal_prefixes::WELCOME, "__MLS_WELCOME__");
         assert_eq!(internal_prefixes::ENCRYPTED, "__MLS_ENC__");
+        assert_eq!(internal_prefixes::CONN_REQUEST, "__CONN_REQ__");
+        assert_eq!(internal_prefixes::CONN_ACCEPT, "__CONN_ACC__");
+        assert_eq!(internal_prefixes::CONN_REJECT, "__CONN_REJ__");
     }
 
     #[test]
@@ -2403,6 +2660,263 @@ mod tests {
             protocol.pending_key_packages.get("sender123").unwrap(),
             &vec![1u8, 2, 3, 4]
         );
+    }
+
+    #[test]
+    fn test_process_internal_message_connection_request_event() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = ConnectionRequestPayload {
+            sender_name: "Alice".to_string(),
+            timestamp_ms: 12345,
+            key_package: Some(vec![9, 8, 7]),
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::CONN_REQUEST,
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        match &captured[0] {
+            Event::ConnectionRequestReceived {
+                sender,
+                sender_name,
+                timestamp,
+                key_package,
+            } => {
+                assert_eq!(sender, "alice");
+                assert_eq!(sender_name, "Alice");
+                assert_eq!(*timestamp, 12345);
+                assert_eq!(key_package.as_ref(), Some(&vec![9, 8, 7]));
+            }
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_process_internal_message_connection_accepted_event() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = ConnectionAcceptedPayload {
+            accepted_by_name: "Bob".to_string(),
+            key_package: Some(vec![1, 2, 3, 4]),
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::CONN_ACCEPT,
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let message = Message::new(
+            UserId::new("bob").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        match &captured[0] {
+            Event::ConnectionAccepted {
+                accepted_by,
+                accepted_by_name,
+                key_package,
+            } => {
+                assert_eq!(accepted_by, "bob");
+                assert_eq!(accepted_by_name, "Bob");
+                assert_eq!(key_package.as_ref(), Some(&vec![1, 2, 3, 4]));
+            }
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_process_internal_message_connection_rejected_event() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let content = internal_prefixes::CONN_REJECT.to_string();
+        let message = Message::new(
+            UserId::new("carol").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        match &captured[0] {
+            Event::ConnectionRejected { rejected_by } => {
+                assert_eq!(rejected_by, "carol");
+            }
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    // ========================================================================
+    // SENDER-SIDE CONNECTION REQUEST TESTS
+    // ========================================================================
+
+    #[test]
+    fn test_send_connection_request_success() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_connection_request("bob", "Alice", None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_send_connection_request_not_started() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let result = protocol.send_connection_request("bob", "Alice", None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_connection_request_with_key_package() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let key_package = vec![1, 2, 3, 4, 5];
+        let result = protocol.send_connection_request("bob", "Alice", Some(key_package));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_accept_connection_request_success() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.accept_connection_request("bob", "Alice", None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_accept_connection_request_not_started() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let result = protocol.accept_connection_request("bob", "Alice", None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_accept_connection_request_with_key_package() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let key_package = vec![10, 20, 30];
+        let result = protocol.accept_connection_request("bob", "Alice", Some(key_package));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_reject_connection_request_success() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.reject_connection_request("bob");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_reject_connection_request_not_started() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let result = protocol.reject_connection_request("bob");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_connection_request_returns_unique_ids() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let id1 = protocol
+            .send_connection_request("bob", "Alice", None)
+            .unwrap();
+        let id2 = protocol
+            .send_connection_request("carol", "Alice", None)
+            .unwrap();
+        assert_ne!(id1, id2);
     }
 
     #[test]


### PR DESCRIPTION
DORS was returning a disconnected transport during its cooldown window, causing messages to fail instead of falling back to BLE/WiFi Direct when Internet went down with preferOnline enabled. Connection requests were also confined to the Internet relay WebSocket and could not be sent over BLE or WiFi Direct.

- Fix DORS select_transport to skip cooldown/hysteresis when the current transport is no longer in the available set, so fallback is immediate
- Add transport-agnostic connection request APIs (send, accept, reject) as internal protocol messages routed through DORS like regular messages
- Add ConnectionRequestReceived, ConnectionAccepted, ConnectionRejected event types with serde tagging, Debug redaction, and constructor helpers
- Wire through UniFFI (UDL + lib.rs), Android (Kotlin), iOS (Swift + ObjC bridge), and React Native JS SDK (types + wrapper methods)
- Add 12 inbound-parsing + 9 sender-side + 1 DORS unit tests (all pass)