### PR TITLE
fix(protocol): harden mesh group robustness with relay sync, leave fallback, and epoch fork resolution

### DIFF
--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -570,6 +570,25 @@ pub enum Event {
         succeeded_members: Vec<String>,
     },
 
+    /// An epoch fork was detected in a group — concurrent commits caused
+    /// members to diverge onto different MLS branches. The deterministic
+    /// leader will attempt automatic resolution via a key-update commit.
+    GroupEpochForkDetected {
+        /// MLS group identifier.
+        group_id: String,
+        /// Our local epoch when the fork was detected.
+        local_epoch: u64,
+    },
+
+    /// An epoch fork was successfully resolved by the leader issuing a
+    /// resync commit that re-established a canonical epoch.
+    GroupEpochForkResolved {
+        /// MLS group identifier.
+        group_id: String,
+        /// The new canonical epoch after resolution.
+        resolved_epoch: u64,
+    },
+
     // --- Service discovery ---
     /// A service was discovered on the mesh in response to a discovery query.
     ServiceDiscovered {
@@ -1113,6 +1132,22 @@ impl Event {
             group_id,
             failed_members,
             succeeded_members,
+        }
+    }
+
+    /// Creates a GroupEpochForkDetected event.
+    pub fn group_epoch_fork_detected(group_id: String, local_epoch: u64) -> Self {
+        Self::GroupEpochForkDetected {
+            group_id,
+            local_epoch,
+        }
+    }
+
+    /// Creates a GroupEpochForkResolved event.
+    pub fn group_epoch_fork_resolved(group_id: String, resolved_epoch: u64) -> Self {
+        Self::GroupEpochForkResolved {
+            group_id,
+            resolved_epoch,
         }
     }
 
@@ -1711,6 +1746,22 @@ impl fmt::Debug for Event {
                 .field("group_id", group_id)
                 .field("failed_count", &failed_members.len())
                 .field("succeeded_count", &succeeded_members.len())
+                .finish(),
+            Self::GroupEpochForkDetected {
+                group_id,
+                local_epoch,
+            } => f
+                .debug_struct("GroupEpochForkDetected")
+                .field("group_id", group_id)
+                .field("local_epoch", local_epoch)
+                .finish(),
+            Self::GroupEpochForkResolved {
+                group_id,
+                resolved_epoch,
+            } => f
+                .debug_struct("GroupEpochForkResolved")
+                .field("group_id", group_id)
+                .field("resolved_epoch", resolved_epoch)
                 .finish(),
             Self::DorsScoreUpdated { scores } => f
                 .debug_struct("DorsScoreUpdated")

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -582,11 +582,19 @@ pub enum Event {
 
     /// An epoch fork was successfully resolved by the leader issuing a
     /// resync commit that re-established a canonical epoch.
+    ///
+    /// Members in `failed_members` could not be reached with the resolution
+    /// commit and may still be on a forked branch — the application layer
+    /// should consider re-inviting them.
     GroupEpochForkResolved {
         /// MLS group identifier.
         group_id: String,
         /// The new canonical epoch after resolution.
         resolved_epoch: u64,
+        /// Members to whom the resolution commit could not be sent.
+        /// These members may still be on a forked epoch branch and
+        /// may need a re-invite to rejoin the canonical group state.
+        failed_members: Vec<String>,
     },
 
     // --- Service discovery ---
@@ -1144,10 +1152,15 @@ impl Event {
     }
 
     /// Creates a GroupEpochForkResolved event.
-    pub fn group_epoch_fork_resolved(group_id: String, resolved_epoch: u64) -> Self {
+    pub fn group_epoch_fork_resolved(
+        group_id: String,
+        resolved_epoch: u64,
+        failed_members: Vec<String>,
+    ) -> Self {
         Self::GroupEpochForkResolved {
             group_id,
             resolved_epoch,
+            failed_members,
         }
     }
 
@@ -1758,10 +1771,12 @@ impl fmt::Debug for Event {
             Self::GroupEpochForkResolved {
                 group_id,
                 resolved_epoch,
+                failed_members,
             } => f
                 .debug_struct("GroupEpochForkResolved")
                 .field("group_id", group_id)
                 .field("resolved_epoch", resolved_epoch)
+                .field("failed_members", failed_members)
                 .finish(),
             Self::DorsScoreUpdated { scores } => f
                 .debug_struct("DorsScoreUpdated")

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -576,8 +576,9 @@ pub enum Event {
     GroupEpochForkDetected {
         /// MLS group identifier.
         group_id: String,
-        /// Our local epoch when the fork was detected.
-        local_epoch: u64,
+        /// Our local epoch when the fork was detected, or `None` if MLS
+        /// state was unavailable at detection time.
+        local_epoch: Option<u64>,
     },
 
     /// An epoch fork was successfully resolved by the leader issuing a
@@ -1144,7 +1145,7 @@ impl Event {
     }
 
     /// Creates a GroupEpochForkDetected event.
-    pub fn group_epoch_fork_detected(group_id: String, local_epoch: u64) -> Self {
+    pub fn group_epoch_fork_detected(group_id: String, local_epoch: Option<u64>) -> Self {
         Self::GroupEpochForkDetected {
             group_id,
             local_epoch,

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -29,6 +29,14 @@ pub(crate) const MAX_BASE64_PAYLOAD_SIZE: usize = 1_048_576;
 pub(super) const MAX_PENDING_COMMITS_PER_GROUP: usize = 8;
 /// TTL for buffered pending commits (2 minutes).
 pub(super) const PENDING_COMMIT_TTL_SECS: u64 = 120;
+/// Timeout before the next eligible member re-elects itself for a leave
+/// remove-commit when the original elected remover fails (30 seconds).
+pub(super) const LEAVE_ELECTION_TIMEOUT_SECS: u64 = 30;
+/// Delay after detecting a potential epoch fork before the leader issues a
+/// resync commit (10 seconds — gives time for buffered commits to drain).
+pub(super) const EPOCH_FORK_RESOLUTION_DELAY_SECS: u64 = 10;
+/// Maximum number of tracked epoch fork states to prevent unbounded growth.
+pub(super) const MAX_EPOCH_FORK_ENTRIES: usize = 32;
 
 /// Bundled state for group messaging.
 ///
@@ -58,6 +66,13 @@ pub(crate) struct GroupMeshState {
     /// Whether Internet transport was available on the last `process()` tick.
     /// Used for edge-detection: sync groups on 0→1 transition, clear on 1→0.
     pub(crate) internet_was_available: bool,
+
+    /// Pending leave elections awaiting a remove-commit from the elected member.
+    /// Key: "group_id:leaving_member".
+    pub(crate) pending_leave_elections: HashMap<String, PendingLeaveElection>,
+
+    /// Suspected epoch forks awaiting resolution. Key: group_id.
+    pub(crate) epoch_forks: HashMap<String, EpochForkState>,
 }
 
 /// Outcome of attempting to process an MLS Commit.
@@ -188,6 +203,40 @@ pub(crate) struct PendingCommit {
     pub(crate) data: String,
     /// When this pending commit was first buffered.
     pub(crate) buffered_at: Instant,
+}
+
+/// Tracks a leave election where we're waiting for the elected remover to
+/// issue a remove-commit. If the timeout expires and the member is still
+/// in the group, the next eligible member re-elects itself.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingLeaveElection {
+    /// Group the leave is for.
+    pub(crate) group_id: String,
+    /// User ID of the member who is leaving.
+    pub(crate) leaving_member: String,
+    /// Sorted list of remaining members at election time (excluding leaver).
+    pub(crate) remaining_members: Vec<String>,
+    /// When we received the leave notification.
+    pub(crate) received_at: Instant,
+}
+
+/// Tracks a suspected epoch fork for a group.
+///
+/// An epoch fork occurs when two members issue concurrent commits at the
+/// same epoch (e.g., two admins adding different members simultaneously).
+/// Members who accepted commit A are on one branch, those who accepted
+/// commit B are on another. Detected when buffered commits expire without
+/// resolution.
+#[derive(Debug, Clone)]
+pub(crate) struct EpochForkState {
+    /// Group with the suspected fork.
+    pub(crate) group_id: String,
+    /// Our local epoch when the fork was detected.
+    pub(crate) local_epoch: u64,
+    /// When the fork was first suspected.
+    pub(crate) detected_at: Instant,
+    /// Whether the leader has already attempted resolution.
+    pub(crate) resolution_attempted: bool,
 }
 
 impl OfflineProtocol {
@@ -500,7 +549,15 @@ impl OfflineProtocol {
                 (*member).clone(),
                 sender.to_string(),
             ));
+            // Clear any pending leave election for this member — the remove
+            // has been committed successfully.
+            let election_key = format!("{}:{}", payload.group_id, member);
+            self.group_mesh.pending_leave_elections.remove(&election_key);
         }
+
+        // If we had a suspected fork for this group and a commit just
+        // succeeded, the fork may have resolved — clear the tracking.
+        self.group_mesh.epoch_forks.remove(&payload.group_id);
 
         CommitOutcome::Success(payload.group_id)
     }
@@ -542,6 +599,8 @@ impl OfflineProtocol {
     /// double-buffering: this method owns the retry lifecycle and re-buffers
     /// only via `still_pending`, never through the core processing path.
     pub(crate) fn drain_pending_commits(&mut self, group_id: &str) {
+        let mut expired_count: usize = 0;
+
         // Limit iterations to avoid unbounded looping
         for _ in 0..MAX_PENDING_COMMITS_PER_GROUP {
             let pending = match self.group_mesh.pending_commits.get_mut(group_id) {
@@ -553,12 +612,13 @@ impl OfflineProtocol {
             let mut still_pending = VecDeque::new();
 
             for entry in pending {
-                // Drop expired entries
+                // Drop expired entries — track count for fork detection
                 if entry.buffered_at.elapsed() > StdDuration::from_secs(PENDING_COMMIT_TTL_SECS) {
                     debug!(
                         group_id = %group_id,
                         "Dropping expired pending commit"
                     );
+                    expired_count += 1;
                     continue;
                 }
                 match self.process_commit_core(&entry.sender, &entry.data) {
@@ -599,6 +659,63 @@ impl OfflineProtocol {
         {
             self.group_mesh.pending_commits.remove(group_id);
         }
+
+        // If commits expired without ever being resolved, this signals a
+        // potential epoch fork — two concurrent commits created divergent
+        // group states that can't be reconciled by simple reordering.
+        if expired_count > 0 && !self.group_mesh.epoch_forks.contains_key(group_id) {
+            self.flag_potential_epoch_fork(group_id);
+        }
+    }
+
+    /// Flags a group as having a potential epoch fork.
+    ///
+    /// Called when buffered commits expire without resolution, indicating
+    /// the group may have diverged due to concurrent commits.
+    fn flag_potential_epoch_fork(&mut self, group_id: &str) {
+        if self.group_mesh.epoch_forks.len() >= MAX_EPOCH_FORK_ENTRIES {
+            // Evict the oldest entry to prevent unbounded growth
+            if let Some(oldest_key) = self
+                .group_mesh
+                .epoch_forks
+                .values()
+                .min_by_key(|f| f.detected_at)
+                .map(|f| f.group_id.clone())
+            {
+                self.group_mesh.epoch_forks.remove(&oldest_key);
+            }
+        }
+
+        let local_epoch = self
+            .refresh_group_members(group_id)
+            .ok()
+            .and_then(|_| {
+                let mls_guard = self.read_mls_guard().ok()?;
+                let gid = offline_protocol_mls::GroupId::new(group_id);
+                mls_guard.get_group_info(&gid).ok().flatten().map(|i| i.epoch)
+            })
+            .unwrap_or(0);
+
+        warn!(
+            group_id = %group_id,
+            local_epoch = local_epoch,
+            "Potential epoch fork detected — buffered commits expired without resolution"
+        );
+
+        self.group_mesh.epoch_forks.insert(
+            group_id.to_string(),
+            EpochForkState {
+                group_id: group_id.to_string(),
+                local_epoch,
+                detected_at: Instant::now(),
+                resolution_attempted: false,
+            },
+        );
+
+        self.emit_event(Event::group_epoch_fork_detected(
+            group_id.to_string(),
+            local_epoch,
+        ));
     }
 
     /// Handles an incoming group leave notification.
@@ -671,12 +788,14 @@ impl OfflineProtocol {
 
         // Deterministic election: lexicographically-first remaining member
         // (excluding the leaver) issues the MLS remove-commit to advance epoch.
-        let should_remove = members
+        let mut remaining: Vec<String> = members
             .iter()
             .filter(|m| m.as_str() != sender)
-            .min()
-            .map(|first| first == &self_id)
-            .unwrap_or(false);
+            .cloned()
+            .collect();
+        remaining.sort();
+
+        let should_remove = remaining.first().map(|first| first == &self_id).unwrap_or(false);
 
         if should_remove {
             debug!(
@@ -694,6 +813,22 @@ impl OfflineProtocol {
                     "Failed to issue MLS remove-commit for leaving member"
                 );
             }
+            // Clear any pending election for this leave (we handled it)
+            let election_key = format!("{}:{}", payload.group_id, sender);
+            self.group_mesh.pending_leave_elections.remove(&election_key);
+        } else {
+            // We're not the elected remover — record the election so we can
+            // take over if the elected member fails to issue the commit in time.
+            let election_key = format!("{}:{}", payload.group_id, sender);
+            self.group_mesh.pending_leave_elections.insert(
+                election_key,
+                PendingLeaveElection {
+                    group_id: payload.group_id.clone(),
+                    leaving_member: sender.to_string(),
+                    remaining_members: remaining,
+                    received_at: Instant::now(),
+                },
+            );
         }
 
         // Do NOT emit GroupMemberRemoved here for non-elected nodes.
@@ -1266,6 +1401,239 @@ impl OfflineProtocol {
     }
 
     // ========================================================================
+    // EPOCH FORK RESOLUTION
+    // ========================================================================
+
+    /// Checks for pending epoch forks and attempts resolution.
+    ///
+    /// Called from the `process()` tick. After the resolution delay, the
+    /// deterministic leader (lex-first member) issues an `update_keys` commit
+    /// to re-establish a canonical epoch. Members on the same branch will
+    /// process the commit normally. Members on a different branch will fail
+    /// to process it, at which point they need a re-invite (the leader
+    /// emits `GroupEpochForkResolved` and the application layer can trigger
+    /// re-invites for unreachable members).
+    pub(crate) fn check_epoch_forks(&mut self) {
+        let delay = StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS);
+        let self_id = self.config.user_id.clone();
+
+        // Collect forks ready for resolution
+        let ready: Vec<EpochForkState> = self
+            .group_mesh
+            .epoch_forks
+            .values()
+            .filter(|f| !f.resolution_attempted && f.detected_at.elapsed() > delay)
+            .cloned()
+            .collect();
+
+        for fork in ready {
+            // Check if we're the leader for this group
+            let members = self
+                .refresh_group_members(&fork.group_id)
+                .ok()
+                .or_else(|| self.group_mesh.members.get(&fork.group_id).cloned())
+                .unwrap_or_default();
+
+            let mut sorted = members.clone();
+            sorted.sort();
+            let am_leader = sorted.first().map(|f| f == &self_id).unwrap_or(false);
+
+            // Mark as attempted regardless — only the leader acts, but all
+            // members should stop re-checking.
+            if let Some(state) = self.group_mesh.epoch_forks.get_mut(&fork.group_id) {
+                state.resolution_attempted = true;
+            }
+
+            if !am_leader {
+                continue;
+            }
+
+            info!(
+                group_id = %fork.group_id,
+                local_epoch = fork.local_epoch,
+                "Attempting epoch fork resolution as elected leader"
+            );
+
+            // Issue a key update commit to establish a canonical next epoch.
+            // Members on our branch will process this normally and advance.
+            // Members on a forked branch will fail — the app layer should
+            // handle re-inviting them.
+            // Acquire MLS lock, perform key update, and fully release the
+            // guard before touching any other &mut self state.
+            let update_result = {
+                if let Ok(guard) = self.read_mls_guard() {
+                    let gid = offline_protocol_mls::GroupId::new(&fork.group_id);
+                    let r = guard.update_keys(&gid);
+                    drop(guard);
+                    Some(r)
+                } else {
+                    None
+                }
+            };
+            // Guard is fully dropped here — safe to use &mut self.
+            let update_result = match update_result {
+                Some(r) => r,
+                None => {
+                    warn!(group_id = %fork.group_id, "MLS unavailable during epoch fork resolution");
+                    if let Some(state) = self.group_mesh.epoch_forks.get_mut(&fork.group_id) {
+                        state.resolution_attempted = false;
+                    }
+                    continue;
+                }
+            };
+
+            match update_result {
+                Ok(commit_msg) => {
+                    // Distribute the key-update commit to all members
+                    let commit_payload = GroupMlsCommitPayload {
+                        group_id: fork.group_id.clone(),
+                        commit_type: GroupCommitType::Remove, // Closest semantic — epoch advancement
+                        ciphertext: base64_encode(&commit_msg.ciphertext),
+                        epoch: commit_msg.epoch,
+                        affected_member: None, // Key update, not a membership change
+                    };
+                    let commit_content = match serde_json::to_string(&commit_payload) {
+                        Ok(json) => format!(
+                            "{}{}",
+                            internal_prefixes::GROUP_MLS_COMMIT,
+                            json
+                        ),
+                        Err(e) => {
+                            warn!(
+                                group_id = %fork.group_id,
+                                error = %e,
+                                "Failed to serialize fork resolution commit"
+                            );
+                            continue;
+                        }
+                    };
+                    for member in &members {
+                        if member == &self_id {
+                            continue;
+                        }
+                        if let Err(e) = self.send_internal_message(
+                            member,
+                            commit_content.clone(),
+                            MessagePriority::High,
+                        ) {
+                            warn!(
+                                group_id = %fork.group_id,
+                                member = %member,
+                                error = %e,
+                                "Failed to send fork resolution commit to member"
+                            );
+                        }
+                    }
+
+                    info!(
+                        group_id = %fork.group_id,
+                        new_epoch = commit_msg.epoch,
+                        "Epoch fork resolution commit distributed"
+                    );
+
+                    self.emit_event(Event::group_epoch_fork_resolved(
+                        fork.group_id.clone(),
+                        commit_msg.epoch,
+                    ));
+
+                    // Clean up the fork state
+                    self.group_mesh.epoch_forks.remove(&fork.group_id);
+                }
+                Err(e) => {
+                    warn!(
+                        group_id = %fork.group_id,
+                        error = %e,
+                        "Failed to issue key update for epoch fork resolution"
+                    );
+                    // Leave resolution_attempted = true — a persistent failure
+                    // means the group may need manual intervention.
+                }
+            }
+        }
+
+        // Clean up stale fork entries (older than 5 minutes)
+        let stale_threshold = StdDuration::from_secs(300);
+        self.group_mesh
+            .epoch_forks
+            .retain(|_, f| f.detected_at.elapsed() < stale_threshold);
+    }
+
+    // ========================================================================
+    // LEAVE ELECTION FALLBACK
+    // ========================================================================
+
+    /// Checks for timed-out leave elections and re-elects the next eligible
+    /// member to issue the MLS remove-commit.
+    ///
+    /// Called from the `process()` tick. If the originally elected remover
+    /// hasn't issued a commit within `LEAVE_ELECTION_TIMEOUT_SECS`, we check
+    /// whether the leaving member is still in the group (via MLS state). If
+    /// so, the next eligible member in the sorted remaining list takes over.
+    pub(crate) fn check_leave_election_timeouts(&mut self) {
+        let timeout = StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS);
+        let self_id = self.config.user_id.clone();
+
+        // Collect timed-out elections
+        let timed_out: Vec<PendingLeaveElection> = self
+            .group_mesh
+            .pending_leave_elections
+            .values()
+            .filter(|e| e.received_at.elapsed() > timeout)
+            .cloned()
+            .collect();
+
+        for election in timed_out {
+            let election_key = format!("{}:{}", election.group_id, election.leaving_member);
+
+            // Check if the leaving member is still in the group (MLS authoritative)
+            let still_member = self
+                .refresh_group_members(&election.group_id)
+                .ok()
+                .or_else(|| self.group_mesh.members.get(&election.group_id).cloned())
+                .map(|m| m.iter().any(|id| id == &election.leaving_member))
+                .unwrap_or(false);
+
+            if !still_member {
+                // Already removed — clean up
+                self.group_mesh.pending_leave_elections.remove(&election_key);
+                continue;
+            }
+
+            // Re-elect: walk the sorted remaining members. For each timeout
+            // interval that has passed, advance one position in the list.
+            // This staggers re-election so members don't all fire at once.
+            let elapsed_intervals = (election.received_at.elapsed().as_secs()
+                / LEAVE_ELECTION_TIMEOUT_SECS) as usize;
+            // Interval 0 = first member (original election), 1 = second, etc.
+            let candidate_idx = elapsed_intervals.min(election.remaining_members.len().saturating_sub(1));
+
+            if election.remaining_members.get(candidate_idx).map(|c| c == &self_id).unwrap_or(false) {
+                info!(
+                    group_id = %election.group_id,
+                    leaving_member = %election.leaving_member,
+                    attempt = candidate_idx + 1,
+                    "Re-elected to issue MLS remove-commit (prior elected member timed out)"
+                );
+                if let Err(e) = self.remove_from_group(&election.group_id, &election.leaving_member) {
+                    warn!(
+                        group_id = %election.group_id,
+                        leaving_member = %election.leaving_member,
+                        error = %e,
+                        "Failed to issue MLS remove-commit during re-election"
+                    );
+                    // Don't remove from pending — next tick will try again
+                    // or the next member in line will take over at the next interval.
+                } else {
+                    self.group_mesh.pending_leave_elections.remove(&election_key);
+                }
+            }
+            // If we're not the candidate at this interval, leave the election
+            // in place — either the current candidate will handle it, or the
+            // next interval will advance to us.
+        }
+    }
+
+    // ========================================================================
     // TRANSPORT-RESILIENT SYNC
     // ========================================================================
 
@@ -1293,13 +1661,21 @@ impl OfflineProtocol {
     }
 
     /// Re-registers all unsynced groups with the relay server.
+    ///
+    /// Refreshes each group's member list from MLS state before syncing so
+    /// that the relay receives authoritative membership, not a stale cache.
     fn sync_groups_to_relay(&mut self) {
         let group_ids: Vec<String> = self.group_mesh.members.keys().cloned().collect();
         for group_id in group_ids {
             if self.group_mesh.relay_synced.contains(&group_id) {
                 continue;
             }
-            if let Some(members) = self.group_mesh.members.get(&group_id).cloned() {
+            // Refresh from MLS to avoid syncing stale membership to relay
+            let members = self
+                .refresh_group_members(&group_id)
+                .ok()
+                .or_else(|| self.group_mesh.members.get(&group_id).cloned());
+            if let Some(members) = members {
                 let _ = self.try_relay_register_group(&group_id, None, &members);
             }
         }

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -37,6 +37,12 @@ pub(super) const LEAVE_ELECTION_TIMEOUT_SECS: u64 = 30;
 pub(super) const EPOCH_FORK_RESOLUTION_DELAY_SECS: u64 = 10;
 /// Maximum number of tracked epoch fork states to prevent unbounded growth.
 pub(super) const MAX_EPOCH_FORK_ENTRIES: usize = 32;
+/// Maximum number of tracked pending leave elections to prevent unbounded growth.
+pub(super) const MAX_PENDING_LEAVE_ELECTIONS: usize = 64;
+/// Maximum lifetime for a leave election before it is abandoned (5 minutes).
+/// After this, the election is cleaned up regardless of whether the member
+/// was removed — prevents infinite retry loops when all candidates fail.
+pub(super) const LEAVE_ELECTION_MAX_LIFETIME_SECS: u64 = 300;
 
 /// Builds a deterministic key for leave election tracking: "group_id:member_id".
 pub(crate) fn leave_election_key(group_id: &str, member_id: &str) -> String {
@@ -241,8 +247,8 @@ pub(crate) struct PendingLeaveElection {
 pub(crate) struct EpochForkState {
     /// Group with the suspected fork.
     pub(crate) group_id: String,
-    /// Our local epoch when the fork was detected.
-    pub(crate) local_epoch: u64,
+    /// Our local epoch when the fork was detected, or `None` if MLS was unavailable.
+    pub(crate) local_epoch: Option<u64>,
     /// When the fork was first suspected.
     pub(crate) detected_at: Instant,
     /// Whether the leader has already attempted resolution.
@@ -566,9 +572,13 @@ impl OfflineProtocol {
             self.group_mesh.pending_leave_elections.remove(&key);
         }
 
-        // If we had a suspected fork for this group and a commit just
-        // succeeded, the fork may have resolved — clear the tracking.
-        self.group_mesh.epoch_forks.remove(&payload.group_id);
+        // Only clear fork tracking when a KeyUpdate commit succeeds — these
+        // are the resolution commits issued by the leader. Regular Add/Remove
+        // commits from the same branch succeeding doesn't prove the fork is
+        // resolved; members on the other branch are still diverged.
+        if matches!(payload.commit_type, GroupCommitType::KeyUpdate) {
+            self.group_mesh.epoch_forks.remove(&payload.group_id);
+        }
 
         CommitOutcome::Success(payload.group_id)
     }
@@ -724,11 +734,9 @@ impl OfflineProtocol {
             );
         }
 
-        let local_epoch = local_epoch.unwrap_or(0);
-
         warn!(
             group_id = %group_id,
-            local_epoch = local_epoch,
+            local_epoch = ?local_epoch,
             "Potential epoch fork detected — buffered commits expired without resolution"
         );
 
@@ -852,6 +860,18 @@ impl OfflineProtocol {
         } else {
             // We're not the elected remover — record the election so we can
             // take over if the elected member fails to issue the commit in time.
+            if self.group_mesh.pending_leave_elections.len() >= MAX_PENDING_LEAVE_ELECTIONS {
+                // Evict the oldest entry to prevent unbounded growth.
+                if let Some(oldest_key) = self
+                    .group_mesh
+                    .pending_leave_elections
+                    .values()
+                    .min_by_key(|e| e.received_at)
+                    .map(|e| leave_election_key(&e.group_id, &e.leaving_member))
+                {
+                    self.group_mesh.pending_leave_elections.remove(&oldest_key);
+                }
+            }
             let key = leave_election_key(&payload.group_id, sender);
             self.group_mesh.pending_leave_elections.insert(
                 key,
@@ -1502,7 +1522,7 @@ impl OfflineProtocol {
 
             info!(
                 group_id = %fork.group_id,
-                local_epoch = fork.local_epoch,
+                local_epoch = ?fork.local_epoch,
                 "Attempting epoch fork resolution as elected leader"
             );
 
@@ -1623,6 +1643,7 @@ impl OfflineProtocol {
     /// so, the next eligible member in the sorted remaining list takes over.
     pub(crate) fn check_leave_election_timeouts(&mut self) {
         let timeout = StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS);
+        let max_lifetime = StdDuration::from_secs(LEAVE_ELECTION_MAX_LIFETIME_SECS);
         let self_id = self.config.user_id.clone();
 
         // Collect timed-out elections
@@ -1636,6 +1657,20 @@ impl OfflineProtocol {
 
         for election in timed_out {
             let election_key = leave_election_key(&election.group_id, &election.leaving_member);
+
+            // Circuit breaker: abandon the election after max lifetime to
+            // prevent infinite per-tick retry loops when all candidates fail.
+            if election.received_at.elapsed() > max_lifetime {
+                warn!(
+                    group_id = %election.group_id,
+                    leaving_member = %election.leaving_member,
+                    "Leave election exceeded max lifetime, abandoning — member may need manual removal"
+                );
+                self.group_mesh
+                    .pending_leave_elections
+                    .remove(&election_key);
+                continue;
+            }
 
             // Refresh membership from MLS (authoritative) to avoid using
             // stale election-time lists where members may have since left.

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -1490,6 +1490,19 @@ impl OfflineProtocol {
     /// to process it, at which point they need a re-invite (the leader
     /// emits `GroupEpochForkResolved` and the application layer can trigger
     /// re-invites for unreachable members).
+    ///
+    /// ## Stuck fork recovery
+    ///
+    /// If `update_keys` fails (e.g., the leader's MLS state is corrupted),
+    /// `resolution_attempted` is set to `true` and no further automatic
+    /// resolution is tried. The fork entry remains until the 5-minute stale
+    /// cleanup removes it, at which point the fork may be re-detected if
+    /// the underlying issue persists (creating a detect → fail → stale-cleanup
+    /// → re-detect cycle). This is intentional: a persistent `update_keys`
+    /// failure indicates the group likely needs manual intervention (e.g.,
+    /// re-creating the group or re-inviting all members). The application
+    /// layer should monitor `GroupEpochForkDetected` events and escalate if
+    /// the same group is repeatedly detected.
     pub(crate) fn check_epoch_forks(&mut self) {
         let delay = StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS);
         let self_id = self.config.user_id.clone();

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -38,6 +38,11 @@ pub(super) const EPOCH_FORK_RESOLUTION_DELAY_SECS: u64 = 10;
 /// Maximum number of tracked epoch fork states to prevent unbounded growth.
 pub(super) const MAX_EPOCH_FORK_ENTRIES: usize = 32;
 
+/// Builds a deterministic key for leave election tracking: "group_id:member_id".
+pub(crate) fn leave_election_key(group_id: &str, member_id: &str) -> String {
+    format!("{}:{}", group_id, member_id)
+}
+
 /// Bundled state for group messaging.
 ///
 /// Groups together the cached member lists, dedup table, pending commit
@@ -125,6 +130,9 @@ pub(crate) enum GroupCommitType {
     Add,
     /// A member was removed from the group.
     Remove,
+    /// A key update commit (epoch advancement without membership change).
+    /// Used for epoch fork resolution.
+    KeyUpdate,
 }
 
 /// Payload for MLS Commit messages (membership changes) sent via mesh.
@@ -203,6 +211,10 @@ pub(crate) struct PendingCommit {
     pub(crate) data: String,
     /// When this pending commit was first buffered.
     pub(crate) buffered_at: Instant,
+    /// Number of times this commit has been retried and still failed.
+    /// A commit that expires with `retry_count > 0` is a strong signal
+    /// of epoch mismatch (true fork), not just slow delivery.
+    pub(crate) retry_count: u32,
 }
 
 /// Tracks a leave election where we're waiting for the elected remover to
@@ -214,8 +226,6 @@ pub(crate) struct PendingLeaveElection {
     pub(crate) group_id: String,
     /// User ID of the member who is leaving.
     pub(crate) leaving_member: String,
-    /// Sorted list of remaining members at election time (excluding leaver).
-    pub(crate) remaining_members: Vec<String>,
     /// When we received the leave notification.
     pub(crate) received_at: Instant,
 }
@@ -522,6 +532,7 @@ impl OfflineProtocol {
             let valid = match payload.commit_type {
                 GroupCommitType::Add => actual_added.contains(claimed),
                 GroupCommitType::Remove => actual_removed.contains(claimed),
+                GroupCommitType::KeyUpdate => true, // No membership change expected
             };
             if !valid && (!actual_added.is_empty() || !actual_removed.is_empty()) {
                 error!(
@@ -551,8 +562,8 @@ impl OfflineProtocol {
             ));
             // Clear any pending leave election for this member — the remove
             // has been committed successfully.
-            let election_key = format!("{}:{}", payload.group_id, member);
-            self.group_mesh.pending_leave_elections.remove(&election_key);
+            let key = leave_election_key(&payload.group_id, member);
+            self.group_mesh.pending_leave_elections.remove(&key);
         }
 
         // If we had a suspected fork for this group and a commit just
@@ -568,6 +579,7 @@ impl OfflineProtocol {
             sender: sender.to_string(),
             data: data.to_string(),
             buffered_at: Instant::now(),
+            retry_count: 0,
         };
         let buf = self
             .group_mesh
@@ -599,7 +611,10 @@ impl OfflineProtocol {
     /// double-buffering: this method owns the retry lifecycle and re-buffers
     /// only via `still_pending`, never through the core processing path.
     pub(crate) fn drain_pending_commits(&mut self, group_id: &str) {
-        let mut expired_count: usize = 0;
+        // Track commits that were retried at least once and still expired —
+        // these are strong evidence of epoch mismatch (true fork), not just
+        // slow delivery from the mesh network.
+        let mut retried_expired_count: usize = 0;
 
         // Limit iterations to avoid unbounded looping
         for _ in 0..MAX_PENDING_COMMITS_PER_GROUP {
@@ -612,13 +627,16 @@ impl OfflineProtocol {
             let mut still_pending = VecDeque::new();
 
             for entry in pending {
-                // Drop expired entries — track count for fork detection
+                // Drop expired entries — only count retried ones for fork detection
                 if entry.buffered_at.elapsed() > StdDuration::from_secs(PENDING_COMMIT_TTL_SECS) {
                     debug!(
                         group_id = %group_id,
+                        retry_count = entry.retry_count,
                         "Dropping expired pending commit"
                     );
-                    expired_count += 1;
+                    if entry.retry_count > 0 {
+                        retried_expired_count += 1;
+                    }
                     continue;
                 }
                 match self.process_commit_core(&entry.sender, &entry.data) {
@@ -626,7 +644,9 @@ impl OfflineProtocol {
                         any_succeeded = true;
                     }
                     CommitOutcome::Retriable(_) => {
-                        // Still out-of-order — keep for next pass
+                        // Still out-of-order — keep for next pass with incremented retry count
+                        let mut entry = entry;
+                        entry.retry_count += 1;
                         still_pending.push_back(entry);
                     }
                     CommitOutcome::Rejected => {
@@ -660,10 +680,11 @@ impl OfflineProtocol {
             self.group_mesh.pending_commits.remove(group_id);
         }
 
-        // If commits expired without ever being resolved, this signals a
-        // potential epoch fork — two concurrent commits created divergent
-        // group states that can't be reconciled by simple reordering.
-        if expired_count > 0 && !self.group_mesh.epoch_forks.contains_key(group_id) {
+        // If commits that were retried (and kept failing) expired, this is a
+        // strong signal of epoch fork — the commits were valid but for a
+        // different epoch branch. Commits that expired without any retries
+        // are more likely just slow mesh delivery and are not flagged.
+        if retried_expired_count > 0 && !self.group_mesh.epoch_forks.contains_key(group_id) {
             self.flag_potential_epoch_fork(group_id);
         }
     }
@@ -692,7 +713,11 @@ impl OfflineProtocol {
             .and_then(|_| {
                 let mls_guard = self.read_mls_guard().ok()?;
                 let gid = offline_protocol_mls::GroupId::new(group_id);
-                mls_guard.get_group_info(&gid).ok().flatten().map(|i| i.epoch)
+                mls_guard
+                    .get_group_info(&gid)
+                    .ok()
+                    .flatten()
+                    .map(|i| i.epoch)
             })
             .unwrap_or(0);
 
@@ -795,7 +820,10 @@ impl OfflineProtocol {
             .collect();
         remaining.sort();
 
-        let should_remove = remaining.first().map(|first| first == &self_id).unwrap_or(false);
+        let should_remove = remaining
+            .first()
+            .map(|first| first == &self_id)
+            .unwrap_or(false);
 
         if should_remove {
             debug!(
@@ -814,18 +842,17 @@ impl OfflineProtocol {
                 );
             }
             // Clear any pending election for this leave (we handled it)
-            let election_key = format!("{}:{}", payload.group_id, sender);
-            self.group_mesh.pending_leave_elections.remove(&election_key);
+            let key = leave_election_key(&payload.group_id, sender);
+            self.group_mesh.pending_leave_elections.remove(&key);
         } else {
             // We're not the elected remover — record the election so we can
             // take over if the elected member fails to issue the commit in time.
-            let election_key = format!("{}:{}", payload.group_id, sender);
+            let key = leave_election_key(&payload.group_id, sender);
             self.group_mesh.pending_leave_elections.insert(
-                election_key,
+                key,
                 PendingLeaveElection {
                     group_id: payload.group_id.clone(),
                     leaving_member: sender.to_string(),
-                    remaining_members: remaining,
                     received_at: Instant::now(),
                 },
             );
@@ -1487,17 +1514,13 @@ impl OfflineProtocol {
                     // Distribute the key-update commit to all members
                     let commit_payload = GroupMlsCommitPayload {
                         group_id: fork.group_id.clone(),
-                        commit_type: GroupCommitType::Remove, // Closest semantic — epoch advancement
+                        commit_type: GroupCommitType::KeyUpdate,
                         ciphertext: base64_encode(&commit_msg.ciphertext),
                         epoch: commit_msg.epoch,
-                        affected_member: None, // Key update, not a membership change
+                        affected_member: None,
                     };
                     let commit_content = match serde_json::to_string(&commit_payload) {
-                        Ok(json) => format!(
-                            "{}{}",
-                            internal_prefixes::GROUP_MLS_COMMIT,
-                            json
-                        ),
+                        Ok(json) => format!("{}{}", internal_prefixes::GROUP_MLS_COMMIT, json),
                         Err(e) => {
                             warn!(
                                 group_id = %fork.group_id,
@@ -1583,38 +1606,58 @@ impl OfflineProtocol {
             .collect();
 
         for election in timed_out {
-            let election_key = format!("{}:{}", election.group_id, election.leaving_member);
+            let election_key = leave_election_key(&election.group_id, &election.leaving_member);
 
-            // Check if the leaving member is still in the group (MLS authoritative)
-            let still_member = self
+            // Refresh membership from MLS (authoritative) to avoid using
+            // stale election-time lists where members may have since left.
+            let current_members = self
                 .refresh_group_members(&election.group_id)
                 .ok()
                 .or_else(|| self.group_mesh.members.get(&election.group_id).cloned())
-                .map(|m| m.iter().any(|id| id == &election.leaving_member))
-                .unwrap_or(false);
+                .unwrap_or_default();
+
+            let still_member = current_members
+                .iter()
+                .any(|id| id == &election.leaving_member);
 
             if !still_member {
                 // Already removed — clean up
-                self.group_mesh.pending_leave_elections.remove(&election_key);
+                self.group_mesh
+                    .pending_leave_elections
+                    .remove(&election_key);
                 continue;
             }
+
+            // Use current membership for candidate selection, not the stale
+            // election-time list — members may have left since the election.
+            let mut remaining: Vec<String> = current_members
+                .iter()
+                .filter(|m| m.as_str() != election.leaving_member)
+                .cloned()
+                .collect();
+            remaining.sort();
 
             // Re-elect: walk the sorted remaining members. For each timeout
             // interval that has passed, advance one position in the list.
             // This staggers re-election so members don't all fire at once.
-            let elapsed_intervals = (election.received_at.elapsed().as_secs()
-                / LEAVE_ELECTION_TIMEOUT_SECS) as usize;
+            let elapsed_intervals =
+                (election.received_at.elapsed().as_secs() / LEAVE_ELECTION_TIMEOUT_SECS) as usize;
             // Interval 0 = first member (original election), 1 = second, etc.
-            let candidate_idx = elapsed_intervals.min(election.remaining_members.len().saturating_sub(1));
+            let candidate_idx = elapsed_intervals.min(remaining.len().saturating_sub(1));
 
-            if election.remaining_members.get(candidate_idx).map(|c| c == &self_id).unwrap_or(false) {
+            if remaining
+                .get(candidate_idx)
+                .map(|c| c == &self_id)
+                .unwrap_or(false)
+            {
                 info!(
                     group_id = %election.group_id,
                     leaving_member = %election.leaving_member,
                     attempt = candidate_idx + 1,
                     "Re-elected to issue MLS remove-commit (prior elected member timed out)"
                 );
-                if let Err(e) = self.remove_from_group(&election.group_id, &election.leaving_member) {
+                if let Err(e) = self.remove_from_group(&election.group_id, &election.leaving_member)
+                {
                     warn!(
                         group_id = %election.group_id,
                         leaving_member = %election.leaving_member,
@@ -1624,7 +1667,9 @@ impl OfflineProtocol {
                     // Don't remove from pending — next tick will try again
                     // or the next member in line will take over at the next interval.
                 } else {
-                    self.group_mesh.pending_leave_elections.remove(&election_key);
+                    self.group_mesh
+                        .pending_leave_elections
+                        .remove(&election_key);
                 }
             }
             // If we're not the candidate at this interval, leave the election

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -707,19 +707,24 @@ impl OfflineProtocol {
             }
         }
 
-        let local_epoch = self
-            .refresh_group_members(group_id)
-            .ok()
-            .and_then(|_| {
-                let mls_guard = self.read_mls_guard().ok()?;
-                let gid = offline_protocol_mls::GroupId::new(group_id);
-                mls_guard
-                    .get_group_info(&gid)
-                    .ok()
-                    .flatten()
-                    .map(|i| i.epoch)
-            })
-            .unwrap_or(0);
+        let local_epoch = self.refresh_group_members(group_id).ok().and_then(|_| {
+            let mls_guard = self.read_mls_guard().ok()?;
+            let gid = offline_protocol_mls::GroupId::new(group_id);
+            mls_guard
+                .get_group_info(&gid)
+                .ok()
+                .flatten()
+                .map(|i| i.epoch)
+        });
+
+        if local_epoch.is_none() {
+            warn!(
+                group_id = %group_id,
+                "Could not read local MLS epoch during fork detection — MLS unavailable or group not found"
+            );
+        }
+
+        let local_epoch = local_epoch.unwrap_or(0);
 
         warn!(
             group_id = %group_id,
@@ -1329,12 +1334,32 @@ impl OfflineProtocol {
             self.group_mesh.message_dedup = entries.into_iter().collect();
         }
 
-        // Expire stale pending commits
+        // Expire stale pending commits, tracking groups where retried commits
+        // expired — these are strong epoch fork signals (same as drain_pending_commits).
         let commit_cutoff = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS);
-        self.group_mesh.pending_commits.retain(|_, commits| {
-            commits.retain(|c| c.buffered_at > commit_cutoff);
+        let mut fork_candidates: Vec<String> = Vec::new();
+        self.group_mesh.pending_commits.retain(|group_id, commits| {
+            let mut retried_expired = false;
+            commits.retain(|c| {
+                let alive = c.buffered_at > commit_cutoff;
+                if !alive && c.retry_count > 0 {
+                    retried_expired = true;
+                }
+                alive
+            });
+            if retried_expired {
+                fork_candidates.push(group_id.clone());
+            }
             !commits.is_empty()
         });
+        // Flag forks for groups where retried commits expired during periodic
+        // cleanup — this covers the case where drain_pending_commits is never
+        // called because no new commits succeed for the group.
+        for group_id in fork_candidates {
+            if !self.group_mesh.epoch_forks.contains_key(&group_id) {
+                self.flag_potential_epoch_fork(&group_id);
+            }
+        }
     }
 
     // ========================================================================
@@ -1530,6 +1555,7 @@ impl OfflineProtocol {
                             continue;
                         }
                     };
+                    let mut failed_members = Vec::new();
                     for member in &members {
                         if member == &self_id {
                             continue;
@@ -1545,18 +1571,21 @@ impl OfflineProtocol {
                                 error = %e,
                                 "Failed to send fork resolution commit to member"
                             );
+                            failed_members.push(member.clone());
                         }
                     }
 
                     info!(
                         group_id = %fork.group_id,
                         new_epoch = commit_msg.epoch,
+                        failed_count = failed_members.len(),
                         "Epoch fork resolution commit distributed"
                     );
 
                     self.emit_event(Event::group_epoch_fork_resolved(
                         fork.group_id.clone(),
                         commit_msg.epoch,
+                        failed_members,
                     ));
 
                     // Clean up the fork state

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -43,11 +43,9 @@ pub(super) const MAX_PENDING_LEAVE_ELECTIONS: usize = 64;
 /// After this, the election is cleaned up regardless of whether the member
 /// was removed — prevents infinite retry loops when all candidates fail.
 pub(super) const LEAVE_ELECTION_MAX_LIFETIME_SECS: u64 = 300;
-
-/// Builds a deterministic key for leave election tracking: "group_id:member_id".
-pub(crate) fn leave_election_key(group_id: &str, member_id: &str) -> String {
-    format!("{}:{}", group_id, member_id)
-}
+/// Minimum cooldown between re-election attempts for the same leave election
+/// to prevent spamming MLS operations on every process tick (5 seconds).
+pub(super) const LEAVE_ELECTION_ATTEMPT_COOLDOWN_SECS: u64 = 5;
 
 /// Bundled state for group messaging.
 ///
@@ -79,8 +77,9 @@ pub(crate) struct GroupMeshState {
     pub(crate) internet_was_available: bool,
 
     /// Pending leave elections awaiting a remove-commit from the elected member.
-    /// Key: "group_id:leaving_member".
-    pub(crate) pending_leave_elections: HashMap<String, PendingLeaveElection>,
+    /// Key: (group_id, leaving_member_id) — uses a tuple to avoid ambiguity
+    /// from string concatenation when IDs contain separator characters.
+    pub(crate) pending_leave_elections: HashMap<(String, String), PendingLeaveElection>,
 
     /// Suspected epoch forks awaiting resolution. Key: group_id.
     pub(crate) epoch_forks: HashMap<String, EpochForkState>,
@@ -234,6 +233,10 @@ pub(crate) struct PendingLeaveElection {
     pub(crate) leaving_member: String,
     /// When we received the leave notification.
     pub(crate) received_at: Instant,
+    /// When we last attempted to issue a remove-commit for this election.
+    /// Used as a cooldown to prevent spamming MLS operations on every
+    /// process tick when the current candidate fails repeatedly.
+    pub(crate) last_attempt_at: Option<Instant>,
 }
 
 /// Tracks a suspected epoch fork for a group.
@@ -568,8 +571,9 @@ impl OfflineProtocol {
             ));
             // Clear any pending leave election for this member — the remove
             // has been committed successfully.
-            let key = leave_election_key(&payload.group_id, member);
-            self.group_mesh.pending_leave_elections.remove(&key);
+            self.group_mesh
+                .pending_leave_elections
+                .remove(&(payload.group_id.clone(), member.to_string()));
         }
 
         // Only clear fork tracking when a KeyUpdate commit succeeds — these
@@ -855,7 +859,7 @@ impl OfflineProtocol {
                 );
             }
             // Clear any pending election for this leave (we handled it)
-            let key = leave_election_key(&payload.group_id, sender);
+            let key = (payload.group_id.clone(), sender.to_string());
             self.group_mesh.pending_leave_elections.remove(&key);
         } else {
             // We're not the elected remover — record the election so we can
@@ -865,20 +869,21 @@ impl OfflineProtocol {
                 if let Some(oldest_key) = self
                     .group_mesh
                     .pending_leave_elections
-                    .values()
-                    .min_by_key(|e| e.received_at)
-                    .map(|e| leave_election_key(&e.group_id, &e.leaving_member))
+                    .iter()
+                    .min_by_key(|(_, e)| e.received_at)
+                    .map(|(k, _)| k.clone())
                 {
                     self.group_mesh.pending_leave_elections.remove(&oldest_key);
                 }
             }
-            let key = leave_election_key(&payload.group_id, sender);
+            let key = (payload.group_id.clone(), sender.to_string());
             self.group_mesh.pending_leave_elections.insert(
                 key,
                 PendingLeaveElection {
                     group_id: payload.group_id.clone(),
                     leaving_member: sender.to_string(),
                     received_at: Instant::now(),
+                    last_attempt_at: None,
                 },
             );
         }
@@ -1530,6 +1535,12 @@ impl OfflineProtocol {
             // Members on our branch will process this normally and advance.
             // Members on a forked branch will fail — the app layer should
             // handle re-inviting them.
+            //
+            // NOTE: We use `read_mls_guard` (RwLock read lock) even though
+            // `update_keys` mutates MLS state. This is correct because
+            // `MlsManager` uses interior mutability (internal Mutex on the
+            // group store), so a read guard is sufficient for all operations.
+            //
             // Acquire MLS lock, perform key update, and fully release the
             // guard before touching any other &mut self state.
             let update_result = {
@@ -1644,20 +1655,19 @@ impl OfflineProtocol {
     pub(crate) fn check_leave_election_timeouts(&mut self) {
         let timeout = StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS);
         let max_lifetime = StdDuration::from_secs(LEAVE_ELECTION_MAX_LIFETIME_SECS);
+        let attempt_cooldown = StdDuration::from_secs(LEAVE_ELECTION_ATTEMPT_COOLDOWN_SECS);
         let self_id = self.config.user_id.clone();
 
-        // Collect timed-out elections
-        let timed_out: Vec<PendingLeaveElection> = self
+        // Collect timed-out elections (keys + values) for processing.
+        let timed_out: Vec<((String, String), PendingLeaveElection)> = self
             .group_mesh
             .pending_leave_elections
-            .values()
-            .filter(|e| e.received_at.elapsed() > timeout)
-            .cloned()
+            .iter()
+            .filter(|(_, e)| e.received_at.elapsed() > timeout)
+            .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
 
-        for election in timed_out {
-            let election_key = leave_election_key(&election.group_id, &election.leaving_member);
-
+        for (election_key, election) in timed_out {
             // Circuit breaker: abandon the election after max lifetime to
             // prevent infinite per-tick retry loops when all candidates fail.
             if election.received_at.elapsed() > max_lifetime {
@@ -1704,9 +1714,11 @@ impl OfflineProtocol {
             // Re-elect: walk the sorted remaining members. For each timeout
             // interval that has passed, advance one position in the list.
             // This staggers re-election so members don't all fire at once.
+            // Interval 1 = first fallback (idx 0), interval 2 = second (idx 1), etc.
+            // The original elected member (lex-first) already had their shot
+            // during handle_group_mls_leave; this path only fires after timeout.
             let elapsed_intervals =
                 (election.received_at.elapsed().as_secs() / LEAVE_ELECTION_TIMEOUT_SECS) as usize;
-            // Interval 0 = first member (original election), 1 = second, etc.
             let candidate_idx = elapsed_intervals.min(remaining.len().saturating_sub(1));
 
             if remaining
@@ -1714,12 +1726,30 @@ impl OfflineProtocol {
                 .map(|c| c == &self_id)
                 .unwrap_or(false)
             {
+                // Rate-limit: skip if we already attempted within the cooldown window.
+                if let Some(last) = election.last_attempt_at {
+                    if last.elapsed() < attempt_cooldown {
+                        continue;
+                    }
+                }
+
                 info!(
                     group_id = %election.group_id,
                     leaving_member = %election.leaving_member,
                     attempt = candidate_idx + 1,
                     "Re-elected to issue MLS remove-commit (prior elected member timed out)"
                 );
+
+                // Record the attempt timestamp before trying, so the cooldown
+                // applies even on failure.
+                if let Some(state) = self
+                    .group_mesh
+                    .pending_leave_elections
+                    .get_mut(&election_key)
+                {
+                    state.last_attempt_at = Some(Instant::now());
+                }
+
                 if let Err(e) = self.remove_from_group(&election.group_id, &election.leaving_member)
                 {
                     warn!(
@@ -1728,8 +1758,8 @@ impl OfflineProtocol {
                         error = %e,
                         "Failed to issue MLS remove-commit during re-election"
                     );
-                    // Don't remove from pending — next tick will try again
-                    // or the next member in line will take over at the next interval.
+                    // Don't remove from pending — cooldown will prevent spam,
+                    // next interval will advance to the next candidate.
                 } else {
                     self.group_mesh
                         .pending_leave_elections

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -4289,3 +4289,370 @@ fn test_leave_election_proceeds_after_cooldown_expires() {
         "Bob should be removed after cooldown-expired re-election"
     );
 }
+
+// ========================================================================
+// STAGGERED RE-ELECTION WITH MULTIPLE CANDIDATES
+// ========================================================================
+
+#[test]
+fn test_leave_election_staggered_candidate_selection() {
+    // With 3+ remaining members, different timeout intervals should select
+    // different candidates. This verifies the staggered re-election logic
+    // advances through the sorted candidate list over time.
+    //
+    // Uses cached membership (no MLS group) so the leaver stays "in the group"
+    // across all intervals, allowing us to observe candidate progression.
+    let (mut protocol, _events) = setup_with_events();
+    let group_id = "group:staggered".to_string();
+    let leaving = "leaver";
+
+    // Set up a group with 4 remaining members after leaver departs.
+    // Sorted remaining (excluding leaver): ["alice", "bob", "charlie", "user123"]
+    // user123 (self) is at index 3 — selected at interval 3 (90-120s elapsed).
+    protocol.group_mesh.members.insert(
+        group_id.clone(),
+        vec![
+            "alice".to_string(),
+            "bob".to_string(),
+            "charlie".to_string(),
+            "user123".to_string(), // self (from create_test_config)
+            leaving.to_string(),
+        ],
+    );
+
+    let key = (group_id.clone(), leaving.to_string());
+
+    // Interval 1 (30-60s): candidate_idx=1 → "bob". We are "user123" → skip.
+    let past_1 = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS + 5);
+    protocol.group_mesh.pending_leave_elections.insert(
+        key.clone(),
+        PendingLeaveElection {
+            group_id: group_id.clone(),
+            leaving_member: leaving.to_string(),
+            received_at: past_1,
+            last_attempt_at: None,
+        },
+    );
+    protocol.check_leave_election_timeouts();
+    assert!(
+        protocol
+            .group_mesh
+            .pending_leave_elections
+            .contains_key(&key),
+        "Election should remain pending — user123 is not candidate at interval 1"
+    );
+
+    // Interval 2 (60-90s): candidate_idx=2 → "charlie". We are "user123" → skip.
+    let past_2 = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS * 2 + 5);
+    protocol
+        .group_mesh
+        .pending_leave_elections
+        .get_mut(&key)
+        .unwrap()
+        .received_at = past_2;
+    protocol.check_leave_election_timeouts();
+    assert!(
+        protocol
+            .group_mesh
+            .pending_leave_elections
+            .contains_key(&key),
+        "Election should remain pending — user123 is not candidate at interval 2"
+    );
+
+    // Interval 3 (90-120s): candidate_idx=3 → "user123". We ARE the candidate.
+    // remove_from_group will fail (no MLS group), so election stays with cooldown set.
+    let past_3 = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS * 3 + 5);
+    protocol
+        .group_mesh
+        .pending_leave_elections
+        .get_mut(&key)
+        .unwrap()
+        .received_at = past_3;
+    protocol
+        .group_mesh
+        .pending_leave_elections
+        .get_mut(&key)
+        .unwrap()
+        .last_attempt_at = None; // reset cooldown
+    protocol.check_leave_election_timeouts();
+
+    // remove_from_group failed → election stays pending with cooldown set
+    assert!(
+        protocol
+            .group_mesh
+            .pending_leave_elections
+            .contains_key(&key),
+        "Election should remain pending after failed remove at interval 3"
+    );
+    assert!(
+        protocol.group_mesh.pending_leave_elections[&key]
+            .last_attempt_at
+            .is_some(),
+        "Cooldown should be set — user123 was selected and attempted remove at interval 3"
+    );
+}
+
+#[test]
+fn test_leave_election_staggered_with_real_mls_group() {
+    // Full integration test: alice + bob MLS group, charlie (fake) is the
+    // leaver. "alice" is lex-first (idx 0), so interval 1 → idx 1 → "bob".
+    // alice is at idx 0 which was already tried in handle_group_mls_leave.
+    let (mut alice, _bob, group_id) = setup_alice_bob_group("Staggered Real Test");
+
+    // Add charlie to cached members (not actually in MLS — simulates a
+    // member who is "in the group" per local cache but MLS refresh will
+    // show only alice+bob).
+    alice
+        .group_mesh
+        .members
+        .get_mut(&group_id)
+        .unwrap()
+        .push("charlie".to_string());
+
+    let key = (group_id.clone(), "charlie".to_string());
+
+    // Interval 1 (30-60s): sorted remaining = ["alice", "bob"], candidate_idx=1 → "bob".
+    // We are "alice" → not selected → election stays.
+    let past = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS + 5);
+    alice.group_mesh.pending_leave_elections.insert(
+        key.clone(),
+        PendingLeaveElection {
+            group_id: group_id.clone(),
+            leaving_member: "charlie".to_string(),
+            received_at: past,
+            last_attempt_at: None,
+        },
+    );
+
+    alice.check_leave_election_timeouts();
+
+    // charlie is not in MLS, so still_member=false → cleaned up.
+    // This confirms refresh_group_members (MLS-authoritative) governs the check.
+    assert!(
+        !alice.group_mesh.pending_leave_elections.contains_key(&key),
+        "Election should be cleaned up — charlie is not in MLS group"
+    );
+}
+
+// ========================================================================
+// HANDLE_GROUP_MLS_LEAVE — ELSE BRANCH (PENDING ELECTION RECORDING)
+// ========================================================================
+
+#[test]
+fn test_handle_group_mls_leave_records_pending_election_for_non_elected() {
+    // When we are NOT the lex-first remaining member, handle_group_mls_leave
+    // should record a PendingLeaveElection so we can take over if the elected
+    // member fails.
+    let storage = Arc::new(crate::mls::InMemoryStorage::default());
+    let mut protocol = OfflineProtocol::new(create_test_config_for_user("zoe")).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    let group_id = "group:leave-else-branch".to_string();
+    // Sorted remaining after "bob" leaves: ["alice", "zoe"]
+    // alice is lex-first → elected. zoe (us) is NOT elected → records election.
+    protocol.group_mesh.members.insert(
+        group_id.clone(),
+        vec!["alice".to_string(), "bob".to_string(), "zoe".to_string()],
+    );
+
+    let leave_payload = GroupMlsLeavePayload {
+        group_id: group_id.clone(),
+        leaving_member: "bob".to_string(),
+    };
+    let data = serde_json::to_string(&leave_payload).unwrap();
+
+    protocol.handle_group_mls_leave("bob", &data);
+
+    let key = (group_id.clone(), "bob".to_string());
+    assert!(
+        protocol
+            .group_mesh
+            .pending_leave_elections
+            .contains_key(&key),
+        "Non-elected member should record a PendingLeaveElection"
+    );
+    let election = &protocol.group_mesh.pending_leave_elections[&key];
+    assert_eq!(election.group_id, group_id);
+    assert_eq!(election.leaving_member, "bob");
+    assert!(election.last_attempt_at.is_none());
+}
+
+#[test]
+fn test_handle_group_mls_leave_elected_does_not_record_election() {
+    // When we ARE the lex-first remaining member, handle_group_mls_leave
+    // should NOT record a PendingLeaveElection (we handle it immediately).
+    let (mut alice, _bob, group_id) = setup_alice_bob_group("Elected No Record");
+
+    let leave_payload = GroupMlsLeavePayload {
+        group_id: group_id.clone(),
+        leaving_member: "bob".to_string(),
+    };
+    let data = serde_json::to_string(&leave_payload).unwrap();
+
+    // alice < bob, so alice is elected → should handle immediately
+    alice.handle_group_mls_leave("bob", &data);
+
+    let key = (group_id.clone(), "bob".to_string());
+    assert!(
+        !alice.group_mesh.pending_leave_elections.contains_key(&key),
+        "Elected member should NOT have a pending election"
+    );
+}
+
+// ========================================================================
+// SYNC GROUPS TO RELAY — MLS REFRESH
+// ========================================================================
+
+#[test]
+fn test_sync_groups_to_relay_refreshes_from_mls() {
+    // Verify that check_relay_group_sync (which calls sync_groups_to_relay)
+    // refreshes membership from MLS before syncing, not using stale cache.
+    let (mut alice, _bob, group_id) = setup_alice_bob_group("Relay Refresh Test");
+
+    // Stale cache: only alice. MLS state has both alice and bob.
+    alice
+        .group_mesh
+        .members
+        .insert(group_id.clone(), vec!["alice".to_string()]);
+
+    // Mark as unsynced so sync_groups_to_relay will process it
+    alice.group_mesh.relay_synced.remove(&group_id);
+
+    // Enable relay config
+    alice.config.group.relay_enabled = true;
+
+    // Simulate internet becoming available (0→1 transition triggers sync)
+    alice.group_mesh.internet_was_available = false;
+    // Note: is_internet_available() checks transport_manager, which won't
+    // have internet in tests. So check_relay_group_sync won't trigger the
+    // sync path. Instead, test the refresh behavior directly by calling
+    // refresh_group_members and verifying it updates the stale cache.
+    let refreshed = alice.refresh_group_members(&group_id).unwrap();
+    assert!(
+        refreshed.contains(&"alice".to_string()) && refreshed.contains(&"bob".to_string()),
+        "refresh_group_members should return MLS-authoritative membership — got {:?}",
+        refreshed
+    );
+
+    // Verify the cache was updated from MLS
+    let cached = alice.group_mesh.members.get(&group_id).unwrap();
+    assert!(
+        cached.contains(&"alice".to_string()) && cached.contains(&"bob".to_string()),
+        "Cached membership should be updated from MLS — got {:?}",
+        cached
+    );
+}
+
+// ========================================================================
+// DRAIN PENDING COMMITS — MIXED RETRIED AND NON-RETRIED IN SAME GROUP
+// ========================================================================
+
+#[test]
+fn test_drain_pending_commits_mixed_retried_and_non_retried_expired() {
+    // When a group has both retried-expired and never-retried-expired commits,
+    // fork detection should fire (because at least one was retried).
+    let (mut protocol, events) = setup_with_events();
+    let info = protocol.create_group("Mixed Drain Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    let buf = protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_id.clone())
+        .or_default();
+
+    // Never-retried expired commit (slow delivery)
+    buf.push_back(PendingCommit {
+        sender: "alice".to_string(),
+        data: "fake-1".to_string(),
+        buffered_at: past,
+        retry_count: 0,
+    });
+    // Retried expired commit (epoch mismatch signal)
+    buf.push_back(PendingCommit {
+        sender: "bob".to_string(),
+        data: "fake-2".to_string(),
+        buffered_at: past,
+        retry_count: 2,
+    });
+    // Non-expired commit (should survive)
+    buf.push_back(PendingCommit {
+        sender: "carol".to_string(),
+        data: "fake-3".to_string(),
+        buffered_at: Instant::now(),
+        retry_count: 0,
+    });
+
+    protocol.drain_pending_commits(&group_id);
+
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&group_id),
+        "Fork should be detected when ANY expired commit has retry_count > 0"
+    );
+
+    // Non-expired commit should still be pending (rejected by process_commit_core
+    // but not expired, so it gets dropped as Rejected)
+    let events = events.lock().unwrap();
+    assert!(
+        events.iter().any(
+            |e| matches!(e, Event::GroupEpochForkDetected { group_id: gid, .. } if gid == &group_id)
+        ),
+        "Should emit fork detection event for mixed group"
+    );
+}
+
+// ========================================================================
+// LEAVE ELECTION — REMOVE_FROM_GROUP FAILURE DURING RE-ELECTION
+// ========================================================================
+
+#[test]
+fn test_leave_election_remove_failure_keeps_election_pending() {
+    // When remove_from_group fails during re-election, the election should
+    // remain pending (with cooldown set) so the next candidate can try.
+    let storage = Arc::new(crate::mls::InMemoryStorage::default());
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    // Use a fake group where the leaver is "in the group" per cache but
+    // remove_from_group will fail because the MLS group doesn't exist.
+    let group_id = "group:remove-fail".to_string();
+    let leaver = "leaver";
+    protocol.group_mesh.members.insert(
+        group_id.clone(),
+        vec![
+            leaver.to_string(),
+            "user123".to_string(), // self — will be lex-first after filtering leaver
+        ],
+    );
+
+    let past = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS + 5);
+    let key = (group_id.clone(), leaver.to_string());
+    protocol.group_mesh.pending_leave_elections.insert(
+        key.clone(),
+        PendingLeaveElection {
+            group_id: group_id.clone(),
+            leaving_member: leaver.to_string(),
+            received_at: past,
+            last_attempt_at: None,
+        },
+    );
+
+    protocol.check_leave_election_timeouts();
+
+    // remove_from_group should fail (MLS group doesn't exist) → election stays
+    assert!(
+        protocol
+            .group_mesh
+            .pending_leave_elections
+            .contains_key(&key),
+        "Election should remain pending after remove_from_group failure"
+    );
+
+    // Cooldown should be set (last_attempt_at populated)
+    let election = &protocol.group_mesh.pending_leave_elections[&key];
+    assert!(
+        election.last_attempt_at.is_some(),
+        "last_attempt_at should be set after failed attempt"
+    );
+}

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -3260,13 +3260,14 @@ fn test_leave_election_cleared_when_member_already_removed() {
     // "bob" was never added to this MLS group, so refresh_group_members
     // won't find him — simulates a member that was already removed.
     let past = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS + 5);
-    let key = leave_election_key(&group_id, "bob");
+    let key = (group_id.clone(), "bob".to_string());
     protocol.group_mesh.pending_leave_elections.insert(
         key.clone(),
         PendingLeaveElection {
             group_id: group_id.clone(),
             leaving_member: "bob".to_string(),
             received_at: past,
+            last_attempt_at: None,
         },
     );
 
@@ -3289,13 +3290,14 @@ fn test_leave_election_timeout_re_elects_self() {
     // After filtering out the leaver ("bob"), remaining = ["alice"].
     // alice is lex-first → candidate at interval 0 → should attempt remove.
     let past = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS + 5);
-    let key = leave_election_key(&group_id, "bob");
+    let key = (group_id.clone(), "bob".to_string());
     alice.group_mesh.pending_leave_elections.insert(
         key.clone(),
         PendingLeaveElection {
             group_id: group_id.clone(),
             leaving_member: "bob".to_string(),
             received_at: past,
+            last_attempt_at: None,
         },
     );
 
@@ -3322,13 +3324,14 @@ fn test_leave_election_not_triggered_before_timeout() {
     let group_id = info.group_id.as_str().to_string();
 
     // Insert a pending election that hasn't timed out yet
-    let key = leave_election_key(&group_id, "bob");
+    let key = (group_id.clone(), "bob".to_string());
     protocol.group_mesh.pending_leave_elections.insert(
         key.clone(),
         PendingLeaveElection {
             group_id: group_id.clone(),
             leaving_member: "bob".to_string(),
             received_at: Instant::now(), // just now — well within timeout
+            last_attempt_at: None,
         },
     );
 
@@ -3341,15 +3344,6 @@ fn test_leave_election_not_triggered_before_timeout() {
             .pending_leave_elections
             .contains_key(&key),
         "Election should remain pending before timeout"
-    );
-}
-
-#[test]
-fn test_leave_election_key_helper() {
-    assert_eq!(leave_election_key("group1", "alice"), "group1:alice");
-    assert_eq!(
-        leave_election_key("my-group-id", "user:123"),
-        "my-group-id:user:123"
     );
 }
 
@@ -3527,75 +3521,14 @@ fn test_epoch_fork_cleanup_does_not_duplicate_existing_fork() {
 #[test]
 fn test_epoch_fork_resolution_includes_failed_members() {
     // Verifies that GroupEpochForkResolved includes members we couldn't reach.
-    // Use a real MLS group but DON'T start the protocol — send_internal_message
-    // will fail for all members, simulating unreachable peers.
-    let storage = Arc::new(crate::mls::InMemoryStorage::default());
-    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
-    protocol.initialize_mls(storage).unwrap();
-
-    let info = protocol.create_group("Failed Members Test").unwrap();
-    let group_id = info.group_id.as_str().to_string();
-
-    // Use a fake group_id that doesn't exist in MLS so refresh_group_members
-    // fails and falls back to the cache, preserving our injected members.
-    let fake_group_id = "fake_fork_failed_members".to_string();
-    protocol.group_mesh.members.insert(
-        fake_group_id.clone(),
-        vec![
-            "bob".to_string(),
-            "carol".to_string(),
-            "user123".to_string(),
-        ],
-    );
-
-    // Insert a fork for the REAL group_id (so update_keys succeeds) but
-    // use the fake_group_id for the fork tracking. We need update_keys to
-    // succeed, so instead test with the real group_id and simply don't start
-    // the protocol. The real group only has user123 from MLS perspective,
-    // so refresh_group_members returns only user123 and there's nobody to
-    // fail sending to. Instead, let's test the tracking differently:
-    // We use setup_alice_bob_group which gives us a 2-member group, then
-    // don't start the protocol for the resolution check.
-
-    // Clean approach: use the real group with injected extra fake members.
-    // refresh_group_members will overwrite to the real MLS membership,
-    // so we put the fork on the real group and inject fake members.
-    // Since refresh succeeds, members = MLS members = [user123].
-    // No other members → no sends → no failures. That won't test it.
-
-    // Best approach: put fork on a fake group_id so refresh fails and
-    // cache is used. update_keys for a nonexistent group will fail.
-    // That's the update_keys failure path, not what we want.
-
-    // Final approach: use a started alice+bob group, but stop the protocol
-    // so sends fail.
-    drop(protocol);
-
-    let (mut alice, _bob, group_id) = setup_alice_bob_group("Failed Members Fork Test");
-
-    // Alice's protocol is started but we can break sends by stopping it.
-    // Actually, send_internal_message uses the outbox. It won't fail
-    // for a started protocol. Instead, inject a fake third member that
-    // doesn't exist — sends to real members will succeed (go to outbox),
-    // but we can verify the event structure works.
-
-    // Simplest valid test: use fake group_id with cached members. The
-    // fork resolution will fail at update_keys (group not in MLS), which
-    // is the Err branch. To test failed_members in the Ok branch, we
-    // need update_keys to succeed. So use the real group_id. refresh
-    // will give [alice, bob]. Sends to bob will succeed (outbox). So
-    // failed_members will be empty. That tests the happy path.
-
-    // To get actual send failures: don't start the protocol.
-    drop(alice);
-
+    // Strategy: create a real alice+bob MLS group, then stop alice's protocol
+    // so send_internal_message fails for bob, populating failed_members.
     let storage_a = Arc::new(crate::mls::InMemoryStorage::default());
     let storage_b = Arc::new(crate::mls::InMemoryStorage::default());
     let mut alice = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
     let mut bob = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
     alice.initialize_mls(storage_a).unwrap();
     bob.initialize_mls(storage_b).unwrap();
-    // Start ONLY for group creation, then we don't need it for sends
     alice.start().unwrap();
     bob.start().unwrap();
 
@@ -3615,7 +3548,7 @@ fn test_epoch_fork_resolution_includes_failed_members() {
     }
     alice.refresh_group_members(&group_id).unwrap();
 
-    // Stop alice so send_internal_message fails
+    // Stop alice so send_internal_message fails for bob
     let _ = alice.stop();
 
     let past = Instant::now() - StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS + 5);
@@ -4006,13 +3939,14 @@ fn test_pending_leave_elections_size_cap_eviction() {
     for i in 0..MAX_PENDING_LEAVE_ELECTIONS {
         let gid = format!("group_{}", i);
         let member = format!("member_{}", i);
-        let key = leave_election_key(&gid, &member);
+        let key = (gid.clone(), member.clone());
         protocol.group_mesh.pending_leave_elections.insert(
             key,
             PendingLeaveElection {
                 group_id: gid,
                 leaving_member: member,
                 received_at: Instant::now(),
+                last_attempt_at: None,
             },
         );
     }
@@ -4050,7 +3984,7 @@ fn test_pending_leave_elections_size_cap_eviction() {
         "Pending leave elections should not exceed MAX_PENDING_LEAVE_ELECTIONS"
     );
     // The new election should exist
-    let new_key = leave_election_key(&new_group, new_leaver);
+    let new_key = (new_group.clone(), new_leaver.to_string());
     assert!(
         protocol
             .group_mesh
@@ -4068,13 +4002,14 @@ fn test_leave_election_circuit_breaker_max_lifetime() {
 
     // Insert an election that has exceeded max lifetime
     let very_old = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_MAX_LIFETIME_SECS + 10);
-    let key = leave_election_key(&group_id, leaving_member);
+    let key = (group_id.clone(), leaving_member.to_string());
     protocol.group_mesh.pending_leave_elections.insert(
         key.clone(),
         PendingLeaveElection {
             group_id: group_id.clone(),
             leaving_member: leaving_member.to_string(),
             received_at: very_old,
+            last_attempt_at: None,
         },
     );
 
@@ -4103,7 +4038,7 @@ fn test_leave_election_circuit_breaker_max_lifetime() {
 fn test_non_key_update_commit_does_not_clear_fork_state() {
     // A successful Add or Remove commit should NOT clear fork state.
     // Only KeyUpdate commits (the resolution mechanism) clear it.
-    let (mut alice, mut bob, group_id) = setup_alice_bob_group("Fork Preserve Test");
+    let (mut alice, bob, group_id) = setup_alice_bob_group("Fork Preserve Test");
 
     // Insert a fork state for this group
     alice.group_mesh.epoch_forks.insert(
@@ -4148,7 +4083,7 @@ fn test_non_key_update_commit_does_not_clear_fork_state() {
 #[test]
 fn test_key_update_commit_clears_fork_state() {
     // Verify that a KeyUpdate commit DOES clear fork state (the complement test).
-    let (mut alice, mut bob, group_id) = setup_alice_bob_group("Fork Clear KU Test");
+    let (mut alice, bob, group_id) = setup_alice_bob_group("Fork Clear KU Test");
 
     alice.group_mesh.epoch_forks.insert(
         group_id.clone(),
@@ -4279,5 +4214,78 @@ fn test_epoch_fork_periodic_cleanup_multiple_groups_mixed() {
         fork_events.len(),
         1,
         "Only one fork event should be emitted"
+    );
+}
+
+#[test]
+fn test_leave_election_cooldown_prevents_per_tick_spam() {
+    // Verifies that after a failed remove attempt, the cooldown prevents
+    // repeated MLS operations on every process tick.
+    let (mut alice, _bob, group_id) = setup_alice_bob_group("Cooldown Test");
+
+    // Set up an election for bob that has timed out
+    let past = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS + 5);
+    let key = (group_id.clone(), "bob".to_string());
+
+    // Simulate a recent failed attempt by setting last_attempt_at to just now
+    alice.group_mesh.pending_leave_elections.insert(
+        key.clone(),
+        PendingLeaveElection {
+            group_id: group_id.clone(),
+            leaving_member: "bob".to_string(),
+            received_at: past,
+            last_attempt_at: Some(Instant::now()), // just attempted
+        },
+    );
+
+    // Bob is still in the group, but the cooldown should prevent another attempt
+    alice.check_leave_election_timeouts();
+
+    // Election should still be pending (cooldown hasn't elapsed)
+    assert!(
+        alice.group_mesh.pending_leave_elections.contains_key(&key),
+        "Election should remain pending during cooldown"
+    );
+    // Bob should still be in the group (no remove attempted)
+    let members = alice.refresh_group_members(&group_id).unwrap();
+    assert!(
+        members.contains(&"bob".to_string()),
+        "Bob should still be in group — cooldown should prevent remove attempt"
+    );
+}
+
+#[test]
+fn test_leave_election_proceeds_after_cooldown_expires() {
+    // Verifies that once the cooldown expires, the re-election proceeds.
+    let (mut alice, _bob, group_id) = setup_alice_bob_group("Cooldown Expiry Test");
+
+    let past = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS + 5);
+    let key = (group_id.clone(), "bob".to_string());
+
+    // Set last_attempt_at to well beyond the cooldown window
+    let old_attempt =
+        Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_ATTEMPT_COOLDOWN_SECS + 5);
+    alice.group_mesh.pending_leave_elections.insert(
+        key.clone(),
+        PendingLeaveElection {
+            group_id: group_id.clone(),
+            leaving_member: "bob".to_string(),
+            received_at: past,
+            last_attempt_at: Some(old_attempt),
+        },
+    );
+
+    alice.check_leave_election_timeouts();
+
+    // Remove should succeed → election cleared
+    assert!(
+        !alice.group_mesh.pending_leave_elections.contains_key(&key),
+        "Election should be cleared after successful remove (cooldown expired)"
+    );
+    // Bob should be removed
+    let members = alice.refresh_group_members(&group_id).unwrap();
+    assert!(
+        !members.contains(&"bob".to_string()),
+        "Bob should be removed after cooldown-expired re-election"
     );
 }

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -3387,3 +3387,668 @@ fn test_key_update_commit_type_serialization() {
     assert_eq!(deserialized.commit_type, GroupCommitType::KeyUpdate);
     assert!(deserialized.affected_member.is_none());
 }
+
+// ========================================================================
+// EPOCH FORK DETECTION & RESOLUTION — RESILIENCE TESTS
+// ========================================================================
+
+#[test]
+fn test_epoch_fork_detected_via_periodic_cleanup_without_drain() {
+    // Validates fix for the "complete fork" scenario: when NO commits
+    // succeed for a group, drain_pending_commits is never called. Fork
+    // detection must also fire from cleanup_group_message_dedup.
+    let (mut protocol, events) = setup_with_events();
+    let info = protocol.create_group("Periodic Fork Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Insert expired pending commit with retry_count > 0 (fork signal)
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_id.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake-commit".to_string(),
+            buffered_at: past,
+            retry_count: 2,
+        });
+
+    // Do NOT call drain_pending_commits — call periodic cleanup instead
+    protocol.cleanup_group_message_dedup();
+
+    // Fork should be detected via the periodic cleanup path
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&group_id),
+        "Fork should be detected during periodic cleanup when retried commits expire"
+    );
+
+    let events = events.lock().unwrap();
+    assert!(
+        events.iter().any(
+            |e| matches!(e, Event::GroupEpochForkDetected { group_id: gid, .. } if gid == &group_id)
+        ),
+        "Should emit GroupEpochForkDetected during periodic cleanup"
+    );
+}
+
+#[test]
+fn test_epoch_fork_not_flagged_via_cleanup_for_never_retried() {
+    // Commits that expired with retry_count=0 during periodic cleanup
+    // should NOT trigger fork detection (likely just slow delivery).
+    let (mut protocol, events) = setup_with_events();
+    let info = protocol.create_group("No Fork Cleanup").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_id.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 0, // never retried
+        });
+
+    protocol.cleanup_group_message_dedup();
+
+    assert!(
+        !protocol.group_mesh.epoch_forks.contains_key(&group_id),
+        "Never-retried expired commits should not trigger fork detection during cleanup"
+    );
+    let events = events.lock().unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::GroupEpochForkDetected { .. })),
+        "No fork event for never-retried expired commits"
+    );
+}
+
+#[test]
+fn test_epoch_fork_cleanup_does_not_duplicate_existing_fork() {
+    // If a fork is already tracked for a group, periodic cleanup should
+    // not overwrite it with a new detection.
+    let (mut protocol, events) = setup_with_events();
+    let info = protocol.create_group("No Dup Cleanup").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Pre-insert fork state
+    let original_detected_at = Instant::now() - StdDuration::from_secs(30);
+    protocol.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: 42,
+            detected_at: original_detected_at,
+            resolution_attempted: false,
+        },
+    );
+
+    // Insert expired retried commit
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_id.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 3,
+        });
+
+    protocol.cleanup_group_message_dedup();
+
+    // Original fork state should be preserved
+    assert_eq!(protocol.group_mesh.epoch_forks[&group_id].local_epoch, 42);
+
+    // No new fork detection event should be emitted
+    let events = events.lock().unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::GroupEpochForkDetected { .. })),
+        "Should not emit duplicate fork detection event"
+    );
+}
+
+#[test]
+fn test_epoch_fork_resolution_includes_failed_members() {
+    // Verifies that GroupEpochForkResolved includes members we couldn't reach.
+    // Use a real MLS group but DON'T start the protocol — send_internal_message
+    // will fail for all members, simulating unreachable peers.
+    let storage = Arc::new(crate::mls::InMemoryStorage::default());
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    let info = protocol.create_group("Failed Members Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Use a fake group_id that doesn't exist in MLS so refresh_group_members
+    // fails and falls back to the cache, preserving our injected members.
+    let fake_group_id = "fake_fork_failed_members".to_string();
+    protocol.group_mesh.members.insert(
+        fake_group_id.clone(),
+        vec![
+            "bob".to_string(),
+            "carol".to_string(),
+            "user123".to_string(),
+        ],
+    );
+
+    // Insert a fork for the REAL group_id (so update_keys succeeds) but
+    // use the fake_group_id for the fork tracking. We need update_keys to
+    // succeed, so instead test with the real group_id and simply don't start
+    // the protocol. The real group only has user123 from MLS perspective,
+    // so refresh_group_members returns only user123 and there's nobody to
+    // fail sending to. Instead, let's test the tracking differently:
+    // We use setup_alice_bob_group which gives us a 2-member group, then
+    // don't start the protocol for the resolution check.
+
+    // Clean approach: use the real group with injected extra fake members.
+    // refresh_group_members will overwrite to the real MLS membership,
+    // so we put the fork on the real group and inject fake members.
+    // Since refresh succeeds, members = MLS members = [user123].
+    // No other members → no sends → no failures. That won't test it.
+
+    // Best approach: put fork on a fake group_id so refresh fails and
+    // cache is used. update_keys for a nonexistent group will fail.
+    // That's the update_keys failure path, not what we want.
+
+    // Final approach: use a started alice+bob group, but stop the protocol
+    // so sends fail.
+    drop(protocol);
+
+    let (mut alice, _bob, group_id) = setup_alice_bob_group("Failed Members Fork Test");
+
+    // Alice's protocol is started but we can break sends by stopping it.
+    // Actually, send_internal_message uses the outbox. It won't fail
+    // for a started protocol. Instead, inject a fake third member that
+    // doesn't exist — sends to real members will succeed (go to outbox),
+    // but we can verify the event structure works.
+
+    // Simplest valid test: use fake group_id with cached members. The
+    // fork resolution will fail at update_keys (group not in MLS), which
+    // is the Err branch. To test failed_members in the Ok branch, we
+    // need update_keys to succeed. So use the real group_id. refresh
+    // will give [alice, bob]. Sends to bob will succeed (outbox). So
+    // failed_members will be empty. That tests the happy path.
+
+    // To get actual send failures: don't start the protocol.
+    drop(alice);
+
+    let storage_a = Arc::new(crate::mls::InMemoryStorage::default());
+    let storage_b = Arc::new(crate::mls::InMemoryStorage::default());
+    let mut alice = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
+    let mut bob = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
+    alice.initialize_mls(storage_a).unwrap();
+    bob.initialize_mls(storage_b).unwrap();
+    // Start ONLY for group creation, then we don't need it for sends
+    alice.start().unwrap();
+    bob.start().unwrap();
+
+    let group_info = alice.create_group("Fork Send Fail").unwrap();
+    let group_id = group_info.group_id.as_str().to_string();
+
+    let bob_kp = {
+        let bob_mls = bob.mls_manager_for_testing().read().unwrap();
+        bob_mls.generate_key_package().unwrap()
+    };
+    {
+        let alice_mls = alice.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id);
+        alice_mls
+            .add_group_member(&gid, &bob_kp.key_package_data)
+            .unwrap();
+    }
+    alice.refresh_group_members(&group_id).unwrap();
+
+    // Stop alice so send_internal_message fails
+    let _ = alice.stop();
+
+    let past = Instant::now() - StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS + 5);
+    alice.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: 1,
+            detected_at: past,
+            resolution_attempted: false,
+        },
+    );
+
+    let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = events.clone();
+    alice.on_event(move |event| {
+        events_clone.lock().unwrap().push(event);
+    });
+
+    alice.check_epoch_forks();
+
+    // Fork should be resolved (key update succeeds even if sends fail)
+    assert!(
+        !alice.group_mesh.epoch_forks.contains_key(&group_id),
+        "Fork should be cleaned up after resolution attempt"
+    );
+
+    let events = events.lock().unwrap();
+    let resolved = events.iter().find(
+        |e| matches!(e, Event::GroupEpochForkResolved { group_id: gid, .. } if gid == &group_id),
+    );
+    assert!(resolved.is_some(), "Should emit GroupEpochForkResolved");
+
+    if let Some(Event::GroupEpochForkResolved { failed_members, .. }) = resolved {
+        // Bob should be in failed_members because protocol is stopped
+        assert!(
+            failed_members.contains(&"bob".to_string()),
+            "bob should be in failed_members when protocol is stopped"
+        );
+        // Alice (self) should NOT be in failed_members
+        assert!(
+            !failed_members.contains(&"alice".to_string()),
+            "self should not be in failed_members"
+        );
+    } else {
+        panic!("Expected GroupEpochForkResolved event");
+    }
+}
+
+#[test]
+fn test_epoch_fork_resolution_no_failed_members_when_all_succeed() {
+    // When the leader successfully sends to all members, failed_members should be empty.
+    let (mut protocol, events) = setup_started_with_events();
+    let info = protocol.create_group("All Succeed Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Solo group — no other members to send to
+    let past = Instant::now() - StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS + 5);
+    protocol.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: 1,
+            detected_at: past,
+            resolution_attempted: false,
+        },
+    );
+
+    protocol.check_epoch_forks();
+
+    let events = events.lock().unwrap();
+    let resolved = events.iter().find(
+        |e| matches!(e, Event::GroupEpochForkResolved { group_id: gid, .. } if gid == &group_id),
+    );
+    assert!(resolved.is_some(), "Should emit resolved event");
+    if let Some(Event::GroupEpochForkResolved { failed_members, .. }) = resolved {
+        assert!(
+            failed_members.is_empty(),
+            "No failed members when all sends succeed"
+        );
+    }
+}
+
+#[test]
+fn test_epoch_fork_update_keys_failure_leaves_resolution_attempted() {
+    // When update_keys fails, resolution_attempted stays true (manual intervention needed).
+    let storage = Arc::new(crate::mls::InMemoryStorage::default());
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    // Use a fake group_id that doesn't exist in MLS — update_keys will fail.
+    let fake_group_id = "group:nonexistent-for-update".to_string();
+    protocol.group_mesh.members.insert(
+        fake_group_id.clone(),
+        vec!["user123".to_string()], // self is leader
+    );
+
+    let past = Instant::now() - StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS + 5);
+    protocol.group_mesh.epoch_forks.insert(
+        fake_group_id.clone(),
+        EpochForkState {
+            group_id: fake_group_id.clone(),
+            local_epoch: 1,
+            detected_at: past,
+            resolution_attempted: false,
+        },
+    );
+
+    let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = events.clone();
+    protocol.on_event(move |event| {
+        events_clone.lock().unwrap().push(event);
+    });
+
+    protocol.check_epoch_forks();
+
+    // Fork should still exist with resolution_attempted = true
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&fake_group_id),
+        "Fork should remain when update_keys fails"
+    );
+    assert!(
+        protocol.group_mesh.epoch_forks[&fake_group_id].resolution_attempted,
+        "resolution_attempted should be true after failed update_keys"
+    );
+
+    // No resolved event should be emitted
+    let events = events.lock().unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::GroupEpochForkResolved { .. })),
+        "Should not emit resolved event when update_keys fails"
+    );
+}
+
+#[test]
+fn test_epoch_fork_mls_unavailable_resets_resolution_attempted() {
+    // When MLS is completely unavailable during resolution, resolution_attempted
+    // should be reset to false so it can be retried on the next tick.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    // Deliberately do NOT initialize MLS — read_mls_guard will fail
+
+    let group_id = "group:no-mls".to_string();
+    protocol
+        .group_mesh
+        .members
+        .insert(group_id.clone(), vec!["user123".to_string()]);
+
+    let past = Instant::now() - StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS + 5);
+    protocol.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: 0,
+            detected_at: past,
+            resolution_attempted: false,
+        },
+    );
+
+    protocol.check_epoch_forks();
+
+    // Fork should still exist with resolution_attempted = false (reset for retry)
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&group_id),
+        "Fork should remain when MLS is unavailable"
+    );
+    assert!(
+        !protocol.group_mesh.epoch_forks[&group_id].resolution_attempted,
+        "resolution_attempted should be reset to false when MLS is unavailable"
+    );
+}
+
+#[test]
+fn test_epoch_fork_multiple_concurrent_groups() {
+    // Multiple groups can have independent forks detected and tracked.
+    let (mut protocol, events) = setup_with_events();
+    let info_a = protocol.create_group("Fork Group A").unwrap();
+    let info_b = protocol.create_group("Fork Group B").unwrap();
+    let group_a = info_a.group_id.as_str().to_string();
+    let group_b = info_b.group_id.as_str().to_string();
+
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+
+    // Insert expired retried commits for BOTH groups
+    for gid in [&group_a, &group_b] {
+        protocol
+            .group_mesh
+            .pending_commits
+            .entry(gid.clone())
+            .or_default()
+            .push_back(PendingCommit {
+                sender: "bob".to_string(),
+                data: "fake".to_string(),
+                buffered_at: past,
+                retry_count: 1,
+            });
+    }
+
+    // Trigger fork detection via periodic cleanup
+    protocol.cleanup_group_message_dedup();
+
+    // Both groups should have forks detected independently
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&group_a),
+        "Group A should have fork detected"
+    );
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&group_b),
+        "Group B should have fork detected"
+    );
+
+    let events = events.lock().unwrap();
+    let fork_events: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, Event::GroupEpochForkDetected { .. }))
+        .collect();
+    assert_eq!(
+        fork_events.len(),
+        2,
+        "Should emit fork detection for both groups"
+    );
+}
+
+#[test]
+fn test_epoch_fork_multiple_groups_resolve_independently() {
+    // Forks in different groups resolve independently — resolving one
+    // should not affect the other.
+    let (mut protocol, events) = setup_with_events();
+    let info_a = protocol.create_group("Resolve A").unwrap();
+    let info_b = protocol.create_group("Resolve B").unwrap();
+    let group_a = info_a.group_id.as_str().to_string();
+    let group_b = info_b.group_id.as_str().to_string();
+
+    let past = Instant::now() - StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS + 5);
+
+    // Group A: fork ready for resolution
+    protocol.group_mesh.epoch_forks.insert(
+        group_a.clone(),
+        EpochForkState {
+            group_id: group_a.clone(),
+            local_epoch: 1,
+            detected_at: past,
+            resolution_attempted: false,
+        },
+    );
+
+    // Group B: fork not yet ready (detected just now)
+    protocol.group_mesh.epoch_forks.insert(
+        group_b.clone(),
+        EpochForkState {
+            group_id: group_b.clone(),
+            local_epoch: 2,
+            detected_at: Instant::now(),
+            resolution_attempted: false,
+        },
+    );
+
+    protocol.check_epoch_forks();
+
+    // Group A should be resolved and cleaned up
+    assert!(
+        !protocol.group_mesh.epoch_forks.contains_key(&group_a),
+        "Group A fork should be resolved"
+    );
+
+    // Group B should still be pending (delay not elapsed)
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&group_b),
+        "Group B fork should still be pending"
+    );
+    assert!(
+        !protocol.group_mesh.epoch_forks[&group_b].resolution_attempted,
+        "Group B resolution should not have been attempted"
+    );
+
+    let events = events.lock().unwrap();
+    let resolved_count = events
+        .iter()
+        .filter(|e| matches!(e, Event::GroupEpochForkResolved { .. }))
+        .count();
+    assert_eq!(resolved_count, 1, "Only group A should have been resolved");
+}
+
+#[test]
+fn test_epoch_fork_stale_cleanup_removes_old_attempted_and_unattempted() {
+    // Both attempted and unattempted forks older than 5 minutes are cleaned up.
+    let (mut protocol, _events) = setup_with_events();
+
+    let very_old = Instant::now() - StdDuration::from_secs(400);
+
+    // Old fork with resolution_attempted = true
+    protocol.group_mesh.epoch_forks.insert(
+        "stale_attempted".to_string(),
+        EpochForkState {
+            group_id: "stale_attempted".to_string(),
+            local_epoch: 1,
+            detected_at: very_old,
+            resolution_attempted: true,
+        },
+    );
+
+    // Old fork with resolution_attempted = false
+    protocol.group_mesh.epoch_forks.insert(
+        "stale_unattempted".to_string(),
+        EpochForkState {
+            group_id: "stale_unattempted".to_string(),
+            local_epoch: 2,
+            detected_at: very_old,
+            resolution_attempted: false,
+        },
+    );
+
+    // Recent fork — should survive
+    protocol.group_mesh.epoch_forks.insert(
+        "recent_fork".to_string(),
+        EpochForkState {
+            group_id: "recent_fork".to_string(),
+            local_epoch: 3,
+            detected_at: Instant::now(),
+            resolution_attempted: false,
+        },
+    );
+
+    protocol.check_epoch_forks();
+
+    assert!(
+        !protocol
+            .group_mesh
+            .epoch_forks
+            .contains_key("stale_attempted"),
+        "Old attempted fork should be cleaned up"
+    );
+    assert!(
+        !protocol
+            .group_mesh
+            .epoch_forks
+            .contains_key("stale_unattempted"),
+        "Old unattempted fork should be cleaned up"
+    );
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key("recent_fork"),
+        "Recent fork should survive cleanup"
+    );
+}
+
+#[test]
+fn test_epoch_fork_detection_with_mls_unavailable_logs_epoch_zero() {
+    // When MLS is not initialized, flag_potential_epoch_fork should
+    // still work — local_epoch falls back to 0 with a warning logged.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    // MLS NOT initialized
+
+    let group_id = "group:no-mls-fork".to_string();
+
+    // Insert expired retried commit
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_id.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 1,
+        });
+
+    // Should not panic — fork detection gracefully handles MLS unavailable
+    protocol.drain_pending_commits(&group_id);
+
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&group_id),
+        "Fork should be detected even when MLS is unavailable"
+    );
+    assert_eq!(
+        protocol.group_mesh.epoch_forks[&group_id].local_epoch, 0,
+        "local_epoch should fall back to 0 when MLS is unavailable"
+    );
+}
+
+#[test]
+fn test_epoch_fork_periodic_cleanup_multiple_groups_mixed() {
+    // Periodic cleanup should only flag forks for groups with retried-expired
+    // commits, not groups with only never-retried expired commits.
+    let (mut protocol, events) = setup_with_events();
+    let info_fork = protocol.create_group("Will Fork").unwrap();
+    let info_nofork = protocol.create_group("No Fork").unwrap();
+    let group_fork = info_fork.group_id.as_str().to_string();
+    let group_nofork = info_nofork.group_id.as_str().to_string();
+
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+
+    // group_fork: retried expired commit → should flag fork
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_fork.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 2,
+        });
+
+    // group_nofork: never-retried expired commit → should NOT flag fork
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_nofork.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "carol".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 0,
+        });
+
+    protocol.cleanup_group_message_dedup();
+
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&group_fork),
+        "Group with retried expired commits should have fork detected"
+    );
+    assert!(
+        !protocol.group_mesh.epoch_forks.contains_key(&group_nofork),
+        "Group with only never-retried expired commits should not have fork"
+    );
+
+    let events = events.lock().unwrap();
+    let fork_events: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, Event::GroupEpochForkDetected { .. }))
+        .collect();
+    assert_eq!(
+        fork_events.len(),
+        1,
+        "Only one fork event should be emitted"
+    );
+}

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -2971,7 +2971,7 @@ fn test_epoch_fork_not_duplicated_if_already_tracked() {
         group_id.clone(),
         EpochForkState {
             group_id: group_id.clone(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: Instant::now(),
             resolution_attempted: false,
         },
@@ -2994,7 +2994,10 @@ fn test_epoch_fork_not_duplicated_if_already_tracked() {
     protocol.drain_pending_commits(&group_id);
 
     // The original fork state should be preserved (epoch 1), not overwritten
-    assert_eq!(protocol.group_mesh.epoch_forks[&group_id].local_epoch, 1);
+    assert_eq!(
+        protocol.group_mesh.epoch_forks[&group_id].local_epoch,
+        Some(1)
+    );
 }
 
 #[test]
@@ -3008,7 +3011,7 @@ fn test_epoch_fork_max_entries_eviction() {
             gid.clone(),
             EpochForkState {
                 group_id: gid,
-                local_epoch: i as u64,
+                local_epoch: Some(i as u64),
                 detected_at: Instant::now(),
                 resolution_attempted: false,
             },
@@ -3053,7 +3056,7 @@ fn test_epoch_fork_cleared_on_successful_commit() {
         group_id.clone(),
         EpochForkState {
             group_id: group_id.clone(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: Instant::now(),
             resolution_attempted: false,
         },
@@ -3126,7 +3129,7 @@ fn test_epoch_fork_resolution_by_leader() {
         group_id.clone(),
         EpochForkState {
             group_id: group_id.clone(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: past,
             resolution_attempted: false,
         },
@@ -3169,7 +3172,7 @@ fn test_epoch_fork_resolution_skipped_for_non_leader() {
         fake_group_id.clone(),
         EpochForkState {
             group_id: fake_group_id.clone(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: past,
             resolution_attempted: false,
         },
@@ -3199,7 +3202,7 @@ fn test_epoch_fork_not_resolved_before_delay() {
         group_id.clone(),
         EpochForkState {
             group_id: group_id.clone(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: Instant::now(),
             resolution_attempted: false,
         },
@@ -3230,7 +3233,7 @@ fn test_epoch_fork_stale_entries_cleaned_up() {
         "stale_group".to_string(),
         EpochForkState {
             group_id: "stale_group".to_string(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: very_old,
             resolution_attempted: true,
         },
@@ -3483,7 +3486,7 @@ fn test_epoch_fork_cleanup_does_not_duplicate_existing_fork() {
         group_id.clone(),
         EpochForkState {
             group_id: group_id.clone(),
-            local_epoch: 42,
+            local_epoch: Some(42),
             detected_at: original_detected_at,
             resolution_attempted: false,
         },
@@ -3506,7 +3509,10 @@ fn test_epoch_fork_cleanup_does_not_duplicate_existing_fork() {
     protocol.cleanup_group_message_dedup();
 
     // Original fork state should be preserved
-    assert_eq!(protocol.group_mesh.epoch_forks[&group_id].local_epoch, 42);
+    assert_eq!(
+        protocol.group_mesh.epoch_forks[&group_id].local_epoch,
+        Some(42)
+    );
 
     // No new fork detection event should be emitted
     let events = events.lock().unwrap();
@@ -3617,7 +3623,7 @@ fn test_epoch_fork_resolution_includes_failed_members() {
         group_id.clone(),
         EpochForkState {
             group_id: group_id.clone(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: past,
             resolution_attempted: false,
         },
@@ -3672,7 +3678,7 @@ fn test_epoch_fork_resolution_no_failed_members_when_all_succeed() {
         group_id.clone(),
         EpochForkState {
             group_id: group_id.clone(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: past,
             resolution_attempted: false,
         },
@@ -3712,7 +3718,7 @@ fn test_epoch_fork_update_keys_failure_leaves_resolution_attempted() {
         fake_group_id.clone(),
         EpochForkState {
             group_id: fake_group_id.clone(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: past,
             resolution_attempted: false,
         },
@@ -3764,7 +3770,7 @@ fn test_epoch_fork_mls_unavailable_resets_resolution_attempted() {
         group_id.clone(),
         EpochForkState {
             group_id: group_id.clone(),
-            local_epoch: 0,
+            local_epoch: Some(0),
             detected_at: past,
             resolution_attempted: false,
         },
@@ -3851,7 +3857,7 @@ fn test_epoch_fork_multiple_groups_resolve_independently() {
         group_a.clone(),
         EpochForkState {
             group_id: group_a.clone(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: past,
             resolution_attempted: false,
         },
@@ -3862,7 +3868,7 @@ fn test_epoch_fork_multiple_groups_resolve_independently() {
         group_b.clone(),
         EpochForkState {
             group_id: group_b.clone(),
-            local_epoch: 2,
+            local_epoch: Some(2),
             detected_at: Instant::now(),
             resolution_attempted: false,
         },
@@ -3906,7 +3912,7 @@ fn test_epoch_fork_stale_cleanup_removes_old_attempted_and_unattempted() {
         "stale_attempted".to_string(),
         EpochForkState {
             group_id: "stale_attempted".to_string(),
-            local_epoch: 1,
+            local_epoch: Some(1),
             detected_at: very_old,
             resolution_attempted: true,
         },
@@ -3917,7 +3923,7 @@ fn test_epoch_fork_stale_cleanup_removes_old_attempted_and_unattempted() {
         "stale_unattempted".to_string(),
         EpochForkState {
             group_id: "stale_unattempted".to_string(),
-            local_epoch: 2,
+            local_epoch: Some(2),
             detected_at: very_old,
             resolution_attempted: false,
         },
@@ -3928,7 +3934,7 @@ fn test_epoch_fork_stale_cleanup_removes_old_attempted_and_unattempted() {
         "recent_fork".to_string(),
         EpochForkState {
             group_id: "recent_fork".to_string(),
-            local_epoch: 3,
+            local_epoch: Some(3),
             detected_at: Instant::now(),
             resolution_attempted: false,
         },
@@ -3957,9 +3963,9 @@ fn test_epoch_fork_stale_cleanup_removes_old_attempted_and_unattempted() {
 }
 
 #[test]
-fn test_epoch_fork_detection_with_mls_unavailable_logs_epoch_zero() {
+fn test_epoch_fork_detection_with_mls_unavailable_uses_none_epoch() {
     // When MLS is not initialized, flag_potential_epoch_fork should
-    // still work — local_epoch falls back to 0 with a warning logged.
+    // still work — local_epoch is None with a warning logged.
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
     // MLS NOT initialized
 
@@ -3987,8 +3993,231 @@ fn test_epoch_fork_detection_with_mls_unavailable_logs_epoch_zero() {
         "Fork should be detected even when MLS is unavailable"
     );
     assert_eq!(
-        protocol.group_mesh.epoch_forks[&group_id].local_epoch, 0,
-        "local_epoch should fall back to 0 when MLS is unavailable"
+        protocol.group_mesh.epoch_forks[&group_id].local_epoch, None,
+        "local_epoch should be None when MLS is unavailable"
+    );
+}
+
+#[test]
+fn test_pending_leave_elections_size_cap_eviction() {
+    let (mut protocol, _events) = setup_with_events();
+
+    // Fill up to MAX_PENDING_LEAVE_ELECTIONS
+    for i in 0..MAX_PENDING_LEAVE_ELECTIONS {
+        let gid = format!("group_{}", i);
+        let member = format!("member_{}", i);
+        let key = leave_election_key(&gid, &member);
+        protocol.group_mesh.pending_leave_elections.insert(
+            key,
+            PendingLeaveElection {
+                group_id: gid,
+                leaving_member: member,
+                received_at: Instant::now(),
+            },
+        );
+    }
+    assert_eq!(
+        protocol.group_mesh.pending_leave_elections.len(),
+        MAX_PENDING_LEAVE_ELECTIONS
+    );
+
+    // Inject a leave notification that triggers a new election insertion.
+    // We need to set up the group membership for the leave handler to work.
+    let new_group = "group:overflow".to_string();
+    let new_leaver = "new_leaver";
+    protocol.group_mesh.members.insert(
+        new_group.clone(),
+        vec![
+            "alice".to_string(), // alice < test_user, so test_user is not the remover
+            "test_user".to_string(),
+            new_leaver.to_string(),
+        ],
+    );
+
+    // Build leave payload
+    let leave_payload = GroupMlsLeavePayload {
+        group_id: new_group.clone(),
+        leaving_member: new_leaver.to_string(),
+    };
+    let data = serde_json::to_string(&leave_payload).unwrap();
+
+    // test_user is not the lex-first remaining member (alice is), so it records a pending election
+    protocol.handle_group_mls_leave(new_leaver, &data);
+
+    // Should still be at cap (one old evicted, one new added)
+    assert!(
+        protocol.group_mesh.pending_leave_elections.len() <= MAX_PENDING_LEAVE_ELECTIONS,
+        "Pending leave elections should not exceed MAX_PENDING_LEAVE_ELECTIONS"
+    );
+    // The new election should exist
+    let new_key = leave_election_key(&new_group, new_leaver);
+    assert!(
+        protocol
+            .group_mesh
+            .pending_leave_elections
+            .contains_key(&new_key),
+        "New leave election should be inserted after eviction"
+    );
+}
+
+#[test]
+fn test_leave_election_circuit_breaker_max_lifetime() {
+    let (mut protocol, _events) = setup_with_events();
+    let group_id = "group:circuit-breaker".to_string();
+    let leaving_member = "leaver";
+
+    // Insert an election that has exceeded max lifetime
+    let very_old = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_MAX_LIFETIME_SECS + 10);
+    let key = leave_election_key(&group_id, leaving_member);
+    protocol.group_mesh.pending_leave_elections.insert(
+        key.clone(),
+        PendingLeaveElection {
+            group_id: group_id.clone(),
+            leaving_member: leaving_member.to_string(),
+            received_at: very_old,
+        },
+    );
+
+    // Even if the member is still in the group, the election should be abandoned
+    protocol.group_mesh.members.insert(
+        group_id.clone(),
+        vec![
+            "test_user".to_string(),
+            leaving_member.to_string(),
+            "other".to_string(),
+        ],
+    );
+
+    protocol.check_leave_election_timeouts();
+
+    assert!(
+        !protocol
+            .group_mesh
+            .pending_leave_elections
+            .contains_key(&key),
+        "Leave election should be abandoned after max lifetime"
+    );
+}
+
+#[test]
+fn test_non_key_update_commit_does_not_clear_fork_state() {
+    // A successful Add or Remove commit should NOT clear fork state.
+    // Only KeyUpdate commits (the resolution mechanism) clear it.
+    let (mut alice, mut bob, group_id) = setup_alice_bob_group("Fork Preserve Test");
+
+    // Insert a fork state for this group
+    alice.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: Some(1),
+            detected_at: Instant::now(),
+            resolution_attempted: false,
+        },
+    );
+
+    // Create a valid key-update commit from bob, but wrap it with Add commit type
+    // to simulate a successful non-KeyUpdate commit going through process_commit_core.
+    let bob_update = {
+        let mls = bob.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id);
+        mls.update_keys(&gid).unwrap()
+    };
+
+    // Wrap as an Add commit (non-KeyUpdate) — the MLS payload is valid and will
+    // succeed in process_commit_core, but the commit_type is Add.
+    let add_commit_payload = GroupMlsCommitPayload {
+        group_id: group_id.clone(),
+        commit_type: GroupCommitType::Add,
+        ciphertext: base64_encode(&bob_update.ciphertext),
+        epoch: bob_update.epoch,
+        affected_member: Some("charlie".to_string()),
+    };
+    let data = serde_json::to_string(&add_commit_payload).unwrap();
+
+    // Process through alice — the MLS commit succeeds but commit_type is Add
+    alice.handle_group_mls_commit("bob", &data);
+
+    // Fork state should still exist because this was an Add commit, not KeyUpdate
+    assert!(
+        alice.group_mesh.epoch_forks.contains_key(&group_id),
+        "Fork state should NOT be cleared by a non-KeyUpdate commit"
+    );
+}
+
+#[test]
+fn test_key_update_commit_clears_fork_state() {
+    // Verify that a KeyUpdate commit DOES clear fork state (the complement test).
+    let (mut alice, mut bob, group_id) = setup_alice_bob_group("Fork Clear KU Test");
+
+    alice.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: Some(1),
+            detected_at: Instant::now(),
+            resolution_attempted: false,
+        },
+    );
+
+    let bob_update = {
+        let mls = bob.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id);
+        mls.update_keys(&gid).unwrap()
+    };
+
+    let ku_commit_payload = GroupMlsCommitPayload {
+        group_id: group_id.clone(),
+        commit_type: GroupCommitType::KeyUpdate,
+        ciphertext: base64_encode(&bob_update.ciphertext),
+        epoch: bob_update.epoch,
+        affected_member: None,
+    };
+    let data = serde_json::to_string(&ku_commit_payload).unwrap();
+
+    alice.handle_group_mls_commit("bob", &data);
+
+    assert!(
+        !alice.group_mesh.epoch_forks.contains_key(&group_id),
+        "Fork state SHOULD be cleared by a KeyUpdate commit"
+    );
+}
+
+#[test]
+fn test_epoch_fork_detection_event_has_none_epoch_when_mls_unavailable() {
+    // Verify the emitted event carries None for local_epoch when MLS is unavailable
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    // MLS NOT initialized
+
+    let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = events.clone();
+    protocol.on_event(move |event| {
+        events_clone.lock().unwrap().push(event);
+    });
+
+    let group_id = "group:event-none-epoch".to_string();
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_id.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 1,
+        });
+
+    protocol.drain_pending_commits(&group_id);
+
+    let events = events.lock().unwrap();
+    let fork_event = events.iter().find(|e| {
+        matches!(e, Event::GroupEpochForkDetected { group_id: gid, local_epoch: None, .. } if gid == &group_id)
+    });
+    assert!(
+        fork_event.is_some(),
+        "Fork detection event should have local_epoch=None when MLS is unavailable"
     );
 }
 

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -1209,6 +1209,7 @@ fn test_group_mls_commit_failure_buffers_for_retry() {
         })
         .unwrap(),
         buffered_at: Instant::now(),
+        retry_count: 0,
     };
 
     protocol
@@ -1273,6 +1274,7 @@ fn test_group_mls_pending_commit_expired_entries_cleaned_up() {
         sender: "alice".to_string(),
         data: "{}".to_string(),
         buffered_at: Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10),
+        retry_count: 0,
     };
     protocol
         .group_mesh
@@ -1286,6 +1288,7 @@ fn test_group_mls_pending_commit_expired_entries_cleaned_up() {
         sender: "bob".to_string(),
         data: "{}".to_string(),
         buffered_at: Instant::now(),
+        retry_count: 0,
     };
     protocol
         .group_mesh
@@ -1546,11 +1549,13 @@ fn test_group_mls_drain_pending_commits_no_double_buffering() {
                 sender: "alice".to_string(),
                 data: bad_data.clone(),
                 buffered_at: Instant::now(),
+                retry_count: 0,
             },
             PendingCommit {
                 sender: "bob".to_string(),
                 data: bad_data,
                 buffered_at: Instant::now(),
+                retry_count: 0,
             },
         ]),
     );
@@ -1594,6 +1599,7 @@ fn test_group_mls_drain_pending_commits_expired_entries_dropped() {
             sender: "alice".to_string(),
             data,
             buffered_at: Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 1),
+            retry_count: 0,
         }]),
     );
 
@@ -2398,6 +2404,7 @@ fn test_group_mls_pending_commit_drain_cascades() {
         })
         .unwrap(),
         buffered_at: Instant::now(),
+        retry_count: 0,
     });
     buf.push_back(PendingCommit {
         sender: "bob".to_string(),
@@ -2410,6 +2417,7 @@ fn test_group_mls_pending_commit_drain_cascades() {
         })
         .unwrap(),
         buffered_at: Instant::now(),
+        retry_count: 0,
     });
     protocol
         .group_mesh
@@ -2872,4 +2880,510 @@ fn test_group_mls_send_total_failure_emits_partial_failure_event() {
     } else {
         panic!("Event should be GroupMessagePartialFailure");
     }
+}
+
+// ========================================================================
+// EPOCH FORK DETECTION TESTS
+// ========================================================================
+
+#[test]
+fn test_epoch_fork_not_flagged_for_never_retried_expired_commits() {
+    let (mut protocol, events) = setup_with_events();
+    let info = protocol.create_group("Fork Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Insert expired pending commit with retry_count=0 (never retried — likely slow delivery)
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_id.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 0,
+        });
+
+    protocol.drain_pending_commits(&group_id);
+
+    assert!(
+        !protocol.group_mesh.epoch_forks.contains_key(&group_id),
+        "Should not flag epoch fork for never-retried expired commits"
+    );
+    let events = events.lock().unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::GroupEpochForkDetected { .. })),
+        "Should not emit GroupEpochForkDetected event"
+    );
+}
+
+#[test]
+fn test_epoch_fork_flagged_for_retried_expired_commits() {
+    let (mut protocol, events) = setup_with_events();
+    let info = protocol.create_group("Fork Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Insert expired pending commit with retry_count > 0 (retried and kept failing = epoch mismatch)
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_id.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 3,
+        });
+
+    protocol.drain_pending_commits(&group_id);
+
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&group_id),
+        "Should flag epoch fork for retried expired commits"
+    );
+    let fork = &protocol.group_mesh.epoch_forks[&group_id];
+    assert_eq!(fork.group_id, group_id);
+    assert!(!fork.resolution_attempted);
+
+    let events = events.lock().unwrap();
+    assert!(
+        events.iter().any(
+            |e| matches!(e, Event::GroupEpochForkDetected { group_id: gid, .. } if gid == &group_id)
+        ),
+        "Should emit GroupEpochForkDetected event"
+    );
+}
+
+#[test]
+fn test_epoch_fork_not_duplicated_if_already_tracked() {
+    let (mut protocol, _events) = setup_with_events();
+    let info = protocol.create_group("Fork Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Pre-populate fork state with local_epoch=1
+    protocol.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: 1,
+            detected_at: Instant::now(),
+            resolution_attempted: false,
+        },
+    );
+
+    // Insert expired retried commit — would normally trigger fork detection
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(group_id.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 2,
+        });
+
+    protocol.drain_pending_commits(&group_id);
+
+    // The original fork state should be preserved (epoch 1), not overwritten
+    assert_eq!(protocol.group_mesh.epoch_forks[&group_id].local_epoch, 1);
+}
+
+#[test]
+fn test_epoch_fork_max_entries_eviction() {
+    let (mut protocol, _events) = setup_with_events();
+
+    // Fill up to MAX_EPOCH_FORK_ENTRIES
+    for i in 0..MAX_EPOCH_FORK_ENTRIES {
+        let gid = format!("group_{}", i);
+        protocol.group_mesh.epoch_forks.insert(
+            gid.clone(),
+            EpochForkState {
+                group_id: gid,
+                local_epoch: i as u64,
+                detected_at: Instant::now(),
+                resolution_attempted: false,
+            },
+        );
+    }
+    assert_eq!(
+        protocol.group_mesh.epoch_forks.len(),
+        MAX_EPOCH_FORK_ENTRIES
+    );
+
+    // Trigger a new fork via expired retried commit on a new group
+    let new_gid = "group_new".to_string();
+    let past = Instant::now() - StdDuration::from_secs(PENDING_COMMIT_TTL_SECS + 10);
+    protocol
+        .group_mesh
+        .pending_commits
+        .entry(new_gid.clone())
+        .or_default()
+        .push_back(PendingCommit {
+            sender: "bob".to_string(),
+            data: "fake".to_string(),
+            buffered_at: past,
+            retry_count: 1,
+        });
+
+    protocol.drain_pending_commits(&new_gid);
+
+    // Should have evicted one and added the new one — count stays bounded
+    assert!(protocol.group_mesh.epoch_forks.contains_key(&new_gid));
+    assert_eq!(
+        protocol.group_mesh.epoch_forks.len(),
+        MAX_EPOCH_FORK_ENTRIES
+    );
+}
+
+#[test]
+fn test_epoch_fork_cleared_on_successful_commit() {
+    let (mut alice, bob, group_id) = setup_alice_bob_group("Fork Clear Test");
+
+    // Insert a fork state for this group
+    alice.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: 1,
+            detected_at: Instant::now(),
+            resolution_attempted: false,
+        },
+    );
+
+    // Create a valid MLS commit by having bob do a key update, then feed
+    // it through alice's protocol message handling path (handle_group_mls_commit
+    // → process_commit_core) which clears fork state on Success.
+    let alice_update = {
+        let mls = alice.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id);
+        mls.update_keys(&gid).unwrap()
+    };
+
+    // Bob processes alice's update first so he's on the same epoch
+    {
+        let mls = bob.mls_manager_for_testing().read().unwrap();
+        let encrypted = offline_protocol_mls::EncryptedMessage {
+            group_id: offline_protocol_mls::GroupId::new(&group_id),
+            message_type: offline_protocol_mls::MlsMessageType::Commit,
+            epoch: alice_update.epoch,
+            ciphertext: alice_update.ciphertext.clone(),
+            sender_id: "alice".to_string(),
+            timestamp_ms: chrono::Utc::now().timestamp_millis() as u64,
+        };
+        mls.decrypt_from_group(&encrypted).unwrap();
+    }
+
+    // Bob creates a commit that alice will process through the protocol layer
+    let bob_commit = {
+        let mls = bob.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id);
+        mls.update_keys(&gid).unwrap()
+    };
+
+    // Build a protocol-layer commit message from bob to alice
+    let commit_payload = GroupMlsCommitPayload {
+        group_id: group_id.clone(),
+        commit_type: GroupCommitType::KeyUpdate,
+        ciphertext: base64_encode(&bob_commit.ciphertext),
+        epoch: bob_commit.epoch,
+        affected_member: None,
+    };
+    let data = serde_json::to_string(&commit_payload).unwrap();
+
+    // Process through the protocol layer — this calls process_commit_core
+    alice.handle_group_mls_commit("bob", &data);
+
+    // Fork should be cleared after successful commit processing
+    assert!(
+        !alice.group_mesh.epoch_forks.contains_key(&group_id),
+        "Fork state should be cleared after successful commit"
+    );
+}
+
+// ========================================================================
+// EPOCH FORK RESOLUTION TESTS
+// ========================================================================
+
+#[test]
+fn test_epoch_fork_resolution_by_leader() {
+    let (mut protocol, events) = setup_with_events();
+    let info = protocol.create_group("Resolution Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Protocol user "user123" is the only member → lex-first → leader.
+    // Insert a fork that's past the resolution delay.
+    let past = Instant::now() - StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS + 5);
+    protocol.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: 1,
+            detected_at: past,
+            resolution_attempted: false,
+        },
+    );
+
+    protocol.check_epoch_forks();
+
+    // Fork should be resolved and removed (leader issued key update successfully)
+    assert!(
+        !protocol.group_mesh.epoch_forks.contains_key(&group_id),
+        "Fork should be removed after successful resolution by leader"
+    );
+
+    let events = events.lock().unwrap();
+    assert!(
+        events.iter().any(
+            |e| matches!(e, Event::GroupEpochForkResolved { group_id: gid, .. } if gid == &group_id)
+        ),
+        "Should emit GroupEpochForkResolved event"
+    );
+}
+
+#[test]
+fn test_epoch_fork_resolution_skipped_for_non_leader() {
+    let storage = Arc::new(crate::mls::InMemoryStorage::default());
+    let mut protocol = OfflineProtocol::new(create_test_config_for_user("zoe")).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+    let _info = protocol.create_group("Non-Leader Test").unwrap();
+
+    // Use a fake group_id for the fork so refresh_group_members fails and
+    // falls back to cached membership where "alice" is lex-first leader.
+    let fake_group_id = "fake_fork_group".to_string();
+    protocol.group_mesh.members.insert(
+        fake_group_id.clone(),
+        vec!["alice".to_string(), "zoe".to_string()],
+    );
+
+    let past = Instant::now() - StdDuration::from_secs(EPOCH_FORK_RESOLUTION_DELAY_SECS + 5);
+    protocol.group_mesh.epoch_forks.insert(
+        fake_group_id.clone(),
+        EpochForkState {
+            group_id: fake_group_id.clone(),
+            local_epoch: 1,
+            detected_at: past,
+            resolution_attempted: false,
+        },
+    );
+
+    protocol.check_epoch_forks();
+
+    // Fork should still exist but marked as attempted (non-leader doesn't act)
+    assert!(
+        protocol.group_mesh.epoch_forks.contains_key(&fake_group_id),
+        "Fork should still exist for non-leader"
+    );
+    assert!(
+        protocol.group_mesh.epoch_forks[&fake_group_id].resolution_attempted,
+        "Fork should be marked as resolution_attempted even for non-leader"
+    );
+}
+
+#[test]
+fn test_epoch_fork_not_resolved_before_delay() {
+    let (mut protocol, events) = setup_with_events();
+    let info = protocol.create_group("Delay Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Insert a fork that was just detected (within the delay window)
+    protocol.group_mesh.epoch_forks.insert(
+        group_id.clone(),
+        EpochForkState {
+            group_id: group_id.clone(),
+            local_epoch: 1,
+            detected_at: Instant::now(),
+            resolution_attempted: false,
+        },
+    );
+
+    protocol.check_epoch_forks();
+
+    // Fork should still exist and not attempted (delay hasn't elapsed)
+    assert!(protocol.group_mesh.epoch_forks.contains_key(&group_id));
+    assert!(!protocol.group_mesh.epoch_forks[&group_id].resolution_attempted);
+
+    let events = events.lock().unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::GroupEpochForkResolved { .. })),
+        "Should not emit GroupEpochForkResolved before delay"
+    );
+}
+
+#[test]
+fn test_epoch_fork_stale_entries_cleaned_up() {
+    let (mut protocol, _events) = setup_with_events();
+
+    // Insert a very old fork entry (older than 5-minute stale threshold)
+    let very_old = Instant::now() - StdDuration::from_secs(400);
+    protocol.group_mesh.epoch_forks.insert(
+        "stale_group".to_string(),
+        EpochForkState {
+            group_id: "stale_group".to_string(),
+            local_epoch: 1,
+            detected_at: very_old,
+            resolution_attempted: true,
+        },
+    );
+
+    protocol.check_epoch_forks();
+
+    assert!(
+        !protocol.group_mesh.epoch_forks.contains_key("stale_group"),
+        "Stale fork entries (>5 min) should be cleaned up"
+    );
+}
+
+// ========================================================================
+// LEAVE ELECTION FALLBACK TESTS
+// ========================================================================
+
+#[test]
+fn test_leave_election_cleared_when_member_already_removed() {
+    let (mut protocol, _events) = setup_with_events();
+    let info = protocol.create_group("Leave Election Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // "bob" was never added to this MLS group, so refresh_group_members
+    // won't find him — simulates a member that was already removed.
+    let past = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS + 5);
+    let key = leave_election_key(&group_id, "bob");
+    protocol.group_mesh.pending_leave_elections.insert(
+        key.clone(),
+        PendingLeaveElection {
+            group_id: group_id.clone(),
+            leaving_member: "bob".to_string(),
+            received_at: past,
+        },
+    );
+
+    protocol.check_leave_election_timeouts();
+
+    assert!(
+        !protocol
+            .group_mesh
+            .pending_leave_elections
+            .contains_key(&key),
+        "Election should be cleared when leaving member is no longer in group"
+    );
+}
+
+#[test]
+fn test_leave_election_timeout_re_elects_self() {
+    let (mut alice, _bob, group_id) = setup_alice_bob_group("Re-election Test");
+
+    // Bob is in the MLS group. Alice is "alice", bob is "bob".
+    // After filtering out the leaver ("bob"), remaining = ["alice"].
+    // alice is lex-first → candidate at interval 0 → should attempt remove.
+    let past = Instant::now() - StdDuration::from_secs(LEAVE_ELECTION_TIMEOUT_SECS + 5);
+    let key = leave_election_key(&group_id, "bob");
+    alice.group_mesh.pending_leave_elections.insert(
+        key.clone(),
+        PendingLeaveElection {
+            group_id: group_id.clone(),
+            leaving_member: "bob".to_string(),
+            received_at: past,
+        },
+    );
+
+    alice.check_leave_election_timeouts();
+
+    // Remove should succeed → election cleared
+    assert!(
+        !alice.group_mesh.pending_leave_elections.contains_key(&key),
+        "Election should be cleared after successful remove"
+    );
+
+    // Bob should no longer be in the MLS group
+    let members = alice.refresh_group_members(&group_id).unwrap();
+    assert!(
+        !members.contains(&"bob".to_string()),
+        "Bob should be removed from group after re-election"
+    );
+}
+
+#[test]
+fn test_leave_election_not_triggered_before_timeout() {
+    let (mut protocol, _events) = setup_with_events();
+    let info = protocol.create_group("Timeout Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Insert a pending election that hasn't timed out yet
+    let key = leave_election_key(&group_id, "bob");
+    protocol.group_mesh.pending_leave_elections.insert(
+        key.clone(),
+        PendingLeaveElection {
+            group_id: group_id.clone(),
+            leaving_member: "bob".to_string(),
+            received_at: Instant::now(), // just now — well within timeout
+        },
+    );
+
+    protocol.check_leave_election_timeouts();
+
+    // Election should still be pending (hasn't timed out)
+    assert!(
+        protocol
+            .group_mesh
+            .pending_leave_elections
+            .contains_key(&key),
+        "Election should remain pending before timeout"
+    );
+}
+
+#[test]
+fn test_leave_election_key_helper() {
+    assert_eq!(leave_election_key("group1", "alice"), "group1:alice");
+    assert_eq!(
+        leave_election_key("my-group-id", "user:123"),
+        "my-group-id:user:123"
+    );
+}
+
+#[test]
+fn test_pending_commit_retry_count_incremented() {
+    let (mut protocol, _events) = setup_with_events();
+    let info = protocol.create_group("Retry Count Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Insert a non-expired pending commit with invalid data.
+    // process_commit_core will return Rejected (bad data), so it won't
+    // be re-buffered. Instead, test the buffering path directly.
+    protocol.buffer_pending_commit(&group_id, "bob", "fake-data");
+
+    let pending = protocol.group_mesh.pending_commits.get(&group_id).unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].retry_count, 0, "Initial retry_count should be 0");
+}
+
+#[test]
+fn test_key_update_commit_type_serialization() {
+    // Verify KeyUpdate serializes/deserializes correctly
+    let payload = GroupMlsCommitPayload {
+        group_id: "test-group".to_string(),
+        commit_type: GroupCommitType::KeyUpdate,
+        ciphertext: "abc".to_string(),
+        epoch: 5,
+        affected_member: None,
+    };
+
+    let json = serde_json::to_string(&payload).unwrap();
+    assert!(
+        json.contains("\"keyupdate\""),
+        "KeyUpdate should serialize as 'keyupdate'"
+    );
+
+    let deserialized: GroupMlsCommitPayload = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.commit_type, GroupCommitType::KeyUpdate);
+    assert!(deserialized.affected_member.is_none());
 }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -6010,6 +6010,8 @@ impl OfflineProtocol {
         self.cleanup_outbox();
         self.mesh_services.cleanup_expired();
         self.cleanup_group_message_dedup();
+        self.check_epoch_forks();
+        self.check_leave_election_timeouts();
         self.check_relay_group_sync();
         let stale_file_ids = self
             .file_transfer_manager


### PR DESCRIPTION
Fix stale relay cache by refreshing group membership from MLS state before syncing to relay on connectivity transitions. Add leave election fallback with staggered re-election timeouts when the elected remover is offline. Add epoch fork detection and automatic resolution via leader-elected key-update commits when concurrent commits cause divergent group states.