### PR TITLE
feat(protocol): add Lamport clocks for causal message ordering

### DIFF
--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -340,6 +340,8 @@ export interface MessageSentEvent extends BaseEvent {
   priority: 'low' | 'medium' | 'high' | 'critical';
   requires_ack: boolean;
   timestamp: number;
+  /** Lamport logical clock value for causal ordering (0 for legacy messages). */
+  lamport_clock: number;
 }
 
 /**
@@ -354,6 +356,8 @@ export interface MessageReceivedEvent extends BaseEvent {
   hop_count: number;
   transport: string;
   timestamp: number;
+  /** Lamport logical clock value for causal ordering (0 for legacy messages). */
+  lamport_clock: number;
   /** Whether the message was encrypted (auto-decrypted) */
   encrypted?: boolean;
 }

--- a/crates/offline-protocol-core/src/lib.rs
+++ b/crates/offline-protocol-core/src/lib.rs
@@ -16,4 +16,4 @@ pub mod types;
 
 pub use error::{Error, Result};
 pub use message::{Message, MessageId, MessagePriority};
-pub use types::{AppId, HopCount, Timestamp, UserId, TTL};
+pub use types::{AppId, HopCount, LamportClock, LocalInstant, Timestamp, UserId, WallClockTimestamp, TTL};

--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -1,6 +1,6 @@
 //! Message types and structures.
 
-use crate::types::{AppId, HopCount, Timestamp, UserId, TTL};
+use crate::types::{AppId, HopCount, LamportClock, Timestamp, UserId, TTL};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -103,8 +103,12 @@ pub struct Message {
     /// Number of hops this message has traversed.
     pub hop_count: HopCount,
 
-    /// Timestamp when the message was created.
+    /// Timestamp when the message was created (wall-clock, for display only).
     pub timestamp: Timestamp,
+
+    /// Lamport logical clock for causal ordering across devices.
+    #[serde(default)]
+    pub lamport_clock: LamportClock,
 
     /// Message content (text, JSON, etc.).
     pub content: String,
@@ -150,6 +154,7 @@ impl Message {
             ttl: TTL::default(),
             hop_count: HopCount::new(),
             timestamp: Timestamp::now(),
+            lamport_clock: LamportClock::default(),
             content: content.into(),
             metadata: HashMap::new(),
             requires_ack: true,
@@ -219,6 +224,7 @@ pub struct MessageBuilder {
     content: String,
     priority: MessagePriority,
     ttl: TTL,
+    lamport_clock: LamportClock,
     metadata: HashMap<String, String>,
     requires_ack: bool,
     reply_to_msg: Option<MessageId>,
@@ -234,6 +240,7 @@ impl MessageBuilder {
             content: String::new(),
             priority: MessagePriority::default(),
             ttl: TTL::default(),
+            lamport_clock: LamportClock::default(),
             metadata: HashMap::new(),
             requires_ack: true,
             reply_to_msg: None,
@@ -276,6 +283,12 @@ impl MessageBuilder {
         self
     }
 
+    /// Sets the Lamport clock value for this message.
+    pub fn lamport_clock(mut self, clock: LamportClock) -> Self {
+        self.lamport_clock = clock;
+        self
+    }
+
     /// Builds the message.
     pub fn build(self) -> Message {
         Message {
@@ -287,6 +300,7 @@ impl MessageBuilder {
             ttl: self.ttl,
             hop_count: HopCount::new(),
             timestamp: Timestamp::now(),
+            lamport_clock: self.lamport_clock,
             content: self.content,
             metadata: self.metadata,
             requires_ack: self.requires_ack,

--- a/crates/offline-protocol-core/src/types.rs
+++ b/crates/offline-protocol-core/src/types.rs
@@ -463,4 +463,59 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(10));
         assert!(instant.elapsed_millis() >= 10);
     }
+
+    #[test]
+    fn test_lamport_clock_serde_roundtrip() {
+        let clock = LamportClock::from_value(42);
+        let json = serde_json::to_string(&clock).unwrap();
+        let deserialized: LamportClock = serde_json::from_str(&json).unwrap();
+        assert_eq!(clock, deserialized);
+    }
+
+    #[test]
+    fn test_lamport_clock_deserialize_default() {
+        // Simulates receiving a legacy message without a lamport_clock field
+        #[derive(serde::Deserialize)]
+        #[allow(dead_code)]
+        struct LegacyMsg {
+            content: String,
+            #[serde(default)]
+            lamport_clock: LamportClock,
+        }
+        let json = r#"{"content":"hello"}"#;
+        let msg: LegacyMsg = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.lamport_clock.value(), 0);
+    }
+
+    #[test]
+    fn test_lamport_clock_merge_with_zero() {
+        // Merging with a legacy (zero) clock should still advance by 1
+        let mut local = LamportClock::from_value(10);
+        let legacy = LamportClock::new(); // value 0
+        let merged = local.merge(legacy);
+        // max(10, 0) + 1 = 11
+        assert_eq!(merged.value(), 11);
+    }
+
+    #[test]
+    fn test_lamport_clock_consecutive_merges_advance() {
+        let mut clock = LamportClock::new();
+        // Simulates receiving multiple messages with the same clock value
+        let peer_clock = LamportClock::from_value(5);
+
+        let m1 = clock.merge(peer_clock);
+        assert_eq!(m1.value(), 6); // max(0, 5) + 1
+
+        let m2 = clock.merge(peer_clock);
+        assert_eq!(m2.value(), 7); // max(6, 5) + 1
+
+        let m3 = clock.merge(peer_clock);
+        assert_eq!(m3.value(), 8); // max(7, 5) + 1
+    }
+
+    #[test]
+    fn test_lamport_clock_display() {
+        let clock = LamportClock::from_value(42);
+        assert_eq!(format!("{}", clock), "L42");
+    }
 }

--- a/crates/offline-protocol-core/src/types.rs
+++ b/crates/offline-protocol-core/src/types.rs
@@ -166,7 +166,40 @@ impl Default for HopCount {
     }
 }
 
-/// Unix timestamp in milliseconds.
+/// Wall-clock timestamp in milliseconds since Unix epoch.
+///
+/// Use for human-readable display ("2:34 PM") only. Do NOT use for message
+/// ordering or cross-device duration calculations — wall clocks are unreliable
+/// across devices in offline/mesh networks.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct WallClockTimestamp(i64);
+
+impl WallClockTimestamp {
+    /// Captures the current wall-clock time.
+    pub fn now() -> Self {
+        Self(chrono::Utc::now().timestamp_millis())
+    }
+
+    /// Creates a wall-clock timestamp from milliseconds since Unix epoch.
+    pub fn from_millis(millis: i64) -> Self {
+        Self(millis)
+    }
+
+    /// Returns the timestamp as milliseconds since Unix epoch.
+    pub fn as_millis(&self) -> i64 {
+        self.0
+    }
+}
+
+impl Default for WallClockTimestamp {
+    fn default() -> Self {
+        Self::now()
+    }
+}
+
+/// Unix timestamp in milliseconds (legacy alias for `WallClockTimestamp`).
+///
+/// Retained for backward compatibility. Prefer `WallClockTimestamp` for new code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Timestamp(i64);
 
@@ -187,6 +220,14 @@ impl Timestamp {
     }
 
     /// Returns the elapsed time since this timestamp in milliseconds.
+    ///
+    /// # Safety Contract
+    ///
+    /// This is only meaningful for timestamps created on the **same device**.
+    /// Using this on a timestamp received from another device will produce
+    /// incorrect results due to clock skew. Prefer `LocalInstant` for
+    /// single-device elapsed time measurements.
+    #[deprecated(note = "Use LocalInstant for elapsed time measurements")]
     pub fn elapsed_millis(&self) -> i64 {
         Self::now().0 - self.0
     }
@@ -195,6 +236,81 @@ impl Timestamp {
 impl Default for Timestamp {
     fn default() -> Self {
         Self::now()
+    }
+}
+
+/// Lamport logical clock for causal message ordering.
+///
+/// Provides a monotonically increasing counter that respects causality:
+/// if message B was sent after receiving message A, then B's clock > A's clock.
+///
+/// Use this — not wall-clock timestamps — for sorting messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct LamportClock(u64);
+
+impl LamportClock {
+    /// Creates a clock at the initial value (0).
+    pub fn new() -> Self {
+        Self(0)
+    }
+
+    /// Creates a clock from a raw value (for deserialization / migration).
+    pub fn from_value(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the raw counter value.
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+
+    /// Advances the clock for a local send event and returns the new value.
+    pub fn tick(&mut self) -> Self {
+        self.0 += 1;
+        *self
+    }
+
+    /// Advances the clock after receiving a message with the given clock value.
+    /// Sets local clock to `max(local, received) + 1`.
+    pub fn merge(&mut self, received: LamportClock) -> Self {
+        self.0 = self.0.max(received.0) + 1;
+        *self
+    }
+}
+
+impl Default for LamportClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for LamportClock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "L{}", self.0)
+    }
+}
+
+/// Local-only monotonic instant for measuring elapsed time on this device.
+///
+/// Cannot be serialized — physically cannot cross a device boundary.
+/// Use this instead of `Timestamp::elapsed_millis()` for single-device timing.
+#[derive(Debug, Clone, Copy)]
+pub struct LocalInstant(std::time::Instant);
+
+impl LocalInstant {
+    /// Captures the current monotonic instant.
+    pub fn now() -> Self {
+        Self(std::time::Instant::now())
+    }
+
+    /// Returns the elapsed time since this instant in milliseconds.
+    pub fn elapsed_millis(&self) -> u64 {
+        self.0.elapsed().as_millis() as u64
+    }
+
+    /// Returns the underlying `std::time::Instant`.
+    pub fn as_std(&self) -> std::time::Instant {
+        self.0
     }
 }
 
@@ -253,12 +369,69 @@ mod tests {
         let ts2 = Timestamp::now();
 
         assert!(ts2.as_millis() > ts1.as_millis());
-        assert!(ts1.elapsed_millis() >= 10);
+        #[allow(deprecated)]
+        {
+            assert!(ts1.elapsed_millis() >= 10);
+        }
     }
 
     #[test]
     fn test_ttl_default() {
         let ttl = TTL::default();
         assert_eq!(ttl.value(), TTL::DEFAULT);
+    }
+
+    #[test]
+    fn test_lamport_clock_tick() {
+        let mut clock = LamportClock::new();
+        assert_eq!(clock.value(), 0);
+
+        let t1 = clock.tick();
+        assert_eq!(t1.value(), 1);
+
+        let t2 = clock.tick();
+        assert_eq!(t2.value(), 2);
+    }
+
+    #[test]
+    fn test_lamport_clock_merge() {
+        let mut local = LamportClock::from_value(5);
+        let received = LamportClock::from_value(10);
+
+        let merged = local.merge(received);
+        assert_eq!(merged.value(), 11);
+        assert_eq!(local.value(), 11);
+    }
+
+    #[test]
+    fn test_lamport_clock_merge_local_higher() {
+        let mut local = LamportClock::from_value(20);
+        let received = LamportClock::from_value(5);
+
+        let merged = local.merge(received);
+        assert_eq!(merged.value(), 21);
+    }
+
+    #[test]
+    fn test_lamport_clock_ordering() {
+        let a = LamportClock::from_value(3);
+        let b = LamportClock::from_value(7);
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_wall_clock_timestamp() {
+        let ts = WallClockTimestamp::now();
+        assert!(ts.as_millis() > 0);
+
+        let from = WallClockTimestamp::from_millis(1000);
+        assert_eq!(from.as_millis(), 1000);
+    }
+
+    #[test]
+    fn test_local_instant_elapsed() {
+        let instant = LocalInstant::now();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        assert!(instant.elapsed_millis() >= 10);
     }
 }

--- a/crates/offline-protocol-core/src/types.rs
+++ b/crates/offline-protocol-core/src/types.rs
@@ -171,7 +171,7 @@ impl Default for HopCount {
 /// Use for human-readable display ("2:34 PM") only. Do NOT use for message
 /// ordering or cross-device duration calculations — wall clocks are unreliable
 /// across devices in offline/mesh networks.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct WallClockTimestamp(i64);
 
 impl WallClockTimestamp {
@@ -248,6 +248,10 @@ impl Default for Timestamp {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct LamportClock(u64);
 
+/// Upper bound for accepted Lamport clock values.
+/// Rejects absurdly large values from malicious or buggy peers.
+pub const LAMPORT_CLOCK_MAX: u64 = u64::MAX / 2;
+
 impl LamportClock {
     /// Creates a clock at the initial value (0).
     pub fn new() -> Self {
@@ -256,7 +260,7 @@ impl LamportClock {
 
     /// Creates a clock from a raw value (for deserialization / migration).
     pub fn from_value(value: u64) -> Self {
-        Self(value)
+        Self(value.min(LAMPORT_CLOCK_MAX))
     }
 
     /// Returns the raw counter value.
@@ -266,14 +270,16 @@ impl LamportClock {
 
     /// Advances the clock for a local send event and returns the new value.
     pub fn tick(&mut self) -> Self {
-        self.0 += 1;
+        self.0 = self.0.saturating_add(1);
         *self
     }
 
     /// Advances the clock after receiving a message with the given clock value.
-    /// Sets local clock to `max(local, received) + 1`.
+    /// Sets local clock to `max(local, received) + 1`, clamping the received
+    /// value to [`LAMPORT_CLOCK_MAX`] to prevent adversarial inflation.
     pub fn merge(&mut self, received: LamportClock) -> Self {
-        self.0 = self.0.max(received.0) + 1;
+        let clamped = received.0.min(LAMPORT_CLOCK_MAX);
+        self.0 = self.0.max(clamped).saturating_add(1);
         *self
     }
 }
@@ -417,6 +423,29 @@ mod tests {
         let a = LamportClock::from_value(3);
         let b = LamportClock::from_value(7);
         assert!(a < b);
+    }
+
+    #[test]
+    fn test_lamport_clock_saturating_tick() {
+        let mut clock = LamportClock::from_value(LAMPORT_CLOCK_MAX);
+        let ticked = clock.tick();
+        assert_eq!(ticked.value(), LAMPORT_CLOCK_MAX.saturating_add(1));
+        // Doesn't panic or wrap
+    }
+
+    #[test]
+    fn test_lamport_clock_merge_clamps_adversarial_value() {
+        let mut local = LamportClock::from_value(5);
+        let adversarial = LamportClock(u64::MAX); // bypass from_value to simulate wire data
+        let merged = local.merge(adversarial);
+        // Should clamp to LAMPORT_CLOCK_MAX + 1, not overflow
+        assert_eq!(merged.value(), LAMPORT_CLOCK_MAX.saturating_add(1));
+    }
+
+    #[test]
+    fn test_lamport_clock_from_value_clamps() {
+        let clock = LamportClock::from_value(u64::MAX);
+        assert_eq!(clock.value(), LAMPORT_CLOCK_MAX);
     }
 
     #[test]

--- a/crates/offline-protocol-mls/src/lib.rs
+++ b/crates/offline-protocol-mls/src/lib.rs
@@ -44,6 +44,6 @@ pub use error::{MlsError, Result};
 pub use manager::MlsManager;
 pub use storage::{MlsStorage, StorageError};
 pub use types::{
-    EncryptedMessage, GroupId, GroupInfo, GroupMetadata, KeyPackageBundle, KeyPackageTransfer,
-    MlsMessageType, WelcomeMessage,
+    EncryptedMessage, GroupId, GroupInfo, GroupMetadata, KeyPackageBundle, MlsMessageType,
+    WelcomeMessage,
 };

--- a/crates/offline-protocol-mls/src/lib.rs
+++ b/crates/offline-protocol-mls/src/lib.rs
@@ -44,6 +44,6 @@ pub use error::{MlsError, Result};
 pub use manager::MlsManager;
 pub use storage::{MlsStorage, StorageError};
 pub use types::{
-    EncryptedMessage, GroupId, GroupInfo, GroupMetadata, KeyPackageBundle, MlsMessageType,
-    WelcomeMessage,
+    EncryptedMessage, GroupId, GroupInfo, GroupMetadata, KeyPackageBundle, KeyPackageTransfer,
+    MlsMessageType, WelcomeMessage,
 };

--- a/crates/offline-protocol-mls/src/types.rs
+++ b/crates/offline-protocol-mls/src/types.rs
@@ -85,11 +85,63 @@ impl KeyPackageBundle {
         }
     }
 
-    /// Checks if the key package has expired.
+    /// Checks if the key package has expired (local device's own packages only).
+    ///
+    /// This compares against the local clock and is valid because `created_at_ms`
+    /// and `expires_at_ms` were set on this same device.
     pub fn is_expired(&self) -> bool {
         let now_ms = chrono::Utc::now().timestamp_millis() as u64;
         now_ms >= self.expires_at_ms
     }
+
+    /// Returns the remaining valid lifetime in milliseconds.
+    ///
+    /// Used when transmitting key packages to peers: the receiver applies
+    /// this duration relative to their own clock, eliminating cross-device
+    /// clock skew from expiry calculations.
+    pub fn remaining_lifetime_ms(&self) -> u64 {
+        let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+        self.expires_at_ms.saturating_sub(now_ms)
+    }
+
+    /// Creates a bundle from received transfer data, computing local expiry
+    /// from the sender-provided remaining lifetime.
+    pub fn from_transfer(
+        package_id: String,
+        user_id: String,
+        key_package_data: Vec<u8>,
+        remaining_lifetime_ms: u64,
+    ) -> Self {
+        let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+        Self {
+            package_id,
+            user_id,
+            key_package_data,
+            created_at_ms: now_ms,
+            expires_at_ms: now_ms + remaining_lifetime_ms,
+            synced: false,
+        }
+    }
+}
+
+/// Wire format for key package exchange between devices.
+///
+/// Uses relative `remaining_lifetime_ms` instead of absolute timestamps
+/// to eliminate cross-device clock skew from expiry calculations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyPackageTransfer {
+    /// Unique identifier for this key package.
+    pub package_id: String,
+
+    /// User ID this key package belongs to.
+    pub user_id: String,
+
+    /// Serialized MLS KeyPackage bytes.
+    pub key_package_data: Vec<u8>,
+
+    /// Remaining valid lifetime in milliseconds (computed by sender).
+    /// Receiver adds this to their local clock to determine expiry.
+    pub remaining_lifetime_ms: u64,
 }
 
 /// Information about an MLS group.

--- a/crates/offline-protocol-mls/src/types.rs
+++ b/crates/offline-protocol-mls/src/types.rs
@@ -118,30 +118,10 @@ impl KeyPackageBundle {
             user_id,
             key_package_data,
             created_at_ms: now_ms,
-            expires_at_ms: now_ms + remaining_lifetime_ms,
+            expires_at_ms: now_ms.saturating_add(remaining_lifetime_ms),
             synced: false,
         }
     }
-}
-
-/// Wire format for key package exchange between devices.
-///
-/// Uses relative `remaining_lifetime_ms` instead of absolute timestamps
-/// to eliminate cross-device clock skew from expiry calculations.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct KeyPackageTransfer {
-    /// Unique identifier for this key package.
-    pub package_id: String,
-
-    /// User ID this key package belongs to.
-    pub user_id: String,
-
-    /// Serialized MLS KeyPackage bytes.
-    pub key_package_data: Vec<u8>,
-
-    /// Remaining valid lifetime in milliseconds (computed by sender).
-    /// Receiver adds this to their local clock to determine expiry.
-    pub remaining_lifetime_ms: u64,
 }
 
 /// Information about an MLS group.

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -1041,6 +1041,7 @@ impl OfflineProtocol {
                 "recipient": msg.recipient.as_str(),
                 "content": msg.content,
                 "timestamp": msg.timestamp.as_millis(),
+                "lamport_clock": msg.lamport_clock.value(),
                 "hop_count": msg.hop_count.value(),
                 "priority": format!("{:?}", msg.priority),
             }))

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -30,8 +30,11 @@ pub enum Event {
         priority: String,
         /// Whether the message requires an acknowledgement.
         requires_ack: bool,
-        /// When the message was queued for delivery.
+        /// When the message was queued for delivery (wall-clock, for display).
         timestamp: i64,
+        /// Lamport logical clock value for causal ordering.
+        #[serde(default)]
+        lamport_clock: u64,
     },
 
     /// A message was received.
@@ -48,8 +51,11 @@ pub enum Event {
         hop_count: u8,
         /// Transport used for final delivery.
         transport: String,
-        /// When the message was received.
+        /// When the message was received (wall-clock, for display).
         timestamp: i64,
+        /// Lamport logical clock value for causal ordering.
+        #[serde(default)]
+        lamport_clock: u64,
         /// ID of the message this is replying to (optional).
         #[serde(skip_serializing_if = "Option::is_none")]
         reply_to_msg: Option<String>,
@@ -267,6 +273,7 @@ impl Event {
             priority: priority.to_string(),
             requires_ack: message.requires_ack,
             timestamp: message.timestamp.as_millis(),
+            lamport_clock: message.lamport_clock.value(),
         }
     }
 
@@ -508,6 +515,7 @@ impl fmt::Debug for Event {
                 priority,
                 requires_ack,
                 timestamp,
+                lamport_clock,
             } => f
                 .debug_struct("MessageSent")
                 .field("message_id", message_id)
@@ -517,6 +525,7 @@ impl fmt::Debug for Event {
                 .field("priority", priority)
                 .field("requires_ack", requires_ack)
                 .field("timestamp", timestamp)
+                .field("lamport_clock", lamport_clock)
                 .finish(),
             Self::MessageReceived {
                 message_id,
@@ -526,6 +535,7 @@ impl fmt::Debug for Event {
                 hop_count,
                 transport,
                 timestamp,
+                lamport_clock,
                 reply_to_msg: _,
             } => f
                 .debug_struct("MessageReceived")
@@ -536,6 +546,7 @@ impl fmt::Debug for Event {
                 .field("hop_count", hop_count)
                 .field("transport", transport)
                 .field("timestamp", timestamp)
+                .field("lamport_clock", lamport_clock)
                 .field("reply_to_msg", &"[REDACTED]")
                 .finish(),
             Self::MessageDelivered {
@@ -744,6 +755,7 @@ mod tests {
                 priority,
                 requires_ack,
                 timestamp,
+                lamport_clock,
             } => {
                 assert_eq!(message_id, message.id.as_str());
                 assert_eq!(sender, message.sender.as_str());
@@ -752,6 +764,7 @@ mod tests {
                 assert_eq!(priority, "high");
                 assert!(requires_ack);
                 assert_eq!(timestamp, message.timestamp.as_millis());
+                assert_eq!(lamport_clock, message.lamport_clock.value());
             }
             _ => panic!("Wrong event type"),
         }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -74,6 +74,16 @@ struct ConnectionAcceptedPayload {
     key_package: Option<Vec<u8>>,
 }
 
+/// A received key package awaiting use for session creation.
+#[derive(Debug, Clone)]
+struct ReceivedKeyPackage {
+    /// Raw MLS key package bytes.
+    key_package_data: Vec<u8>,
+    /// Local wall-clock deadline (ms since epoch) computed from the sender's
+    /// `remaining_lifetime_ms`, anchored to *our* clock at receive time.
+    local_expires_at_ms: u64,
+}
+
 /// Result of processing an internal protocol message.
 enum InternalMessageResult {
     /// Message was consumed internally (don't surface to app).
@@ -101,6 +111,10 @@ struct PendingMessage {
 mod storage_keys {
     /// Key type for pending encrypted messages.
     pub const PENDING_MESSAGES: &str = "pending_messages";
+    /// Key type for the Lamport clock value.
+    pub const LAMPORT_CLOCK: &str = "lamport_clock";
+    /// Key ID for the single Lamport clock entry.
+    pub const LAMPORT_CLOCK_ID: &str = "current";
 }
 
 /// Protocol state.
@@ -197,8 +211,8 @@ pub struct OfflineProtocol {
     /// Pending messages waiting for session establishment (recipient -> messages).
     pending_encrypted_messages: HashMap<String, Vec<PendingMessage>>,
 
-    /// Key packages received but not yet used (sender_id -> key_package_data).
-    pending_key_packages: HashMap<String, Vec<u8>>,
+    /// Key packages received but not yet used (sender_id -> package).
+    pending_key_packages: HashMap<String, ReceivedKeyPackage>,
 
     /// Set of peers we've already sent our key package to.
     key_package_sent_to: std::collections::HashSet<String>,
@@ -278,8 +292,9 @@ impl OfflineProtocol {
         // Also use this storage for pending message persistence
         self.message_storage = Some(storage);
 
-        // Restore any pending messages from previous session
+        // Restore state from previous session
         self.restore_pending_messages()?;
+        self.restore_lamport_clock();
 
         info!(user_id = %self.config.user_id, "MLS encryption initialized with message persistence");
         Ok(())
@@ -296,6 +311,7 @@ impl OfflineProtocol {
     pub fn enable_message_persistence(&mut self, storage: Arc<dyn MlsStorage>) -> Result<()> {
         self.message_storage = Some(storage);
         self.restore_pending_messages()?;
+        self.restore_lamport_clock();
         info!("Message persistence enabled");
         Ok(())
     }
@@ -490,6 +506,7 @@ impl OfflineProtocol {
         let app_id = AppId::new(&self.config.app_id)?;
 
         let clock_value = self.lamport_clock.tick();
+        self.persist_lamport_clock();
 
         let mut builder = Message::builder(sender, recipient, app_id)
             .content(content)
@@ -799,12 +816,18 @@ impl OfflineProtocol {
         if !has_session {
             // Try to create session from stored key package
             // Clone first, only remove after all operations succeed to avoid losing the key package on failure
-            if let Some(key_pkg) = self.pending_key_packages.get(recipient).cloned() {
+            if let Some(received_pkg) = self.pending_key_packages.get(recipient).cloned() {
+                // Check if key package has expired (using local clock)
+                let now_ms = Utc::now().timestamp_millis() as u64;
+                if now_ms >= received_pkg.local_expires_at_ms {
+                    warn!(recipient = %recipient, "Received key package has expired, discarding");
+                    self.pending_key_packages.remove(recipient);
+                } else {
                 {
                     let manager = mls
                         .read()
                         .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
-                    manager.import_key_package(recipient, &key_pkg)?;
+                    manager.import_key_package(recipient, &received_pkg.key_package_data)?;
                 }
 
                 // Create session and send welcome message
@@ -843,6 +866,7 @@ impl OfflineProtocol {
                 if self.config.encryption.store_pending {
                     return Err(Error::SessionPending);
                 }
+                } // end else (not expired)
             } else {
                 // No key package available
                 if self.config.encryption.store_pending {
@@ -978,6 +1002,10 @@ impl OfflineProtocol {
                             .metadata
                             .insert("delayed_decrypt".to_string(), "true".to_string());
 
+                        // Advance local Lamport clock for delayed-decrypted messages
+                        self.lamport_clock.merge(decrypted_msg.lamport_clock);
+                        self.persist_lamport_clock();
+
                         if let Ok(mut state) = lock_shared_state(&self.shared_state) {
                             state.received_messages.push(decrypted_msg.clone());
 
@@ -1082,6 +1110,50 @@ impl OfflineProtocol {
         }
 
         Ok(())
+    }
+
+    // ========================================================================
+    // LAMPORT CLOCK PERSISTENCE
+    // ========================================================================
+
+    /// Persists the current Lamport clock value to storage.
+    fn persist_lamport_clock(&self) {
+        let Some(storage) = &self.message_storage else {
+            return;
+        };
+        let value = self.lamport_clock.value().to_le_bytes();
+        if let Err(e) = storage.store(
+            storage_keys::LAMPORT_CLOCK,
+            storage_keys::LAMPORT_CLOCK_ID,
+            &value,
+        ) {
+            warn!(error = %e, "Failed to persist Lamport clock");
+        }
+    }
+
+    /// Restores the Lamport clock from storage.
+    ///
+    /// Uses `max(current, restored)` so the clock never goes backward even
+    /// if the in-memory value has advanced before storage was attached.
+    fn restore_lamport_clock(&mut self) {
+        let Some(storage) = &self.message_storage else {
+            return;
+        };
+        if let Ok(Some(data)) = storage.load(
+            storage_keys::LAMPORT_CLOCK,
+            storage_keys::LAMPORT_CLOCK_ID,
+        ) {
+            if data.len() == 8 {
+                let restored = u64::from_le_bytes(
+                    data.try_into().expect("verified length is 8"),
+                );
+                let restored_clock = LamportClock::from_value(restored);
+                if restored_clock > self.lamport_clock {
+                    self.lamport_clock = restored_clock;
+                }
+                debug!(clock = %self.lamport_clock, "Restored Lamport clock from storage");
+            }
+        }
     }
 
     // ========================================================================
@@ -1204,44 +1276,51 @@ impl OfflineProtocol {
 
         // Check for pending key package
         // Clone first, only remove after all operations succeed to avoid losing the key package on failure
-        if let Some(key_pkg) = self.pending_key_packages.get(peer_id).cloned() {
-            {
-                let manager = mls
-                    .read()
-                    .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
-                manager.import_key_package(peer_id, &key_pkg)?;
+        if let Some(received_pkg) = self.pending_key_packages.get(peer_id).cloned() {
+            // Check if key package has expired (using local clock)
+            let now_ms = Utc::now().timestamp_millis() as u64;
+            if now_ms >= received_pkg.local_expires_at_ms {
+                warn!(peer_id = %peer_id, "Received key package has expired, discarding");
+                self.pending_key_packages.remove(peer_id);
+            } else {
+                {
+                    let manager = mls
+                        .read()
+                        .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+                    manager.import_key_package(peer_id, &received_pkg.key_package_data)?;
+                }
+
+                // Create session and get welcome message
+                let welcome = {
+                    let manager = mls
+                        .read()
+                        .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+                    manager.create_session(peer_id)?
+                };
+
+                // Send welcome message to peer
+                self.send_welcome_message(peer_id, &welcome)?;
+
+                // All operations succeeded, now safe to remove the key package
+                self.pending_key_packages.remove(peer_id);
+
+                let group_id = welcome.group_id.as_str().to_string();
+                let is_session = group_id.starts_with("session:");
+
+                info!(peer_id = %peer_id, group_id = %group_id, "Established secure session");
+
+                // Emit secure session established event
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::secure_session_established(
+                        peer_id.to_string(),
+                        group_id,
+                        is_session,
+                        true, // initiated_by_local is true - we sent the Welcome
+                    ));
+                }
+
+                return Ok(Some(welcome));
             }
-
-            // Create session and get welcome message
-            let welcome = {
-                let manager = mls
-                    .read()
-                    .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
-                manager.create_session(peer_id)?
-            };
-
-            // Send welcome message to peer
-            self.send_welcome_message(peer_id, &welcome)?;
-
-            // All operations succeeded, now safe to remove the key package
-            self.pending_key_packages.remove(peer_id);
-
-            let group_id = welcome.group_id.as_str().to_string();
-            let is_session = group_id.starts_with("session:");
-
-            info!(peer_id = %peer_id, group_id = %group_id, "Established secure session");
-
-            // Emit secure session established event
-            if let Ok(state) = lock_shared_state(&self.shared_state) {
-                state.emit_event(Event::secure_session_established(
-                    peer_id.to_string(),
-                    group_id,
-                    is_session,
-                    true, // initiated_by_local is true - we sent the Welcome
-                ));
-            }
-
-            return Ok(Some(welcome));
         }
 
         // No key package available - peer hasn't sent one yet
@@ -1494,6 +1573,7 @@ impl OfflineProtocol {
 
                     // Advance local Lamport clock based on received message
                     self.lamport_clock.merge(message.lamport_clock);
+                    self.persist_lamport_clock();
 
                     if message.requires_ack {
                         if let Err(err) = self.send_delivery_ack(&message, transport_used) {
@@ -1554,8 +1634,21 @@ impl OfflineProtocol {
             let data = &content[internal_prefixes::KEY_PACKAGE.len()..];
             if let Ok(payload) = serde_json::from_str::<KeyPackagePayload>(data) {
                 debug!(sender = %sender, "Received key package");
-                self.pending_key_packages
-                    .insert(sender.to_string(), payload.key_package_data);
+                let now_ms = Utc::now().timestamp_millis() as u64;
+                let local_expires_at_ms = if payload.remaining_lifetime_ms > 0 {
+                    now_ms.saturating_add(payload.remaining_lifetime_ms)
+                } else {
+                    // Legacy sender didn't include remaining_lifetime_ms;
+                    // assume 30-day default lifetime.
+                    now_ms.saturating_add(30 * 24 * 60 * 60 * 1000)
+                };
+                self.pending_key_packages.insert(
+                    sender.to_string(),
+                    ReceivedKeyPackage {
+                        key_package_data: payload.key_package_data,
+                        local_expires_at_ms,
+                    },
+                );
 
                 // Send our key package back if auto_key_exchange is enabled
                 if self.config.encryption.auto_key_exchange && self.config.encryption.enabled {
@@ -2635,10 +2728,9 @@ mod tests {
 
         // Key package should be stored
         assert!(protocol.pending_key_packages.contains_key("sender123"));
-        assert_eq!(
-            protocol.pending_key_packages.get("sender123").unwrap(),
-            &vec![1u8, 2, 3, 4]
-        );
+        let received = protocol.pending_key_packages.get("sender123").unwrap();
+        assert_eq!(received.key_package_data, vec![1u8, 2, 3, 4]);
+        assert!(received.local_expires_at_ms > 0);
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -3,7 +3,7 @@
 use crate::constants::{ACK_FOR_KEY, ACK_HOP_COUNT_KEY, ACK_TRANSPORT_KEY, MAX_OUTBOX_ENTRIES};
 use crate::{Error, Event, EventCallback, ProtocolConfig, Result, TransportManager};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
-use offline_protocol_core::{AppId, Message, MessageId, MessagePriority, UserId, TTL};
+use offline_protocol_core::{AppId, LamportClock, Message, MessageId, MessagePriority, UserId, TTL};
 use offline_protocol_mls::{EncryptedMessage, MlsManager, MlsStorage, WelcomeMessage};
 use offline_protocol_reliability::{
     AckConfig, AckManager, Deduplicator, DeduplicatorConfig, DeduplicatorStats, RetryConfig,
@@ -39,7 +39,13 @@ struct KeyPackagePayload {
     user_id: String,
     /// Raw key package data.
     key_package_data: Vec<u8>,
-    /// Timestamp of creation.
+    /// Remaining valid lifetime in milliseconds (relative, not absolute).
+    /// Receiver applies this to their local clock, avoiding clock skew issues.
+    #[serde(default)]
+    remaining_lifetime_ms: u64,
+    /// Legacy absolute timestamp field — ignored on receive, kept for
+    /// backward compatibility with old nodes that may still send it.
+    #[serde(default)]
     timestamp_ms: u64,
 }
 
@@ -208,6 +214,10 @@ pub struct OfflineProtocol {
     /// Storage for persisting pending messages (reuses MLS storage).
     /// When set, pending messages survive app crashes/restarts.
     message_storage: Option<Arc<dyn MlsStorage>>,
+
+    /// Lamport logical clock for causal message ordering.
+    /// Ticked on send, merged on receive.
+    lamport_clock: LamportClock,
 }
 
 impl OfflineProtocol {
@@ -248,6 +258,7 @@ impl OfflineProtocol {
             confirmed_sessions: std::collections::HashSet::new(),
             pending_decryption: HashMap::new(),
             message_storage: None,
+            lamport_clock: LamportClock::new(),
             config,
         })
     }
@@ -468,7 +479,7 @@ impl OfflineProtocol {
 
     /// Creates a new message from the given parameters.
     fn create_message(
-        &self,
+        &mut self,
         recipient: impl Into<String>,
         content: impl Into<String>,
         priority: Option<MessagePriority>,
@@ -478,10 +489,13 @@ impl OfflineProtocol {
         let recipient = UserId::new(recipient)?;
         let app_id = AppId::new(&self.config.app_id)?;
 
+        let clock_value = self.lamport_clock.tick();
+
         let mut builder = Message::builder(sender, recipient, app_id)
             .content(content)
             .priority(priority.unwrap_or(MessagePriority::Medium))
-            .ttl(TTL::new(self.config.initial_ttl)?);
+            .ttl(TTL::new(self.config.initial_ttl)?)
+            .lamport_clock(clock_value);
 
         if let Some(reply_to) = reply_to_msg {
             builder = builder.reply_to_msg(reply_to);
@@ -976,6 +990,7 @@ impl OfflineProtocol {
                                 hop_count: decrypted_msg.hop_count.value(),
                                 transport: "delayed".to_string(),
                                 timestamp: Utc::now().timestamp_millis(),
+                                lamport_clock: decrypted_msg.lamport_clock.value(),
                                 reply_to_msg: decrypted_msg
                                     .reply_to_msg
                                     .as_ref()
@@ -1086,7 +1101,8 @@ impl OfflineProtocol {
 
         let payload = KeyPackagePayload {
             user_id: self.config.user_id.clone(),
-            key_package_data: key_pkg.key_package_data,
+            key_package_data: key_pkg.key_package_data.clone(),
+            remaining_lifetime_ms: key_pkg.remaining_lifetime_ms(),
             timestamp_ms: Utc::now().timestamp_millis() as u64,
         };
 
@@ -1476,6 +1492,9 @@ impl OfflineProtocol {
                         }
                     }
 
+                    // Advance local Lamport clock based on received message
+                    self.lamport_clock.merge(message.lamport_clock);
+
                     if message.requires_ack {
                         if let Err(err) = self.send_delivery_ack(&message, transport_used) {
                             error!(
@@ -1494,6 +1513,7 @@ impl OfflineProtocol {
                         hop_count: message.hop_count.value(),
                         transport: transport_used.to_string(),
                         timestamp: message.timestamp.as_millis(),
+                        lamport_clock: message.lamport_clock.value(),
                         reply_to_msg: message
                             .reply_to_msg
                             .as_ref()
@@ -2591,6 +2611,7 @@ mod tests {
         let key_pkg_payload = KeyPackagePayload {
             user_id: "sender123".to_string(),
             key_package_data: vec![1, 2, 3, 4],
+            remaining_lifetime_ms: 30 * 24 * 60 * 60 * 1000,
             timestamp_ms: 12345,
         };
         let content = format!(

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -706,17 +706,11 @@ impl OfflineProtocol {
             match self.encrypt_content_for_recipient(&recipient_str, &content_str, priority) {
                 Ok(encrypted) => encrypted,
                 Err(Error::SessionPending) => {
-                    // Create message first to get an ID before queuing
-                    // This ensures we always return a message ID, even when queued
-                    let temp_message = self.create_message(
-                        &recipient_str,
-                        content_str.clone(),
-                        Some(priority),
-                        reply_to_msg_id.clone(),
-                    )?;
-                    let message_id = temp_message.id.clone();
+                    // Generate an ID without ticking the Lamport clock.
+                    // The real tick happens when flush_pending_messages re-sends
+                    // via send_message after the session is established.
+                    let message_id = MessageId::new();
 
-                    // Queue the pending message with the message ID
                     debug!(recipient = %recipient_str, message_id = %message_id, "Message queued pending session establishment");
                     self.queue_pending_message(
                         &recipient_str,
@@ -726,7 +720,6 @@ impl OfflineProtocol {
                         reply_to_msg_id.clone(),
                     );
 
-                    // Return the message ID even though it's queued
                     return Ok(message_id);
                 }
                 Err(Error::NoKeyPackage(ref r)) => {
@@ -823,50 +816,51 @@ impl OfflineProtocol {
                     warn!(recipient = %recipient, "Received key package has expired, discarding");
                     self.pending_key_packages.remove(recipient);
                 } else {
-                {
-                    let manager = mls
-                        .read()
-                        .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
-                    manager.import_key_package(recipient, &received_pkg.key_package_data)?;
+                    {
+                        let manager = mls
+                            .read()
+                            .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+                        manager
+                            .import_key_package(recipient, &received_pkg.key_package_data)?;
+                    }
+
+                    // Create session and send welcome message
+                    let welcome = {
+                        let manager = mls
+                            .read()
+                            .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+                        manager.create_session(recipient)?
+                    };
+
+                    // Send welcome as internal message
+                    self.send_welcome_message(recipient, &welcome)?;
+
+                    // All operations succeeded, now safe to remove the key package
+                    self.pending_key_packages.remove(recipient);
+
+                    let group_id = welcome.group_id.as_str().to_string();
+                    let is_session = group_id.starts_with("session:");
+
+                    debug!(recipient = %recipient, group_id = %group_id, "Created MLS session and sent welcome");
+
+                    // Emit secure session established event
+                    if let Ok(state) = lock_shared_state(&self.shared_state) {
+                        state.emit_event(Event::secure_session_established(
+                            recipient.to_string(),
+                            group_id,
+                            is_session,
+                            true, // initiated_by_local is true - we sent the Welcome
+                        ));
+                    }
+
+                    // Don't encrypt immediately after creating session.
+                    // Queue message until session is confirmed (peer processes our Welcome
+                    // and we successfully decrypt their first message, or we receive their Welcome).
+                    // This avoids race conditions where both peers create sessions.
+                    if self.config.encryption.store_pending {
+                        return Err(Error::SessionPending);
+                    }
                 }
-
-                // Create session and send welcome message
-                let welcome = {
-                    let manager = mls
-                        .read()
-                        .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
-                    manager.create_session(recipient)?
-                };
-
-                // Send welcome as internal message
-                self.send_welcome_message(recipient, &welcome)?;
-
-                // All operations succeeded, now safe to remove the key package
-                self.pending_key_packages.remove(recipient);
-
-                let group_id = welcome.group_id.as_str().to_string();
-                let is_session = group_id.starts_with("session:");
-
-                debug!(recipient = %recipient, group_id = %group_id, "Created MLS session and sent welcome");
-
-                // Emit secure session established event
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::secure_session_established(
-                        recipient.to_string(),
-                        group_id,
-                        is_session,
-                        true, // initiated_by_local is true - we sent the Welcome
-                    ));
-                }
-
-                // Don't encrypt immediately after creating session.
-                // Queue message until session is confirmed (peer processes our Welcome
-                // and we successfully decrypt their first message, or we receive their Welcome).
-                // This avoids race conditions where both peers create sessions.
-                if self.config.encryption.store_pending {
-                    return Err(Error::SessionPending);
-                }
-                } // end else (not expired)
             } else {
                 // No key package available
                 if self.config.encryption.store_pending {
@@ -1152,6 +1146,11 @@ impl OfflineProtocol {
                     self.lamport_clock = restored_clock;
                 }
                 debug!(clock = %self.lamport_clock, "Restored Lamport clock from storage");
+            } else {
+                warn!(
+                    len = data.len(),
+                    "Corrupted Lamport clock in storage (expected 8 bytes), starting fresh"
+                );
             }
         }
     }
@@ -1543,6 +1542,14 @@ impl OfflineProtocol {
         loop {
             match self.transport_manager.receive() {
                 Ok(Some((transport_used, mut message))) => {
+                    // Merge Lamport clock for every received message — including
+                    // duplicates, ACKs, and internal protocol messages — so the
+                    // local clock always advances past any observed peer value.
+                    if message.lamport_clock.value() > 0 {
+                        self.lamport_clock.merge(message.lamport_clock);
+                        self.persist_lamport_clock();
+                    }
+
                     if message.metadata.contains_key(ACK_FOR_KEY) {
                         self.handle_ack_message(&message);
                         continue;
@@ -1570,10 +1577,6 @@ impl OfflineProtocol {
                             }
                         }
                     }
-
-                    // Advance local Lamport clock based on received message
-                    self.lamport_clock.merge(message.lamport_clock);
-                    self.persist_lamport_clock();
 
                     if message.requires_ack {
                         if let Err(err) = self.send_delivery_ack(&message, transport_used) {
@@ -3248,5 +3251,428 @@ mod tests {
 
         // Without MLS initialized, should return placeholder text
         assert!(matches!(result, Some(InternalMessageResult::Decrypted(_))));
+    }
+
+    // ========================================================================
+    // LAMPORT CLOCK TESTS
+    // ========================================================================
+
+    use crate::mls::InMemoryStorage;
+
+    #[test]
+    fn test_lamport_clock_advances_on_send() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport.clone()));
+
+        protocol.start().unwrap();
+
+        assert_eq!(protocol.lamport_clock.value(), 0);
+
+        protocol
+            .send_message("bob", "msg1", None::<MessagePriority>, None::<String>)
+            .unwrap();
+        assert_eq!(protocol.lamport_clock.value(), 1);
+
+        protocol
+            .send_message("bob", "msg2", None::<MessagePriority>, None::<String>)
+            .unwrap();
+        assert_eq!(protocol.lamport_clock.value(), 2);
+    }
+
+    #[test]
+    fn test_lamport_clock_merges_on_receive() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+
+        // Create a message with a high Lamport clock from a peer
+        let mut message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "Hello",
+        );
+        message.lamport_clock = LamportClock::from_value(50);
+        mock_transport.queue_message(message);
+
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        protocol.start().unwrap();
+
+        assert_eq!(protocol.lamport_clock.value(), 0);
+
+        let received = protocol.receive_message();
+        assert!(received.is_some());
+
+        // Clock should be max(0, 50) + 1 = 51
+        assert_eq!(protocol.lamport_clock.value(), 51);
+    }
+
+    #[test]
+    fn test_lamport_clock_monotonic_across_send_receive() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+
+        // Send a message first (clock -> 1)
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport.clone()));
+        protocol.start().unwrap();
+
+        protocol
+            .send_message("bob", "hi", None::<MessagePriority>, None::<String>)
+            .unwrap();
+        assert_eq!(protocol.lamport_clock.value(), 1);
+
+        // Receive a message with lower clock (clock should still advance)
+        let mut message = Message::new(
+            UserId::new("bob").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "reply",
+        );
+        message.lamport_clock = LamportClock::from_value(0);
+        mock_transport.queue_message(message);
+
+        // Legacy message (clock=0) — merge is skipped so clock stays at 1
+        let received = protocol.receive_message();
+        assert!(received.is_some());
+        assert_eq!(protocol.lamport_clock.value(), 1);
+
+        // Now receive a message with higher clock
+        let mut message2 = Message::new(
+            UserId::new("bob").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "another",
+        );
+        message2.lamport_clock = LamportClock::from_value(10);
+        mock_transport.queue_message(message2);
+
+        let received2 = protocol.receive_message();
+        assert!(received2.is_some());
+        // max(1, 10) + 1 = 11
+        assert_eq!(protocol.lamport_clock.value(), 11);
+    }
+
+    #[test]
+    fn test_lamport_clock_persists_and_restores() {
+        let storage = Arc::new(InMemoryStorage::new());
+
+        // First session: send messages to advance the clock
+        {
+            let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+            let mut mock_transport = MockTransport::new(TransportType::BLE);
+            mock_transport.start().unwrap();
+            protocol.transport_manager_mut().add_transport(
+                TransportType::BLE,
+                Box::new(mock_transport),
+            );
+
+            protocol
+                .enable_message_persistence(storage.clone())
+                .unwrap();
+            protocol.start().unwrap();
+
+            // Send 5 messages to advance clock to 5
+            for i in 0..5 {
+                protocol
+                    .send_message(
+                        "bob",
+                        format!("msg{}", i),
+                        None::<MessagePriority>,
+                        None::<String>,
+                    )
+                    .unwrap();
+            }
+            assert_eq!(protocol.lamport_clock.value(), 5);
+        }
+
+        // Second session: clock should restore from storage
+        {
+            let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+            let mut mock_transport = MockTransport::new(TransportType::BLE);
+            mock_transport.start().unwrap();
+            protocol.transport_manager_mut().add_transport(
+                TransportType::BLE,
+                Box::new(mock_transport),
+            );
+
+            assert_eq!(protocol.lamport_clock.value(), 0);
+
+            protocol
+                .enable_message_persistence(storage.clone())
+                .unwrap();
+
+            // After attaching storage, clock should be restored
+            assert_eq!(protocol.lamport_clock.value(), 5);
+
+            // Next send should be 6, not 1
+            protocol.start().unwrap();
+            protocol
+                .send_message("bob", "after restart", None::<MessagePriority>, None::<String>)
+                .unwrap();
+            assert_eq!(protocol.lamport_clock.value(), 6);
+        }
+    }
+
+    #[test]
+    fn test_lamport_clock_restore_with_corrupted_data() {
+        let storage = Arc::new(InMemoryStorage::new());
+
+        // Write corrupted data (wrong length)
+        storage
+            .store(
+                storage_keys::LAMPORT_CLOCK,
+                storage_keys::LAMPORT_CLOCK_ID,
+                &[1, 2, 3], // only 3 bytes, not 8
+            )
+            .unwrap();
+
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        protocol
+            .enable_message_persistence(storage.clone())
+            .unwrap();
+
+        // Clock should remain at 0 (corrupted data ignored)
+        assert_eq!(protocol.lamport_clock.value(), 0);
+    }
+
+    #[test]
+    fn test_lamport_clock_restore_never_goes_backward() {
+        let storage = Arc::new(InMemoryStorage::new());
+
+        // Store a value of 10 in storage
+        storage
+            .store(
+                storage_keys::LAMPORT_CLOCK,
+                storage_keys::LAMPORT_CLOCK_ID,
+                &10u64.to_le_bytes(),
+            )
+            .unwrap();
+
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // Advance in-memory clock to 20 before attaching storage
+        for _ in 0..20 {
+            protocol.lamport_clock.tick();
+        }
+        assert_eq!(protocol.lamport_clock.value(), 20);
+
+        // Attaching storage should NOT regress to 10
+        protocol
+            .enable_message_persistence(storage.clone())
+            .unwrap();
+        assert_eq!(protocol.lamport_clock.value(), 20);
+    }
+
+    #[test]
+    fn test_lamport_clock_merge_on_internal_message() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+
+        // Create a key package message with a high Lamport clock
+        let key_pkg_payload = KeyPackagePayload {
+            user_id: "sender456".to_string(),
+            key_package_data: vec![5, 6, 7, 8],
+            remaining_lifetime_ms: 30 * 24 * 60 * 60 * 1000,
+            timestamp_ms: 12345,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::KEY_PACKAGE,
+            serde_json::to_string(&key_pkg_payload).unwrap()
+        );
+        let mut message = Message::new(
+            UserId::new("sender456").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+        message.lamport_clock = LamportClock::from_value(100);
+        mock_transport.queue_message(message);
+
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        protocol.start().unwrap();
+
+        assert_eq!(protocol.lamport_clock.value(), 0);
+
+        // Receiving the internal message should merge the clock even
+        // though process_internal_message returns Consumed
+        let received = protocol.receive_message();
+        // Internal messages are consumed, not surfaced
+        assert!(received.is_none());
+
+        // Clock should have merged: max(0, 100) + 1 = 101
+        assert_eq!(protocol.lamport_clock.value(), 101);
+    }
+
+    #[test]
+    fn test_lamport_clock_merge_on_duplicate_message() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+
+        // Create two copies of the same message (simulate duplicate delivery)
+        let mut message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "Hello",
+        );
+        message.lamport_clock = LamportClock::from_value(42);
+        let message_dup = message.clone();
+
+        mock_transport.queue_message(message);
+        mock_transport.queue_message(message_dup);
+
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        protocol.start().unwrap();
+
+        // First receive: message delivered
+        let received = protocol.receive_message();
+        assert!(received.is_some());
+        // max(0, 42) + 1 = 43
+        assert_eq!(protocol.lamport_clock.value(), 43);
+
+        // Second receive: duplicate detected, but clock should have
+        // already merged (merge happens before dedup).
+        // The duplicate carries the same clock=42, so merge would yield
+        // max(43, 42) + 1 = 44
+        let received2 = protocol.receive_message();
+        assert!(received2.is_none());
+        assert_eq!(protocol.lamport_clock.value(), 44);
+    }
+
+    #[test]
+    fn test_lamport_clock_no_tick_on_pending_message() {
+        let mut config = create_test_config();
+        config.encryption.enabled = false;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        protocol.start().unwrap();
+
+        // Send two messages, verify each tick advances by exactly 1
+        let clock_before = protocol.lamport_clock.value();
+        protocol
+            .send_message("bob", "first", None::<MessagePriority>, None::<String>)
+            .unwrap();
+        assert_eq!(protocol.lamport_clock.value(), clock_before + 1);
+
+        protocol
+            .send_message("bob", "second", None::<MessagePriority>, None::<String>)
+            .unwrap();
+        assert_eq!(protocol.lamport_clock.value(), clock_before + 2);
+    }
+
+    #[test]
+    fn test_lamport_clock_sent_message_carries_clock_value() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport.clone()));
+        protocol.start().unwrap();
+
+        protocol
+            .send_message("bob", "test", None::<MessagePriority>, None::<String>)
+            .unwrap();
+
+        // Verify the sent message carries the Lamport clock
+        let sent = mock_transport.sent_messages();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].lamport_clock.value(), 1);
+    }
+
+    #[test]
+    fn test_key_package_remaining_lifetime_ms() {
+        let mut config = create_test_config();
+        config.encryption.enabled = true;
+        config.encryption.auto_key_exchange = true;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+
+        // Create a key package with remaining_lifetime_ms = 0 (legacy sender)
+        let key_pkg_payload = KeyPackagePayload {
+            user_id: "legacy_peer".to_string(),
+            key_package_data: vec![1, 2, 3],
+            remaining_lifetime_ms: 0,
+            timestamp_ms: 12345,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::KEY_PACKAGE,
+            serde_json::to_string(&key_pkg_payload).unwrap()
+        );
+        let message = Message::new(
+            UserId::new("legacy_peer").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+
+        // Should have stored with a 30-day default lifetime
+        let received = protocol.pending_key_packages.get("legacy_peer").unwrap();
+        let now_ms = Utc::now().timestamp_millis() as u64;
+        let thirty_days_ms: u64 = 30 * 24 * 60 * 60 * 1000;
+        // Should expire roughly 30 days from now (within 1 second tolerance)
+        let diff = received.local_expires_at_ms.abs_diff(now_ms + thirty_days_ms);
+        assert!(diff < 1000, "Expiry should be ~30 days from now, diff was {}", diff);
+    }
+
+    #[test]
+    fn test_key_package_expired_discarded() {
+        let mut config = create_test_config();
+        config.encryption.enabled = true;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+
+        // MLS must be initialized so establish_secure_session reaches the
+        // expiry check instead of short-circuiting with MlsNotInitialized.
+        let storage = Arc::new(InMemoryStorage::new());
+        protocol.initialize_mls(storage).unwrap();
+
+        // Manually insert an already-expired key package
+        protocol.pending_key_packages.insert(
+            "expired_peer".to_string(),
+            ReceivedKeyPackage {
+                key_package_data: vec![1, 2, 3],
+                local_expires_at_ms: 0, // expired at epoch
+            },
+        );
+
+        assert!(protocol.pending_key_packages.contains_key("expired_peer"));
+
+        // Attempting to establish session should detect expiry and discard
+        let result = protocol.establish_secure_session("expired_peer");
+        assert!(result.is_err());
+        assert!(!protocol.pending_key_packages.contains_key("expired_peer"));
     }
 }

--- a/examples/react-native-app/src/components/MessageList.tsx
+++ b/examples/react-native-app/src/components/MessageList.tsx
@@ -66,7 +66,7 @@ export function MessageList({
           recipient: e.recipient,
           status: 'delivered',
           timestamp: e.timestamp,
-          lamportClock: (e as any).lamport_clock ?? 0,
+          lamportClock: e.lamport_clock ?? 0,
           priority: e.priority,
           requiresAck: e.requires_ack,
         });
@@ -80,7 +80,7 @@ export function MessageList({
           recipient: e.recipient,
           status: 'delivered',
           timestamp: e.timestamp,
-          lamportClock: (e as any).lamport_clock ?? 0,
+          lamportClock: e.lamport_clock ?? 0,
           transport: e.transport,
           hopCount: e.hop_count,
         });
@@ -121,15 +121,18 @@ export function MessageList({
       }
     });
 
-    // Sort by Lamport clock for causal ordering; fall back to wall-clock
-    // for legacy messages (lamportClock === 0), tiebreak by sender ID.
+    // Sort by Lamport clock for causal ordering.
+    // Legacy messages (lamportClock === 0) fall back to wall-clock timestamp.
+    // When one message is legacy and the other is not, legacy sorts first
+    // (it predates Lamport support) then tiebreak by message ID for stability.
     return Array.from(messageMap.values()).sort((a, b) => {
-      if (a.lamportClock === 0 && b.lamportClock === 0) {
-        return a.timestamp - b.timestamp;
-      }
+      const aLegacy = a.lamportClock === 0;
+      const bLegacy = b.lamportClock === 0;
+      if (aLegacy && bLegacy) return a.timestamp - b.timestamp;
+      if (aLegacy !== bLegacy) return aLegacy ? -1 : 1;
       const clockDiff = a.lamportClock - b.lamportClock;
       if (clockDiff !== 0) return clockDiff;
-      return (a.sender ?? '').localeCompare(b.sender ?? '');
+      return a.id.localeCompare(b.id);
     });
   }, [events]);
 

--- a/examples/react-native-app/src/components/MessageList.tsx
+++ b/examples/react-native-app/src/components/MessageList.tsx
@@ -8,6 +8,7 @@ import type {
   MessageDeliveredEvent,
   MessageFailedEvent,
 } from '@offline-protocol/mesh-sdk';
+import { compareByCausalOrder } from '../utils/messageSort';
 
 interface Message {
   id: string;
@@ -121,19 +122,7 @@ export function MessageList({
       }
     });
 
-    // Sort by Lamport clock for causal ordering.
-    // Legacy messages (lamportClock === 0) fall back to wall-clock timestamp.
-    // When one message is legacy and the other is not, legacy sorts first
-    // (it predates Lamport support) then tiebreak by message ID for stability.
-    return Array.from(messageMap.values()).sort((a, b) => {
-      const aLegacy = a.lamportClock === 0;
-      const bLegacy = b.lamportClock === 0;
-      if (aLegacy && bLegacy) return a.timestamp - b.timestamp;
-      if (aLegacy !== bLegacy) return aLegacy ? -1 : 1;
-      const clockDiff = a.lamportClock - b.lamportClock;
-      if (clockDiff !== 0) return clockDiff;
-      return a.id.localeCompare(b.id);
-    });
+    return Array.from(messageMap.values()).sort(compareByCausalOrder);
   }, [events]);
 
   React.useEffect(() => {

--- a/examples/react-native-app/src/components/MessageList.tsx
+++ b/examples/react-native-app/src/components/MessageList.tsx
@@ -17,6 +17,7 @@ interface Message {
   recipient?: string;
   status: 'pending' | 'delivered' | 'failed';
   timestamp: number;
+  lamportClock: number;
   transport?: string;
   hopCount?: number;
   priority?: string;
@@ -65,6 +66,7 @@ export function MessageList({
           recipient: e.recipient,
           status: 'delivered',
           timestamp: e.timestamp,
+          lamportClock: (e as any).lamport_clock ?? 0,
           priority: e.priority,
           requiresAck: e.requires_ack,
         });
@@ -78,6 +80,7 @@ export function MessageList({
           recipient: e.recipient,
           status: 'delivered',
           timestamp: e.timestamp,
+          lamportClock: (e as any).lamport_clock ?? 0,
           transport: e.transport,
           hopCount: e.hop_count,
         });
@@ -95,6 +98,7 @@ export function MessageList({
             content: '',
             status: 'delivered',
             timestamp: Date.now(),
+            lamportClock: 0,
             transport: e.transport,
             hopCount: e.hop_count,
           });
@@ -111,12 +115,22 @@ export function MessageList({
             content: '',
             status: 'failed',
             timestamp: Date.now(),
+            lamportClock: 0,
           });
         }
       }
     });
 
-    return Array.from(messageMap.values()).sort((a, b) => a.timestamp - b.timestamp);
+    // Sort by Lamport clock for causal ordering; fall back to wall-clock
+    // for legacy messages (lamportClock === 0), tiebreak by sender ID.
+    return Array.from(messageMap.values()).sort((a, b) => {
+      if (a.lamportClock === 0 && b.lamportClock === 0) {
+        return a.timestamp - b.timestamp;
+      }
+      const clockDiff = a.lamportClock - b.lamportClock;
+      if (clockDiff !== 0) return clockDiff;
+      return (a.sender ?? '').localeCompare(b.sender ?? '');
+    });
   }, [events]);
 
   React.useEffect(() => {

--- a/examples/react-native-app/src/screens/ChatScreen.tsx
+++ b/examples/react-native-app/src/screens/ChatScreen.tsx
@@ -21,6 +21,7 @@ interface Message {
   type: 'sent' | 'received';
   content: string;
   timestamp: number;
+  lamportClock: number;
   status: 'pending' | 'delivered' | 'failed';
   priority?: string;
 }
@@ -67,6 +68,7 @@ export function ChatScreen({
             type: 'sent',
             content: e.content,
             timestamp: e.timestamp,
+            lamportClock: e.lamport_clock ?? 0,
             status: 'delivered',
             priority: e.priority,
           });
@@ -79,6 +81,7 @@ export function ChatScreen({
             type: 'received',
             content: e.content,
             timestamp: e.timestamp,
+            lamportClock: e.lamport_clock ?? 0,
             status: 'delivered',
           });
         }
@@ -97,7 +100,16 @@ export function ChatScreen({
       }
     });
 
-    return Array.from(messageMap.values()).sort((a, b) => a.timestamp - b.timestamp);
+    // Sort by Lamport clock for causal ordering; fall back to wall-clock
+    // for legacy messages (lamportClock === 0).
+    return Array.from(messageMap.values()).sort((a, b) => {
+      if (a.lamportClock === 0 && b.lamportClock === 0) {
+        return a.timestamp - b.timestamp;
+      }
+      const clockDiff = a.lamportClock - b.lamportClock;
+      if (clockDiff !== 0) return clockDiff;
+      return a.id.localeCompare(b.id);
+    });
   }, [events, peerId]);
 
   // Auto-scroll to bottom when new messages arrive

--- a/examples/react-native-app/src/screens/ChatScreen.tsx
+++ b/examples/react-native-app/src/screens/ChatScreen.tsx
@@ -100,12 +100,15 @@ export function ChatScreen({
       }
     });
 
-    // Sort by Lamport clock for causal ordering; fall back to wall-clock
-    // for legacy messages (lamportClock === 0).
+    // Sort by Lamport clock for causal ordering.
+    // Legacy messages (lamportClock === 0) fall back to wall-clock timestamp.
+    // When one message is legacy and the other is not, legacy sorts first
+    // (it predates Lamport support) then tiebreak by message ID for stability.
     return Array.from(messageMap.values()).sort((a, b) => {
-      if (a.lamportClock === 0 && b.lamportClock === 0) {
-        return a.timestamp - b.timestamp;
-      }
+      const aLegacy = a.lamportClock === 0;
+      const bLegacy = b.lamportClock === 0;
+      if (aLegacy && bLegacy) return a.timestamp - b.timestamp;
+      if (aLegacy !== bLegacy) return aLegacy ? -1 : 1;
       const clockDiff = a.lamportClock - b.lamportClock;
       if (clockDiff !== 0) return clockDiff;
       return a.id.localeCompare(b.id);

--- a/examples/react-native-app/src/screens/ChatScreen.tsx
+++ b/examples/react-native-app/src/screens/ChatScreen.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MessagePriority, type ProtocolEvent } from '@offline-protocol/mesh-sdk';
+import { compareByCausalOrder } from '../utils/messageSort';
 
 interface Message {
   id: string;
@@ -100,19 +101,7 @@ export function ChatScreen({
       }
     });
 
-    // Sort by Lamport clock for causal ordering.
-    // Legacy messages (lamportClock === 0) fall back to wall-clock timestamp.
-    // When one message is legacy and the other is not, legacy sorts first
-    // (it predates Lamport support) then tiebreak by message ID for stability.
-    return Array.from(messageMap.values()).sort((a, b) => {
-      const aLegacy = a.lamportClock === 0;
-      const bLegacy = b.lamportClock === 0;
-      if (aLegacy && bLegacy) return a.timestamp - b.timestamp;
-      if (aLegacy !== bLegacy) return aLegacy ? -1 : 1;
-      const clockDiff = a.lamportClock - b.lamportClock;
-      if (clockDiff !== 0) return clockDiff;
-      return a.id.localeCompare(b.id);
-    });
+    return Array.from(messageMap.values()).sort(compareByCausalOrder);
   }, [events, peerId]);
 
   // Auto-scroll to bottom when new messages arrive

--- a/examples/react-native-app/src/utils/messageSort.ts
+++ b/examples/react-native-app/src/utils/messageSort.ts
@@ -1,0 +1,29 @@
+/**
+ * Comparator for causal message ordering using Lamport clocks.
+ *
+ * Rules:
+ * - Legacy messages (lamportClock === 0) sort by wall-clock timestamp.
+ * - Legacy messages always sort before Lamport-bearing messages
+ *   (they predate Lamport support).
+ * - Among Lamport-bearing messages, sort by clock value ascending.
+ * - Ties are broken by message ID for deterministic stability.
+ */
+
+interface Sortable {
+  id: string;
+  lamportClock: number;
+  timestamp: number;
+}
+
+export function compareByCausalOrder(a: Sortable, b: Sortable): number {
+  const aLegacy = a.lamportClock === 0;
+  const bLegacy = b.lamportClock === 0;
+
+  if (aLegacy && bLegacy) return a.timestamp - b.timestamp;
+  if (aLegacy !== bLegacy) return aLegacy ? -1 : 1;
+
+  const clockDiff = a.lamportClock - b.lamportClock;
+  if (clockDiff !== 0) return clockDiff;
+
+  return a.id.localeCompare(b.id);
+}


### PR DESCRIPTION
- Add LamportClock, WallClockTimestamp, LocalInstant types
- Add lamport_clock to Message for ordering across devices
- Use remaining_lifetime_ms in key package exchange to avoid clock skew
- Deprecate Timestamp::elapsed_millis() in favor of LocalInstant
- Update MessageList and ChatScreen to sort by Lamport clock