### PR TITLE
feat(protocol): add presence, typing indicators, and read receipts

### DIFF
--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -9,7 +9,8 @@
 use offline_protocol::{
     EstablishmentState as CoreEstablishmentState, Event as CoreEvent, NetworkVisualizer,
     OfflineProtocol as CoreProtocol, OverflowPolicy as CoreOverflowPolicy,
-    PendingQueueConfig as CorePendingQueueConfig, ProtocolConfig as CoreConfig,
+    PendingQueueConfig as CorePendingQueueConfig, PresenceStatus as CorePresenceStatus,
+    ProtocolConfig as CoreConfig,
 };
 use offline_protocol_core::{
     ContentType as CoreContentType, MediaMetadata as CoreMediaMetadata,
@@ -297,6 +298,24 @@ impl From<MessagePriority> for CorePriority {
             MessagePriority::Medium => CorePriority::Medium,
             MessagePriority::High => CorePriority::High,
             MessagePriority::Critical => CorePriority::Critical,
+        }
+    }
+}
+
+/// Presence status for a peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PresenceStatus {
+    Online,
+    Away,
+    Offline,
+}
+
+impl From<PresenceStatus> for CorePresenceStatus {
+    fn from(status: PresenceStatus) -> Self {
+        match status {
+            PresenceStatus::Online => CorePresenceStatus::Online,
+            PresenceStatus::Away => CorePresenceStatus::Away,
+            PresenceStatus::Offline => CorePresenceStatus::Offline,
         }
     }
 }
@@ -3058,15 +3077,14 @@ impl OfflineProtocol {
     // ========================================================================
 
     /// Send a presence update to a peer via the protocol (routed through DORS).
-    /// Status should be "online", "away", or "offline".
     pub fn send_presence_update(
         &self,
         recipient: String,
-        status: String,
+        status: PresenceStatus,
     ) -> Result<String, ProtocolError> {
         let mut protocol = self.inner.lock().unwrap();
         let message_id = protocol
-            .send_presence_update(&recipient, &status)
+            .send_presence_update(&recipient, status.into())
             .map_err(ProtocolError::from)?;
         Ok(message_id.as_str())
     }

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -3054,10 +3054,58 @@ impl OfflineProtocol {
     }
 
     // ========================================================================
-    // PRESENCE AND KEY MANAGEMENT (RELAY SERVER API)
+    // PRESENCE, TYPING INDICATORS, AND READ RECEIPTS
     // ========================================================================
 
-    /// Check if a user is online.
+    /// Send a presence update to a peer via the protocol (routed through DORS).
+    /// Status should be "online", "away", or "offline".
+    pub fn send_presence_update(
+        &self,
+        recipient: String,
+        status: String,
+    ) -> Result<String, ProtocolError> {
+        let mut protocol = self.inner.lock().unwrap();
+        let message_id = protocol
+            .send_presence_update(&recipient, &status)
+            .map_err(ProtocolError::from)?;
+        Ok(message_id.as_str())
+    }
+
+    /// Send a typing indicator to a peer via the protocol (routed through DORS).
+    /// For direct messages, conversation_id should be the recipient's username.
+    /// For group chats, conversation_id should be the group_id.
+    pub fn send_typing_indicator(
+        &self,
+        recipient: String,
+        conversation_id: String,
+        is_typing: bool,
+    ) -> Result<String, ProtocolError> {
+        let mut protocol = self.inner.lock().unwrap();
+        let message_id = protocol
+            .send_typing_indicator(&recipient, &conversation_id, is_typing)
+            .map_err(ProtocolError::from)?;
+        Ok(message_id.as_str())
+    }
+
+    /// Send a read receipt to a peer via the protocol (routed through DORS).
+    /// Indicates that the given messages have been read.
+    pub fn send_read_receipt(
+        &self,
+        recipient: String,
+        message_ids: Vec<String>,
+    ) -> Result<String, ProtocolError> {
+        let mut protocol = self.inner.lock().unwrap();
+        let message_id = protocol
+            .send_read_receipt(&recipient, message_ids)
+            .map_err(ProtocolError::from)?;
+        Ok(message_id.as_str())
+    }
+
+    // ========================================================================
+    // RELAY SERVER API (JSON payload formatters for WebSocket relay)
+    // ========================================================================
+
+    /// Check if a user is online via relay server.
     /// Returns JSON string to send via WebSocket relay.
     pub fn check_presence(&self, username: String) -> Result<String, ProtocolError> {
         let payload = serde_json::json!({
@@ -3082,14 +3130,12 @@ impl OfflineProtocol {
 
     /// Upload identity key and prekeys for Signal Protocol.
     /// Returns JSON string to send via WebSocket relay.
-    /// Parameters are JSON strings that will be parsed and included in the payload.
     pub fn upload_keys(
         &self,
         identity_key: String,
         signed_prekey_json: String,
         one_time_prekeys_json: String,
     ) -> Result<String, ProtocolError> {
-        // Parse the JSON strings into values
         let signed_prekey: serde_json::Value =
             serde_json::from_str(&signed_prekey_json).map_err(|e| {
                 ProtocolError::Other(format!("Failed to parse signed_prekey JSON: {}", e))
@@ -3110,9 +3156,7 @@ impl OfflineProtocol {
             .map_err(|e| ProtocolError::Other(format!("Failed to serialize UploadKeys: {}", e)))
     }
 
-    /// Set typing indicator in a conversation.
-    /// For direct messages, conversation_id should be the recipient's username.
-    /// For group chats, conversation_id should be the group_id.
+    /// Set typing indicator via relay server (JSON payload formatter).
     /// Returns JSON string to send via WebSocket relay.
     pub fn set_typing(&self, conversation_id: String) -> Result<String, ProtocolError> {
         let payload = serde_json::json!({
@@ -3123,9 +3167,7 @@ impl OfflineProtocol {
             .map_err(|e| ProtocolError::Other(format!("Failed to serialize SetTyping: {}", e)))
     }
 
-    /// Clear typing indicator in a conversation.
-    /// For direct messages, conversation_id should be the recipient's username.
-    /// For group chats, conversation_id should be the group_id.
+    /// Clear typing indicator via relay server (JSON payload formatter).
     /// Returns JSON string to send via WebSocket relay.
     pub fn clear_typing(&self, conversation_id: String) -> Result<String, ProtocolError> {
         let payload = serde_json::json!({

--- a/crates/offline-protocol-uniffi/src/offline_protocol.udl
+++ b/crates/offline-protocol-uniffi/src/offline_protocol.udl
@@ -740,35 +740,54 @@ interface OfflineProtocol {
     boolean verify_signature(sequence<u8> public_key, sequence<u8> data, sequence<u8> signature);
     
     // ========================================================================
-    // PRESENCE AND KEY MANAGEMENT (RELAY SERVER API)
+    // PRESENCE, TYPING INDICATORS, AND READ RECEIPTS
     // ========================================================================
-    
-    // Check if a user is online.
+
+    // Send a presence update to a peer via the protocol (routed through DORS).
+    // Status should be "online", "away", or "offline".
+    // Returns the message ID.
+    [Throws=ProtocolError]
+    string send_presence_update(string recipient, string status);
+
+    // Send a typing indicator to a peer via the protocol (routed through DORS).
+    // For direct messages, conversation_id should be the recipient's username.
+    // For group chats, conversation_id should be the group_id.
+    // Returns the message ID.
+    [Throws=ProtocolError]
+    string send_typing_indicator(string recipient, string conversation_id, boolean is_typing);
+
+    // Send a read receipt to a peer via the protocol (routed through DORS).
+    // Indicates that the given messages have been read.
+    // Returns the message ID.
+    [Throws=ProtocolError]
+    string send_read_receipt(string recipient, sequence<string> message_ids);
+
+    // ========================================================================
+    // RELAY SERVER API (JSON payload formatters for WebSocket relay)
+    // ========================================================================
+
+    // Check if a user is online via relay server.
     // Returns JSON string to send via WebSocket relay.
     [Throws=ProtocolError]
     string check_presence(string username);
-    
+
     // Request prekey bundle for a user to establish encrypted communication.
     // Returns JSON string to send via WebSocket relay.
     [Throws=ProtocolError]
     string request_prekey_bundle(string username);
-    
+
     // Upload identity key and prekeys for Signal Protocol.
     // Returns JSON string to send via WebSocket relay.
     // Parameters are JSON strings that will be parsed and included in the payload.
     [Throws=ProtocolError]
     string upload_keys(string identity_key, string signed_prekey_json, string one_time_prekeys_json);
-    
-    // Set typing indicator in a conversation.
-    // For direct messages, conversation_id should be the recipient's username.
-    // For group chats, conversation_id should be the group_id.
+
+    // Set typing indicator via relay server (JSON payload formatter).
     // Returns JSON string to send via WebSocket relay.
     [Throws=ProtocolError]
     string set_typing(string conversation_id);
-    
-    // Clear typing indicator in a conversation.
-    // For direct messages, conversation_id should be the recipient's username.
-    // For group chats, conversation_id should be the group_id.
+
+    // Clear typing indicator via relay server (JSON payload formatter).
     // Returns JSON string to send via WebSocket relay.
     [Throws=ProtocolError]
     string clear_typing(string conversation_id);

--- a/crates/offline-protocol-uniffi/src/offline_protocol.udl
+++ b/crates/offline-protocol-uniffi/src/offline_protocol.udl
@@ -112,6 +112,13 @@ enum MessagePriority {
     "Critical",
 };
 
+// Presence status
+enum PresenceStatus {
+    "Online",
+    "Away",
+    "Offline",
+};
+
 // Transport types
 enum TransportType {
     "Internet",
@@ -744,10 +751,9 @@ interface OfflineProtocol {
     // ========================================================================
 
     // Send a presence update to a peer via the protocol (routed through DORS).
-    // Status should be "online", "away", or "offline".
     // Returns the message ID.
     [Throws=ProtocolError]
-    string send_presence_update(string recipient, string status);
+    string send_presence_update(string recipient, PresenceStatus status);
 
     // Send a typing indicator to a peer via the protocol (routed through DORS).
     // For direct messages, conversation_id should be the recipient's username.

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -643,6 +643,39 @@ pub enum Event {
         provider_peer_id: String,
     },
 
+    // --- Presence, typing, and read receipts ---
+    /// A peer's presence status was updated.
+    PresenceUpdated {
+        /// Peer whose presence changed.
+        peer_id: String,
+        /// Presence status (e.g. "online", "away", "offline").
+        status: String,
+        /// Timestamp of the update (Unix ms).
+        timestamp: i64,
+    },
+
+    /// A typing indicator was received from a peer.
+    TypingIndicatorReceived {
+        /// User who is typing (or stopped typing).
+        sender: String,
+        /// Conversation identifier (recipient username for DMs, group_id for groups).
+        conversation_id: String,
+        /// Whether the user is currently typing.
+        is_typing: bool,
+        /// Timestamp of the indicator (Unix ms).
+        timestamp: i64,
+    },
+
+    /// A read receipt was received from a peer.
+    ReadReceiptReceived {
+        /// User who read the messages.
+        sender: String,
+        /// IDs of the messages that were read.
+        message_ids: Vec<String>,
+        /// Timestamp when the messages were read (Unix ms).
+        timestamp: i64,
+    },
+
     // --- DORS observability (OFF-258) ---
     /// DORS scored all available transports for this decision cycle.
     DorsScoreUpdated {
@@ -1047,6 +1080,39 @@ impl Event {
     /// Creates a ConnectionRejected event.
     pub fn connection_rejected(rejected_by: String) -> Self {
         Self::ConnectionRejected { rejected_by }
+    }
+
+    /// Creates a PresenceUpdated event.
+    pub fn presence_updated(peer_id: String, status: String, timestamp: i64) -> Self {
+        Self::PresenceUpdated {
+            peer_id,
+            status,
+            timestamp,
+        }
+    }
+
+    /// Creates a TypingIndicatorReceived event.
+    pub fn typing_indicator_received(
+        sender: String,
+        conversation_id: String,
+        is_typing: bool,
+        timestamp: i64,
+    ) -> Self {
+        Self::TypingIndicatorReceived {
+            sender,
+            conversation_id,
+            is_typing,
+            timestamp,
+        }
+    }
+
+    /// Creates a ReadReceiptReceived event.
+    pub fn read_receipt_received(sender: String, message_ids: Vec<String>, timestamp: i64) -> Self {
+        Self::ReadReceiptReceived {
+            sender,
+            message_ids,
+            timestamp,
+        }
     }
 
     /// Creates a GroupCreated event.
@@ -1778,6 +1844,38 @@ impl fmt::Debug for Event {
                 .field("group_id", group_id)
                 .field("resolved_epoch", resolved_epoch)
                 .field("failed_members", failed_members)
+                .finish(),
+            Self::PresenceUpdated {
+                peer_id: _,
+                status,
+                timestamp,
+            } => f
+                .debug_struct("PresenceUpdated")
+                .field("peer_id", &"[REDACTED]")
+                .field("status", status)
+                .field("timestamp", timestamp)
+                .finish(),
+            Self::TypingIndicatorReceived {
+                sender: _,
+                conversation_id,
+                is_typing,
+                timestamp,
+            } => f
+                .debug_struct("TypingIndicatorReceived")
+                .field("sender", &"[REDACTED]")
+                .field("conversation_id", conversation_id)
+                .field("is_typing", is_typing)
+                .field("timestamp", timestamp)
+                .finish(),
+            Self::ReadReceiptReceived {
+                sender: _,
+                message_ids,
+                timestamp,
+            } => f
+                .debug_struct("ReadReceiptReceived")
+                .field("sender", &"[REDACTED]")
+                .field("message_count", &message_ids.len())
+                .field("timestamp", timestamp)
                 .finish(),
             Self::DorsScoreUpdated { scores } => f
                 .debug_struct("DorsScoreUpdated")

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -8,6 +8,18 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
+/// Presence status for a peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PresenceStatus {
+    /// Peer is online and available.
+    Online,
+    /// Peer is away / idle.
+    Away,
+    /// Peer is explicitly offline.
+    Offline,
+}
+
 /// Event callback type for handling protocol events.
 pub type EventCallback = Arc<dyn Fn(Event) + Send + Sync>;
 
@@ -648,8 +660,8 @@ pub enum Event {
     PresenceUpdated {
         /// Peer whose presence changed.
         peer_id: String,
-        /// Presence status (e.g. "online", "away", "offline").
-        status: String,
+        /// Presence status.
+        status: PresenceStatus,
         /// Timestamp of the update (Unix ms).
         timestamp: i64,
     },
@@ -1083,7 +1095,7 @@ impl Event {
     }
 
     /// Creates a PresenceUpdated event.
-    pub fn presence_updated(peer_id: String, status: String, timestamp: i64) -> Self {
+    pub fn presence_updated(peer_id: String, status: PresenceStatus, timestamp: i64) -> Self {
         Self::PresenceUpdated {
             peer_id,
             status,
@@ -1857,13 +1869,13 @@ impl fmt::Debug for Event {
                 .finish(),
             Self::TypingIndicatorReceived {
                 sender: _,
-                conversation_id,
+                conversation_id: _,
                 is_typing,
                 timestamp,
             } => f
                 .debug_struct("TypingIndicatorReceived")
                 .field("sender", &"[REDACTED]")
-                .field("conversation_id", conversation_id)
+                .field("conversation_id", &"[REDACTED]")
                 .field("is_typing", is_typing)
                 .field("timestamp", timestamp)
                 .finish(),

--- a/crates/offline-protocol/src/lib.rs
+++ b/crates/offline-protocol/src/lib.rs
@@ -26,7 +26,7 @@ pub use config::{
 pub use error::{Error, EstablishmentState, Result, SessionStateError};
 pub use events::{
     DecryptionFailureCode, DorsEscalationPhase, DorsEscalationReasonCode, DorsReasonCode, Event,
-    EventCallback, GroupInfoMember, UserGroupSummary,
+    EventCallback, GroupInfoMember, PresenceStatus, UserGroupSummary,
 };
 pub use offline_protocol_services::MeshServices;
 pub use protocol::OfflineProtocol;

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -1,7 +1,7 @@
 //! Main protocol engine.
 
 use crate::constants::{ACK_FOR_KEY, ACK_HOP_COUNT_KEY, ACK_TRANSPORT_KEY, MAX_OUTBOX_ENTRIES};
-use crate::events::DecryptionFailureCode;
+use crate::events::{DecryptionFailureCode, PresenceStatus};
 use crate::file_transfer::{FileChunk, FileTransferManager, OutboundTransferState};
 #[cfg(feature = "mls-observability")]
 use crate::mls_observability::{opaque_id, timestamp_now_ms, MlsLifecycleEvent};
@@ -170,11 +170,14 @@ struct ConnectionAcceptedPayload {
 
 // --- Presence, typing, and read receipt payloads ---
 
+/// Maximum number of message IDs allowed in a single read receipt.
+const MAX_READ_RECEIPT_IDS: usize = 256;
+
 /// Payload for a presence update message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PresencePayload {
-    /// Presence status (e.g. "online", "away", "offline").
-    status: String,
+    /// Presence status.
+    status: PresenceStatus,
     /// Timestamp of the update (Unix ms).
     timestamp_ms: i64,
 }
@@ -4732,10 +4735,14 @@ impl OfflineProtocol {
     /// # Arguments
     ///
     /// * `recipient` - The user ID of the peer to notify
-    /// * `status` - Presence status (e.g. "online", "away", "offline")
-    pub fn send_presence_update(&mut self, recipient: &str, status: &str) -> Result<MessageId> {
+    /// * `status` - Presence status
+    pub fn send_presence_update(
+        &mut self,
+        recipient: &str,
+        status: PresenceStatus,
+    ) -> Result<MessageId> {
         let payload = PresencePayload {
-            status: status.to_string(),
+            status,
             timestamp_ms: Utc::now().timestamp_millis(),
         };
 
@@ -4744,7 +4751,7 @@ impl OfflineProtocol {
         let content = format!("{}{}", internal_prefixes::PRESENCE, serialized);
 
         let message_id = self.send_internal_message(recipient, content, MessagePriority::Low)?;
-        debug!(recipient = %recipient, status = %status, "Sent presence update");
+        debug!(recipient = %recipient, status = ?status, "Sent presence update");
         Ok(message_id)
     }
 
@@ -4761,6 +4768,12 @@ impl OfflineProtocol {
         conversation_id: &str,
         is_typing: bool,
     ) -> Result<MessageId> {
+        if conversation_id.is_empty() {
+            return Err(Error::Other(
+                "conversation_id must not be empty".to_string(),
+            ));
+        }
+
         let payload = TypingIndicatorPayload {
             conversation_id: conversation_id.to_string(),
             is_typing,
@@ -4772,7 +4785,7 @@ impl OfflineProtocol {
         let content = format!("{}{}", internal_prefixes::TYPING_INDICATOR, serialized);
 
         let message_id = self.send_internal_message(recipient, content, MessagePriority::Low)?;
-        debug!(recipient = %recipient, conversation_id = %conversation_id, is_typing = %is_typing, "Sent typing indicator");
+        debug!(recipient = %recipient, is_typing = %is_typing, "Sent typing indicator");
         Ok(message_id)
     }
 
@@ -4781,7 +4794,7 @@ impl OfflineProtocol {
     /// # Arguments
     ///
     /// * `recipient` - The user ID of the peer who sent the messages
-    /// * `message_ids` - IDs of the messages that were read
+    /// * `message_ids` - IDs of the messages that were read (max 256)
     pub fn send_read_receipt(
         &mut self,
         recipient: &str,
@@ -4789,6 +4802,11 @@ impl OfflineProtocol {
     ) -> Result<MessageId> {
         if message_ids.is_empty() {
             return Err(Error::Other("message_ids must not be empty".to_string()));
+        }
+        if message_ids.len() > MAX_READ_RECEIPT_IDS {
+            return Err(Error::Other(format!(
+                "message_ids exceeds maximum of {MAX_READ_RECEIPT_IDS}"
+            )));
         }
 
         let payload = ReadReceiptPayload {
@@ -5557,13 +5575,17 @@ impl OfflineProtocol {
 
         if let Some(data) = content.strip_prefix(internal_prefixes::PRESENCE) {
             if let Ok(payload) = serde_json::from_str::<PresencePayload>(data) {
-                debug!(sender = %sender, status = %payload.status, "Received presence update");
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::presence_updated(
-                        sender.to_string(),
-                        payload.status,
-                        payload.timestamp_ms,
-                    ));
+                if payload.timestamp_ms < 0 {
+                    warn!("Dropping presence update with negative timestamp");
+                } else {
+                    debug!(sender = %sender, status = ?payload.status, "Received presence update");
+                    if let Ok(state) = lock_shared_state(&self.shared_state) {
+                        state.emit_event(Event::presence_updated(
+                            sender.to_string(),
+                            payload.status,
+                            payload.timestamp_ms,
+                        ));
+                    }
                 }
             } else {
                 warn!("Failed to parse Presence payload");
@@ -5573,14 +5595,20 @@ impl OfflineProtocol {
 
         if let Some(data) = content.strip_prefix(internal_prefixes::TYPING_INDICATOR) {
             if let Ok(payload) = serde_json::from_str::<TypingIndicatorPayload>(data) {
-                debug!(sender = %sender, conversation_id = %payload.conversation_id, is_typing = %payload.is_typing, "Received typing indicator");
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::typing_indicator_received(
-                        sender.to_string(),
-                        payload.conversation_id,
-                        payload.is_typing,
-                        payload.timestamp_ms,
-                    ));
+                if payload.timestamp_ms < 0 {
+                    warn!("Dropping typing indicator with negative timestamp");
+                } else if payload.conversation_id.is_empty() {
+                    warn!("Dropping typing indicator with empty conversation_id");
+                } else {
+                    debug!(sender = %sender, is_typing = %payload.is_typing, "Received typing indicator");
+                    if let Ok(state) = lock_shared_state(&self.shared_state) {
+                        state.emit_event(Event::typing_indicator_received(
+                            sender.to_string(),
+                            payload.conversation_id,
+                            payload.is_typing,
+                            payload.timestamp_ms,
+                        ));
+                    }
                 }
             } else {
                 warn!("Failed to parse TypingIndicator payload");
@@ -5590,13 +5618,24 @@ impl OfflineProtocol {
 
         if let Some(data) = content.strip_prefix(internal_prefixes::READ_RECEIPT) {
             if let Ok(payload) = serde_json::from_str::<ReadReceiptPayload>(data) {
-                debug!(sender = %sender, count = %payload.message_ids.len(), "Received read receipt");
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::read_receipt_received(
-                        sender.to_string(),
-                        payload.message_ids,
-                        payload.timestamp_ms,
-                    ));
+                if payload.timestamp_ms < 0 {
+                    warn!("Dropping read receipt with negative timestamp");
+                } else if payload.message_ids.is_empty() {
+                    warn!("Dropping read receipt with empty message_ids");
+                } else if payload.message_ids.len() > MAX_READ_RECEIPT_IDS {
+                    warn!(
+                        count = payload.message_ids.len(),
+                        "Dropping read receipt exceeding max message_ids"
+                    );
+                } else {
+                    debug!(sender = %sender, count = %payload.message_ids.len(), "Received read receipt");
+                    if let Ok(state) = lock_shared_state(&self.shared_state) {
+                        state.emit_event(Event::read_receipt_received(
+                            sender.to_string(),
+                            payload.message_ids,
+                            payload.timestamp_ms,
+                        ));
+                    }
                 }
             } else {
                 warn!("Failed to parse ReadReceipt payload");
@@ -7575,7 +7614,7 @@ pub(crate) mod tests {
         });
 
         let payload = PresencePayload {
-            status: "online".to_string(),
+            status: PresenceStatus::Online,
             timestamp_ms: 12345,
         };
         let content = format!(
@@ -7603,7 +7642,7 @@ pub(crate) mod tests {
                 timestamp,
             } => {
                 assert_eq!(peer_id, "alice");
-                assert_eq!(status, "online");
+                assert_eq!(*status, PresenceStatus::Online);
                 assert_eq!(*timestamp, 12345);
             }
             _ => panic!("Wrong event type"),
@@ -7769,14 +7808,14 @@ pub(crate) mod tests {
 
         protocol.start().unwrap();
 
-        let result = protocol.send_presence_update("bob", "online");
+        let result = protocol.send_presence_update("bob", PresenceStatus::Online);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_send_presence_update_not_started() {
         let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
-        let result = protocol.send_presence_update("bob", "online");
+        let result = protocol.send_presence_update("bob", PresenceStatus::Online);
         assert!(result.is_err());
     }
 
@@ -7840,6 +7879,188 @@ pub(crate) mod tests {
 
         let result = protocol.send_read_receipt("bob", vec![]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_read_receipt_exceeds_max_ids() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let ids: Vec<String> = (0..257).map(|i| format!("msg-{i}")).collect();
+        let result = protocol.send_read_receipt("bob", ids);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_typing_indicator_empty_conversation_id() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_typing_indicator("bob", "", true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_process_internal_message_presence_malformed_payload() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let content = format!("{}not-valid-json", internal_prefixes::PRESENCE);
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_process_internal_message_presence_negative_timestamp() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = PresencePayload {
+            status: PresenceStatus::Online,
+            timestamp_ms: -1,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::PRESENCE,
+            serde_json::to_string(&payload).unwrap()
+        );
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_process_internal_message_typing_empty_conversation_id() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = TypingIndicatorPayload {
+            conversation_id: String::new(),
+            is_typing: true,
+            timestamp_ms: 12345,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::TYPING_INDICATOR,
+            serde_json::to_string(&payload).unwrap()
+        );
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_process_internal_message_read_receipt_empty_ids() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = ReadReceiptPayload {
+            message_ids: vec![],
+            timestamp_ms: 12345,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::READ_RECEIPT,
+            serde_json::to_string(&payload).unwrap()
+        );
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_process_internal_message_read_receipt_exceeds_max_ids() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let ids: Vec<String> = (0..257).map(|i| format!("msg-{i}")).collect();
+        let payload = ReadReceiptPayload {
+            message_ids: ids,
+            timestamp_ms: 12345,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::READ_RECEIPT,
+            serde_json::to_string(&payload).unwrap()
+        );
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+        assert!(events.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -4730,7 +4730,10 @@ impl OfflineProtocol {
     // PRESENCE, TYPING INDICATORS, AND READ RECEIPTS
     // ========================================================================
 
-    /// Sends a presence update to a peer.
+    /// Sends a presence update to a single peer (unicast).
+    ///
+    /// This sends to one recipient at a time. To broadcast presence to multiple
+    /// peers, the caller must invoke this method once per peer.
     ///
     /// # Arguments
     ///
@@ -4741,6 +4744,10 @@ impl OfflineProtocol {
         recipient: &str,
         status: PresenceStatus,
     ) -> Result<MessageId> {
+        if recipient.is_empty() {
+            return Err(Error::Other("recipient must not be empty".to_string()));
+        }
+
         let payload = PresencePayload {
             status,
             timestamp_ms: Utc::now().timestamp_millis(),
@@ -4768,6 +4775,9 @@ impl OfflineProtocol {
         conversation_id: &str,
         is_typing: bool,
     ) -> Result<MessageId> {
+        if recipient.is_empty() {
+            return Err(Error::Other("recipient must not be empty".to_string()));
+        }
         if conversation_id.is_empty() {
             return Err(Error::Other(
                 "conversation_id must not be empty".to_string(),
@@ -4800,6 +4810,9 @@ impl OfflineProtocol {
         recipient: &str,
         message_ids: Vec<String>,
     ) -> Result<MessageId> {
+        if recipient.is_empty() {
+            return Err(Error::Other("recipient must not be empty".to_string()));
+        }
         if message_ids.is_empty() {
             return Err(Error::Other("message_ids must not be empty".to_string()));
         }
@@ -8045,6 +8058,149 @@ pub(crate) mod tests {
         let payload = ReadReceiptPayload {
             message_ids: ids,
             timestamp_ms: 12345,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::READ_RECEIPT,
+            serde_json::to_string(&payload).unwrap()
+        );
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_send_presence_update_empty_recipient() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_presence_update("", PresenceStatus::Online);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_typing_indicator_empty_recipient() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_typing_indicator("", "convo", true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_read_receipt_empty_recipient() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_read_receipt("", vec!["msg-1".to_string()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_presence_update_away_status() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_presence_update("bob", PresenceStatus::Away);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_send_presence_update_offline_status() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_presence_update("bob", PresenceStatus::Offline);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_process_internal_message_typing_negative_timestamp() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = TypingIndicatorPayload {
+            conversation_id: "bob".to_string(),
+            is_typing: true,
+            timestamp_ms: -1,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::TYPING_INDICATOR,
+            serde_json::to_string(&payload).unwrap()
+        );
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_process_internal_message_read_receipt_negative_timestamp() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = ReadReceiptPayload {
+            message_ids: vec!["msg-1".to_string()],
+            timestamp_ms: -1,
         };
         let content = format!(
             "{}{}",

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -98,6 +98,12 @@ pub(crate) mod internal_prefixes {
     pub const GROUP_RELAY_REGISTER: &str = "__GRP_RELAY_REG__";
     /// Prefix for relay group broadcast (SDK → relay server fan-out).
     pub const GROUP_RELAY_BROADCAST: &str = "__GRP_RELAY_BCAST__";
+    /// Prefix for presence update messages.
+    pub const PRESENCE: &str = "__PRESENCE__";
+    /// Prefix for typing indicator messages.
+    pub const TYPING_INDICATOR: &str = "__TYPING__";
+    /// Prefix for read receipt messages.
+    pub const READ_RECEIPT: &str = "__READ_RECEIPT__";
 }
 
 /// Retry interval for persisting session confirmation after a transient storage error.
@@ -160,6 +166,37 @@ struct ConnectionAcceptedPayload {
     /// Optional MLS key package data for encrypted session setup.
     #[serde(skip_serializing_if = "Option::is_none")]
     key_package: Option<Vec<u8>>,
+}
+
+// --- Presence, typing, and read receipt payloads ---
+
+/// Payload for a presence update message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PresencePayload {
+    /// Presence status (e.g. "online", "away", "offline").
+    status: String,
+    /// Timestamp of the update (Unix ms).
+    timestamp_ms: i64,
+}
+
+/// Payload for a typing indicator message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TypingIndicatorPayload {
+    /// Conversation identifier (recipient username for DMs, group_id for groups).
+    conversation_id: String,
+    /// Whether the user is currently typing.
+    is_typing: bool,
+    /// Timestamp of the indicator (Unix ms).
+    timestamp_ms: i64,
+}
+
+/// Payload for a read receipt message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ReadReceiptPayload {
+    /// IDs of the messages that were read.
+    message_ids: Vec<String>,
+    /// Timestamp when the messages were read (Unix ms).
+    timestamp_ms: i64,
 }
 
 // --- Group (relay) payloads ---
@@ -4687,6 +4724,88 @@ impl OfflineProtocol {
     }
 
     // ========================================================================
+    // PRESENCE, TYPING INDICATORS, AND READ RECEIPTS
+    // ========================================================================
+
+    /// Sends a presence update to a peer.
+    ///
+    /// # Arguments
+    ///
+    /// * `recipient` - The user ID of the peer to notify
+    /// * `status` - Presence status (e.g. "online", "away", "offline")
+    pub fn send_presence_update(&mut self, recipient: &str, status: &str) -> Result<MessageId> {
+        let payload = PresencePayload {
+            status: status.to_string(),
+            timestamp_ms: Utc::now().timestamp_millis(),
+        };
+
+        let serialized =
+            serde_json::to_string(&payload).map_err(|e| Error::Serialization(e.to_string()))?;
+        let content = format!("{}{}", internal_prefixes::PRESENCE, serialized);
+
+        let message_id = self.send_internal_message(recipient, content, MessagePriority::Low)?;
+        debug!(recipient = %recipient, status = %status, "Sent presence update");
+        Ok(message_id)
+    }
+
+    /// Sends a typing indicator to a peer.
+    ///
+    /// # Arguments
+    ///
+    /// * `recipient` - The user ID of the peer to notify
+    /// * `conversation_id` - Conversation identifier (recipient's username for DMs, group_id for groups)
+    /// * `is_typing` - Whether the user started or stopped typing
+    pub fn send_typing_indicator(
+        &mut self,
+        recipient: &str,
+        conversation_id: &str,
+        is_typing: bool,
+    ) -> Result<MessageId> {
+        let payload = TypingIndicatorPayload {
+            conversation_id: conversation_id.to_string(),
+            is_typing,
+            timestamp_ms: Utc::now().timestamp_millis(),
+        };
+
+        let serialized =
+            serde_json::to_string(&payload).map_err(|e| Error::Serialization(e.to_string()))?;
+        let content = format!("{}{}", internal_prefixes::TYPING_INDICATOR, serialized);
+
+        let message_id = self.send_internal_message(recipient, content, MessagePriority::Low)?;
+        debug!(recipient = %recipient, conversation_id = %conversation_id, is_typing = %is_typing, "Sent typing indicator");
+        Ok(message_id)
+    }
+
+    /// Sends a read receipt to a peer, indicating that the given messages have been read.
+    ///
+    /// # Arguments
+    ///
+    /// * `recipient` - The user ID of the peer who sent the messages
+    /// * `message_ids` - IDs of the messages that were read
+    pub fn send_read_receipt(
+        &mut self,
+        recipient: &str,
+        message_ids: Vec<String>,
+    ) -> Result<MessageId> {
+        if message_ids.is_empty() {
+            return Err(Error::Other("message_ids must not be empty".to_string()));
+        }
+
+        let payload = ReadReceiptPayload {
+            message_ids,
+            timestamp_ms: Utc::now().timestamp_millis(),
+        };
+
+        let serialized =
+            serde_json::to_string(&payload).map_err(|e| Error::Serialization(e.to_string()))?;
+        let content = format!("{}{}", internal_prefixes::READ_RECEIPT, serialized);
+
+        let message_id = self.send_internal_message(recipient, content, MessagePriority::Low)?;
+        debug!(recipient = %recipient, "Sent read receipt");
+        Ok(message_id)
+    }
+
+    // ========================================================================
     // SERVICE DISCOVERY & REQUEST/RESPONSE
     // ========================================================================
 
@@ -5430,6 +5549,57 @@ impl OfflineProtocol {
             info!(sender = %sender, "Connection request rejected");
             if let Ok(state) = lock_shared_state(&self.shared_state) {
                 state.emit_event(Event::connection_rejected(sender.to_string()));
+            }
+            return Some(InternalMessageResult::Consumed);
+        }
+
+        // --- Presence, typing, and read receipt messages ---
+
+        if let Some(data) = content.strip_prefix(internal_prefixes::PRESENCE) {
+            if let Ok(payload) = serde_json::from_str::<PresencePayload>(data) {
+                debug!(sender = %sender, status = %payload.status, "Received presence update");
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::presence_updated(
+                        sender.to_string(),
+                        payload.status,
+                        payload.timestamp_ms,
+                    ));
+                }
+            } else {
+                warn!("Failed to parse Presence payload");
+            }
+            return Some(InternalMessageResult::Consumed);
+        }
+
+        if let Some(data) = content.strip_prefix(internal_prefixes::TYPING_INDICATOR) {
+            if let Ok(payload) = serde_json::from_str::<TypingIndicatorPayload>(data) {
+                debug!(sender = %sender, conversation_id = %payload.conversation_id, is_typing = %payload.is_typing, "Received typing indicator");
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::typing_indicator_received(
+                        sender.to_string(),
+                        payload.conversation_id,
+                        payload.is_typing,
+                        payload.timestamp_ms,
+                    ));
+                }
+            } else {
+                warn!("Failed to parse TypingIndicator payload");
+            }
+            return Some(InternalMessageResult::Consumed);
+        }
+
+        if let Some(data) = content.strip_prefix(internal_prefixes::READ_RECEIPT) {
+            if let Ok(payload) = serde_json::from_str::<ReadReceiptPayload>(data) {
+                debug!(sender = %sender, count = %payload.message_ids.len(), "Received read receipt");
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::read_receipt_received(
+                        sender.to_string(),
+                        payload.message_ids,
+                        payload.timestamp_ms,
+                    ));
+                }
+            } else {
+                warn!("Failed to parse ReadReceipt payload");
             }
             return Some(InternalMessageResult::Consumed);
         }
@@ -7074,6 +7244,9 @@ pub(crate) mod tests {
         assert_eq!(internal_prefixes::CONN_REQUEST, "__CONN_REQ__");
         assert_eq!(internal_prefixes::CONN_ACCEPT, "__CONN_ACC__");
         assert_eq!(internal_prefixes::CONN_REJECT, "__CONN_REJ__");
+        assert_eq!(internal_prefixes::PRESENCE, "__PRESENCE__");
+        assert_eq!(internal_prefixes::TYPING_INDICATOR, "__TYPING__");
+        assert_eq!(internal_prefixes::READ_RECEIPT, "__READ_RECEIPT__");
         assert_eq!(
             offline_protocol_services::SVC_DISCOVER_QUERY,
             "__SVC_DISC_Q__"
@@ -7385,6 +7558,288 @@ pub(crate) mod tests {
             .send_connection_request("carol", "Alice", None)
             .unwrap();
         assert_ne!(id1, id2);
+    }
+
+    // ========================================================================
+    // PRESENCE, TYPING, AND READ RECEIPT TESTS
+    // ========================================================================
+
+    #[test]
+    fn test_process_internal_message_presence_update_event() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = PresencePayload {
+            status: "online".to_string(),
+            timestamp_ms: 12345,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::PRESENCE,
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        match &captured[0] {
+            Event::PresenceUpdated {
+                peer_id,
+                status,
+                timestamp,
+            } => {
+                assert_eq!(peer_id, "alice");
+                assert_eq!(status, "online");
+                assert_eq!(*timestamp, 12345);
+            }
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_process_internal_message_typing_indicator_event() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = TypingIndicatorPayload {
+            conversation_id: "bob".to_string(),
+            is_typing: true,
+            timestamp_ms: 67890,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::TYPING_INDICATOR,
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let message = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        match &captured[0] {
+            Event::TypingIndicatorReceived {
+                sender,
+                conversation_id,
+                is_typing,
+                timestamp,
+            } => {
+                assert_eq!(sender, "alice");
+                assert_eq!(conversation_id, "bob");
+                assert!(*is_typing);
+                assert_eq!(*timestamp, 67890);
+            }
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_process_internal_message_typing_indicator_stopped() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = TypingIndicatorPayload {
+            conversation_id: "group-123".to_string(),
+            is_typing: false,
+            timestamp_ms: 99999,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::TYPING_INDICATOR,
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let message = Message::new(
+            UserId::new("bob").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        match &captured[0] {
+            Event::TypingIndicatorReceived {
+                sender,
+                conversation_id,
+                is_typing,
+                ..
+            } => {
+                assert_eq!(sender, "bob");
+                assert_eq!(conversation_id, "group-123");
+                assert!(!*is_typing);
+            }
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_process_internal_message_read_receipt_event() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_handle = Arc::clone(&events);
+
+        protocol.on_event(move |event| {
+            events_handle.lock().unwrap().push(event);
+        });
+
+        let payload = ReadReceiptPayload {
+            message_ids: vec![
+                "msg-1".to_string(),
+                "msg-2".to_string(),
+                "msg-3".to_string(),
+            ],
+            timestamp_ms: 11111,
+        };
+        let content = format!(
+            "{}{}",
+            internal_prefixes::READ_RECEIPT,
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let message = Message::new(
+            UserId::new("carol").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &content,
+        );
+
+        let result = protocol.process_internal_message(&message);
+        assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        match &captured[0] {
+            Event::ReadReceiptReceived {
+                sender,
+                message_ids,
+                timestamp,
+            } => {
+                assert_eq!(sender, "carol");
+                assert_eq!(message_ids, &vec!["msg-1", "msg-2", "msg-3"]);
+                assert_eq!(*timestamp, 11111);
+            }
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_send_presence_update_success() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_presence_update("bob", "online");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_send_presence_update_not_started() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let result = protocol.send_presence_update("bob", "online");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_typing_indicator_success() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_typing_indicator("bob", "bob", true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_send_typing_indicator_not_started() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let result = protocol.send_typing_indicator("bob", "bob", true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_read_receipt_success() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_read_receipt("bob", vec!["msg-1".to_string()]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_send_read_receipt_not_started() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let result = protocol.send_read_receipt("bob", vec!["msg-1".to_string()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_read_receipt_empty_message_ids() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+
+        protocol.start().unwrap();
+
+        let result = protocol.send_read_receipt("bob", vec![]);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -10456,6 +10911,9 @@ pub(crate) mod tests {
             internal_prefixes::CONN_REQUEST,
             internal_prefixes::CONN_ACCEPT,
             internal_prefixes::CONN_REJECT,
+            internal_prefixes::PRESENCE,
+            internal_prefixes::TYPING_INDICATOR,
+            internal_prefixes::READ_RECEIPT,
             internal_prefixes::GROUP_CREATED,
             internal_prefixes::GROUP_MSG,
             internal_prefixes::GROUP_MEMBER_ADDED,


### PR DESCRIPTION
Add protocol-level support for presence updates, typing indicators, and read receipts using internal message prefixes (`__PRESENCE__`, `__TYPING__`, `__READ_RECEIPT__`) routed through DORS. Each feature emits events on receive and exposes UniFFI bindings for mobile. Includes 11 new tests. Existing relay server JSON stubs preserved.