### PR TITLE
feat(offline-protocol): add typed SessionStateError for session readiness decisions

### DIFF
--- a/crates/offline-protocol/src/error.rs
+++ b/crates/offline-protocol/src/error.rs
@@ -5,6 +5,86 @@ use thiserror::Error;
 /// Result type alias.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Stable, machine-readable error classes used for session readiness decisions.
+///
+/// This enum is the single SDK boundary that maps heterogeneous upstream error
+/// types into deterministic categories for protocol control flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionStateError {
+    /// Session exists but cannot process application traffic yet.
+    SessionNotReady,
+    /// Session/group state does not exist locally.
+    GroupNotFound,
+    /// MLS stack is not initialized.
+    NotInitialized,
+    /// Underlying transport failure.
+    TransportFailure,
+    /// Cryptographic operation failure.
+    CryptoFailure,
+    /// Error that does not match a known class.
+    Unknown,
+}
+
+impl SessionStateError {
+    /// Returns a stable, non-localized machine-readable error code.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::SessionNotReady => "SESSION_NOT_READY",
+            Self::GroupNotFound => "GROUP_NOT_FOUND",
+            Self::NotInitialized => "NOT_INITIALIZED",
+            Self::TransportFailure => "TRANSPORT_FAILURE",
+            Self::CryptoFailure => "CRYPTO_FAILURE",
+            Self::Unknown => "UNKNOWN",
+        }
+    }
+
+    /// Classifies protocol-level errors for session state control flow.
+    pub fn classify(error: &Error) -> Self {
+        match error {
+            Error::SessionPending => Self::SessionNotReady,
+            Error::MlsNotInitialized => Self::NotInitialized,
+            Error::Transport(_) => Self::TransportFailure,
+            Error::EncryptFailed(_) => Self::CryptoFailure,
+            Error::Mls(inner) => Self::from(inner),
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Maps session state class into welcome lifecycle reason taxonomy.
+    pub fn to_welcome_reason_code(&self) -> crate::events::WelcomeReasonCode {
+        match self {
+            Self::TransportFailure => crate::events::WelcomeReasonCode::TransportUnavailable,
+            Self::SessionNotReady
+            | Self::GroupNotFound
+            | Self::NotInitialized
+            | Self::CryptoFailure
+            | Self::Unknown => crate::events::WelcomeReasonCode::InternalError,
+        }
+    }
+}
+
+impl From<&offline_protocol_mls::MlsError> for SessionStateError {
+    fn from(error: &offline_protocol_mls::MlsError) -> Self {
+        match error {
+            offline_protocol_mls::MlsError::GroupNotFound(_)
+            | offline_protocol_mls::MlsError::SessionNotFound(_) => Self::GroupNotFound,
+            offline_protocol_mls::MlsError::NotInitialized => Self::NotInitialized,
+            offline_protocol_mls::MlsError::Storage(_)
+            | offline_protocol_mls::MlsError::OpenMls(_)
+            | offline_protocol_mls::MlsError::Deserialization(_)
+            | offline_protocol_mls::MlsError::Serialization(_)
+            | offline_protocol_mls::MlsError::InvalidMessage(_)
+            | offline_protocol_mls::MlsError::Encryption(_)
+            | offline_protocol_mls::MlsError::Decryption(_)
+            | offline_protocol_mls::MlsError::CryptoGeneration(_)
+            | offline_protocol_mls::MlsError::Signing(_)
+            | offline_protocol_mls::MlsError::VerificationFailed(_)
+            | offline_protocol_mls::MlsError::InvalidPublicKey(_) => Self::CryptoFailure,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 /// Protocol errors.
 #[derive(Debug, Error)]
 pub enum Error {
@@ -63,4 +143,66 @@ pub enum Error {
     /// Generic error.
     #[error("{0}")]
     Other(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, SessionStateError};
+    use offline_protocol_mls::MlsError;
+    use offline_protocol_transport::Error as TransportError;
+
+    #[test]
+    fn session_state_code_values_are_stable() {
+        assert_eq!(SessionStateError::SessionNotReady.code(), "SESSION_NOT_READY");
+        assert_eq!(SessionStateError::GroupNotFound.code(), "GROUP_NOT_FOUND");
+        assert_eq!(SessionStateError::NotInitialized.code(), "NOT_INITIALIZED");
+        assert_eq!(SessionStateError::TransportFailure.code(), "TRANSPORT_FAILURE");
+        assert_eq!(SessionStateError::CryptoFailure.code(), "CRYPTO_FAILURE");
+        assert_eq!(SessionStateError::Unknown.code(), "UNKNOWN");
+    }
+
+    #[test]
+    fn classify_maps_mls_group_not_found() {
+        let classified = SessionStateError::from(&MlsError::GroupNotFound("g1".to_string()));
+        assert_eq!(classified, SessionStateError::GroupNotFound);
+    }
+
+    #[test]
+    fn classify_maps_not_initialized() {
+        let classified = SessionStateError::from(&MlsError::NotInitialized);
+        assert_eq!(classified, SessionStateError::NotInitialized);
+    }
+
+    #[test]
+    fn classify_maps_crypto_failures() {
+        let classified = SessionStateError::from(&MlsError::Decryption("failed".to_string()));
+        assert_eq!(classified, SessionStateError::CryptoFailure);
+    }
+
+    #[test]
+    fn classify_unknown_fallback_is_safe() {
+        let classified = SessionStateError::classify(&Error::Other("opaque".to_string()));
+        assert_eq!(classified, SessionStateError::Unknown);
+    }
+
+    #[test]
+    fn welcome_reason_mapping_uses_typed_transport_failure() {
+        let classified =
+            SessionStateError::classify(&Error::Transport(TransportError::SendFailed(
+                "send failed".to_string(),
+            )));
+        assert_eq!(
+            classified.to_welcome_reason_code(),
+            crate::events::WelcomeReasonCode::TransportUnavailable
+        );
+    }
+
+    #[test]
+    fn welcome_reason_mapping_unknown_defaults_internal_error() {
+        let classified = SessionStateError::classify(&Error::Other("opaque".to_string()));
+        assert_eq!(
+            classified.to_welcome_reason_code(),
+            crate::events::WelcomeReasonCode::InternalError
+        );
+    }
 }

--- a/crates/offline-protocol/src/lib.rs
+++ b/crates/offline-protocol/src/lib.rs
@@ -19,7 +19,7 @@ pub mod transport_manager;
 pub mod visualization;
 
 pub use config::{EncryptionConfig, ProtocolConfig};
-pub use error::{Error, Result};
+pub use error::{Error, Result, SessionStateError};
 pub use events::{Event, EventCallback, GroupInfoMember, UserGroupSummary};
 pub use protocol::OfflineProtocol;
 pub use transport_manager::TransportManager;

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -1,7 +1,7 @@
 //! Main protocol engine.
 
 use crate::constants::{ACK_FOR_KEY, ACK_HOP_COUNT_KEY, ACK_TRANSPORT_KEY, MAX_OUTBOX_ENTRIES};
-use crate::{Error, Event, EventCallback, ProtocolConfig, Result, TransportManager};
+use crate::{Error, Event, EventCallback, ProtocolConfig, Result, SessionStateError, TransportManager};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use offline_protocol_core::{
     AppId, LamportClock, Message, MessageId, MessagePriority, UserId, TTL,
@@ -1235,20 +1235,7 @@ impl OfflineProtocol {
     }
 
     fn map_welcome_reason_code(error: &Error) -> crate::events::WelcomeReasonCode {
-        let message = error.to_string().to_ascii_lowercase();
-        if message.contains("timeout") {
-            return crate::events::WelcomeReasonCode::Timeout;
-        }
-        if message.contains("disconnected") || message.contains("unavailable") {
-            return crate::events::WelcomeReasonCode::PeerDisconnected;
-        }
-        if message.contains("no available transport")
-            || message.contains("transport")
-            || message.contains("all transports failed")
-        {
-            return crate::events::WelcomeReasonCode::TransportUnavailable;
-        }
-        crate::events::WelcomeReasonCode::InternalError
+        SessionStateError::classify(error).to_welcome_reason_code()
     }
 
     fn can_confirm_from_source(&self, peer_id: &str, source_event: &str) -> bool {
@@ -1587,10 +1574,7 @@ impl OfflineProtocol {
         let Some(peer_id) = self.find_welcome_peer_by_message_id(message_id) else {
             return Ok(());
         };
-        let reason = transport_error
-            .as_ref()
-            .map(|err| Self::map_welcome_reason_code(&Error::Other(err.clone())))
-            .unwrap_or(crate::events::WelcomeReasonCode::TransportUnavailable);
+        let reason = crate::events::WelcomeReasonCode::TransportUnavailable;
         let _ =
             self.apply_welcome_send_failure(&peer_id, reason, transport_error, "transport_failed")?;
         Ok(())
@@ -3348,17 +3332,47 @@ impl OfflineProtocol {
                                 DecryptResult::Empty
                             }
                             Err(e) => {
-                                let error_str = e.to_string();
-                                if error_str.contains("not found")
-                                    || error_str.contains("GroupNotFound")
-                                {
-                                    info!(sender = %sender, "Encrypted message received before session ready, queuing");
-                                    DecryptResult::SessionNotReady {
-                                        sender: sender.to_string(),
+                                let session_state_error = SessionStateError::from(&e);
+                                match session_state_error {
+                                    SessionStateError::SessionNotReady
+                                    | SessionStateError::GroupNotFound => {
+                                        info!(
+                                            sender = %sender,
+                                            error_code = session_state_error.code(),
+                                            "Encrypted message received before session ready, queuing"
+                                        );
+                                        debug!(
+                                            sender = %sender,
+                                            error = %e,
+                                            error_code = session_state_error.code(),
+                                            "Queued encrypted message due to session state classification"
+                                        );
+                                        DecryptResult::SessionNotReady {
+                                            sender: sender.to_string(),
+                                        }
                                     }
-                                } else {
-                                    warn!(error = %e, sender = %sender, "Failed to decrypt message");
-                                    DecryptResult::Failed { _error: error_str }
+                                    SessionStateError::NotInitialized => {
+                                        warn!(
+                                            sender = %sender,
+                                            error = %e,
+                                            error_code = session_state_error.code(),
+                                            "MLS decrypt attempted before initialization"
+                                        );
+                                        DecryptResult::MlsNotInitialized
+                                    }
+                                    SessionStateError::TransportFailure
+                                    | SessionStateError::CryptoFailure
+                                    | SessionStateError::Unknown => {
+                                        warn!(
+                                            sender = %sender,
+                                            error = %e,
+                                            error_code = session_state_error.code(),
+                                            "Failed to decrypt message"
+                                        );
+                                        DecryptResult::Failed {
+                                            _error: e.to_string(),
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -6885,6 +6899,35 @@ mod tests {
 
         // Without MLS initialized, should return placeholder text
         assert!(matches!(result, Some(InternalMessageResult::Decrypted(_))));
+    }
+
+    #[test]
+    fn test_encrypted_message_group_not_found_is_queued_with_typed_classification() {
+        let mut config = create_test_config();
+        config.encryption.enabled = true;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+        protocol
+            .initialize_mls(Arc::new(crate::mls::InMemoryStorage::new()))
+            .unwrap();
+
+        let encrypted_content = format!(
+            "{}{{\"group_id\":\"session:sender123:user123\",\"message_type\":\"Application\",\"epoch\":0,\"ciphertext\":[1,2,3],\"sender_id\":\"sender123\",\"timestamp_ms\":12345}}",
+            internal_prefixes::ENCRYPTED
+        );
+
+        let message = Message::new(
+            UserId::new("sender123").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &encrypted_content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+        assert!(protocol.pending_decryption.contains_key("sender123"));
+        assert_eq!(protocol.pending_decryption["sender123"].len(), 1);
     }
 
     // ========================================================================

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -8,7 +8,9 @@ use crate::constants::{HOP_COUNT_EMA_ALPHA, LATENCY_EMA_ALPHA, OBSERVED_STATS_CO
 use crate::{Error, Result};
 use offline_protocol_core::Message;
 use offline_protocol_router::{DorsConfig, TransportSelector};
-use offline_protocol_transport::{Transport, TransportMetrics, TransportStatus, TransportType};
+use offline_protocol_transport::{
+    Error as TransportError, Transport, TransportMetrics, TransportStatus, TransportType,
+};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -166,9 +168,9 @@ impl TransportManager {
     pub fn send(&mut self, message: &Message) -> Result<()> {
         let available = self.get_available_transports();
         if available.is_empty() {
-            return Err(Error::Other(
-                "No available transport. Ensure at least one transport (BLE, WiFi Direct, or Internet) is enabled and available.".to_string(),
-            ));
+            return Err(Error::Transport(TransportError::TransportNotAvailable(
+                "No available transport".to_string(),
+            )));
         }
 
         // DORS selects the primary transport (applies hysteresis/cooldown/stability).
@@ -176,9 +178,9 @@ impl TransportManager {
             .selector
             .select_transport(message, &available)
             .ok_or_else(|| {
-                Error::Other(
-                    "No suitable transport selected from available transports.".to_string(),
-                )
+                Error::Transport(TransportError::TransportNotAvailable(
+                    "No suitable transport selected from available transports".to_string(),
+                ))
             })?;
 
         // Try the primary transport first.
@@ -253,11 +255,13 @@ impl TransportManager {
             }
         }
 
-        Err(Error::Other(format!(
-            "All transports failed (tried {:?}). Last error: {}",
-            attempted,
-            last_error.map(|e| e.to_string()).unwrap_or_default()
-        )))
+        let terminal_error = last_error.unwrap_or_else(|| {
+            TransportError::SendFailed(format!(
+                "All transports failed (tried {:?})",
+                attempted
+            ))
+        });
+        Err(Error::Transport(terminal_error))
     }
 
     /// Sends a message via a specific transport, bypassing DORS selection.


### PR DESCRIPTION


- Introduce SessionStateError enum with stable machine-readable codes

- Replace error string parsing in decrypt readiness and welcome reason mapping

- Route transport send failures through Error::Transport for typed classification

- Add to_welcome_reason_code() mapping for welcome lifecycle events