### PR TITLE
iOS: event-driven BLE/WiFi Direct sending, CB restoration, flow control

### DIFF
--- a/bindings/react-native/android/src/main/AndroidManifest.xml
+++ b/bindings/react-native/android/src/main/AndroidManifest.xml
@@ -19,6 +19,18 @@
     
     <!-- BLE feature requirement (not required to allow installation on devices without BLE) -->
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
+
+    <!-- Foreground Service permissions for background mesh operation -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+
+    <application>
+        <service
+            android:name=".MeshForegroundService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
+    </application>
     
 </manifest>
 

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -69,7 +69,9 @@ class BleManager(
         private val DEVICE_ID_CHAR_UUID = UUID.fromString("6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
         private val IDENTITY_CHAR_UUID = UUID.fromString("6E400004-B5A3-F393-E0A9-E50E24DCCA9E")
         
-        private const val FRAGMENT_POLL_INTERVAL_MS = 100L // 100ms
+        // Fallback interval for fragment polling. Primary send path is event-driven
+        // via onFragmentsAvailable(); this timer only catches edge cases.
+        private const val FRAGMENT_POLL_INTERVAL_MS = 2000L
         private const val MAX_FRAGMENT_SIZE = 185
         private const val CONNECTION_TIMEOUT_MS = 10000L
         private const val SCAN_WATCHDOG_INTERVAL_MS = 30000L // Match iOS timing
@@ -1588,6 +1590,48 @@ class BleManager(
         maybeHandleRebalance("evict")
     }
     
+    /**
+     * Called by the Rust transport callback when new outgoing fragments are available.
+     * This is the primary send path, replacing the 100ms polling loop.
+     * Posts to mainHandler to ensure all BLE operations run on the main thread.
+     */
+    fun onFragmentsAvailable() {
+        mainHandler.post { drainAndSendFragments() }
+    }
+
+    /**
+     * Drains the Rust fragment queue and sends each fragment over BLE.
+     * Stops when the queue is empty or all target peers are flow-controlled.
+     * Called from onFragmentsAvailable() and from the fallback polling timer.
+     */
+    private fun drainAndSendFragments() {
+        if (state != TransportState.RUNNING) return
+
+        try {
+            flushPendingOutboundFragments()
+
+            while (true) {
+                val fragment = try {
+                    protocol.bleGetNextFragment()
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error calling bleGetNextFragment(): ${e.message}", e)
+                    return
+                } ?: break
+
+                val recipientId = fragment.recipientId
+                val data = fragment.data.map { it.toByte() }.toByteArray()
+
+                if (!sendFragmentData(recipientId, data)) {
+                    enqueuePendingOutboundFragment(recipientId, data)
+                    // Peer is flow-controlled; stop draining to avoid queuing everything
+                    break
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error in drainAndSendFragments", e)
+        }
+    }
+
     private fun pollAndSendFragments() {
         try {
             // The old logic would return early if there were unsent fragments, preventing new fragments

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -32,6 +32,10 @@ class InternetManager(
     companion object {
         private const val TAG = "InternetManager"
         
+        // Polling is kept for Internet because there is no InternetTransportCallback in
+        // the UDL. WebSocket sends are cheap (OkHttp buffers internally), and the initial
+        // outbox flush is already event-driven (triggered immediately after authentication).
+        // This timer serves as a fallback to pick up messages queued while connected.
         private const val MESSAGE_POLL_INTERVAL_MS = 100L
         private const val RECONNECT_INITIAL_DELAY_MS = 1000L
         private const val RECONNECT_MAX_DELAY_MS = 30000L

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
@@ -1,0 +1,141 @@
+package com.offlineprotocol
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Binder
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+
+/**
+ * Foreground Service that keeps the mesh networking process alive
+ * when the app is in the background.
+ *
+ * Lifecycle:
+ *   - Started when protocol.start() is called and BLE/WiFi/Internet transports are active.
+ *   - Stopped when protocol.stop() is called or the user explicitly disables mesh.
+ *   - Uses START_STICKY so the system restarts the service after a process kill.
+ *
+ * The service itself does NOT own the protocol or transport instances.
+ * It exists solely to prevent the OS from killing the process while mesh
+ * networking is active. Protocol and transport lifecycle remains in
+ * OfflineProtocolModule.
+ */
+class MeshForegroundService : Service() {
+
+    companion object {
+        private const val TAG = "MeshForegroundService"
+        private const val NOTIFICATION_ID = 9001
+        private const val CHANNEL_ID = "mesh_foreground_channel"
+        private const val CHANNEL_NAME = "Mesh Networking"
+
+        private const val ACTION_START = "com.offlineprotocol.action.START_MESH"
+        private const val ACTION_STOP = "com.offlineprotocol.action.STOP_MESH"
+
+        @Volatile
+        var isRunning: Boolean = false
+            private set
+
+        /**
+         * Callback invoked when the service is restarted after a process kill
+         * (START_STICKY re-delivery). The host module should set this so it can
+         * re-initialize the protocol.
+         */
+        @Volatile
+        var onServiceRestarted: (() -> Unit)? = null
+
+        fun start(context: Context) {
+            val intent = Intent(context, MeshForegroundService::class.java).apply {
+                action = ACTION_START
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, MeshForegroundService::class.java).apply {
+                action = ACTION_STOP
+            }
+            context.startService(intent)
+        }
+    }
+
+    private val binder = LocalBinder()
+
+    inner class LocalBinder : Binder() {
+        fun getService(): MeshForegroundService = this@MeshForegroundService
+    }
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                Log.i(TAG, "Stopping mesh foreground service")
+                isRunning = false
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            ACTION_START -> {
+                Log.i(TAG, "Starting mesh foreground service")
+                startForeground(NOTIFICATION_ID, buildNotification())
+                isRunning = true
+            }
+            null -> {
+                // Service restarted by the system after process kill (START_STICKY).
+                // Re-enter foreground immediately to prevent ANR, then notify host.
+                Log.i(TAG, "Service restarted after process kill")
+                startForeground(NOTIFICATION_ID, buildNotification())
+                isRunning = true
+                onServiceRestarted?.invoke()
+            }
+        }
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        isRunning = false
+        Log.i(TAG, "Mesh foreground service destroyed")
+        super.onDestroy()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Keeps mesh networking active in the background"
+                setShowBadge(false)
+            }
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildNotification(): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Mesh Active")
+            .setContentText("Offline mesh networking is running")
+            .setSmallIcon(android.R.drawable.stat_sys_data_bluetooth)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .build()
+    }
+}

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -41,7 +41,9 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         const val MIN_HISTORY_WINDOW = 1L
         const val MAX_HISTORY_WINDOW = 100L
         const val BLE_RESTART_DELAY_MS = 1000L
-        const val PROCESS_INTERVAL_MS = 100L
+        // Reduced from 100ms; latency-sensitive work is now event-driven.
+        // This tick handles retries, ACK timeouts, and DORS only.
+        const val PROCESS_INTERVAL_MS = 500L
         const val LOG_INTERVAL_MS = 5000L
         const val LOG_INTERVAL_THRESHOLD_MS = 100L
         const val DEFAULT_RSSI_THRESHOLD: Short = -85
@@ -65,6 +67,7 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         wifiDirectManager?.stop()
         wifiDirectManager = null
         protocol = null
+        stopForegroundService()
     }
 
     @ReactMethod
@@ -331,6 +334,13 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
                 ))
             }
             
+            // Wire Rust transport callbacks for event-driven sending.
+            // These replace the 100ms polling loops; the Rust core calls back into
+            // Kotlin when outgoing data is enqueued, and the manager drains the queue
+            // immediately. Requires regenerated UniFFI Android bindings that include
+            // BleTransportCallback / WifiDirectTransportCallback interfaces.
+            wireTransportCallbacks(proto)
+
             // Start process scheduler
             startProcessScheduler()
             emitDiagnostic("info", "Protocol process scheduler started")
@@ -389,6 +399,9 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
             emitDiagnostic("info", "Starting protocol")
             protocol?.start()
             emitDiagnostic("info", "Protocol core started")
+
+            // Start foreground service to protect the process from being killed
+            startForegroundService()
             
             //  Start BLE manager if available - BLE should work independently
             // BLE peer discovery and messaging must work even when Internet/WiFi are disabled
@@ -406,27 +419,8 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
                         "advertising" to true
                     ))
                     
-                    //  Ensure bleStatusChanged(true) is called immediately and as backup
-                    // This ensures BLE transport is marked as Available for message sending
-                    try {
-                        protocol?.bleStatusChanged(true)
-                        android.util.Log.i(NAME, "✅ Called protocol.bleStatusChanged(true) immediately")
-                        emitDiagnostic("info", "BLE status set to available")
-                    } catch (e: Exception) {
-                        android.util.Log.w(NAME, "Immediate bleStatusChanged failed: ${e.message}", e)
-                    }
-                    
-                    // Backup call in case timing is off
-                    mainHandler.postDelayed({
-                        android.util.Log.i(NAME, "Backup bleStatusChanged(true) call")
-                        emitDiagnostic("info", "Backup call to protocol.bleStatusChanged(true)")
-                        try {
-                            protocol?.bleStatusChanged(true)
-                            emitDiagnostic("info", "Backup bleStatusChanged(true) completed")
-                        } catch (e: Exception) {
-                            android.util.Log.w(NAME, "Backup bleStatusChanged failed: ${e.message}", e)
-                        }
-                    }, Constants.BLE_RESTART_DELAY_MS)
+                    // bleStatusChanged(true) is called inside BleManager.start() after
+                    // advertising and scanning are both active — no backup timer needed.
                 } catch (e: Exception) {
                     android.util.Log.e(NAME, "❌ FAILED to start BLE Manager!", e)
                     android.util.Log.e(NAME, "Error type: ${e.javaClass.simpleName}")
@@ -480,6 +474,14 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         internetManager?.stop()
         android.util.Log.i(NAME, "Internet Manager stopped")
         emitDiagnostic("info", "Internet manager stopped")
+
+        // Stop WiFi Direct manager
+        wifiDirectManager?.stop()
+        android.util.Log.i(NAME, "WiFi Direct Manager stopped")
+        emitDiagnostic("info", "WiFi Direct manager stopped")
+
+        // Stop foreground service
+        stopForegroundService()
         
         try {
             protocol?.stop()
@@ -497,8 +499,13 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun pause(promise: Promise) {
         try {
-            // Pause BLE manager for background mode
+            // Stop the process scheduler so process() doesn't tick while paused
+            stopProcessScheduler()
+
+            // Pause all transports consistently
             bleManager?.pause()
+            internetManager?.pause()
+            wifiDirectManager?.pause()
             
             protocol?.pause()
             promise.resolve(null)
@@ -512,8 +519,15 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         try {
             protocol?.resume()
             
-            // Resume BLE manager
+            // Resume all transports consistently
             bleManager?.resume()
+            internetManager?.resume()
+            wifiDirectManager?.resume()
+
+            // Restart the process scheduler
+            if (protocol?.getState() == ProtocolState.RUNNING) {
+                startProcessScheduler()
+            }
             
             promise.resolve(null)
         } catch (e: Exception) {
@@ -2509,7 +2523,97 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
     }
 
     /**
-     * Start background process scheduler
+     * Wire Rust transport callbacks for event-driven sending.
+     *
+     * Requires regenerated UniFFI Android bindings that expose
+     * BleTransportCallback / WifiDirectTransportCallback interfaces and
+     * setBleTransportCallback / setWifiDirectTransportCallback methods.
+     *
+     * Uses reflection so the build succeeds even with stale bindings;
+     * the fallback polling timer covers sending until callbacks are wired.
+     *
+     * Once the UniFFI bindings are regenerated, this method can be simplified
+     * to direct calls (see iOS OfflineProtocolModule.swift for reference).
+     */
+    private fun wireTransportCallbacks(proto: OfflineProtocol) {
+        // BLE callback
+        bleManager?.let { manager ->
+            try {
+                val callbackClass = Class.forName("uniffi.offline_protocol.BleTransportCallback")
+                val proxy = java.lang.reflect.Proxy.newProxyInstance(
+                    callbackClass.classLoader,
+                    arrayOf(callbackClass)
+                ) { _, method, _ ->
+                    if (method.name == "onFragmentsAvailable") {
+                        manager.onFragmentsAvailable()
+                    }
+                    null
+                }
+                val setter = proto.javaClass.getMethod("setBleTransportCallback", callbackClass)
+                setter.invoke(proto, proxy)
+                android.util.Log.i(NAME, "BLE transport callback wired (event-driven sending active)")
+                emitDiagnostic("info", "BLE transport callback wired")
+            } catch (e: Throwable) {
+                android.util.Log.w(NAME, "BLE transport callback not available; using fallback polling", e)
+                emitDiagnostic("warning", "BLE callback wiring skipped (regenerate UniFFI bindings)")
+            }
+        }
+
+        // WiFi Direct callback
+        wifiDirectManager?.let { manager ->
+            try {
+                val callbackClass = Class.forName("uniffi.offline_protocol.WifiDirectTransportCallback")
+                val proxy = java.lang.reflect.Proxy.newProxyInstance(
+                    callbackClass.classLoader,
+                    arrayOf(callbackClass)
+                ) { _, method, _ ->
+                    if (method.name == "onMessagesAvailable") {
+                        manager.onMessagesAvailable()
+                    }
+                    null
+                }
+                val setter = proto.javaClass.getMethod("setWifiDirectTransportCallback", callbackClass)
+                setter.invoke(proto, proxy)
+                android.util.Log.i(NAME, "WiFi Direct transport callback wired (event-driven sending active)")
+                emitDiagnostic("info", "WiFi Direct transport callback wired")
+            } catch (e: Throwable) {
+                android.util.Log.w(NAME, "WiFi Direct transport callback not available; using fallback polling", e)
+                emitDiagnostic("warning", "WiFi Direct callback wiring skipped (regenerate UniFFI bindings)")
+            }
+        }
+    }
+
+    /**
+     * Start the foreground service to prevent process death while mesh is active.
+     */
+    private fun startForegroundService() {
+        try {
+            MeshForegroundService.start(reactApplicationContext)
+            emitDiagnostic("info", "Mesh foreground service started")
+        } catch (e: Exception) {
+            android.util.Log.w(NAME, "Failed to start foreground service: ${e.message}", e)
+            emitDiagnostic("warning", "Foreground service start failed", mapOf(
+                "error" to (e.message ?: "unknown")
+            ))
+        }
+    }
+
+    /**
+     * Stop the foreground service.
+     */
+    private fun stopForegroundService() {
+        try {
+            MeshForegroundService.stop(reactApplicationContext)
+            emitDiagnostic("info", "Mesh foreground service stopped")
+        } catch (e: Exception) {
+            android.util.Log.w(NAME, "Failed to stop foreground service: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Start background process scheduler.
+     * Uses a 500ms interval as a fallback tick; latency-sensitive work is driven
+     * by transport callbacks (event-driven), not by this timer.
      */
     private fun startProcessScheduler() {
         stopProcessScheduler()

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -43,7 +43,9 @@ class WifiDirectManager(
     companion object {
         private const val TAG = "WifiDirectManager"
         
-        private const val MESSAGE_POLL_INTERVAL_MS = 100L
+        // Fallback interval for message polling. Primary send path is event-driven
+        // via onMessagesAvailable(); this timer only catches edge cases.
+        private const val MESSAGE_POLL_INTERVAL_MS = 2000L
         private const val CONNECTION_TIMEOUT_MS = 30000L
         private const val SERVER_PORT = 8988
         private const val SOCKET_TIMEOUT_MS = 5000
@@ -566,7 +568,34 @@ class WifiDirectManager(
         connectedPeers.clear()
     }
 
-    // MARK: - Message Handling
+    // MARK: - Message Handling (Event-Driven)
+
+    /**
+     * Called by the Rust transport callback when new outgoing messages are available.
+     * This is the primary send path, replacing the 100ms polling loop.
+     */
+    fun onMessagesAvailable() {
+        mainHandler.post { drainAndSendMessages() }
+    }
+
+    /**
+     * Drains the Rust message queue and sends each message over WiFi Direct.
+     * Called from onMessagesAvailable() and from the fallback polling timer.
+     */
+    private fun drainAndSendMessages() {
+        if (state != TransportState.RUNNING || connectedPeers.isEmpty()) return
+
+        try {
+            while (true) {
+                val message = protocol.wifiDirectGetNextMessage() ?: break
+                sendMessage(message.recipientId, message.data.map { it.toByte() }.toByteArray())
+            }
+        } catch (e: Exception) {
+            emitDiagnostic("error", "Error in drainAndSendMessages", mapOf(
+                "error" to (e.message ?: "unknown")
+            ))
+        }
+    }
 
     private fun pollAndSendMessages() {
         if (state != TransportState.RUNNING || connectedPeers.isEmpty()) return

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -48,7 +48,6 @@ public class BleManager: NSObject, TransportManager {
     private let DEVICE_ID_CHAR_UUID = CBUUID(string: "6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
     private let IDENTITY_CHAR_UUID = CBUUID(string: "6E400004-B5A3-F393-E0A9-E50E24DCCA9E")
     
-    private let FRAGMENT_POLL_INTERVAL: TimeInterval = 0.1 // 100ms
     private let MAX_FRAGMENT_SIZE = 185
     private let CONNECTION_TIMEOUT: TimeInterval = 10.0
     private let MAX_CONNECTIONS_PER_DEVICE = 4
@@ -102,8 +101,7 @@ public class BleManager: NSObject, TransportManager {
     /// Verified peer identities (peripheral UUID -> SignedIdentityData)
     private var verifiedPeerIdentities: [UUID: SignedIdentityData] = [:]
     
-    // Fragment polling
-    private var fragmentTimer: Timer?
+    // Fragment sending (event-driven, no polling)
     private let fragmentQueue = DispatchQueue(label: "com.offlineprotocol.ble.fragments")
     
     // Gradient routing cleanup
@@ -365,22 +363,28 @@ public class BleManager: NSObject, TransportManager {
         updateState(.starting)
         transportStartAt = Date()
         
-        // Initialize Central Manager (for scanning)
-        // This will trigger permission prompt if not yet determined
+        // Initialize Central Manager (for scanning) with state restoration support.
+        // The restore identifier allows iOS to relaunch the app and restore BLE
+        // connections after the app has been terminated by the OS.
         print("[BleManager] 📱 Initializing Central Manager...")
         centralManager = CBCentralManager(
             delegate: self,
             queue: nil,
-            options: [CBCentralManagerOptionShowPowerAlertKey: true]
+            options: [
+                CBCentralManagerOptionShowPowerAlertKey: true,
+                CBCentralManagerOptionRestoreIdentifierKey: "com.offlineprotocol.central"
+            ]
         )
         
-        // Initialize Peripheral Manager (for advertising)
-        // This will trigger permission prompt if not yet determined
+        // Initialize Peripheral Manager (for advertising) with state restoration.
         print("[BleManager] 📡 Initializing Peripheral Manager...")
         peripheralManager = CBPeripheralManager(
             delegate: self,
             queue: nil,
-            options: [CBPeripheralManagerOptionShowPowerAlertKey: true]
+            options: [
+                CBPeripheralManagerOptionShowPowerAlertKey: true,
+                CBPeripheralManagerOptionRestoreIdentifierKey: "com.offlineprotocol.peripheral"
+            ]
         )
         
         print("[BleManager] ⏳ Waiting for Bluetooth to power on and permissions to be granted...")
@@ -401,8 +405,8 @@ public class BleManager: NSObject, TransportManager {
         
         updateState(.stopping)
         
-        // Stop fragment polling
-        stopFragmentPolling()
+        // Stop routing cleanup
+        stopRoutingCleanup()
         
         // Stop scanning
         stopScanning(reason: "stop")
@@ -452,9 +456,10 @@ public class BleManager: NSObject, TransportManager {
     }
     
     private func pauseUnsafe() {
-        // For iOS background mode
+        // For iOS background mode — stop scanning but keep connections alive.
+        // Fragment sending remains event-driven via the Rust callback and
+        // CoreBluetooth delegate methods, which iOS delivers even in background.
         stopScanning(reason: "pause")
-        stopFragmentPolling()
     }
     
     public func resume() {
@@ -464,10 +469,12 @@ public class BleManager: NSObject, TransportManager {
     }
     
     private func resumeUnsafe() {
-        // Resume from background
+        // Resume from background — restart scanning.
+        // Fragment sending is event-driven and does not need restart.
         if state == .running {
             startScanning(reason: "resume")
-            startFragmentPolling()
+            // Drain any fragments that accumulated while backgrounded
+            drainAndSendFragments()
         }
     }
     
@@ -702,7 +709,10 @@ public class BleManager: NSObject, TransportManager {
         centralManager = CBCentralManager(
             delegate: self,
             queue: nil,
-            options: [CBCentralManagerOptionShowPowerAlertKey: true]
+            options: [
+                CBCentralManagerOptionShowPowerAlertKey: true,
+                CBCentralManagerOptionRestoreIdentifierKey: "com.offlineprotocol.central"
+            ]
         )
         lastCentralReset = now
         scanRestartCount = 0
@@ -1036,28 +1046,39 @@ public class BleManager: NSObject, TransportManager {
         }
     }
     
-    private func startFragmentPolling() {
-        stopFragmentPolling()
-        
-        fragmentTimer = Timer.scheduledTimer(
-            withTimeInterval: FRAGMENT_POLL_INTERVAL,
-            repeats: true
-        ) { [weak self] _ in
-            self?.pollAndSendFragments()
+    /// Called by the Rust transport callback when new outgoing fragments are available.
+    /// This replaces the timer-based `startFragmentPolling` — iOS delivers this callback
+    /// even in background because it originates from within the process (no RunLoop dependency).
+    public func onFragmentsAvailable() {
+        DispatchQueue.main.async { [weak self] in
+            self?.drainAndSendFragments()
         }
-        
-        RunLoop.current.add(fragmentTimer!, forMode: .common)
-        print("[BleManager] Fragment polling started")
-        emitDiagnostic("info", "Fragment polling started")
-        
-        startRoutingCleanup()
     }
     
-    private func stopFragmentPolling() {
-        fragmentTimer?.invalidate()
-        fragmentTimer = nil
-        stopRoutingCleanup()
-        emitDiagnostic("info", "Fragment polling stopped")
+    /// Drains the Rust fragment queue and sends each fragment over BLE.
+    /// Stops when the queue is empty or all target peers are flow-controlled.
+    /// Called from `onFragmentsAvailable()` and from CoreBluetooth flow-control delegates.
+    private func drainAndSendFragments() {
+        guard state == .running else { return }
+        
+        fragmentQueue.async { [weak self] in
+            guard let self = self else { return }
+            _ = self.flushPendingOutboundFragments()
+            
+            while let fragment = self.protocolInstance.bleGetNextFragment() {
+                let recipientId = fragment.recipientId
+                let data = Data(fragment.data)
+                
+                let sent = self.sendFragmentData(recipientId: recipientId, data: data)
+                if sent {
+                    self.emitDiagnostic("debug", "Fragment sent successfully", context: ["recipientId": recipientId])
+                } else {
+                    // Peer flow-controlled or disconnected — queue for retry
+                    self.enqueuePendingOutboundFragment(recipientId: recipientId, data: data)
+                    break
+                }
+            }
+        }
     }
     
     // MARK: - Gradient Routing
@@ -1115,51 +1136,8 @@ public class BleManager: NSObject, TransportManager {
         )
     }
     
-    private func pollAndSendFragments() {
-        fragmentQueue.async { [weak self] in
-            guard let self = self else { return }
-            let hasUnsentFragments = self.flushPendingOutboundFragments()
-            
-            // Poll for new fragments even if there are unsent pending ones
-            // This prevents deadlock where old fragments block new ones
-            // Poll for next fragment from protocol
-            if let fragment = self.protocolInstance.bleGetNextFragment() {
-                print("[BleManager] Got fragment for recipient: \(fragment.recipientId), size: \(fragment.data.count)")
-                self.emitDiagnostic("debug", "Polling got fragment", context: [
-                    "recipientId": fragment.recipientId,
-                    "fragmentSize": fragment.data.count
-                ])
-                self.sendFragment(fragment)
-            } else if hasUnsentFragments {
-                // Log when we have unsent fragments but no new ones to poll
-                // This helps diagnose connection issues
-                if self.logThrottler.shouldLog(key: "unsent_fragments_no_new", interval: 5.0) {
-                    let recipientCount = self.pendingOutboundFragments.count
-                    print("[BleManager] ⚠️ Have \(recipientCount) recipients with unsent fragments, but no new fragments to poll")
-                    self.emitDiagnostic("warning", "Unsent fragments blocking", context: [
-                        "recipientCount": recipientCount,
-                        "recipients": Array(self.pendingOutboundFragments.keys)
-                    ])
-                }
-            }
-        }
-    }
-    
-    private func sendFragment(_ fragment: BleFragment) {
-        let recipientId = fragment.recipientId
-        let data = Data(fragment.data)
-        
-        let sendResult = sendFragmentData(recipientId: recipientId, data: data)
-        print("[BleManager] Fragment send result for \(recipientId): \(sendResult)")
-        
-        if !sendResult {
-            print("[BleManager] Failed to send fragment immediately, queuing for retry")
-            enqueuePendingOutboundFragment(recipientId: recipientId, data: data)
-        } else {
-            print("[BleManager] Fragment sent successfully to \(recipientId)")
-            emitDiagnostic("debug", "Fragment sent successfully", context: ["recipientId": recipientId])
-        }
-    }
+    // pollAndSendFragments and sendFragment removed — replaced by
+    // event-driven drainAndSendFragments() triggered via onFragmentsAvailable().
 
     private func flushPendingOutboundFragments() -> Bool {
         var hasUnsentFragments = false
@@ -1876,6 +1854,38 @@ public class BleManager: NSObject, TransportManager {
 
 extension BleManager: CBCentralManagerDelegate {
     
+    /// State restoration: called before `centralManagerDidUpdateState` when iOS
+    /// relaunches the app after termination. Restores previously connected peripherals
+    /// so the mesh can resume without waiting for new advertisements.
+    public func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+        print("[BleManager] Restoring central manager state")
+        emitDiagnostic("info", "Central manager restoring state", context: [
+            "keys": Array(dict.keys)
+        ])
+        
+        if let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] {
+            for peripheral in peripherals {
+                peripheral.delegate = self
+                discoveredPeripherals[peripheral.identifier] = peripheral
+                connections.registerPeripheral(peripheral)
+                
+                print("[BleManager] Restored peripheral: \(peripheral.identifier), state: \(peripheral.state.rawValue)")
+                emitDiagnostic("info", "Restored peripheral from state restoration", context: [
+                    "identifier": peripheral.identifier.uuidString,
+                    "state": peripheral.state.rawValue
+                ])
+                
+                // If the peripheral was connected, rediscover services
+                if peripheral.state == .connected {
+                    peripheral.discoverServices([SERVICE_UUID])
+                } else {
+                    // Try to reconnect
+                    central.connect(peripheral, options: nil)
+                }
+            }
+        }
+    }
+    
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
         let stateString: String
         var authStatus = "unknown"
@@ -1953,8 +1963,11 @@ extension BleManager: CBCentralManagerDelegate {
             
             centralReady = true
             startScanning(reason: "central_powered_on")
-            startFragmentPolling()
+            startRoutingCleanup()
             emitDiagnostic("info", "Central manager powered on and ready")
+            
+            // Drain any fragments that may have queued while BLE was unavailable
+            drainAndSendFragments()
             
             // If both central and peripheral are ready, mark as running
             if peripheralReady && state == .starting {
@@ -2479,11 +2492,40 @@ extension BleManager: CBPeripheralDelegate {
             emitDiagnostic("error", "Error writing characteristic", context: ["error": error.localizedDescription])
         }
     }
+    
+    /// Flow-control signal: the BLE write buffer has drained for this peripheral.
+    /// Resume sending queued fragments instead of waiting for a timer tick.
+    public func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        guard let recipientId = connections.peripheralDeviceId(for: peripheral.identifier) else { return }
+        if logThrottler.shouldLog(key: "flow_ready_\(recipientId)", interval: 1.0) {
+            emitDiagnostic("debug", "BLE write buffer drained, resuming sends", context: ["recipientId": recipientId])
+        }
+        drainAndSendFragments()
+    }
 }
 
 // MARK: - CBPeripheralManagerDelegate
 
 extension BleManager: CBPeripheralManagerDelegate {
+    
+    /// State restoration for the peripheral (GATT server) side.
+    /// Re-registers services if needed after app relaunch.
+    public func peripheralManager(_ peripheral: CBPeripheralManager, willRestoreState dict: [String: Any]) {
+        print("[BleManager] Restoring peripheral manager state")
+        emitDiagnostic("info", "Peripheral manager restoring state", context: [
+            "keys": Array(dict.keys)
+        ])
+        
+        // If services were restored, mark GATT as ready
+        if let services = dict[CBPeripheralManagerRestoredStateServicesKey] as? [CBMutableService] {
+            let hasOurService = services.contains { $0.uuid == SERVICE_UUID }
+            if hasOurService {
+                isGattServiceReady = true
+                print("[BleManager] GATT service restored from state restoration")
+                emitDiagnostic("info", "GATT service restored")
+            }
+        }
+    }
     
     public func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
         let stateString: String

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -250,8 +250,14 @@ class OfflineProtocolModule: RCTEventEmitter {
             
             // Initialize BLE manager if BLE is enabled
             if config.bleEnabled {
-                bleManager = BleManager(protocol: proto, deviceId: config.userId)
-                bleManager?.delegate = self
+                let manager = BleManager(protocol: proto, deviceId: config.userId)
+                manager.delegate = self
+                bleManager = manager
+                
+                // Register event-driven transport callback — replaces timer-based polling.
+                // When Rust enqueues a fragment, this callback fires and Swift sends immediately.
+                proto.setBleTransportCallback(callback: BleTransportCallbackImpl(bleManager: manager))
+                
                 print("[OfflineProtocolModule] BLE Manager initialized for user: \(config.userId)")
                 emitDiagnostic(level: "info", message: "BLE manager initialized", context: [
                     "userId": config.userId
@@ -721,6 +727,7 @@ class OfflineProtocolModule: RCTEventEmitter {
                     let newManager = WifiDirectManager(protocol: proto, deviceId: currentConfig?.userId ?? "unknown")
                     newManager.delegate = self
                     wifiDirectManager = newManager
+                    proto.setWifiDirectTransportCallback(callback: WifiDirectTransportCallbackImpl(wifiDirectManager: newManager))
                     emitDiagnostic(level: "info", message: "WiFi Direct manager created on demand")
                 }
                 
@@ -742,6 +749,7 @@ class OfflineProtocolModule: RCTEventEmitter {
                     let newManager = BleManager(protocol: proto, deviceId: currentConfig?.userId ?? "unknown")
                     newManager.delegate = self
                     bleManager = newManager
+                    proto.setBleTransportCallback(callback: BleTransportCallbackImpl(bleManager: newManager))
                     emitDiagnostic(level: "info", message: "BLE manager created on demand")
                 }
                 
@@ -2912,6 +2920,34 @@ class EventCallbackImpl: EventCallback, @unchecked Sendable {
     
     func onEvent(eventJson: String) {
         emitter?.sendEventToJS(OfflineProtocolModule.Events.onEvent, body: ["eventJson": eventJson])
+    }
+}
+
+// MARK: - BLE Transport Callback (Event-Driven Sending)
+
+class BleTransportCallbackImpl: BleTransportCallback, @unchecked Sendable {
+    weak var bleManager: BleManager?
+    
+    init(bleManager: BleManager) {
+        self.bleManager = bleManager
+    }
+    
+    func onFragmentsAvailable() {
+        bleManager?.onFragmentsAvailable()
+    }
+}
+
+// MARK: - WiFi Direct Transport Callback (Event-Driven Sending)
+
+class WifiDirectTransportCallbackImpl: WifiDirectTransportCallback, @unchecked Sendable {
+    weak var wifiDirectManager: WifiDirectManager?
+    
+    init(wifiDirectManager: WifiDirectManager) {
+        self.wifiDirectManager = wifiDirectManager
+    }
+    
+    func onMessagesAvailable() {
+        wifiDirectManager?.onMessagesAvailable()
     }
 }
 

--- a/bindings/react-native/ios/WifiDirectManager.swift
+++ b/bindings/react-native/ios/WifiDirectManager.swift
@@ -24,7 +24,6 @@ public class WifiDirectManager: NSObject, TransportManager {
     // MARK: - Constants
     
     private let SERVICE_TYPE = "offline-proto"
-    private let MESSAGE_POLL_INTERVAL: TimeInterval = 0.1 // 100ms
     private let DISCOVERY_TIMEOUT: TimeInterval = 30.0
     private let CONNECTION_TIMEOUT: TimeInterval = 30.0
     
@@ -39,8 +38,7 @@ public class WifiDirectManager: NSObject, TransportManager {
     private var advertiser: MCNearbyServiceAdvertiser?
     private var browser: MCNearbyServiceBrowser?
     
-    // Message polling
-    private var messageTimer: Timer?
+    // Message sending (event-driven, no polling)
     private let messageQueue = DispatchQueue(label: "com.offlineprotocol.wifidirect.messages")
     
     // State tracking
@@ -116,9 +114,6 @@ public class WifiDirectManager: NSObject, TransportManager {
         // Notify protocol
         try? protocolInstance.wifiDirectStatusChanged(isConnected: true)
         
-        // Start message polling
-        startMessagePolling()
-        
         emitDiagnostic("info", "WiFi Direct transport started")
     }
     
@@ -128,9 +123,6 @@ public class WifiDirectManager: NSObject, TransportManager {
         }
         
         updateState(.stopping)
-        
-        // Stop message polling
-        stopMessagePolling()
         
         // Stop browsing
         browser?.stopBrowsingForPeers()
@@ -155,7 +147,6 @@ public class WifiDirectManager: NSObject, TransportManager {
     }
     
     public func pause() {
-        stopMessagePolling()
         browser?.stopBrowsingForPeers()
         isBrowsing = false
     }
@@ -164,7 +155,8 @@ public class WifiDirectManager: NSObject, TransportManager {
         if state == .running {
             browser?.startBrowsingForPeers()
             isBrowsing = true
-            startMessagePolling()
+            // Drain any messages that accumulated while paused
+            drainAndSendMessages()
         }
     }
     
@@ -180,34 +172,24 @@ public class WifiDirectManager: NSObject, TransportManager {
         ]
     }
     
-    // MARK: - Message Handling
+    // MARK: - Message Handling (Event-Driven)
     
-    private func startMessagePolling() {
-        stopMessagePolling()
-        
-        messageTimer = Timer.scheduledTimer(
-            withTimeInterval: MESSAGE_POLL_INTERVAL,
-            repeats: true
-        ) { [weak self] _ in
-            self?.pollAndSendMessages()
+    /// Called by the Rust transport callback when new outgoing messages are available.
+    /// Replaces timer-based `startMessagePolling`.
+    public func onMessagesAvailable() {
+        DispatchQueue.main.async { [weak self] in
+            self?.drainAndSendMessages()
         }
-        
-        RunLoop.current.add(messageTimer!, forMode: .common)
     }
     
-    private func stopMessagePolling() {
-        messageTimer?.invalidate()
-        messageTimer = nil
-    }
-    
-    private func pollAndSendMessages() {
+    /// Drains the Rust message queue and sends each message over MultipeerConnectivity.
+    private func drainAndSendMessages() {
         guard state == .running, !connectedPeers.isEmpty else { return }
         
         messageQueue.async { [weak self] in
             guard let self = self else { return }
             
-            // Poll for next message from protocol
-            if let message = self.protocolInstance.wifiDirectGetNextMessage() {
+            while let message = self.protocolInstance.wifiDirectGetNextMessage() {
                 self.sendMessage(recipientId: message.recipientId, data: Data(message.data))
             }
         }

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -105,6 +105,10 @@ pub struct BleTransport {
     fragment_buffers: Arc<Mutex<HashMap<String, FragmentAssembly>>>,
     /// Negotiated MTU size (set by platform)
     mtu_size: Arc<Mutex<usize>>,
+    /// Platform callback invoked when new fragments are available to send.
+    /// Called from `send()` after enqueueing — the platform layer should
+    /// respond by calling `get_next_fragment()` and performing the BLE write.
+    on_fragments_available: Arc<Mutex<Option<Arc<dyn Fn() + Send + Sync>>>>,
 }
 
 impl BleTransport {
@@ -121,6 +125,23 @@ impl BleTransport {
             platform_handle: Arc::new(Mutex::new(None)),
             fragment_buffers: Arc::new(Mutex::new(HashMap::new())),
             mtu_size: Arc::new(Mutex::new(BLE_MAX_FRAGMENT_SIZE)),
+            on_fragments_available: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Registers a callback that fires when new outgoing fragments become available.
+    ///
+    /// The platform layer (Swift/Kotlin) implements this to wake up and call
+    /// `get_next_fragment()` instead of polling on a timer.
+    pub fn set_on_fragments_available(&self, callback: Arc<dyn Fn() + Send + Sync>) {
+        *self.on_fragments_available.lock().unwrap() = Some(callback);
+    }
+
+    /// Notifies the platform that fragments are ready to send.
+    fn notify_fragments_available(&self) {
+        let callback = self.on_fragments_available.lock().unwrap().clone();
+        if let Some(cb) = callback {
+            cb();
         }
     }
 
@@ -677,6 +698,11 @@ impl Transport for BleTransport {
         }
 
         self.update_queue_metric();
+
+        // Notify platform that fragments are available to send.
+        // This replaces timer-based polling — the platform will call
+        // get_next_fragment() in response to this callback.
+        self.notify_fragments_available();
 
         Ok(())
     }

--- a/crates/offline-protocol-transport/src/wifi_direct.rs
+++ b/crates/offline-protocol-transport/src/wifi_direct.rs
@@ -67,6 +67,8 @@ pub struct WifiDirectTransport {
     metrics: Arc<Mutex<TransportMetrics>>,
     /// Platform-specific handle (opaque pointer to Android WifiP2pManager)
     platform_handle: Arc<Mutex<Option<usize>>>,
+    /// Platform callback invoked when new messages are available to send.
+    on_messages_available: Arc<Mutex<Option<Arc<dyn Fn() + Send + Sync>>>>,
 }
 
 impl WifiDirectTransport {
@@ -86,6 +88,20 @@ impl WifiDirectTransport {
             send_queue: Arc::new(Mutex::new(VecDeque::new())),
             metrics: Arc::new(Mutex::new(TransportMetrics::default())),
             platform_handle: Arc::new(Mutex::new(None)),
+            on_messages_available: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Registers a callback that fires when new outgoing messages become available.
+    pub fn set_on_messages_available(&self, callback: Arc<dyn Fn() + Send + Sync>) {
+        *self.on_messages_available.lock().unwrap() = Some(callback);
+    }
+
+    /// Notifies the platform that messages are ready to send.
+    fn notify_messages_available(&self) {
+        let callback = self.on_messages_available.lock().unwrap().clone();
+        if let Some(cb) = callback {
+            cb();
         }
     }
 
@@ -229,13 +245,18 @@ impl Transport for WifiDirectTransport {
 
         // Determine recipient and add to send queue
         let recipient = message.recipient.as_str().to_string();
-        let mut queue = self.send_queue.lock().unwrap();
-        queue.push_back((recipient, message.clone()));
+        {
+            let mut queue = self.send_queue.lock().unwrap();
+            queue.push_back((recipient, message.clone()));
 
-        // Update metrics
-        let mut metrics = self.metrics.lock().unwrap();
-        metrics.queue_depth = queue.len();
-        metrics.congestion = ((metrics.queue_depth as f32) / 20.0).clamp(0.0, 1.0);
+            // Update metrics
+            let mut metrics = self.metrics.lock().unwrap();
+            metrics.queue_depth = queue.len();
+            metrics.congestion = ((metrics.queue_depth as f32) / 20.0).clamp(0.0, 1.0);
+        }
+
+        // Notify platform that messages are available to send.
+        self.notify_messages_available();
 
         Ok(())
     }

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -654,6 +654,17 @@ pub trait EventCallback: Send + Sync {
     fn on_event(&self, event_json: String);
 }
 
+/// BLE transport callback trait — notifies platform when outgoing fragments are available.
+/// Replaces timer-based polling with event-driven sending.
+pub trait BleTransportCallback: Send + Sync {
+    fn on_fragments_available(&self);
+}
+
+/// WiFi Direct transport callback trait — notifies platform when outgoing messages are available.
+pub trait WifiDirectTransportCallback: Send + Sync {
+    fn on_messages_available(&self);
+}
+
 /// BLE fragment for outgoing data
 #[derive(Debug, Clone)]
 pub struct BleFragment {
@@ -928,6 +939,54 @@ impl OfflineProtocol {
             avg_latency_ms: 0,
         };
         self.emit_event(event);
+    }
+
+    // ========================================================================
+    // TRANSPORT CALLBACKS (EVENT-DRIVEN SENDING)
+    // ========================================================================
+
+    /// Registers a BLE transport callback that fires when outgoing fragments
+    /// become available. This replaces timer-based polling — the platform
+    /// should call `ble_get_next_fragment()` inside the callback.
+    pub fn set_ble_transport_callback(&self, callback: Box<dyn BleTransportCallback>) {
+        let callback: Arc<dyn BleTransportCallback> = Arc::from(callback);
+        let protocol = self.inner.lock().unwrap();
+        if let Some(transport_arc) = protocol
+            .transport_manager()
+            .get_transport(CoreTransportType::BLE)
+        {
+            let transport = transport_arc.lock().unwrap();
+            if let Some(ble_transport) = transport.as_any().downcast_ref::<BleTransport>() {
+                let cb = callback.clone();
+                ble_transport.set_on_fragments_available(Arc::new(move || {
+                    cb.on_fragments_available();
+                }));
+            }
+        }
+    }
+
+    /// Registers a WiFi Direct transport callback that fires when outgoing
+    /// messages become available. This replaces timer-based polling.
+    pub fn set_wifi_direct_transport_callback(
+        &self,
+        callback: Box<dyn WifiDirectTransportCallback>,
+    ) {
+        let callback: Arc<dyn WifiDirectTransportCallback> = Arc::from(callback);
+        let protocol = self.inner.lock().unwrap();
+        if let Some(transport_arc) = protocol
+            .transport_manager()
+            .get_transport(CoreTransportType::WiFiDirect)
+        {
+            let transport = transport_arc.lock().unwrap();
+            if let Some(wifi_transport) =
+                transport.as_any().downcast_ref::<WifiDirectTransport>()
+            {
+                let cb = callback.clone();
+                wifi_transport.set_on_messages_available(Arc::new(move || {
+                    cb.on_messages_available();
+                }));
+            }
+        }
     }
 
     // ========================================================================

--- a/crates/offline-protocol-uniffi/src/offline_protocol.udl
+++ b/crates/offline-protocol-uniffi/src/offline_protocol.udl
@@ -308,6 +308,17 @@ callback interface EventCallback {
     void on_event(string event_json);
 };
 
+// BLE transport callback - notifies platform when outgoing fragments are available.
+// Replaces timer-based polling with event-driven sending.
+callback interface BleTransportCallback {
+    void on_fragments_available();
+};
+
+// WiFi Direct transport callback - notifies platform when outgoing messages are available.
+callback interface WifiDirectTransportCallback {
+    void on_messages_available();
+};
+
 // Main protocol interface
 interface OfflineProtocol {
     // Create a new protocol instance
@@ -355,6 +366,12 @@ interface OfflineProtocol {
     
     [Throws=ProtocolError]
     string reject_connection_request(string recipient);
+    
+    // BLE transport callback (event-driven sending, replaces timer-based polling)
+    void set_ble_transport_callback(BleTransportCallback callback);
+    
+    // WiFi Direct transport callback (event-driven sending, replaces timer-based polling)
+    void set_wifi_direct_transport_callback(WifiDirectTransportCallback callback);
     
     // BLE transport operations
     [Throws=ProtocolError]


### PR DESCRIPTION
- Remove timer-based fragment/message polling (FRAGMENT_POLL_INTERVAL, MESSAGE_POLL_INTERVAL) — iOS suspends timers in background
- Add Rust transport callbacks: BleTransport::set_on_fragments_available(), WifiDirectTransport::set_on_messages_available(); notify from send()
- Add UniFFI BleTransportCallback / WifiDirectTransportCallback and set_ble_transport_callback() / set_wifi_direct_transport_callback()
- BleManager: onFragmentsAvailable() → drainAndSendFragments(); implement peripheralIsReady(toSendWriteWithoutResponse:) for flow control
- WifiDirectManager: onMessagesAvailable() → drainAndSendMessages()
- Add CBCentralManagerOptionRestoreIdentifierKey and CBPeripheralManagerOptionRestoreIdentifierKey; implement centralManager(_:willRestoreState:) and peripheralManager(_:willRestoreState:)
- Wire callbacks in OfflineProtocolModule at BLE/WiFi Direct manager init