### PR TITLE
fix(ble): restrict discovery to known mesh candidates only

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleDiscoveryBootstrapPolicy.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleDiscoveryBootstrapPolicy.kt
@@ -1,0 +1,35 @@
+package com.offlineprotocol
+
+internal object BleDiscoveryBootstrapPolicy {
+    fun shouldAllowCandidate(
+        isConnectable: Boolean,
+        currentConnectionCount: Int,
+        maxConnectionsPerDevice: Int,
+        estimatedVisiblePeerCount: Int,
+        densePeerThreshold: Int,
+        rssi: Int,
+        hasScanRecord: Boolean,
+        minRssiWithScanRecord: Int,
+        minRssiWithoutScanRecord: Int,
+        lastAttemptAt: Long?,
+        now: Long,
+        perDeviceCooldownMs: Long,
+        recentBootstrapAttempts: Int,
+        maxBootstrapAttemptsPerMinute: Int,
+        recentConnectionAttempts: Int,
+        maxConnectionAttemptsPerMinute: Int
+    ): Boolean {
+        if (!isConnectable) return false
+        if (currentConnectionCount >= maxConnectionsPerDevice) return false
+        if (estimatedVisiblePeerCount > densePeerThreshold) return false
+
+        val minRssi = if (hasScanRecord) minRssiWithScanRecord else minRssiWithoutScanRecord
+        if (rssi < minRssi) return false
+
+        if (lastAttemptAt != null && now - lastAttemptAt < perDeviceCooldownMs) return false
+        if (recentBootstrapAttempts >= maxBootstrapAttemptsPerMinute) return false
+        if (recentConnectionAttempts >= maxConnectionAttemptsPerMinute) return false
+
+        return true
+    }
+}

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -99,12 +99,6 @@ class BleManager(
         private const val ADAPTIVE_COOLDOWN_PER_DEVICE_MS = 30_000L
         /** Interval for updating visible peer count estimate (ms) */
         private const val ADAPTIVE_PEER_COUNT_WINDOW_MS = 5_000L
-        /** Rate limit for unknown device GATT verification attempts (ms) */
-        private const val UNKNOWN_DEVICE_RATE_LIMIT_MS = 5_000L // More aggressive for cross-platform discovery
-        /** Minimum RSSI for unknown device to be considered for GATT verification */
-        private const val UNKNOWN_DEVICE_MIN_RSSI = -80 // More lenient for cross-platform discovery
-        /** Maximum unknown device verification attempts per minute */
-        private const val MAX_UNKNOWN_DEVICE_ATTEMPTS_PER_MINUTE = 10
         /** Proactive scan refresh interval even when discoveries are occurring (ms) */
         private const val PROACTIVE_SCAN_REFRESH_MS = 60_000L
         /** Force a complete BLE stack refresh periodically even when things seem healthy (ms) */
@@ -183,8 +177,6 @@ class BleManager(
     /** Last time we updated the peer count estimate */
     @Volatile private var lastPeerCountUpdate: Long = 0L
     @Volatile private var lastMeshAdvertisement: MeshAdvertisementData? = null
-    /** Rate limiting for unknown connectable devices that need GATT verification */
-    private val unknownDeviceAttempts = ConcurrentHashMap<String, Long>()
     /** Last time we proactively refreshed the scan */
     @Volatile private var lastProactiveScanRefresh: Long = 0L
     /** Last time we performed a forced BLE refresh */
@@ -512,7 +504,6 @@ class BleManager(
         pendingFragments.clear()
         pendingOutboundFragments.clear()
         lastSeenMeshAdvertisements.clear()
-        unknownDeviceAttempts.clear()
         verifiedNonMeshDevices.clear()
         recentAdvertisementHashes.clear()
         connectionRetryCount.clear()
@@ -1118,7 +1109,7 @@ class BleManager(
             true // Assume connectable on older Android
         }
         
-        if (!shouldProcessDiscoveredDevice(address, scanRecord, rssi, isConnectable, now)) {
+        if (!shouldProcessDiscoveredDevice(address, scanRecord, now)) {
             return
         }
         
@@ -1256,13 +1247,11 @@ class BleManager(
      * - Devices advertising our service UUID
      * - Devices with our service data
      * - Previously discovered mesh devices
-     * - Unknown connectable devices (rate-limited, verified via GATT)
+     * - Previously verified peer/device mappings
      */
     private fun shouldProcessDiscoveredDevice(
         address: String,
         scanRecord: android.bluetooth.le.ScanRecord?,
-        rssi: Int,
-        isConnectable: Boolean,
         now: Long
     ): Boolean {
         // 0. Skip devices previously verified as non-mesh via GATT
@@ -1340,50 +1329,6 @@ class BleManager(
         // 5. Check if we have an active GATT connection to this device
         if (connections.getGatt(address) != null) {
             return true
-        }
-        
-        // 6. For unknown connectable devices, allow with rate limiting
-        //    These will be verified via GATT service discovery after connection
-        //    This is important for iOS ↔ Android cross-platform discovery since
-        //    each platform may not recognize the other's service UUID format in advertisements
-        if (isConnectable) {
-            // Rate limit unknown device connection attempts
-            val lastAttempt = unknownDeviceAttempts[address]
-            if (lastAttempt != null && now - lastAttempt < UNKNOWN_DEVICE_RATE_LIMIT_MS) {
-                return false
-            }
-            
-            // Check global rate limit for unknown device attempts
-            val recentUnknownAttempts = unknownDeviceAttempts.values.count { 
-                now - it < 60_000L 
-            }
-            if (recentUnknownAttempts >= MAX_UNKNOWN_DEVICE_ATTEMPTS_PER_MINUTE) {
-                return false
-            }
-            
-            // More lenient RSSI threshold for cross-platform discovery
-            // iOS devices may not advertise service UUID in a format Android recognizes,
-            // so we need to be more aggressive about connecting to verify via GATT
-            val shouldAttempt = when {
-                rssi >= -70 -> true  // Strong signal - always try
-                rssi >= -85 -> true  // Medium signal - be more lenient for iOS compatibility
-                rssi >= UNKNOWN_DEVICE_MIN_RSSI && recentUnknownAttempts < MAX_UNKNOWN_DEVICE_ATTEMPTS_PER_MINUTE / 2 -> true
-                else -> false
-            }
-            
-            if (shouldAttempt) {
-                unknownDeviceAttempts[address] = now
-                if (logThrottler.shouldLog("unknown_connectable_$address", intervalMs = 30_000)) {
-                    Log.d(TAG, "🔍 Allowing unknown connectable device for GATT verification: $address RSSI=$rssi (iOS compatibility mode)")
-                    emitDiagnostic("info", "Allowing unknown device for GATT verification", mapOf(
-                        "address" to address,
-                        "rssi" to rssi,
-                        "recentAttempts" to recentUnknownAttempts,
-                        "reason" to "ios_compatibility"
-                    ))
-                }
-                return true
-            }
         }
         
         // Filter out all other devices (not our mesh network)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -99,6 +99,14 @@ class BleManager(
         private const val ADAPTIVE_COOLDOWN_PER_DEVICE_MS = 30_000L
         /** Interval for updating visible peer count estimate (ms) */
         private const val ADAPTIVE_PEER_COUNT_WINDOW_MS = 5_000L
+        /** Cooldown between provisional bootstrap attempts for unknown devices */
+        private const val UNKNOWN_BOOTSTRAP_RATE_LIMIT_MS = 12_000L
+        /** Minimum RSSI required for provisional bootstrap attempt */
+        private const val UNKNOWN_BOOTSTRAP_MIN_RSSI = -75
+        /** Stricter RSSI requirement when scan record is missing */
+        private const val UNKNOWN_BOOTSTRAP_MIN_RSSI_NO_SCAN_RECORD = -68
+        /** Max provisional bootstrap attempts per minute */
+        private const val MAX_UNKNOWN_BOOTSTRAP_ATTEMPTS_PER_MINUTE = 4
         /** Proactive scan refresh interval even when discoveries are occurring (ms) */
         private const val PROACTIVE_SCAN_REFRESH_MS = 60_000L
         /** Force a complete BLE stack refresh periodically even when things seem healthy (ms) */
@@ -181,6 +189,8 @@ class BleManager(
     @Volatile private var lastProactiveScanRefresh: Long = 0L
     /** Last time we performed a forced BLE refresh */
     @Volatile private var lastForcedBleRefresh: Long = 0L
+    /** Rate limiter for provisional unknown-device bootstrap attempts */
+    private val unknownBootstrapAttempts = ConcurrentHashMap<String, Long>()
     /** Tracks recently seen advertisements to avoid duplicate processing (hash, timestamp) */
     private data class AdvertisementCacheEntry(val hash: Int, val timestamp: Long)
     private val recentAdvertisementHashes = ConcurrentHashMap<String, AdvertisementCacheEntry>()
@@ -505,6 +515,7 @@ class BleManager(
         pendingOutboundFragments.clear()
         lastSeenMeshAdvertisements.clear()
         verifiedNonMeshDevices.clear()
+        unknownBootstrapAttempts.clear()
         recentAdvertisementHashes.clear()
         connectionRetryCount.clear()
         connectedCentrals.clear()
@@ -1109,7 +1120,7 @@ class BleManager(
             true // Assume connectable on older Android
         }
         
-        if (!shouldProcessDiscoveredDevice(address, scanRecord, now)) {
+        if (!shouldProcessDiscoveredDevice(address, scanRecord, rssi, isConnectable, now)) {
             return
         }
         
@@ -1248,16 +1259,20 @@ class BleManager(
      * - Devices with our service data
      * - Previously discovered mesh devices
      * - Previously verified peer/device mappings
+     * - Strictly rate-limited bootstrap attempts for unknown connectable devices
      */
     private fun shouldProcessDiscoveredDevice(
         address: String,
         scanRecord: android.bluetooth.le.ScanRecord?,
+        rssi: Int,
+        isConnectable: Boolean,
         now: Long
     ): Boolean {
         // 0. Skip devices previously verified as non-mesh via GATT
         val nonMeshTimestamp = verifiedNonMeshDevices[address]
         if (nonMeshTimestamp != null) {
             if (now - nonMeshTimestamp < NON_MESH_CACHE_TTL_MS) {
+                logDiscoveryRejection(address, "non_mesh_cache", now, mapOf("ageMs" to (now - nonMeshTimestamp)))
                 return false
             }
             // Entry expired, remove it and allow re-evaluation
@@ -1330,9 +1345,84 @@ class BleManager(
         if (connections.getGatt(address) != null) {
             return true
         }
+
+        // 6. Controlled bootstrap for unknown connectable devices.
+        // Missing advertisement fields are treated as unknown (not invalid), but we keep
+        // strict safeguards to avoid probing arbitrary peripherals.
+        if (shouldAllowUnknownBootstrap(address, scanRecord != null, rssi, isConnectable, now)) {
+            if (logThrottler.shouldLog("bootstrap_allow_$address", intervalMs = 30_000L)) {
+                Log.d(TAG, "Allowing provisional bootstrap for $address (rssi=$rssi, scanRecord=${scanRecord != null})")
+                emitDiagnostic("debug", "Allowing provisional bootstrap candidate", mapOf(
+                    "address" to address,
+                    "rssi" to rssi,
+                    "scanRecordPresent" to (scanRecord != null),
+                    "connectable" to isConnectable
+                ))
+            }
+            return true
+        }
         
         // Filter out all other devices (not our mesh network)
+        logDiscoveryRejection(address, "unknown_candidate_blocked", now, mapOf(
+            "rssi" to rssi,
+            "connectable" to isConnectable,
+            "scanRecordPresent" to (scanRecord != null)
+        ))
         return false
+    }
+
+    private fun shouldAllowUnknownBootstrap(
+        address: String,
+        hasScanRecord: Boolean,
+        rssi: Int,
+        isConnectable: Boolean,
+        now: Long
+    ): Boolean {
+        val lastAttempt = unknownBootstrapAttempts[address]
+        val oneMinuteAgo = now - 60_000L
+        val recentBootstrapAttempts = unknownBootstrapAttempts.values.count { it >= oneMinuteAgo }
+
+        val recentConnectionAttempts = synchronized(globalConnectionAttempts) {
+            globalConnectionAttempts.count { it >= oneMinuteAgo }
+        }
+        val shouldAllow = BleDiscoveryBootstrapPolicy.shouldAllowCandidate(
+            isConnectable = isConnectable,
+            currentConnectionCount = currentConnectionCount(),
+            maxConnectionsPerDevice = MAX_CONNECTIONS_PER_DEVICE,
+            estimatedVisiblePeerCount = estimatedVisiblePeerCount,
+            densePeerThreshold = ADAPTIVE_HIGH_DENSITY_THRESHOLD,
+            rssi = rssi,
+            hasScanRecord = hasScanRecord,
+            minRssiWithScanRecord = UNKNOWN_BOOTSTRAP_MIN_RSSI,
+            minRssiWithoutScanRecord = UNKNOWN_BOOTSTRAP_MIN_RSSI_NO_SCAN_RECORD,
+            lastAttemptAt = lastAttempt,
+            now = now,
+            perDeviceCooldownMs = UNKNOWN_BOOTSTRAP_RATE_LIMIT_MS,
+            recentBootstrapAttempts = recentBootstrapAttempts,
+            maxBootstrapAttemptsPerMinute = MAX_UNKNOWN_BOOTSTRAP_ATTEMPTS_PER_MINUTE,
+            recentConnectionAttempts = recentConnectionAttempts,
+            maxConnectionAttemptsPerMinute = ADAPTIVE_MAX_CONNECTIONS_PER_MINUTE
+        )
+        if (!shouldAllow) return false
+
+        unknownBootstrapAttempts[address] = now
+        return true
+    }
+
+    private fun logDiscoveryRejection(
+        address: String,
+        reason: String,
+        now: Long,
+        details: Map<String, Any?> = emptyMap()
+    ) {
+        if (!logThrottler.shouldLog("reject_${reason}_$address", intervalMs = 30_000L, nowMs = now)) {
+            return
+        }
+        Log.v(TAG, "Skipping discovered device $address ($reason)")
+        emitDiagnostic("debug", "Skipping discovered BLE device", details + mapOf(
+            "address" to address,
+            "reason" to reason
+        ))
     }
     
     /**
@@ -1963,6 +2053,13 @@ class BleManager(
             val entry = iterator.next()
             if (now - entry.value.timestamp > MESH_OBSERVATION_TTL_MS) {
                 iterator.remove()
+            }
+        }
+
+        val unknownIterator = unknownBootstrapAttempts.entries.iterator()
+        while (unknownIterator.hasNext()) {
+            if (now - unknownIterator.next().value > 60_000L) {
+                unknownIterator.remove()
             }
         }
     }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -68,6 +68,10 @@ class BleManager(
         private val MESSAGE_CHAR_UUID = UUID.fromString("6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
         private val DEVICE_ID_CHAR_UUID = UUID.fromString("6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
         private val IDENTITY_CHAR_UUID = UUID.fromString("6E400004-B5A3-F393-E0A9-E50E24DCCA9E")
+        private const val AD_TYPE_INCOMPLETE_128_BIT_SERVICE_UUIDS = 0x06
+        private const val AD_TYPE_COMPLETE_128_BIT_SERVICE_UUIDS = 0x07
+        private const val UUID_128_BIT_LENGTH_BYTES = 16
+        private val SERVICE_UUID_LE_BYTES = uuidToLittleEndianBytes(SERVICE_UUID)
         
         // Fallback interval for fragment polling. Primary send path is event-driven
         // via onFragmentsAvailable(); this timer only catches edge cases.
@@ -121,6 +125,12 @@ class BleManager(
         private const val AGGRESSIVE_DISCOVERY_PHASE_MS = 30_000L
         /** TTL for negative cache entries of verified non-mesh devices (ms) */
         private const val NON_MESH_CACHE_TTL_MS = 300_000L // 5 minutes
+
+        private fun uuidToLittleEndianBytes(uuid: UUID): ByteArray {
+            val hexUuid = uuid.toString().uppercase().replace("-", "")
+            val bigEndianBytes = hexUuid.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+            return bigEndianBytes.reversedArray()
+        }
     }
     
     // MARK: - Properties
@@ -1293,36 +1303,15 @@ class BleManager(
             }
         }
         
-        // Also check service UUIDs in scan record bytes (for iOS compatibility)
-        // iOS sometimes advertises service UUIDs in a format Android's API doesn't parse correctly
+        // Also check service UUIDs in scan record AD structures (for iOS compatibility)
+        // iOS sometimes advertises service UUIDs in a format Android's API doesn't parse correctly.
+        // Restrict this fallback to 128-bit Service UUID AD fields only.
         val scanRecordBytes = scanRecord?.bytes
-        if (scanRecordBytes != null) {
-            // Convert UUID to byte array in little-endian format (BLE advertisement byte order).
-            // BLE stores 128-bit UUIDs with least-significant byte first.
-            val uuidString = SERVICE_UUID.toString().uppercase().replace("-", "")
-            val bigEndianBytes = uuidString.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
-            val uuidBytesLE = bigEndianBytes.reversedArray()
-            // Check if UUID bytes appear in scan record (simple substring search)
-            var found = false
-            for (i in 0..(scanRecordBytes.size - uuidBytesLE.size)) {
-                var match = true
-                for (j in uuidBytesLE.indices) {
-                    if (scanRecordBytes[i + j] != uuidBytesLE[j]) {
-                        match = false
-                        break
-                    }
-                }
-                if (match) {
-                    found = true
-                    break
-                }
+        if (scanRecordBytes != null && containsServiceUuidInAdStructures(scanRecordBytes)) {
+            if (logThrottler.shouldLog("service_uuid_bytes_match_$address", intervalMs = 30_000)) {
+                Log.d(TAG, "✅ Device $address matches service UUID in scan record AD structures")
             }
-            if (found) {
-                if (logThrottler.shouldLog("service_uuid_bytes_match_$address", intervalMs = 30_000)) {
-                    Log.d(TAG, "✅ Device $address matches service UUID in raw bytes")
-                }
-                return true
-            }
+            return true
         }
         
         // 2. Check for our service data
@@ -1368,6 +1357,45 @@ class BleManager(
             "connectable" to isConnectable,
             "scanRecordPresent" to (scanRecord != null)
         ))
+        return false
+    }
+
+    private fun containsServiceUuidInAdStructures(scanRecordBytes: ByteArray): Boolean {
+        var offset = 0
+        while (offset < scanRecordBytes.size) {
+            val length = scanRecordBytes[offset].toInt() and 0xFF
+            if (length == 0) break
+
+            val nextStructureOffset = offset + length + 1
+            if (nextStructureOffset > scanRecordBytes.size) {
+                return false
+            }
+            if (length < 2) {
+                offset = nextStructureOffset
+                continue
+            }
+
+            val adType = scanRecordBytes[offset + 1].toInt() and 0xFF
+            if (adType == AD_TYPE_INCOMPLETE_128_BIT_SERVICE_UUIDS || adType == AD_TYPE_COMPLETE_128_BIT_SERVICE_UUIDS) {
+                val dataStart = offset + 2
+                val dataLength = length - 1
+                val uuidCount = dataLength / UUID_128_BIT_LENGTH_BYTES
+
+                for (uuidIndex in 0 until uuidCount) {
+                    val uuidOffset = dataStart + (uuidIndex * UUID_128_BIT_LENGTH_BYTES)
+                    var matches = true
+                    for (byteIndex in 0 until UUID_128_BIT_LENGTH_BYTES) {
+                        if (scanRecordBytes[uuidOffset + byteIndex] != SERVICE_UUID_LE_BYTES[byteIndex]) {
+                            matches = false
+                            break
+                        }
+                    }
+                    if (matches) return true
+                }
+            }
+
+            offset = nextStructureOffset
+        }
         return false
     }
 

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/BleDiscoveryBootstrapPolicyTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/BleDiscoveryBootstrapPolicyTest.kt
@@ -1,0 +1,80 @@
+package com.offlineprotocol
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BleDiscoveryBootstrapPolicyTest {
+
+    @Test
+    fun `allows connectable unknown candidate on cold start with strong signal`() {
+        val allowed = BleDiscoveryBootstrapPolicy.shouldAllowCandidate(
+            isConnectable = true,
+            currentConnectionCount = 0,
+            maxConnectionsPerDevice = 4,
+            estimatedVisiblePeerCount = 3,
+            densePeerThreshold = 50,
+            rssi = -62,
+            hasScanRecord = false,
+            minRssiWithScanRecord = -75,
+            minRssiWithoutScanRecord = -68,
+            lastAttemptAt = null,
+            now = 1_000L,
+            perDeviceCooldownMs = 12_000L,
+            recentBootstrapAttempts = 0,
+            maxBootstrapAttemptsPerMinute = 4,
+            recentConnectionAttempts = 0,
+            maxConnectionAttemptsPerMinute = 6
+        )
+
+        assertTrue(allowed)
+    }
+
+    @Test
+    fun `rejects unknown candidate when signal is weak and advertisement is partial`() {
+        val allowed = BleDiscoveryBootstrapPolicy.shouldAllowCandidate(
+            isConnectable = true,
+            currentConnectionCount = 0,
+            maxConnectionsPerDevice = 4,
+            estimatedVisiblePeerCount = 4,
+            densePeerThreshold = 50,
+            rssi = -82,
+            hasScanRecord = false,
+            minRssiWithScanRecord = -75,
+            minRssiWithoutScanRecord = -68,
+            lastAttemptAt = null,
+            now = 2_000L,
+            perDeviceCooldownMs = 12_000L,
+            recentBootstrapAttempts = 0,
+            maxBootstrapAttemptsPerMinute = 4,
+            recentConnectionAttempts = 0,
+            maxConnectionAttemptsPerMinute = 6
+        )
+
+        assertFalse(allowed)
+    }
+
+    @Test
+    fun `rejects candidate when per-device cooldown is active`() {
+        val allowed = BleDiscoveryBootstrapPolicy.shouldAllowCandidate(
+            isConnectable = true,
+            currentConnectionCount = 0,
+            maxConnectionsPerDevice = 4,
+            estimatedVisiblePeerCount = 2,
+            densePeerThreshold = 50,
+            rssi = -60,
+            hasScanRecord = true,
+            minRssiWithScanRecord = -75,
+            minRssiWithoutScanRecord = -68,
+            lastAttemptAt = 10_000L,
+            now = 15_000L,
+            perDeviceCooldownMs = 12_000L,
+            recentBootstrapAttempts = 1,
+            maxBootstrapAttemptsPerMinute = 4,
+            recentConnectionAttempts = 1,
+            maxConnectionAttemptsPerMinute = 6
+        )
+
+        assertFalse(allowed)
+    }
+}

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -175,6 +175,14 @@ public class BleManager: NSObject, TransportManager {
     private let MAX_CONSECUTIVE_SCAN_RESTARTS = 3
     private let CENTRAL_RESET_BACKOFF: TimeInterval = 45.0
     private let MINIMUM_RSSI_TO_CONNECT: Int16 = -90
+    /// Cooldown between provisional bootstrap attempts for unknown peripherals
+    private let UNKNOWN_BOOTSTRAP_RATE_LIMIT: TimeInterval = 12.0
+    /// Minimum RSSI for provisional bootstrap when advertisement keys are present
+    private let UNKNOWN_BOOTSTRAP_MIN_RSSI: Int16 = -75
+    /// Stricter RSSI threshold when expected advertisement keys are missing
+    private let UNKNOWN_BOOTSTRAP_MIN_RSSI_WITH_MISSING_KEYS: Int16 = -68
+    /// Max provisional unknown bootstrap attempts per minute
+    private let MAX_UNKNOWN_BOOTSTRAP_ATTEMPTS_PER_MINUTE = 4
     /// Proactive scan refresh interval even when discoveries are occurring
     private let PROACTIVE_SCAN_REFRESH_INTERVAL: TimeInterval = 60.0
     private var lastProactiveScanRefresh: Date?
@@ -186,6 +194,8 @@ public class BleManager: NSObject, TransportManager {
     private var aggressiveDiscoveryStarted: Date?
     /// Negative cache: devices verified via GATT as non-mesh (identifier -> timestamp)
     private var verifiedNonMeshDevices: [UUID: Date] = [:]
+    /// Rate limiter for provisional unknown bootstrap attempts
+    private var unknownBootstrapAttempts: [UUID: Date] = [:]
     private let NON_MESH_CACHE_TTL: TimeInterval = 300.0 // 5 minutes
 
     // MARK: - Thread helpers
@@ -419,6 +429,7 @@ public class BleManager: NSObject, TransportManager {
         pendingFragments.removeAll()
         pendingOutboundFragments.removeAll()
         lastSeenMeshAdvertisements.removeAll()
+        unknownBootstrapAttempts.removeAll()
         verifiedNonMeshDevices.removeAll()
         recentAdvertisementHashes.removeAll()
         pendingAdvertiseRestart?.cancel()
@@ -1521,6 +1532,7 @@ public class BleManager: NSObject, TransportManager {
 
     private func pruneMeshObservations(now: Date = Date()) {
         lastSeenMeshAdvertisements = lastSeenMeshAdvertisements.filter { now.timeIntervalSince($0.value.timestamp) <= MESH_OBSERVATION_TTL }
+        unknownBootstrapAttempts = unknownBootstrapAttempts.filter { now.timeIntervalSince($0.value) <= 60.0 }
         
     }
     
@@ -1659,14 +1671,23 @@ public class BleManager: NSObject, TransportManager {
     /// - Devices with our service data
     /// - Previously discovered mesh devices
     /// - Previously verified peer/device mappings
+    /// - Strictly rate-limited bootstrap attempts for unknown connectable peripherals
     private func shouldProcessDiscoveredPeripheral(
         peripheral: CBPeripheral,
         advertisementData: [String: Any],
+        rssi: Int16,
+        isConnectable: Bool,
         now: Date
     ) -> Bool {
         // 0. Skip devices previously verified as non-mesh via GATT
         if let nonMeshTimestamp = verifiedNonMeshDevices[peripheral.identifier] {
             if now.timeIntervalSince(nonMeshTimestamp) < NON_MESH_CACHE_TTL {
+                logDiscoveryRejection(
+                    peripheral: peripheral,
+                    reason: "non_mesh_cache",
+                    now: now,
+                    context: ["ageMs": Int(now.timeIntervalSince(nonMeshTimestamp) * 1000)]
+                )
                 return false
             }
             // Entry expired, remove it and allow re-evaluation
@@ -1718,9 +1739,97 @@ public class BleManager: NSObject, TransportManager {
            connections.centralDeviceId(for: peripheral.identifier) != nil {
             return true
         }
+
+        // Controlled bootstrap for unknown connectable peripherals.
+        // Missing advertisement keys are treated as unknown (not invalid), while
+        // strict rate/rssi limits prevent broad probing.
+        if shouldAllowUnknownBootstrap(
+            peripheral: peripheral,
+            advertisementData: advertisementData,
+            rssi: rssi,
+            isConnectable: isConnectable,
+            now: now
+        ) {
+            if logThrottler.shouldLog(key: "bootstrap_allow_\(peripheral.identifier.uuidString)", interval: 30) {
+                print("[BleManager] Allowing provisional bootstrap for \(peripheral.identifier) RSSI=\(rssi)")
+                emitDiagnostic("debug", "Allowing provisional bootstrap candidate", context: [
+                    "identifier": peripheral.identifier.uuidString,
+                    "rssi": rssi,
+                    "connectable": isConnectable
+                ])
+            }
+            return true
+        }
         
         // Filter out all other devices (not our mesh network)
+        logDiscoveryRejection(
+            peripheral: peripheral,
+            reason: "unknown_candidate_blocked",
+            now: now,
+            context: [
+                "rssi": rssi,
+                "connectable": isConnectable,
+                "hasServiceUUIDs": advertisementData[CBAdvertisementDataServiceUUIDsKey] != nil,
+                "hasServiceData": advertisementData[CBAdvertisementDataServiceDataKey] != nil
+            ]
+        )
         return false
+    }
+
+    private func shouldAllowUnknownBootstrap(
+        peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi: Int16,
+        isConnectable: Bool,
+        now: Date
+    ) -> Bool {
+        let hasAnyServiceKey =
+            advertisementData[CBAdvertisementDataServiceUUIDsKey] != nil ||
+            advertisementData[CBAdvertisementDataServiceDataKey] != nil ||
+            advertisementData[CBAdvertisementDataOverflowServiceUUIDsKey] != nil ||
+            advertisementData[CBAdvertisementDataSolicitedServiceUUIDsKey] != nil
+
+        let lastAttempt = unknownBootstrapAttempts[peripheral.identifier]
+        let oneMinuteAgo = now.addingTimeInterval(-60.0)
+        let recentBootstrapAttempts = unknownBootstrapAttempts.values.filter { $0 > oneMinuteAgo }.count
+        let recentConnectionAttempts = globalConnectionAttempts.filter { $0 > oneMinuteAgo }.count
+        let shouldAllow = BleDiscoveryBootstrapPolicy.shouldAllowCandidate(
+            isConnectable: isConnectable,
+            currentConnectionCount: currentConnectionCount(),
+            maxConnectionsPerDevice: MAX_CONNECTIONS_PER_DEVICE,
+            estimatedVisiblePeerCount: estimatedVisiblePeerCount,
+            densePeerThreshold: ADAPTIVE_HIGH_DENSITY_THRESHOLD,
+            rssi: rssi,
+            hasAnyServiceKey: hasAnyServiceKey,
+            minRssiWithServiceKeys: UNKNOWN_BOOTSTRAP_MIN_RSSI,
+            minRssiWithoutServiceKeys: UNKNOWN_BOOTSTRAP_MIN_RSSI_WITH_MISSING_KEYS,
+            lastAttemptAt: lastAttempt,
+            now: now,
+            perDeviceCooldown: UNKNOWN_BOOTSTRAP_RATE_LIMIT,
+            recentBootstrapAttempts: recentBootstrapAttempts,
+            maxBootstrapAttemptsPerMinute: MAX_UNKNOWN_BOOTSTRAP_ATTEMPTS_PER_MINUTE,
+            recentConnectionAttempts: recentConnectionAttempts,
+            maxConnectionAttemptsPerMinute: ADAPTIVE_MAX_CONNECTIONS_PER_MINUTE
+        )
+        guard shouldAllow else { return false }
+
+        unknownBootstrapAttempts[peripheral.identifier] = now
+        return true
+    }
+
+    private func logDiscoveryRejection(
+        peripheral: CBPeripheral,
+        reason: String,
+        now: Date,
+        context: [String: Any] = [:]
+    ) {
+        let key = "reject_\(reason)_\(peripheral.identifier.uuidString)"
+        guard logThrottler.shouldLog(key: key, interval: 30, now: now) else { return }
+        print("[BleManager] Skipping discovered peripheral \(peripheral.identifier) (\(reason))")
+        emitDiagnostic("debug", "Skipping discovered BLE peripheral", context: context.merging([
+            "identifier": peripheral.identifier.uuidString,
+            "reason": reason
+        ]) { current, _ in current })
     }
 
     private func identifierForNodeHash(_ nodeHash: UInt64) -> UUID? {
@@ -1983,9 +2092,18 @@ extension BleManager: CBCentralManagerDelegate {
         // Smart filtering for iOS ↔ Android interoperability
         // Since we scan without a service UUID filter (for Android compatibility),
         // we need to filter discovered peripherals here instead.
+        let isConnectable: Bool
+        if #available(iOS 13.0, *) {
+            isConnectable = (advertisementData[CBAdvertisementDataIsConnectable] as? NSNumber)?.boolValue ?? true
+        } else {
+            isConnectable = true
+        }
+
         let shouldProcess = shouldProcessDiscoveredPeripheral(
             peripheral: peripheral,
             advertisementData: advertisementData,
+            rssi: rssiValue,
+            isConnectable: isConnectable,
             now: now
         )
         
@@ -2009,12 +2127,6 @@ extension BleManager: CBCentralManagerDelegate {
         discoveredPeripherals[peripheral.identifier] = peripheral
         peripheralRSSI[peripheral.identifier] = rssiValue
         
-        let isConnectable: Bool
-        if #available(iOS 13.0, *) {
-            isConnectable = (advertisementData[CBAdvertisementDataIsConnectable] as? NSNumber)?.boolValue ?? true
-        } else {
-            isConnectable = true
-        }
         if discoveryLogTimestamps[peripheral.identifier] == nil || (now.timeIntervalSince(discoveryLogTimestamps[peripheral.identifier]!) > 30) {
             discoveryLogTimestamps[peripheral.identifier] = now
             print("[BleManager] Discovered peripheral: \(peripheral.identifier) RSSI=\(rssiValue) (density: \(estimatedVisiblePeerCount))")

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -175,11 +175,6 @@ public class BleManager: NSObject, TransportManager {
     private let MAX_CONSECUTIVE_SCAN_RESTARTS = 3
     private let CENTRAL_RESET_BACKOFF: TimeInterval = 45.0
     private let MINIMUM_RSSI_TO_CONNECT: Int16 = -90
-    /// Rate limiting for unknown connectable devices that need GATT verification
-    private var unknownDeviceAttempts: [UUID: Date] = [:]
-    private let UNKNOWN_DEVICE_RATE_LIMIT: TimeInterval = 5.0 // More aggressive for cross-platform discovery
-    private let UNKNOWN_DEVICE_MIN_RSSI: Int16 = -80 // More lenient for cross-platform discovery
-    private let MAX_UNKNOWN_DEVICE_ATTEMPTS_PER_MINUTE = 10
     /// Proactive scan refresh interval even when discoveries are occurring
     private let PROACTIVE_SCAN_REFRESH_INTERVAL: TimeInterval = 60.0
     private var lastProactiveScanRefresh: Date?
@@ -424,7 +419,6 @@ public class BleManager: NSObject, TransportManager {
         pendingFragments.removeAll()
         pendingOutboundFragments.removeAll()
         lastSeenMeshAdvertisements.removeAll()
-        unknownDeviceAttempts.removeAll()
         verifiedNonMeshDevices.removeAll()
         recentAdvertisementHashes.removeAll()
         pendingAdvertiseRestart?.cancel()
@@ -1528,8 +1522,6 @@ public class BleManager: NSObject, TransportManager {
     private func pruneMeshObservations(now: Date = Date()) {
         lastSeenMeshAdvertisements = lastSeenMeshAdvertisements.filter { now.timeIntervalSince($0.value.timestamp) <= MESH_OBSERVATION_TTL }
         
-        // Also clean up stale unknown device rate limiting entries
-        unknownDeviceAttempts = unknownDeviceAttempts.filter { now.timeIntervalSince($0.value) <= UNKNOWN_DEVICE_RATE_LIMIT * 3 }
     }
     
     // MARK: - Adaptive Scan Methods
@@ -1666,11 +1658,10 @@ public class BleManager: NSObject, TransportManager {
     /// - Devices advertising our service UUID (iOS devices)
     /// - Devices with our service data
     /// - Previously discovered mesh devices
-    /// - Unknown connectable devices (rate-limited, verified via GATT)
+    /// - Previously verified peer/device mappings
     private func shouldProcessDiscoveredPeripheral(
         peripheral: CBPeripheral,
         advertisementData: [String: Any],
-        rssi: Int16,
         now: Date
     ) -> Bool {
         // 0. Skip devices previously verified as non-mesh via GATT
@@ -1726,60 +1717,6 @@ public class BleManager: NSObject, TransportManager {
         if connections.peripheralDeviceId(for: peripheral.identifier) != nil ||
            connections.centralDeviceId(for: peripheral.identifier) != nil {
             return true
-        }
-        
-        // 6. For unknown connectable devices, allow with rate limiting
-        //    These will be verified via GATT service discovery after connection
-        //    each platform may not recognize the other's service UUID format in advertisements
-        let isConnectable: Bool
-        if #available(iOS 13.0, *) {
-            isConnectable = (advertisementData[CBAdvertisementDataIsConnectable] as? NSNumber)?.boolValue ?? false
-        } else {
-            isConnectable = true
-        }
-        
-        if isConnectable {
-            // Rate limit unknown device connection attempts
-            if let lastAttempt = unknownDeviceAttempts[peripheral.identifier],
-               now.timeIntervalSince(lastAttempt) < UNKNOWN_DEVICE_RATE_LIMIT {
-                return false
-            }
-            
-            // Check global rate limit for unknown device attempts
-            let oneMinuteAgo = now.addingTimeInterval(-60.0)
-            let recentUnknownAttempts = unknownDeviceAttempts.values.filter { $0 > oneMinuteAgo }.count
-            if recentUnknownAttempts >= MAX_UNKNOWN_DEVICE_ATTEMPTS_PER_MINUTE {
-                return false
-            }
-            
-            // Use a tiered approach: stronger signals get priority
-            // Matches Android tiering for cross-platform discovery parity
-            let shouldAttempt: Bool
-            if rssi >= -70 {
-                // Strong signal - always try
-                shouldAttempt = true
-            } else if rssi >= -85 {
-                // Medium signal - be lenient for cross-platform discovery
-                shouldAttempt = true
-            } else if rssi >= UNKNOWN_DEVICE_MIN_RSSI && recentUnknownAttempts < MAX_UNKNOWN_DEVICE_ATTEMPTS_PER_MINUTE / 2 {
-                // Weaker signal and we have budget
-                shouldAttempt = true
-            } else {
-                shouldAttempt = false
-            }
-            
-            if shouldAttempt {
-                unknownDeviceAttempts[peripheral.identifier] = now
-                if logThrottler.shouldLog(key: "unknown_connectable_\(peripheral.identifier.uuidString)", interval: 30) {
-                    print("[BleManager] Allowing unknown connectable device for GATT verification: \(peripheral.identifier) RSSI=\(rssi)")
-                    emitDiagnostic("debug", "Allowing unknown device for GATT verification", context: [
-                        "identifier": peripheral.identifier.uuidString,
-                        "rssi": rssi,
-                        "recentAttempts": recentUnknownAttempts
-                    ])
-                }
-                return true
-            }
         }
         
         // Filter out all other devices (not our mesh network)
@@ -2049,7 +1986,6 @@ extension BleManager: CBCentralManagerDelegate {
         let shouldProcess = shouldProcessDiscoveredPeripheral(
             peripheral: peripheral,
             advertisementData: advertisementData,
-            rssi: rssiValue,
             now: now
         )
         

--- a/bindings/react-native/ios/ble/BleDiscoveryBootstrapPolicy.swift
+++ b/bindings/react-native/ios/ble/BleDiscoveryBootstrapPolicy.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+internal enum BleDiscoveryBootstrapPolicy {
+    static func shouldAllowCandidate(
+        isConnectable: Bool,
+        currentConnectionCount: Int,
+        maxConnectionsPerDevice: Int,
+        estimatedVisiblePeerCount: Int,
+        densePeerThreshold: Int,
+        rssi: Int16,
+        hasAnyServiceKey: Bool,
+        minRssiWithServiceKeys: Int16,
+        minRssiWithoutServiceKeys: Int16,
+        lastAttemptAt: Date?,
+        now: Date,
+        perDeviceCooldown: TimeInterval,
+        recentBootstrapAttempts: Int,
+        maxBootstrapAttemptsPerMinute: Int,
+        recentConnectionAttempts: Int,
+        maxConnectionAttemptsPerMinute: Int
+    ) -> Bool {
+        if !isConnectable { return false }
+        if currentConnectionCount >= maxConnectionsPerDevice { return false }
+        if estimatedVisiblePeerCount > densePeerThreshold { return false }
+
+        let minRssi = hasAnyServiceKey ? minRssiWithServiceKeys : minRssiWithoutServiceKeys
+        if rssi < minRssi { return false }
+
+        if let lastAttemptAt, now.timeIntervalSince(lastAttemptAt) < perDeviceCooldown { return false }
+        if recentBootstrapAttempts >= maxBootstrapAttemptsPerMinute { return false }
+        if recentConnectionAttempts >= maxConnectionAttemptsPerMinute { return false }
+
+        return true
+    }
+}

--- a/bindings/react-native/ios/tests/BleDiscoveryBootstrapPolicyTests.swift
+++ b/bindings/react-native/ios/tests/BleDiscoveryBootstrapPolicyTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import OfflineProtocol
+
+final class BleDiscoveryBootstrapPolicyTests: XCTestCase {
+
+    func testAllowsColdStartBootstrapWithStrongSignalAndMissingKeys() {
+        let allowed = BleDiscoveryBootstrapPolicy.shouldAllowCandidate(
+            isConnectable: true,
+            currentConnectionCount: 0,
+            maxConnectionsPerDevice: 4,
+            estimatedVisiblePeerCount: 3,
+            densePeerThreshold: 50,
+            rssi: -64,
+            hasAnyServiceKey: false,
+            minRssiWithServiceKeys: -75,
+            minRssiWithoutServiceKeys: -68,
+            lastAttemptAt: nil,
+            now: Date(),
+            perDeviceCooldown: 12.0,
+            recentBootstrapAttempts: 0,
+            maxBootstrapAttemptsPerMinute: 4,
+            recentConnectionAttempts: 0,
+            maxConnectionAttemptsPerMinute: 6
+        )
+
+        XCTAssertTrue(allowed)
+    }
+
+    func testRejectsWeakSignalForUnknownCandidateWhenKeysMissing() {
+        let allowed = BleDiscoveryBootstrapPolicy.shouldAllowCandidate(
+            isConnectable: true,
+            currentConnectionCount: 0,
+            maxConnectionsPerDevice: 4,
+            estimatedVisiblePeerCount: 4,
+            densePeerThreshold: 50,
+            rssi: -80,
+            hasAnyServiceKey: false,
+            minRssiWithServiceKeys: -75,
+            minRssiWithoutServiceKeys: -68,
+            lastAttemptAt: nil,
+            now: Date(),
+            perDeviceCooldown: 12.0,
+            recentBootstrapAttempts: 0,
+            maxBootstrapAttemptsPerMinute: 4,
+            recentConnectionAttempts: 0,
+            maxConnectionAttemptsPerMinute: 6
+        )
+
+        XCTAssertFalse(allowed)
+    }
+
+    func testRejectsWhenPerDeviceCooldownIsActive() {
+        let now = Date()
+        let allowed = BleDiscoveryBootstrapPolicy.shouldAllowCandidate(
+            isConnectable: true,
+            currentConnectionCount: 0,
+            maxConnectionsPerDevice: 4,
+            estimatedVisiblePeerCount: 2,
+            densePeerThreshold: 50,
+            rssi: -60,
+            hasAnyServiceKey: true,
+            minRssiWithServiceKeys: -75,
+            minRssiWithoutServiceKeys: -68,
+            lastAttemptAt: now.addingTimeInterval(-5.0),
+            now: now,
+            perDeviceCooldown: 12.0,
+            recentBootstrapAttempts: 1,
+            maxBootstrapAttemptsPerMinute: 4,
+            recentConnectionAttempts: 1,
+            maxConnectionAttemptsPerMinute: 6
+        )
+
+        XCTAssertFalse(allowed)
+    }
+}


### PR DESCRIPTION
Stop probing unknown connectable devices to prevent random Bluetooth pairing prompts from nearby non-app peripherals. iOS and Android managers now connect only to devices advertising our service UUID/data or previously verified peers.