### PR TITLE
fix(mls): unify MLS state ownership and make init transactional

### DIFF
--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -806,8 +806,6 @@ pub struct OfflineProtocol {
     relay_priority: RwLock<RelayPriority>,
     forced_transport: RwLock<Option<TransportType>>,
     dors_config: RwLock<Option<DorsConfig>>,
-    /// MLS manager for end-to-end encryption
-    mls_manager: RwLock<Option<CoreMlsManager>>,
     #[allow(dead_code)]
     user_id: String,
 }
@@ -896,7 +894,6 @@ impl OfflineProtocol {
             relay_priority: RwLock::new(RelayPriority::Medium),
             forced_transport: RwLock::new(None),
             dors_config: RwLock::new(None),
-            mls_manager: RwLock::new(None),
             user_id,
         })
     }
@@ -2177,7 +2174,7 @@ impl OfflineProtocol {
         let mut path_selector = self.path_selector.lock().unwrap();
         path_selector
             .routing_table_mut()
-            .learn_route(&destination, &next_hop, hop_count, quality);
+            .learn_route(&destination, &next_hop, hop_count, quality, 0);
     }
 
     /// Gets the best (highest quality) route to a destination.
@@ -2347,50 +2344,52 @@ impl OfflineProtocol {
             provider: Arc::from(storage),
         });
 
-        // Initialize MLS in the core protocol for auto-encryption
-        {
-            let mut protocol = self.inner.lock().unwrap();
-            protocol
-                .initialize_mls(wrapper.clone())
-                .map_err(|e| ProtocolError::MlsError(e.to_string()))?;
+        // Single-authority lifecycle:
+        // - CoreProtocol owns the only MlsManager instance for this runtime.
+        // - UniFFI manual MLS APIs must route through that owner.
+        // - Repeated calls are idempotent and never replace the existing manager.
+        let mut protocol = self
+            .inner
+            .lock()
+            .map_err(|_| ProtocolError::Other("Protocol lock poisoned".to_string()))?;
+        if protocol.is_mls_initialized() {
+            return Ok(());
         }
-
-        // Also store a reference for direct MLS API access
-        let user_id = {
-            let protocol = self.inner.lock().unwrap();
-            protocol.config().user_id.clone()
-        };
-
-        let manager = CoreMlsManager::new(&user_id, wrapper)
+        protocol
+            .initialize_mls(wrapper)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))?;
-
-        *self.mls_manager.write().unwrap() = Some(manager);
         Ok(())
     }
 
     /// Check if MLS is initialized
     pub fn is_mls_initialized(&self) -> bool {
-        // Check both the wrapper's MLS manager and the core protocol's
         let protocol = self.inner.lock().unwrap();
-        protocol.is_mls_initialized() || self.mls_manager.read().unwrap().is_some()
+        protocol.is_mls_initialized()
     }
 
-    /// Helper to get MLS manager or error
-    fn get_mls_manager(
-        &self,
-    ) -> Result<std::sync::RwLockReadGuard<'_, Option<CoreMlsManager>>, ProtocolError> {
-        let guard = self.mls_manager.read().unwrap();
-        if guard.is_none() {
-            return Err(ProtocolError::MlsNotInitialized);
-        }
-        Ok(guard)
+    /// Returns the core-owned MLS manager handle.
+    ///
+    /// This is the only MLS state owner for the runtime. UniFFI must never
+    /// create or cache an independent manager because that would diverge
+    /// key-package/session/group state from auto-encryption flows.
+    fn get_mls_manager(&self) -> Result<Arc<RwLock<CoreMlsManager>>, ProtocolError> {
+        let protocol = self
+            .inner
+            .lock()
+            .map_err(|_| ProtocolError::Other("Protocol lock poisoned".to_string()))?;
+        protocol
+            .mls_manager()
+            .cloned()
+            .ok_or(ProtocolError::MlsNotInitialized)
     }
 
     /// Generate a key package for distribution
     pub fn mls_generate_key_package(&self) -> Result<MlsKeyPackageBundle, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .generate_key_package()
             .map(MlsKeyPackageBundle::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2398,9 +2397,11 @@ impl OfflineProtocol {
 
     /// Get an existing key package or generate a new one
     pub fn mls_get_or_create_key_package(&self) -> Result<MlsKeyPackageBundle, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .get_or_create_key_package()
             .map(MlsKeyPackageBundle::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2412,53 +2413,55 @@ impl OfflineProtocol {
         user_id: String,
         key_package_data: Vec<u8>,
     ) -> Result<(), ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .import_key_package(&user_id, &key_package_data)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
 
     /// Get pending key packages
     pub fn mls_get_pending_key_packages(&self) -> Vec<MlsKeyPackageBundle> {
-        let guard = match self.mls_manager.read() {
-            Ok(g) => g,
-            Err(_) => {
-                return Vec::new();
-            }
+        let manager = match self.get_mls_manager() {
+            Ok(m) => m,
+            Err(_) => return Vec::new(),
         };
-        match guard.as_ref() {
-            Some(manager) => manager
-                .get_pending_key_packages()
-                .unwrap_or_default()
-                .into_iter()
-                .map(MlsKeyPackageBundle::from)
-                .collect(),
-            None => Vec::new(),
-        }
+        let guard = match manager.read() {
+            Ok(g) => g,
+            Err(_) => return Vec::new(),
+        };
+        guard
+            .get_pending_key_packages()
+            .unwrap_or_default()
+            .into_iter()
+            .map(MlsKeyPackageBundle::from)
+            .collect()
     }
 
     /// Mark a key package as synced
     pub fn mls_mark_key_package_synced(&self, package_id: String) -> Result<(), ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .mark_key_package_synced(&package_id)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
 
     /// Check if a 1:1 session exists
     pub fn mls_has_session(&self, other_user_id: String) -> bool {
-        let guard = match self.mls_manager.read() {
-            Ok(g) => g,
-            Err(_) => {
-                return false;
-            }
+        let manager = match self.get_mls_manager() {
+            Ok(m) => m,
+            Err(_) => return false,
         };
-        match guard.as_ref() {
-            Some(manager) => manager.has_session(&other_user_id).unwrap_or(false),
-            None => false,
-        }
+        let guard = match manager.read() {
+            Ok(g) => g,
+            Err(_) => return false,
+        };
+        guard.has_session(&other_user_id).unwrap_or(false)
     }
 
     /// Check if a pending key package is available for a peer
@@ -2498,9 +2501,11 @@ impl OfflineProtocol {
         &self,
         other_user_id: String,
     ) -> Result<MlsWelcomeMessage, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .create_session(&other_user_id)
             .map(MlsWelcomeMessage::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2511,9 +2516,11 @@ impl OfflineProtocol {
         &self,
         welcome: MlsWelcomeMessage,
     ) -> Result<MlsGroupInfo, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .join_session(&welcome.into())
             .map(MlsGroupInfo::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2525,9 +2532,11 @@ impl OfflineProtocol {
         other_user_id: String,
         plaintext: Vec<u8>,
     ) -> Result<MlsEncryptedMessage, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .encrypt_for_user(&other_user_id, &plaintext)
             .map(MlsEncryptedMessage::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2538,41 +2547,44 @@ impl OfflineProtocol {
         &self,
         encrypted: MlsEncryptedMessage,
     ) -> Result<Option<Vec<u8>>, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .decrypt_from_user(&encrypted.into())
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
 
     /// List all active 1:1 sessions
     pub fn mls_list_sessions(&self) -> Vec<String> {
-        let guard = match self.mls_manager.read() {
-            Ok(g) => g,
-            Err(_) => {
-                return Vec::new();
-            }
+        let manager = match self.get_mls_manager() {
+            Ok(m) => m,
+            Err(_) => return Vec::new(),
         };
-        match guard.as_ref() {
-            Some(manager) => manager.list_sessions().unwrap_or_default(),
-            None => Vec::new(),
-        }
+        let guard = match manager.read() {
+            Ok(g) => g,
+            Err(_) => return Vec::new(),
+        };
+        guard.list_sessions().unwrap_or_default()
     }
 
     /// Delete a 1:1 session
     pub fn mls_delete_session(&self, other_user_id: String) -> Result<(), ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .delete_session(&other_user_id)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
 
     /// Get a pending Welcome message
     pub fn mls_get_pending_welcome(&self, other_user_id: String) -> Option<MlsWelcomeMessage> {
-        let guard = self.mls_manager.read().ok()?;
-        let manager = guard.as_ref()?;
-        manager
+        let manager = self.get_mls_manager().ok()?;
+        let guard = manager.read().ok()?;
+        guard
             .get_pending_welcome(&other_user_id)
             .ok()
             .flatten()
@@ -2581,18 +2593,22 @@ impl OfflineProtocol {
 
     /// Clear a pending Welcome message
     pub fn mls_clear_pending_welcome(&self, other_user_id: String) -> Result<(), ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .clear_pending_welcome(&other_user_id)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
 
     /// Create a new group
     pub fn mls_create_group(&self, group_name: String) -> Result<MlsGroupInfo, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .create_group(&group_name)
             .map(MlsGroupInfo::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2604,9 +2620,11 @@ impl OfflineProtocol {
         group_id: String,
         member_key_package: Vec<u8>,
     ) -> Result<MlsWelcomeMessage, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .add_group_member(&CoreGroupId::new(group_id), &member_key_package)
             .map(MlsWelcomeMessage::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2618,9 +2636,11 @@ impl OfflineProtocol {
         group_id: String,
         member_id: String,
     ) -> Result<MlsEncryptedMessage, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .remove_group_member(&CoreGroupId::new(group_id), &member_id)
             .map(MlsEncryptedMessage::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2628,9 +2648,11 @@ impl OfflineProtocol {
 
     /// Leave a group
     pub fn mls_leave_group(&self, group_id: String) -> Result<(), ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .leave_group(&CoreGroupId::new(group_id))
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
@@ -2641,9 +2663,11 @@ impl OfflineProtocol {
         group_id: String,
         plaintext: Vec<u8>,
     ) -> Result<MlsEncryptedMessage, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .encrypt_for_group(&CoreGroupId::new(group_id), &plaintext)
             .map(MlsEncryptedMessage::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2654,9 +2678,11 @@ impl OfflineProtocol {
         &self,
         encrypted: MlsEncryptedMessage,
     ) -> Result<Option<Vec<u8>>, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .decrypt_from_group(&encrypted.into())
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
@@ -2666,9 +2692,11 @@ impl OfflineProtocol {
         &self,
         welcome: MlsWelcomeMessage,
     ) -> Result<MlsGroupInfo, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .join_group(&welcome.into())
             .map(MlsGroupInfo::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2676,28 +2704,27 @@ impl OfflineProtocol {
 
     /// List all groups
     pub fn mls_list_groups(&self) -> Vec<String> {
-        let guard = match self.mls_manager.read() {
-            Ok(g) => g,
-            Err(_) => {
-                return Vec::new();
-            }
+        let manager = match self.get_mls_manager() {
+            Ok(m) => m,
+            Err(_) => return Vec::new(),
         };
-        match guard.as_ref() {
-            Some(manager) => manager
-                .list_groups()
-                .unwrap_or_default()
-                .into_iter()
-                .map(|g| g.as_str().to_string())
-                .collect(),
-            None => Vec::new(),
-        }
+        let guard = match manager.read() {
+            Ok(g) => g,
+            Err(_) => return Vec::new(),
+        };
+        guard
+            .list_groups()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|g| g.as_str().to_string())
+            .collect()
     }
 
     /// Get information about a group
     pub fn mls_get_group_info(&self, group_id: String) -> Option<MlsGroupInfo> {
-        let guard = self.mls_manager.read().ok()?;
-        let manager = guard.as_ref()?;
-        manager
+        let manager = self.get_mls_manager().ok()?;
+        let guard = manager.read().ok()?;
+        guard
             .get_group_info(&CoreGroupId::new(group_id))
             .ok()
             .flatten()
@@ -2709,9 +2736,11 @@ impl OfflineProtocol {
         &self,
         encrypted: MlsEncryptedMessage,
     ) -> Result<Option<Vec<u8>>, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .decrypt(&encrypted.into())
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
@@ -2721,9 +2750,11 @@ impl OfflineProtocol {
         &self,
         welcome: MlsWelcomeMessage,
     ) -> Result<MlsGroupInfo, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .process_welcome(&welcome.into())
             .map(MlsGroupInfo::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
@@ -2738,9 +2769,11 @@ impl OfflineProtocol {
     /// This is the public key used for MLS operations and can be shared with others
     /// to establish identity and verify signatures.
     pub fn get_identity_public_key(&self) -> Result<Vec<u8>, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .get_identity_public_key()
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
@@ -2757,9 +2790,11 @@ impl OfflineProtocol {
     ///
     /// Returns the signature as raw bytes (64 bytes).
     pub fn sign_data(&self, data: Vec<u8>) -> Result<Vec<u8>, ProtocolError> {
-        let guard = self.get_mls_manager()?;
-        let manager = guard.as_ref().unwrap();
-        manager
+        let manager = self.get_mls_manager()?;
+        let guard = manager
+            .read()
+            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        guard
             .sign_data(&data)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
@@ -3011,6 +3046,52 @@ impl OfflineProtocol {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[derive(Default)]
+    struct TestMlsStorageProvider {
+        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+    }
+
+    impl MlsStorageProvider for TestMlsStorageProvider {
+        fn store(
+            &self,
+            key_type: String,
+            key_id: String,
+            data: Vec<u8>,
+        ) -> Result<(), MlsStorageError> {
+            let mut guard = self.data.lock().map_err(|_| MlsStorageError::StoreFailed)?;
+            guard.insert((key_type, key_id), data);
+            Ok(())
+        }
+
+        fn load(&self, key_type: String, key_id: String) -> Result<Option<Vec<u8>>, MlsStorageError> {
+            let guard = self.data.lock().map_err(|_| MlsStorageError::LoadFailed)?;
+            Ok(guard.get(&(key_type, key_id)).cloned())
+        }
+
+        fn delete(&self, key_type: String, key_id: String) -> Result<(), MlsStorageError> {
+            let mut guard = self.data.lock().map_err(|_| MlsStorageError::DeleteFailed)?;
+            guard.remove(&(key_type, key_id));
+            Ok(())
+        }
+
+        fn list_keys(&self, key_type: String) -> Result<Vec<String>, MlsStorageError> {
+            let guard = self.data.lock().map_err(|_| MlsStorageError::LoadFailed)?;
+            Ok(guard
+                .keys()
+                .filter_map(|(stored_type, key_id)| {
+                    if stored_type == &key_type {
+                        Some(key_id.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect())
+        }
+    }
 
     fn create_test_config() -> ProtocolConfig {
         ProtocolConfig {
@@ -3049,6 +3130,108 @@ mod tests {
             max_pending_global: 4096,
             pending_ttl_ms: 120_000,
             overflow_policy: OverflowPolicy::DropOldest,
+        }
+    }
+
+    #[test]
+    fn test_mls_initialize_is_idempotent_for_legacy_entrypoint() {
+        let config = create_test_config();
+        let protocol = OfflineProtocol::new(config).unwrap();
+
+        protocol
+            .initialize_mls(Box::new(TestMlsStorageProvider::default()))
+            .unwrap();
+        let first_handle = {
+            let guard = protocol.inner.lock().unwrap();
+            guard.mls_manager().cloned().unwrap()
+        };
+
+        protocol
+            .initialize_mls(Box::new(TestMlsStorageProvider::default()))
+            .unwrap();
+        let second_handle = {
+            let guard = protocol.inner.lock().unwrap();
+            guard.mls_manager().cloned().unwrap()
+        };
+
+        assert!(protocol.is_mls_initialized());
+        assert!(Arc::ptr_eq(&first_handle, &second_handle));
+        assert!(protocol.mls_generate_key_package().is_ok());
+    }
+
+    #[test]
+    fn test_mls_initialize_is_race_safe_single_instance() {
+        let protocol = Arc::new(OfflineProtocol::new(create_test_config()).unwrap());
+        let mut join_handles = Vec::new();
+
+        for _ in 0..8 {
+            let protocol_clone = Arc::clone(&protocol);
+            join_handles.push(thread::spawn(move || {
+                protocol_clone
+                    .initialize_mls(Box::new(TestMlsStorageProvider::default()))
+                    .unwrap();
+                let core_guard = protocol_clone.inner.lock().unwrap();
+                let mls_handle = core_guard.mls_manager().cloned().unwrap();
+                Arc::as_ptr(&mls_handle) as usize
+            }));
+        }
+
+        let first_ptr = join_handles.remove(0).join().unwrap();
+        for handle in join_handles {
+            let ptr = handle.join().unwrap();
+            assert_eq!(ptr, first_ptr);
+        }
+    }
+
+    #[test]
+    fn test_mls_manual_and_core_paths_share_single_state_under_concurrency() {
+        let protocol = Arc::new(OfflineProtocol::new(create_test_config()).unwrap());
+        protocol
+            .initialize_mls(Box::new(TestMlsStorageProvider::default()))
+            .unwrap();
+
+        let core_mls_handle = {
+            let core_guard = protocol.inner.lock().unwrap();
+            core_guard.mls_manager().cloned().unwrap()
+        };
+
+        let manual_protocol = Arc::clone(&protocol);
+        let manual_thread = thread::spawn(move || {
+            for i in 0..20 {
+                manual_protocol
+                    .mls_create_group(format!("manual-group-{}", i))
+                    .unwrap();
+            }
+        });
+
+        let core_thread = thread::spawn(move || {
+            for i in 0..20 {
+                let manager = core_mls_handle.read().unwrap();
+                manager.create_group(&format!("core-group-{}", i)).unwrap();
+            }
+        });
+
+        manual_thread.join().unwrap();
+        core_thread.join().unwrap();
+
+        let from_manual_api = protocol.mls_list_groups();
+        let from_core_api = {
+            let core_guard = protocol.inner.lock().unwrap();
+            let manager = core_guard.mls_manager().cloned().unwrap();
+            let groups = manager
+                .read()
+                .unwrap()
+                .list_groups()
+                .unwrap()
+                .into_iter()
+                .map(|group_id| group_id.as_str().to_string())
+                .collect::<Vec<_>>();
+            groups
+        };
+
+        assert_eq!(from_manual_api.len(), from_core_api.len());
+        for group_id in from_core_api {
+            assert!(from_manual_api.contains(&group_id));
         }
     }
 

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -2573,12 +2573,12 @@ impl OfflineProtocol {
 
     /// Delete a 1:1 session
     pub fn mls_delete_session(&self, other_user_id: String) -> Result<(), ProtocolError> {
-        let manager = self.get_mls_manager()?;
-        let guard = manager
-            .read()
-            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ProtocolError::Other("Protocol lock poisoned".to_string()))?;
         guard
-            .delete_session(&other_user_id)
+            .manual_mls_delete_session(&other_user_id)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
 

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -2501,12 +2501,12 @@ impl OfflineProtocol {
         &self,
         other_user_id: String,
     ) -> Result<MlsWelcomeMessage, ProtocolError> {
-        let manager = self.get_mls_manager()?;
-        let guard = manager
-            .read()
-            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ProtocolError::Other("Protocol lock poisoned".to_string()))?;
         guard
-            .create_session(&other_user_id)
+            .manual_mls_create_session(&other_user_id)
             .map(MlsWelcomeMessage::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
@@ -2516,12 +2516,13 @@ impl OfflineProtocol {
         &self,
         welcome: MlsWelcomeMessage,
     ) -> Result<MlsGroupInfo, ProtocolError> {
-        let manager = self.get_mls_manager()?;
-        let guard = manager
-            .read()
-            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        let core_welcome: CoreWelcomeMessage = welcome.into();
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ProtocolError::Other("Protocol lock poisoned".to_string()))?;
         guard
-            .join_session(&welcome.into())
+            .manual_mls_join_session(&core_welcome)
             .map(MlsGroupInfo::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
@@ -2547,12 +2548,13 @@ impl OfflineProtocol {
         &self,
         encrypted: MlsEncryptedMessage,
     ) -> Result<Option<Vec<u8>>, ProtocolError> {
-        let manager = self.get_mls_manager()?;
-        let guard = manager
-            .read()
-            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        let core_encrypted: CoreEncryptedMessage = encrypted.into();
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ProtocolError::Other("Protocol lock poisoned".to_string()))?;
         guard
-            .decrypt_from_user(&encrypted.into())
+            .manual_mls_decrypt_from_user(&core_encrypted)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
 
@@ -2736,12 +2738,13 @@ impl OfflineProtocol {
         &self,
         encrypted: MlsEncryptedMessage,
     ) -> Result<Option<Vec<u8>>, ProtocolError> {
-        let manager = self.get_mls_manager()?;
-        let guard = manager
-            .read()
-            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        let core_encrypted: CoreEncryptedMessage = encrypted.into();
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ProtocolError::Other("Protocol lock poisoned".to_string()))?;
         guard
-            .decrypt(&encrypted.into())
+            .manual_mls_decrypt(&core_encrypted)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }
 
@@ -2750,12 +2753,13 @@ impl OfflineProtocol {
         &self,
         welcome: MlsWelcomeMessage,
     ) -> Result<MlsGroupInfo, ProtocolError> {
-        let manager = self.get_mls_manager()?;
-        let guard = manager
-            .read()
-            .map_err(|_| ProtocolError::Other("MLS manager lock poisoned".to_string()))?;
+        let core_welcome: CoreWelcomeMessage = welcome.into();
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ProtocolError::Other("Protocol lock poisoned".to_string()))?;
         guard
-            .process_welcome(&welcome.into())
+            .manual_mls_process_welcome(&core_welcome)
             .map(MlsGroupInfo::from)
             .map_err(|e| ProtocolError::MlsError(e.to_string()))
     }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -556,20 +556,52 @@ impl OfflineProtocol {
     /// backend should be a platform-native secure storage implementation
     /// (iOS Keychain, Android EncryptedSharedPreferences, etc.).
     ///
+    /// Ownership model:
+    /// - `OfflineProtocol` is the single authoritative owner of `MlsManager`
+    /// - initialization is idempotent per protocol instance
+    /// - subsequent calls return without replacing the existing manager
+    /// - manager publication is transactional: restore must succeed before
+    ///   `mls_manager` becomes visible to callers
+    ///
     /// The same storage is also used for persisting pending messages,
     /// ensuring they survive app crashes/restarts.
     pub fn initialize_mls(&mut self, storage: Arc<dyn MlsStorage>) -> Result<()> {
-        let manager = MlsManager::new(&self.config.user_id, storage.clone())?;
-        self.mls_manager = Some(Arc::new(RwLock::new(manager)));
+        if self.mls_manager.is_some() {
+            return Ok(());
+        }
+
+        let manager = Arc::new(RwLock::new(MlsManager::new(&self.config.user_id, storage.clone())?));
+
+        // Keep initialization transactional so a restore failure cannot leave
+        // partially-initialized MLS state visible and then permanently block retries.
+        let previous_message_storage = self.message_storage.clone();
+        let previous_pending_messages = self.pending_encrypted_messages.clone();
+        let previous_confirmed_sessions = self.confirmed_sessions.clone();
+        let previous_welcome_lifecycles = self.welcome_lifecycles.clone();
+        let previous_lamport_clock = self.lamport_clock.value();
 
         // Also use this storage for pending message persistence
         self.message_storage = Some(storage);
 
         // Restore state from previous session
-        self.restore_pending_messages()?;
-        self.restore_lamport_clock();
-        self.restore_session_states()?;
-        self.restore_welcome_lifecycles()?;
+        let restore_result = (|| {
+            self.restore_pending_messages()?;
+            self.restore_lamport_clock();
+            self.restore_session_states_from_manager(manager.clone())?;
+            self.restore_welcome_lifecycles()?;
+            Ok(())
+        })();
+
+        if let Err(err) = restore_result {
+            self.message_storage = previous_message_storage;
+            self.pending_encrypted_messages = previous_pending_messages;
+            self.confirmed_sessions = previous_confirmed_sessions;
+            self.welcome_lifecycles = previous_welcome_lifecycles;
+            self.lamport_clock = LamportClock::from_value(previous_lamport_clock);
+            return Err(err);
+        }
+
+        self.mls_manager = Some(manager);
 
         info!(user_id = %self.config.user_id, "MLS encryption initialized with message persistence");
         Ok(())
@@ -2959,12 +2991,8 @@ impl OfflineProtocol {
     }
 
     /// Reconstructs runtime confirmation cache from persisted session states.
-    fn restore_session_states(&mut self) -> Result<()> {
+    fn restore_session_states_from_manager(&mut self, mls: Arc<RwLock<MlsManager>>) -> Result<()> {
         self.confirmed_sessions.clear();
-
-        let Some(mls) = self.mls_manager.clone() else {
-            return Ok(());
-        };
 
         let sessions = {
             let manager = mls
@@ -4872,6 +4900,47 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct FailingPendingListStorage {
+        inner: crate::mls::InMemoryStorage,
+    }
+
+    impl MlsStorage for FailingPendingListStorage {
+        fn store(
+            &self,
+            key_type: &str,
+            key_id: &str,
+            data: &[u8],
+        ) -> offline_protocol_mls::storage::StorageResult<()> {
+            self.inner.store(key_type, key_id, data)
+        }
+
+        fn load(
+            &self,
+            key_type: &str,
+            key_id: &str,
+        ) -> offline_protocol_mls::storage::StorageResult<Option<Vec<u8>>> {
+            self.inner.load(key_type, key_id)
+        }
+
+        fn delete(
+            &self,
+            key_type: &str,
+            key_id: &str,
+        ) -> offline_protocol_mls::storage::StorageResult<()> {
+            self.inner.delete(key_type, key_id)
+        }
+
+        fn list_keys(&self, key_type: &str) -> offline_protocol_mls::storage::StorageResult<Vec<String>> {
+            if key_type == storage_keys::PENDING_MESSAGES {
+                return Err(offline_protocol_mls::StorageError::LoadFailed(
+                    "forced restore failure".to_string(),
+                ));
+            }
+            self.inner.list_keys(key_type)
+        }
+    }
+
     #[test]
     fn test_protocol_creation() {
         let protocol = OfflineProtocol::new(create_test_config());
@@ -6011,6 +6080,124 @@ mod tests {
             .unwrap()
             .content
             .starts_with(internal_prefixes::ENCRYPTED));
+    }
+
+    #[test]
+    fn test_initialize_mls_restore_failure_does_not_publish_partial_state() {
+        let mut config = create_test_config_for_user("alice");
+        config.encryption.enabled = true;
+        config.encryption.store_pending = true;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+        let initial_clock = protocol.lamport_clock.value();
+
+        let result = protocol.initialize_mls(Arc::new(FailingPendingListStorage::default()));
+        assert!(result.is_err());
+        assert!(protocol.mls_manager.is_none());
+        assert!(protocol.message_storage.is_none());
+        assert!(protocol.pending_encrypted_messages.is_empty());
+        assert!(protocol.confirmed_sessions.is_empty());
+        assert!(protocol.welcome_lifecycles.is_empty());
+        assert_eq!(protocol.lamport_clock.value(), initial_clock);
+    }
+
+    #[test]
+    fn test_auto_send_and_manual_mls_share_single_state_under_concurrency() {
+        let mut config = create_test_config_for_user("alice");
+        config.encryption.enabled = true;
+        config.encryption.store_pending = true;
+        config.encryption.require_encryption = false;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+        protocol
+            .initialize_mls(Arc::new(crate::mls::InMemoryStorage::new()))
+            .unwrap();
+
+        let mut transport = MockTransport::new(TransportType::BLE);
+        transport.start().unwrap();
+        let transport_handle = transport.clone();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(transport));
+        protocol.start().unwrap();
+
+        let bob_manager = MlsManager::new("bob", Arc::new(crate::mls::InMemoryStorage::new())).unwrap();
+        let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+        {
+            let manager = protocol.mls_manager.as_ref().unwrap().read().unwrap();
+            manager
+                .import_key_package("bob", &bob_key_package.key_package_data)
+                .unwrap();
+            manager.create_session("bob").unwrap();
+        }
+        protocol.confirm_session_state("bob", "test_setup").unwrap();
+
+        let mls_handle_before = protocol.mls_manager.as_ref().unwrap().clone();
+        let sessions_before = {
+            let manager = mls_handle_before.read().unwrap();
+            manager.list_sessions().unwrap()
+        };
+        let groups_before = {
+            let manager = mls_handle_before.read().unwrap();
+            manager.list_groups().unwrap().len()
+        };
+
+        let shared = Arc::new(Mutex::new(protocol));
+        let manual_shared = Arc::clone(&shared);
+        let manual_thread = thread::spawn(move || {
+            for i in 0..24 {
+                let mls = {
+                    let guard = manual_shared.lock().unwrap();
+                    guard.mls_manager.as_ref().unwrap().clone()
+                };
+                let manager = mls.read().unwrap();
+                manager
+                    .create_group(&format!("manual-concurrent-group-{}", i))
+                    .unwrap();
+            }
+        });
+
+        let auto_shared = Arc::clone(&shared);
+        let auto_thread = thread::spawn(move || {
+            for i in 0..24 {
+                let content = format!("auto-encrypted-{}", i);
+                let mut guard = auto_shared.lock().unwrap();
+                guard
+                    .send_message("bob", &content, None::<MessagePriority>, None::<String>)
+                    .unwrap();
+            }
+        });
+
+        manual_thread.join().unwrap();
+        auto_thread.join().unwrap();
+
+        let mls_handle_after = {
+            let protocol = shared.lock().unwrap();
+            protocol.mls_manager.as_ref().unwrap().clone()
+        };
+        assert!(Arc::ptr_eq(&mls_handle_before, &mls_handle_after));
+
+        let sessions_after = {
+            let manager = mls_handle_after.read().unwrap();
+            manager.list_sessions().unwrap()
+        };
+        assert_eq!(sessions_before, sessions_after);
+
+        let sent = transport_handle.sent_messages();
+        assert!(
+            sent.iter()
+                .filter(|message| message.recipient.as_str() == "bob")
+                .all(|message| message.content.starts_with(internal_prefixes::ENCRYPTED))
+        );
+
+        let groups_after = {
+            let manager = mls_handle_after.read().unwrap();
+            manager.list_groups().unwrap().len()
+        };
+        assert_eq!(groups_after, groups_before + 24);
+
+        let mut protocol = shared.lock().unwrap();
+        protocol.stop().unwrap();
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -3429,6 +3429,129 @@ impl OfflineProtocol {
         self.pending_key_packages.contains_key(peer_id)
     }
 
+    /// Creates a session using manually imported key material.
+    ///
+    /// This entrypoint is for bindings that expose low-level MLS APIs. It must
+    /// still keep protocol-level session lifecycle state in sync with MLS state.
+    pub fn manual_mls_create_session(&mut self, peer_id: &str) -> Result<WelcomeMessage> {
+        let mls = self.mls_manager.clone().ok_or(Error::MlsNotInitialized)?;
+        let welcome = {
+            let manager = mls
+                .read()
+                .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+            manager.create_session(peer_id)?
+        };
+        if let Err(err) = self.ensure_session_state_entry(peer_id, "manual_session_created") {
+            warn!(
+                peer_id = %peer_id,
+                error = %err,
+                "Failed to persist pending session state after manual session create"
+            );
+        }
+        Ok(welcome)
+    }
+
+    /// Joins a session from a Welcome message and synchronizes confirmation state.
+    pub fn manual_mls_join_session(
+        &mut self,
+        welcome: &WelcomeMessage,
+    ) -> Result<offline_protocol_mls::GroupInfo> {
+        let mls = self.mls_manager.clone().ok_or(Error::MlsNotInitialized)?;
+        let group_info = {
+            let manager = mls
+                .read()
+                .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+            manager.join_session(welcome)?
+        };
+        self.handle_manual_welcome_confirmation(&welcome.inviter_id);
+        Ok(group_info)
+    }
+
+    /// Processes an MLS Welcome message and synchronizes confirmation state.
+    pub fn manual_mls_process_welcome(
+        &mut self,
+        welcome: &WelcomeMessage,
+    ) -> Result<offline_protocol_mls::GroupInfo> {
+        let mls = self.mls_manager.clone().ok_or(Error::MlsNotInitialized)?;
+        let group_info = {
+            let manager = mls
+                .read()
+                .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+            manager.process_welcome(welcome)?
+        };
+        self.handle_manual_welcome_confirmation(&welcome.inviter_id);
+        Ok(group_info)
+    }
+
+    /// Decrypts a user-scoped MLS message and synchronizes confirmation state.
+    pub fn manual_mls_decrypt_from_user(
+        &mut self,
+        encrypted: &EncryptedMessage,
+    ) -> Result<Option<Vec<u8>>> {
+        let mls = self.mls_manager.clone().ok_or(Error::MlsNotInitialized)?;
+        let plaintext = {
+            let manager = mls
+                .read()
+                .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+            manager.decrypt_from_user(encrypted)?
+        };
+        if plaintext.is_some() {
+            self.handle_manual_decrypt_confirmation(&encrypted.sender_id);
+        }
+        Ok(plaintext)
+    }
+
+    /// Decrypts any MLS message and synchronizes confirmation state for 1:1 flows.
+    pub fn manual_mls_decrypt(&mut self, encrypted: &EncryptedMessage) -> Result<Option<Vec<u8>>> {
+        let mls = self.mls_manager.clone().ok_or(Error::MlsNotInitialized)?;
+        let plaintext = {
+            let manager = mls
+                .read()
+                .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+            manager.decrypt(encrypted)?
+        };
+        if plaintext.is_some() {
+            self.handle_manual_decrypt_confirmation(&encrypted.sender_id);
+        }
+        Ok(plaintext)
+    }
+
+    fn handle_manual_welcome_confirmation(&mut self, peer_id: &str) {
+        match self.confirm_session_state(peer_id, "welcome_received") {
+            Ok(true) => {
+                let _ = self.flush_pending_messages(peer_id);
+                self.process_pending_decryption(peer_id);
+            }
+            Ok(false) => {}
+            Err(err) => {
+                warn!(
+                    peer_id = %peer_id,
+                    error = %err,
+                    "Failed to persist session confirmation after manual welcome processing"
+                );
+            }
+        }
+    }
+
+    fn handle_manual_decrypt_confirmation(&mut self, peer_id: &str) {
+        if !self.can_confirm_from_source(peer_id, "decrypt_success") {
+            return;
+        }
+        match self.confirm_session_state(peer_id, "decrypt_success") {
+            Ok(true) => {
+                let _ = self.flush_pending_messages(peer_id);
+            }
+            Ok(false) => {}
+            Err(err) => {
+                warn!(
+                    peer_id = %peer_id,
+                    error = %err,
+                    "Failed to persist session confirmation after manual decrypt"
+                );
+            }
+        }
+    }
+
     /// Gets access to the MLS manager for advanced operations.
     ///
     /// Returns `None` if MLS is not initialized.
@@ -6197,6 +6320,60 @@ mod tests {
         assert_eq!(groups_after, groups_before + 24);
 
         let mut protocol = shared.lock().unwrap();
+        protocol.stop().unwrap();
+    }
+
+    #[test]
+    fn test_manual_welcome_processing_confirms_session_for_auto_encrypt_flow() {
+        let mut config = create_test_config_for_user("alice");
+        config.encryption.enabled = true;
+        config.encryption.store_pending = true;
+        config.encryption.require_encryption = false;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+        protocol
+            .initialize_mls(Arc::new(crate::mls::InMemoryStorage::new()))
+            .unwrap();
+
+        let mut transport = MockTransport::new(TransportType::BLE);
+        transport.start().unwrap();
+        let transport_handle = transport.clone();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(transport));
+        protocol.start().unwrap();
+
+        let bob_storage = Arc::new(InMemoryStorage::new());
+        let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+        let alice_key_package = {
+            let manager = protocol.mls_manager.as_ref().unwrap().read().unwrap();
+            manager.get_or_create_key_package().unwrap()
+        };
+        bob_manager
+            .import_key_package("alice", &alice_key_package.key_package_data)
+            .unwrap();
+        let welcome = bob_manager.create_session("alice").unwrap();
+
+        protocol.manual_mls_process_welcome(&welcome).unwrap();
+
+        let persisted = protocol.load_session_state_entry("bob").unwrap().unwrap();
+        assert_eq!(persisted, SessionState::Confirmed);
+
+        protocol
+            .send_message(
+                "bob",
+                "manual-welcome-unblocks-auto-send",
+                None::<MessagePriority>,
+                None::<String>,
+            )
+            .unwrap();
+
+        let sent = transport_handle.sent_messages();
+        assert!(sent
+            .iter()
+            .filter(|message| message.recipient.as_str() == "bob")
+            .any(|message| message.content.starts_with(internal_prefixes::ENCRYPTED)));
+
         protocol.stop().unwrap();
     }
 

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -2595,6 +2595,20 @@ impl OfflineProtocol {
         Ok(())
     }
 
+    fn clear_session_state_entry(&self, peer_id: &str) -> Result<()> {
+        let Some(storage) = &self.message_storage else {
+            return Ok(());
+        };
+        storage
+            .delete(storage_keys::SESSION_STATES, peer_id)
+            .map_err(|e| {
+                Error::Other(format!(
+                    "Failed to clear session state for {}: {}",
+                    peer_id, e
+                ))
+            })
+    }
+
     fn load_welcome_lifecycle_entry(
         &self,
         peer_id: &str,
@@ -2638,6 +2652,20 @@ impl OfflineProtocol {
                 Error::Other(format!(
                     "Failed to persist welcome lifecycle for {}: {}",
                     record.peer_id, e
+                ))
+            })
+    }
+
+    fn clear_welcome_lifecycle_entry(&self, peer_id: &str) -> Result<()> {
+        let Some(storage) = &self.message_storage else {
+            return Ok(());
+        };
+        storage
+            .delete(storage_keys::WELCOME_LIFECYCLES, peer_id)
+            .map_err(|e| {
+                Error::Other(format!(
+                    "Failed to clear welcome lifecycle for {}: {}",
+                    peer_id, e
                 ))
             })
     }
@@ -3451,6 +3479,22 @@ impl OfflineProtocol {
         Ok(welcome)
     }
 
+    /// Deletes a 1:1 session and clears protocol-level lifecycle state.
+    pub fn manual_mls_delete_session(&mut self, peer_id: &str) -> Result<()> {
+        self.clear_session_state_entry(peer_id)?;
+        self.confirmed_sessions.remove(peer_id);
+        self.clear_confirmation_recovery_tracking(peer_id);
+        self.welcome_lifecycles.remove(peer_id);
+        self.clear_welcome_lifecycle_entry(peer_id)?;
+
+        let mls = self.mls_manager.clone().ok_or(Error::MlsNotInitialized)?;
+        let manager = mls
+            .read()
+            .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
+        manager.delete_session(peer_id)?;
+        Ok(())
+    }
+
     /// Joins a session from a Welcome message and synchronizes confirmation state.
     pub fn manual_mls_join_session(
         &mut self,
@@ -3510,10 +3554,14 @@ impl OfflineProtocol {
                 .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
             manager.decrypt(encrypted)?
         };
-        if plaintext.is_some() {
+        if plaintext.is_some() && Self::is_session_group_id(encrypted.group_id.as_str()) {
             self.handle_manual_decrypt_confirmation(&encrypted.sender_id);
         }
         Ok(plaintext)
+    }
+
+    fn is_session_group_id(group_id: &str) -> bool {
+        group_id.starts_with("session:")
     }
 
     fn handle_manual_welcome_confirmation(&mut self, peer_id: &str) {
@@ -6375,6 +6423,48 @@ mod tests {
             .any(|message| message.content.starts_with(internal_prefixes::ENCRYPTED)));
 
         protocol.stop().unwrap();
+    }
+
+    #[test]
+    fn test_manual_delete_session_clears_protocol_session_state() {
+        let mut config = create_test_config_for_user("alice");
+        config.encryption.enabled = true;
+        config.encryption.store_pending = true;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+        protocol
+            .initialize_mls(Arc::new(crate::mls::InMemoryStorage::new()))
+            .unwrap();
+
+        let bob_manager = MlsManager::new("bob", Arc::new(InMemoryStorage::new())).unwrap();
+        let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+        {
+            let manager = protocol.mls_manager.as_ref().unwrap().read().unwrap();
+            manager
+                .import_key_package("bob", &bob_key_package.key_package_data)
+                .unwrap();
+            manager.create_session("bob").unwrap();
+        }
+        protocol.confirm_session_state("bob", "test_setup").unwrap();
+        assert_eq!(
+            protocol.load_session_state_entry("bob").unwrap().unwrap(),
+            SessionState::Confirmed
+        );
+
+        protocol.manual_mls_delete_session("bob").unwrap();
+
+        {
+            let manager = protocol.mls_manager.as_ref().unwrap().read().unwrap();
+            assert!(!manager.has_session("bob").unwrap());
+        }
+        assert!(!protocol.confirmed_sessions.contains("bob"));
+        assert!(protocol.load_session_state_entry("bob").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_session_group_detection_for_manual_decrypt_confirmation() {
+        assert!(OfflineProtocol::is_session_group_id("session:alice:bob"));
+        assert!(!OfflineProtocol::is_session_group_id("group:team"));
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -2934,6 +2934,30 @@ impl OfflineProtocol {
             .load_session_state_entry(peer_id)?
             .unwrap_or(SessionState::Pending);
         if matches!(persisted, SessionState::Confirmed) {
+            if !self.has_mls_session(peer_id)? {
+                warn!(
+                    peer_id = %peer_id,
+                    "Persisted confirmed state has no matching MLS session; clearing stale state"
+                );
+                self.confirmed_sessions.remove(peer_id);
+                self.clear_confirmation_recovery_tracking(peer_id);
+                self.welcome_lifecycles.remove(peer_id);
+                if let Err(err) = self.clear_session_state_entry(peer_id) {
+                    warn!(
+                        peer_id = %peer_id,
+                        error = %err,
+                        "Failed to clear stale persisted session state"
+                    );
+                }
+                if let Err(err) = self.clear_welcome_lifecycle_entry(peer_id) {
+                    warn!(
+                        peer_id = %peer_id,
+                        error = %err,
+                        "Failed to clear stale persisted welcome lifecycle"
+                    );
+                }
+                return Ok(false);
+            }
             self.confirmed_sessions.insert(peer_id.to_string());
             return Ok(true);
         }
@@ -3481,17 +3505,18 @@ impl OfflineProtocol {
 
     /// Deletes a 1:1 session and clears protocol-level lifecycle state.
     pub fn manual_mls_delete_session(&mut self, peer_id: &str) -> Result<()> {
-        self.clear_session_state_entry(peer_id)?;
-        self.confirmed_sessions.remove(peer_id);
-        self.clear_confirmation_recovery_tracking(peer_id);
-        self.welcome_lifecycles.remove(peer_id);
-        self.clear_welcome_lifecycle_entry(peer_id)?;
-
         let mls = self.mls_manager.clone().ok_or(Error::MlsNotInitialized)?;
         let manager = mls
             .read()
             .map_err(|_| Error::Other("MLS lock poisoned".to_string()))?;
         manager.delete_session(peer_id)?;
+
+        // Apply protocol-state cleanup only after MLS deletion succeeds.
+        self.confirmed_sessions.remove(peer_id);
+        self.clear_confirmation_recovery_tracking(peer_id);
+        self.welcome_lifecycles.remove(peer_id);
+        self.clear_session_state_entry(peer_id)?;
+        self.clear_welcome_lifecycle_entry(peer_id)?;
         Ok(())
     }
 
@@ -6459,6 +6484,64 @@ mod tests {
         }
         assert!(!protocol.confirmed_sessions.contains("bob"));
         assert!(protocol.load_session_state_entry("bob").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_manual_delete_session_failure_keeps_protocol_state_unchanged() {
+        let mut config = create_test_config_for_user("alice");
+        config.encryption.enabled = true;
+        config.encryption.store_pending = true;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+        protocol
+            .initialize_mls(Arc::new(crate::mls::InMemoryStorage::new()))
+            .unwrap();
+
+        protocol.confirm_session_state("bob", "test_setup").unwrap();
+        assert_eq!(
+            protocol.load_session_state_entry("bob").unwrap().unwrap(),
+            SessionState::Confirmed
+        );
+        assert!(protocol.confirmed_sessions.contains("bob"));
+
+        // Force a deterministic failure path by poisoning the MLS lock.
+        let poisoned_handle = protocol.mls_manager.as_ref().unwrap().clone();
+        let poison_result = thread::spawn(move || {
+            let _guard = poisoned_handle.write().unwrap();
+            panic!("poison mls lock");
+        })
+        .join();
+        assert!(poison_result.is_err());
+
+        let result = protocol.manual_mls_delete_session("bob");
+        assert!(result.is_err());
+        assert_eq!(
+            protocol.load_session_state_entry("bob").unwrap().unwrap(),
+            SessionState::Confirmed
+        );
+        assert!(protocol.confirmed_sessions.contains("bob"));
+    }
+
+    #[test]
+    fn test_is_session_confirmed_clears_stale_confirmed_state_without_mls_session() {
+        let mut config = create_test_config_for_user("alice");
+        config.encryption.enabled = true;
+        config.encryption.store_pending = true;
+
+        let mut protocol = OfflineProtocol::new(config).unwrap();
+        protocol
+            .initialize_mls(Arc::new(crate::mls::InMemoryStorage::new()))
+            .unwrap();
+
+        protocol.confirm_session_state("bob", "test_setup").unwrap();
+        assert_eq!(
+            protocol.load_session_state_entry("bob").unwrap().unwrap(),
+            SessionState::Confirmed
+        );
+
+        assert!(!protocol.is_session_confirmed("bob").unwrap());
+        assert!(protocol.load_session_state_entry("bob").unwrap().is_none());
+        assert!(!protocol.confirmed_sessions.contains("bob"));
     }
 
     #[test]


### PR DESCRIPTION
- CoreProtocol is sole MLS owner; UniFFI routes through core handle
- Remove duplicate MlsManager in UniFFI layer
- Make initialize_mls transactional: rollback on restore failure
- Add restore_session_states_from_manager for pre-publish restore
- Add tests: rollback on restore failure, concurrent auto+manual MLS