### PR TITLE
fix(protocol): harden control message authentication and sender verification

### DIFF
--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -243,6 +243,14 @@ pub struct Message {
     ///
     /// When `Some`, the protocol layer validates that `sender` matches this value
     /// before processing security-sensitive control messages.
+    ///
+    /// # Security
+    ///
+    /// **Do not set this field from application code.** It must only be set by
+    /// authenticated transport layers (BLE, WiFi Direct, Internet relay) via
+    /// [`set_transport_peer_id`](Self::set_transport_peer_id). Setting it
+    /// incorrectly bypasses sender verification.
+    #[doc(hidden)]
     #[serde(skip)]
     pub transport_peer_id: Option<String>,
 }
@@ -328,6 +336,25 @@ impl Message {
     /// Deserializes a message from JSON.
     pub fn from_json(json: &str) -> crate::Result<Self> {
         serde_json::from_str(json).map_err(|e| crate::Error::DeserializationError(e.to_string()))
+    }
+
+    /// Sets the transport-verified peer identity.
+    ///
+    /// # Security
+    ///
+    /// This method must only be called by authenticated transport layers to bind
+    /// a message to the physical peer that delivered it. The protocol layer uses
+    /// this value to reject control messages where the claimed `sender` does not
+    /// match the transport-authenticated peer.
+    ///
+    /// **Never call this from application code.**
+    pub fn set_transport_peer_id(&mut self, peer_id: String) {
+        self.transport_peer_id = Some(peer_id);
+    }
+
+    /// Returns the transport-verified peer identity, if set.
+    pub fn transport_peer_id(&self) -> Option<&str> {
+        self.transport_peer_id.as_deref()
     }
 
     /// Serializes the message to binary (MessagePack-like JSON bytes).

--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -246,13 +246,12 @@ pub struct Message {
     ///
     /// # Security
     ///
-    /// **Do not set this field from application code.** It must only be set by
-    /// authenticated transport layers (BLE, WiFi Direct, Internet relay) via
-    /// [`set_transport_peer_id`](Self::set_transport_peer_id). Setting it
-    /// incorrectly bypasses sender verification.
-    #[doc(hidden)]
+    /// This field is private to prevent application code from bypassing sender
+    /// verification. Use [`set_transport_peer_id`](Self::set_transport_peer_id)
+    /// (transport layers only) and [`transport_peer_id`](Self::transport_peer_id)
+    /// to interact with it.
     #[serde(skip)]
-    pub transport_peer_id: Option<String>,
+    transport_peer_id: Option<String>,
 }
 
 fn default_requires_ack() -> bool {
@@ -348,6 +347,7 @@ impl Message {
     /// match the transport-authenticated peer.
     ///
     /// **Never call this from application code.**
+    #[doc(hidden)]
     pub fn set_transport_peer_id(&mut self, peer_id: String) {
         self.transport_peer_id = Some(peer_id);
     }

--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -359,6 +359,7 @@ impl Message {
     ///
     /// Returns an error if `peer_id` is empty, since an empty transport peer
     /// identity cannot meaningfully authenticate a sender.
+    #[doc(hidden)]
     pub fn set_transport_peer_id(&mut self, peer_id: String) -> crate::Result<()> {
         if peer_id.is_empty() {
             return Err(crate::Error::InvalidMessage(

--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -347,9 +347,20 @@ impl Message {
     /// match the transport-authenticated peer.
     ///
     /// **Never call this from application code.**
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `peer_id` is empty, since an empty transport peer
+    /// identity cannot meaningfully authenticate a sender.
     #[doc(hidden)]
-    pub fn set_transport_peer_id(&mut self, peer_id: String) {
+    pub fn set_transport_peer_id(&mut self, peer_id: String) -> crate::Result<()> {
+        if peer_id.is_empty() {
+            return Err(crate::Error::InvalidMessage(
+                "transport_peer_id must not be empty".to_string(),
+            ));
+        }
         self.transport_peer_id = Some(peer_id);
+        Ok(())
     }
 
     /// Returns the transport-verified peer identity, if set.

--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -234,6 +234,17 @@ pub struct Message {
     /// ID of the message this is replying to (optional).
     #[serde(default)]
     pub reply_to_msg: Option<MessageId>,
+
+    /// Transport-verified peer identity.
+    ///
+    /// Set by the transport layer when a message is received, binding the message
+    /// to the physical peer that delivered it. This field is **never serialized**
+    /// over the wire — it exists only in-process to prevent sender spoofing.
+    ///
+    /// When `Some`, the protocol layer validates that `sender` matches this value
+    /// before processing security-sensitive control messages.
+    #[serde(skip)]
+    pub transport_peer_id: Option<String>,
 }
 
 fn default_requires_ack() -> bool {
@@ -272,6 +283,7 @@ impl Message {
             metadata: HashMap::new(),
             requires_ack: true,
             reply_to_msg: None,
+            transport_peer_id: None,
         }
     }
 
@@ -437,6 +449,7 @@ impl MessageBuilder {
             metadata: self.metadata,
             requires_ack: self.requires_ack,
             reply_to_msg: self.reply_to_msg,
+            transport_peer_id: None,
         }
     }
 }

--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -341,18 +341,24 @@ impl Message {
     ///
     /// # Security
     ///
-    /// This method must only be called by authenticated transport layers to bind
-    /// a message to the physical peer that delivered it. The protocol layer uses
-    /// this value to reject control messages where the claimed `sender` does not
-    /// match the transport-authenticated peer.
+    /// This method must only be called by transport layer implementations
+    /// (e.g., `BleTransport::on_message_received_from`) to bind a message to
+    /// the physical peer that delivered it. The protocol layer uses this value
+    /// to reject control messages where the claimed `sender` does not match the
+    /// transport-authenticated peer.
     ///
-    /// **Never call this from application code.**
+    /// This method is `pub` because transport implementations live in a
+    /// separate crate (`offline-protocol-transport`). It is **not** exposed
+    /// through UniFFI bindings, and the underlying field is private +
+    /// `#[serde(skip)]`, so application code cannot set it via deserialization
+    /// or direct field access.
+    ///
+    /// **Do not call from application code or expose via FFI.**
     ///
     /// # Errors
     ///
     /// Returns an error if `peer_id` is empty, since an empty transport peer
     /// identity cannot meaningfully authenticate a sender.
-    #[doc(hidden)]
     pub fn set_transport_peer_id(&mut self, peer_id: String) -> crate::Result<()> {
         if peer_id.is_empty() {
             return Err(crate::Error::InvalidMessage(

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -201,7 +201,7 @@ impl BleTransport {
     ///   UUID, etc.). The protocol layer uses this value to verify that
     ///   `message.sender` matches the physical peer that delivered it.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
-        message.transport_peer_id = Some(peer_id);
+        message.set_transport_peer_id(peer_id);
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push_back(message);
     }
@@ -537,7 +537,7 @@ impl BleTransport {
     pub fn on_fragment_received_from(&self, fragment_data: Vec<u8>, peer_id: String) -> Result<()> {
         match self.process_fragment(&fragment_data) {
             Ok(Some(mut message)) => {
-                message.transport_peer_id = Some(peer_id);
+                message.set_transport_peer_id(peer_id);
                 let msg_id = message.id.clone();
                 let mut queue = self.receive_queue.lock().unwrap();
                 queue.push_back(message);

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -201,9 +201,14 @@ impl BleTransport {
     ///   UUID, etc.). The protocol layer uses this value to verify that
     ///   `message.sender` matches the physical peer that delivered it.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
-        message
-            .set_transport_peer_id(peer_id)
-            .expect("transport must provide non-empty peer_id");
+        if let Err(e) = message.set_transport_peer_id(peer_id) {
+            tracing::warn!(
+                error = %e,
+                message_id = %message.id,
+                "Dropping message: transport provided invalid peer_id"
+            );
+            return;
+        }
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push_back(message);
     }

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -201,7 +201,9 @@ impl BleTransport {
     ///   UUID, etc.). The protocol layer uses this value to verify that
     ///   `message.sender` matches the physical peer that delivered it.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
-        message.set_transport_peer_id(peer_id);
+        message
+            .set_transport_peer_id(peer_id)
+            .expect("transport must provide non-empty peer_id");
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push_back(message);
     }
@@ -537,7 +539,7 @@ impl BleTransport {
     pub fn on_fragment_received_from(&self, fragment_data: Vec<u8>, peer_id: String) -> Result<()> {
         match self.process_fragment(&fragment_data) {
             Ok(Some(mut message)) => {
-                message.set_transport_peer_id(peer_id);
+                message.set_transport_peer_id(peer_id)?;
                 let msg_id = message.id.clone();
                 let mut queue = self.receive_queue.lock().unwrap();
                 queue.push_back(message);

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -190,6 +190,18 @@ impl BleTransport {
         queue.push_back(message);
     }
 
+    /// Called when a message is received from a peer whose transport-level
+    /// identity is known (e.g. the BLE device ID / MAC address of the
+    /// connected peripheral).
+    ///
+    /// The `peer_id` is attached to the message so the protocol layer can
+    /// verify that `message.sender` matches the physical peer.
+    pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
+        message.transport_peer_id = Some(peer_id);
+        let mut queue = self.receive_queue.lock().unwrap();
+        queue.push_back(message);
+    }
+
     /// Called when connection status changes.
     pub fn on_status_changed(&self, status: TransportStatus) {
         *self.status.lock().unwrap() = status;
@@ -502,6 +514,31 @@ impl BleTransport {
             }
             Err(e) => {
                 // Log error but don't fail - just drop bad fragment
+                tracing::warn!(error = %e, "Error processing fragment, dropping bad fragment");
+                Ok(())
+            }
+        }
+    }
+
+    /// Like [`on_fragment_received`](Self::on_fragment_received), but attaches a
+    /// transport-verified `peer_id` to the reassembled message.
+    pub fn on_fragment_received_from(&self, fragment_data: Vec<u8>, peer_id: String) -> Result<()> {
+        match self.process_fragment(&fragment_data) {
+            Ok(Some(mut message)) => {
+                message.transport_peer_id = Some(peer_id);
+                let mut queue = self.receive_queue.lock().unwrap();
+                queue.push_back(message.clone());
+                tracing::debug!(
+                    message_id = %message.id,
+                    "Complete message assembled from fragments (with peer identity)"
+                );
+                Ok(())
+            }
+            Ok(None) => {
+                tracing::debug!("Fragment received, more needed for complete message");
+                Ok(())
+            }
+            Err(e) => {
                 tracing::warn!(error = %e, "Error processing fragment, dropping bad fragment");
                 Ok(())
             }

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -190,12 +190,16 @@ impl BleTransport {
         queue.push_back(message);
     }
 
-    /// Called when a message is received from a peer whose transport-level
-    /// identity is known (e.g. the BLE device ID / MAC address of the
-    /// connected peripheral).
+    /// Like [`on_message_received`](Self::on_message_received), but attaches a
+    /// transport-verified `peer_id` to the message.
     ///
-    /// The `peer_id` is attached to the message so the protocol layer can
-    /// verify that `message.sender` matches the physical peer.
+    /// # Parameters
+    ///
+    /// * `peer_id` — The **user-level identifier** (i.e., the remote peer's
+    ///   `UserId` string) that the transport layer has authenticated for this
+    ///   connection. This is **not** the raw transport address (MAC, BLE device
+    ///   UUID, etc.). The protocol layer uses this value to verify that
+    ///   `message.sender` matches the physical peer that delivered it.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
         message.transport_peer_id = Some(peer_id);
         let mut queue = self.receive_queue.lock().unwrap();
@@ -522,14 +526,23 @@ impl BleTransport {
 
     /// Like [`on_fragment_received`](Self::on_fragment_received), but attaches a
     /// transport-verified `peer_id` to the reassembled message.
+    ///
+    /// # Parameters
+    ///
+    /// * `peer_id` — The **user-level identifier** (i.e., the remote peer's
+    ///   `UserId` string) that the transport layer has authenticated for this
+    ///   connection. This is **not** the raw transport address (MAC, BLE device
+    ///   UUID, etc.). The protocol layer uses this value to verify that
+    ///   `message.sender` matches the physical peer that delivered it.
     pub fn on_fragment_received_from(&self, fragment_data: Vec<u8>, peer_id: String) -> Result<()> {
         match self.process_fragment(&fragment_data) {
             Ok(Some(mut message)) => {
                 message.transport_peer_id = Some(peer_id);
+                let msg_id = message.id.clone();
                 let mut queue = self.receive_queue.lock().unwrap();
-                queue.push_back(message.clone());
+                queue.push_back(message);
                 tracing::debug!(
-                    message_id = %message.id,
+                    message_id = %msg_id,
                     "Complete message assembled from fragments (with peer identity)"
                 );
                 Ok(())

--- a/crates/offline-protocol-transport/src/internet.rs
+++ b/crates/offline-protocol-transport/src/internet.rs
@@ -195,8 +195,17 @@ impl InternetTransport {
         queue.push_back(message);
     }
 
-    /// Called when a message is received and the relay server has authenticated
-    /// the sending peer (e.g. via WebSocket session token).
+    /// Like [`on_message_received`](Self::on_message_received), but attaches a
+    /// transport-verified `peer_id` to the message.
+    ///
+    /// # Parameters
+    ///
+    /// * `peer_id` — The **user-level identifier** (i.e., the remote peer's
+    ///   `UserId` string) that the relay server has authenticated for this
+    ///   connection (e.g. via WebSocket session token). This is **not** the raw
+    ///   transport address (IP, session token, etc.). The protocol layer uses
+    ///   this value to verify that `message.sender` matches the authenticated
+    ///   peer.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
         message.transport_peer_id = Some(peer_id);
         let mut queue = self.receive_queue.lock().unwrap();
@@ -236,6 +245,14 @@ impl InternetTransport {
 
     /// Like [`on_data_received`](Self::on_data_received), but attaches a
     /// transport-verified `peer_id` to the deserialized message.
+    ///
+    /// # Parameters
+    ///
+    /// * `peer_id` — The **user-level identifier** (i.e., the remote peer's
+    ///   `UserId` string) that the relay server has authenticated for this
+    ///   connection. This is **not** the raw transport address (IP, session
+    ///   token, etc.). The protocol layer uses this value to verify that
+    ///   `message.sender` matches the authenticated peer.
     pub fn on_data_received_from(&self, data: Vec<u8>, peer_id: String) -> Result<()> {
         match self.deserialize_message(&data) {
             Ok(mut message) => {

--- a/crates/offline-protocol-transport/src/internet.rs
+++ b/crates/offline-protocol-transport/src/internet.rs
@@ -207,9 +207,14 @@ impl InternetTransport {
     ///   this value to verify that `message.sender` matches the authenticated
     ///   peer.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
-        message
-            .set_transport_peer_id(peer_id)
-            .expect("transport must provide non-empty peer_id");
+        if let Err(e) = message.set_transport_peer_id(peer_id) {
+            tracing::warn!(
+                error = %e,
+                message_id = %message.id,
+                "Dropping message: transport provided invalid peer_id"
+            );
+            return;
+        }
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push_back(message);
     }

--- a/crates/offline-protocol-transport/src/internet.rs
+++ b/crates/offline-protocol-transport/src/internet.rs
@@ -207,7 +207,9 @@ impl InternetTransport {
     ///   this value to verify that `message.sender` matches the authenticated
     ///   peer.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
-        message.set_transport_peer_id(peer_id);
+        message
+            .set_transport_peer_id(peer_id)
+            .expect("transport must provide non-empty peer_id");
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push_back(message);
     }
@@ -256,7 +258,7 @@ impl InternetTransport {
     pub fn on_data_received_from(&self, data: Vec<u8>, peer_id: String) -> Result<()> {
         match self.deserialize_message(&data) {
             Ok(mut message) => {
-                message.set_transport_peer_id(peer_id);
+                message.set_transport_peer_id(peer_id)?;
                 let mut queue = self.receive_queue.lock().unwrap();
                 queue.push_back(message);
                 Ok(())

--- a/crates/offline-protocol-transport/src/internet.rs
+++ b/crates/offline-protocol-transport/src/internet.rs
@@ -195,6 +195,14 @@ impl InternetTransport {
         queue.push_back(message);
     }
 
+    /// Called when a message is received and the relay server has authenticated
+    /// the sending peer (e.g. via WebSocket session token).
+    pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
+        message.transport_peer_id = Some(peer_id);
+        let mut queue = self.receive_queue.lock().unwrap();
+        queue.push_back(message);
+    }
+
     /// Serializes a message to JSON bytes.
     pub fn serialize_message(&self, message: &Message) -> Result<Vec<u8>> {
         serde_json::to_vec(message).map_err(|e| {
@@ -222,6 +230,23 @@ impl InternetTransport {
             Err(e) => {
                 tracing::warn!(error = %e, "Error deserializing message, dropping bad data");
                 Ok(()) // Don't fail - just drop bad data
+            }
+        }
+    }
+
+    /// Like [`on_data_received`](Self::on_data_received), but attaches a
+    /// transport-verified `peer_id` to the deserialized message.
+    pub fn on_data_received_from(&self, data: Vec<u8>, peer_id: String) -> Result<()> {
+        match self.deserialize_message(&data) {
+            Ok(mut message) => {
+                message.transport_peer_id = Some(peer_id);
+                let mut queue = self.receive_queue.lock().unwrap();
+                queue.push_back(message);
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Error deserializing message, dropping bad data");
+                Ok(())
             }
         }
     }

--- a/crates/offline-protocol-transport/src/internet.rs
+++ b/crates/offline-protocol-transport/src/internet.rs
@@ -207,7 +207,7 @@ impl InternetTransport {
     ///   this value to verify that `message.sender` matches the authenticated
     ///   peer.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
-        message.transport_peer_id = Some(peer_id);
+        message.set_transport_peer_id(peer_id);
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push_back(message);
     }
@@ -256,7 +256,7 @@ impl InternetTransport {
     pub fn on_data_received_from(&self, data: Vec<u8>, peer_id: String) -> Result<()> {
         match self.deserialize_message(&data) {
             Ok(mut message) => {
-                message.transport_peer_id = Some(peer_id);
+                message.set_transport_peer_id(peer_id);
                 let mut queue = self.receive_queue.lock().unwrap();
                 queue.push_back(message);
                 Ok(())

--- a/crates/offline-protocol-transport/src/mock.rs
+++ b/crates/offline-protocol-transport/src/mock.rs
@@ -50,6 +50,13 @@ impl MockTransport {
         queue.push(message);
     }
 
+    /// Adds a message to the receive queue with a transport-verified peer identity.
+    pub fn queue_message_from(&self, mut message: Message, peer_id: String) {
+        message.transport_peer_id = Some(peer_id);
+        let mut queue = self.receive_queue.lock().unwrap();
+        queue.push(message);
+    }
+
     /// Returns all messages that were sent through this transport.
     pub fn sent_messages(&self) -> Vec<Message> {
         self.sent_messages.lock().unwrap().clone()

--- a/crates/offline-protocol-transport/src/mock.rs
+++ b/crates/offline-protocol-transport/src/mock.rs
@@ -52,7 +52,7 @@ impl MockTransport {
 
     /// Adds a message to the receive queue with a transport-verified peer identity.
     pub fn queue_message_from(&self, mut message: Message, peer_id: String) {
-        message.transport_peer_id = Some(peer_id);
+        message.set_transport_peer_id(peer_id);
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push(message);
     }

--- a/crates/offline-protocol-transport/src/mock.rs
+++ b/crates/offline-protocol-transport/src/mock.rs
@@ -52,7 +52,9 @@ impl MockTransport {
 
     /// Adds a message to the receive queue with a transport-verified peer identity.
     pub fn queue_message_from(&self, mut message: Message, peer_id: String) {
-        message.set_transport_peer_id(peer_id);
+        message
+            .set_transport_peer_id(peer_id)
+            .expect("test must provide non-empty peer_id");
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push(message);
     }

--- a/crates/offline-protocol-transport/src/wifi_direct.rs
+++ b/crates/offline-protocol-transport/src/wifi_direct.rs
@@ -159,7 +159,9 @@ impl WifiDirectTransport {
     ///   The protocol layer uses this value to verify that `message.sender`
     ///   matches the physical peer that delivered it.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
-        message.set_transport_peer_id(peer_id);
+        message
+            .set_transport_peer_id(peer_id)
+            .expect("transport must provide non-empty peer_id");
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push_back(message);
     }
@@ -223,7 +225,7 @@ impl WifiDirectTransport {
     pub fn on_data_received_from(&self, data: Vec<u8>, peer_id: String) -> Result<()> {
         match self.deserialize_message(&data) {
             Ok(mut message) => {
-                message.set_transport_peer_id(peer_id);
+                message.set_transport_peer_id(peer_id)?;
                 let mut queue = self.receive_queue.lock().unwrap();
                 queue.push_back(message);
                 Ok(())

--- a/crates/offline-protocol-transport/src/wifi_direct.rs
+++ b/crates/offline-protocol-transport/src/wifi_direct.rs
@@ -148,6 +148,14 @@ impl WifiDirectTransport {
         queue.push_back(message);
     }
 
+    /// Called when a message is received from a peer whose transport-level
+    /// identity is known (e.g. Wi-Fi Direct MAC address).
+    pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
+        message.transport_peer_id = Some(peer_id);
+        let mut queue = self.receive_queue.lock().unwrap();
+        queue.push_back(message);
+    }
+
     /// Gets all discovered peers.
     pub fn get_peers(&self) -> Vec<WifiDirectPeer> {
         let peers = self.peers.lock().unwrap();
@@ -190,6 +198,23 @@ impl WifiDirectTransport {
             Err(e) => {
                 tracing::warn!(error = %e, "Error deserializing message, dropping bad data");
                 Ok(()) // Don't fail - just drop bad data
+            }
+        }
+    }
+
+    /// Like [`on_data_received`](Self::on_data_received), but attaches a
+    /// transport-verified `peer_id` to the deserialized message.
+    pub fn on_data_received_from(&self, data: Vec<u8>, peer_id: String) -> Result<()> {
+        match self.deserialize_message(&data) {
+            Ok(mut message) => {
+                message.transport_peer_id = Some(peer_id);
+                let mut queue = self.receive_queue.lock().unwrap();
+                queue.push_back(message);
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Error deserializing message, dropping bad data");
+                Ok(())
             }
         }
     }

--- a/crates/offline-protocol-transport/src/wifi_direct.rs
+++ b/crates/offline-protocol-transport/src/wifi_direct.rs
@@ -159,9 +159,14 @@ impl WifiDirectTransport {
     ///   The protocol layer uses this value to verify that `message.sender`
     ///   matches the physical peer that delivered it.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
-        message
-            .set_transport_peer_id(peer_id)
-            .expect("transport must provide non-empty peer_id");
+        if let Err(e) = message.set_transport_peer_id(peer_id) {
+            tracing::warn!(
+                error = %e,
+                message_id = %message.id,
+                "Dropping message: transport provided invalid peer_id"
+            );
+            return;
+        }
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push_back(message);
     }

--- a/crates/offline-protocol-transport/src/wifi_direct.rs
+++ b/crates/offline-protocol-transport/src/wifi_direct.rs
@@ -159,7 +159,7 @@ impl WifiDirectTransport {
     ///   The protocol layer uses this value to verify that `message.sender`
     ///   matches the physical peer that delivered it.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
-        message.transport_peer_id = Some(peer_id);
+        message.set_transport_peer_id(peer_id);
         let mut queue = self.receive_queue.lock().unwrap();
         queue.push_back(message);
     }
@@ -223,7 +223,7 @@ impl WifiDirectTransport {
     pub fn on_data_received_from(&self, data: Vec<u8>, peer_id: String) -> Result<()> {
         match self.deserialize_message(&data) {
             Ok(mut message) => {
-                message.transport_peer_id = Some(peer_id);
+                message.set_transport_peer_id(peer_id);
                 let mut queue = self.receive_queue.lock().unwrap();
                 queue.push_back(message);
                 Ok(())

--- a/crates/offline-protocol-transport/src/wifi_direct.rs
+++ b/crates/offline-protocol-transport/src/wifi_direct.rs
@@ -148,8 +148,16 @@ impl WifiDirectTransport {
         queue.push_back(message);
     }
 
-    /// Called when a message is received from a peer whose transport-level
-    /// identity is known (e.g. Wi-Fi Direct MAC address).
+    /// Like [`on_message_received`](Self::on_message_received), but attaches a
+    /// transport-verified `peer_id` to the message.
+    ///
+    /// # Parameters
+    ///
+    /// * `peer_id` — The **user-level identifier** (i.e., the remote peer's
+    ///   `UserId` string) that the transport layer has authenticated for this
+    ///   connection. This is **not** the raw transport address (MAC, IP, etc.).
+    ///   The protocol layer uses this value to verify that `message.sender`
+    ///   matches the physical peer that delivered it.
     pub fn on_message_received_from(&self, mut message: Message, peer_id: String) {
         message.transport_peer_id = Some(peer_id);
         let mut queue = self.receive_queue.lock().unwrap();
@@ -204,6 +212,14 @@ impl WifiDirectTransport {
 
     /// Like [`on_data_received`](Self::on_data_received), but attaches a
     /// transport-verified `peer_id` to the deserialized message.
+    ///
+    /// # Parameters
+    ///
+    /// * `peer_id` — The **user-level identifier** (i.e., the remote peer's
+    ///   `UserId` string) that the transport layer has authenticated for this
+    ///   connection. This is **not** the raw transport address (MAC, IP, etc.).
+    ///   The protocol layer uses this value to verify that `message.sender`
+    ///   matches the physical peer that delivered it.
     pub fn on_data_received_from(&self, data: Vec<u8>, peer_id: String) -> Result<()> {
         match self.deserialize_message(&data) {
             Ok(mut message) => {

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -732,6 +732,15 @@ pub enum Event {
         #[serde(skip_serializing_if = "Option::is_none")]
         reason_detail: Option<String>,
     },
+
+    /// A security-relevant anomaly was detected (e.g. sender spoofing, TOFU
+    /// key mismatch, unsigned control message when signatures are required).
+    SecurityWarning {
+        /// Peer ID involved in the warning.
+        peer_id: String,
+        /// Human-readable description of the security issue.
+        reason: String,
+    },
 }
 
 /// Member entry in GroupInfo.
@@ -1350,6 +1359,11 @@ impl Event {
         }
     }
 
+    /// Creates a SecurityWarning event.
+    pub fn security_warning(peer_id: String, reason: String) -> Self {
+        Self::SecurityWarning { peer_id, reason }
+    }
+
     /// Converts the event to JSON.
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
@@ -1930,6 +1944,11 @@ impl fmt::Debug for Event {
                 .field("to", to)
                 .field("reason_code", reason_code)
                 .field("reason_detail", reason_detail)
+                .finish(),
+            Self::SecurityWarning { peer_id, reason } => f
+                .debug_struct("SecurityWarning")
+                .field("peer_id", peer_id)
+                .field("reason", reason)
                 .finish(),
         }
     }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -385,6 +385,12 @@ pub(crate) struct ReceivedKeyPackage {
 pub(crate) enum InternalMessageResult {
     /// Message was consumed internally (don't surface to app).
     Consumed,
+    /// Message was rejected by the security gate (spoofed sender, bad
+    /// signature, TOFU violation, etc.). Like `Consumed`, the message is not
+    /// surfaced to the app — but unlike `Consumed`, a delivery ACK must NOT
+    /// be sent back, to avoid confirming to the attacker that the target is
+    /// online and processing messages.
+    SecurityRejected,
     /// Message was decrypted, here's the plaintext.
     Decrypted(String),
 }
@@ -3284,6 +3290,9 @@ impl OfflineProtocol {
                     InternalMessageResult::Consumed => {
                         debug!(message_id = %msg.id, "Delayed message was consumed internally");
                     }
+                    InternalMessageResult::SecurityRejected => {
+                        debug!(message_id = %msg.id, "Delayed message was rejected by security gate");
+                    }
                 }
             }
         }
@@ -5153,6 +5162,13 @@ impl OfflineProtocol {
                                 // Internal message handled, don't surface to app
                                 continue;
                             }
+                            InternalMessageResult::SecurityRejected => {
+                                // Security gate rejected this message (spoofed sender,
+                                // bad signature, TOFU violation). Do NOT send a delivery
+                                // ACK — acknowledging would confirm to the attacker that
+                                // the target peer is online and processing messages.
+                                continue;
+                            }
                             InternalMessageResult::Decrypted(plaintext) => {
                                 // Replace content with decrypted plaintext
                                 message.content = plaintext;
@@ -6421,7 +6437,6 @@ impl OfflineProtocol {
             Err(e) => {
                 let reason = format!("MLS lock poisoned — cannot sign control message: {}", e);
                 error!(error = %e, "MLS lock poisoned — cannot sign control message");
-                self.emit_security_warning(message.sender.as_str(), &reason);
                 return Err(Error::Other(reason));
             }
         };
@@ -6431,7 +6446,6 @@ impl OfflineProtocol {
             Err(e) => {
                 let reason = format!("Failed to get identity public key: {}", e);
                 error!(error = %e, "Failed to get identity public key — cannot sign control message");
-                self.emit_security_warning(message.sender.as_str(), &reason);
                 return Err(Error::Other(reason));
             }
         };
@@ -6441,7 +6455,6 @@ impl OfflineProtocol {
             Err(e) => {
                 let reason = format!("Failed to sign control message: {}", e);
                 error!(error = %e, "Failed to sign control message");
-                self.emit_security_warning(message.sender.as_str(), &reason);
                 return Err(Error::Other(reason));
             }
         };
@@ -6593,8 +6606,9 @@ impl OfflineProtocol {
     /// identity and cryptographic signature before allowing the message to
     /// proceed through `process_internal_message`.
     ///
-    /// Returns `Some(InternalMessageResult::Consumed)` to drop the message,
-    /// or `None` to allow it through.
+    /// Returns `Some(InternalMessageResult::SecurityRejected)` to drop the
+    /// message (without sending a delivery ACK), or `None` to allow it
+    /// through.
     fn security_gate_control_message(
         &mut self,
         message: &Message,
@@ -6617,7 +6631,7 @@ impl OfflineProtocol {
                 sender,
                 "Control message sender does not match transport peer identity",
             );
-            return Some(InternalMessageResult::Consumed);
+            return Some(InternalMessageResult::SecurityRejected);
         }
 
         // Cryptographic signature check
@@ -6639,7 +6653,7 @@ impl OfflineProtocol {
                         sender,
                         "Unsigned control message from peer with pinned key (possible downgrade attack)",
                     );
-                    return Some(InternalMessageResult::Consumed);
+                    return Some(InternalMessageResult::SecurityRejected);
                 }
                 debug!(
                     sender = %sender,
@@ -6656,7 +6670,7 @@ impl OfflineProtocol {
                     "Dropping control message: signature verification failed"
                 );
                 self.emit_security_warning(sender, format!("Control message rejected: {}", err));
-                return Some(InternalMessageResult::Consumed);
+                return Some(InternalMessageResult::SecurityRejected);
             }
         }
 
@@ -13479,11 +13493,11 @@ pub(crate) mod tests {
         );
         msg.set_transport_peer_id("eve".to_string()).unwrap();
 
-        // process_internal_message should consume (drop) the message
+        // process_internal_message should reject (drop without ACK) the message
         let result = protocol.process_internal_message(&msg);
         assert!(
-            matches!(result, Some(InternalMessageResult::Consumed)),
-            "Expected spoofed control message to be dropped"
+            matches!(result, Some(InternalMessageResult::SecurityRejected)),
+            "Expected spoofed control message to be rejected by security gate"
         );
     }
 
@@ -13641,8 +13655,8 @@ pub(crate) mod tests {
         // Should be rejected because alice has a TOFU-pinned key
         let result = protocol.process_internal_message(&msg);
         assert!(
-            matches!(result, Some(InternalMessageResult::Consumed)),
-            "Unsigned control message from TOFU-pinned peer should be dropped"
+            matches!(result, Some(InternalMessageResult::SecurityRejected)),
+            "Unsigned control message from TOFU-pinned peer should be rejected by security gate"
         );
     }
 
@@ -14366,8 +14380,8 @@ pub(crate) mod tests {
 
             let result = protocol.process_internal_message(&msg);
             assert!(
-                matches!(result, Some(InternalMessageResult::Consumed)),
-                "Security gate should drop spoofed message for prefix '{}'",
+                matches!(result, Some(InternalMessageResult::SecurityRejected)),
+                "Security gate should reject spoofed message for prefix '{}'",
                 prefix
             );
         }
@@ -14444,8 +14458,8 @@ pub(crate) mod tests {
 
         let result = protocol.process_internal_message(&msg);
         assert!(
-            matches!(result, Some(InternalMessageResult::Consumed)),
-            "Malformed message (pk without sig) should be dropped by security gate"
+            matches!(result, Some(InternalMessageResult::SecurityRejected)),
+            "Malformed message (pk without sig) should be rejected by security gate"
         );
     }
 
@@ -14528,6 +14542,141 @@ pub(crate) mod tests {
         assert!(
             result.is_err(),
             "Zero-byte public key must be rejected during verification"
+        );
+    }
+
+    #[test]
+    fn test_signature_downgrade_detection_for_tofu_pinned_peer() {
+        // A peer that has previously sent signed control messages (TOFU-pinned)
+        // must have subsequent unsigned control messages rejected as a possible
+        // downgrade attack (impersonation attempt).
+        let mut protocol = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
+        let storage = Arc::new(crate::mls::InMemoryStorage::new());
+        protocol.initialize_mls(storage).unwrap();
+
+        // Set up "alice" as a sender with MLS so she can sign.
+        let mut alice = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
+        let storage_a = Arc::new(crate::mls::InMemoryStorage::new());
+        alice.initialize_mls(storage_a).unwrap();
+
+        // Alice creates and signs a control message.
+        let mut signed_msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"first\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        alice.sign_control_message(&mut signed_msg).unwrap();
+        assert!(signed_msg.metadata.contains_key(CTRL_SIG_META_KEY));
+
+        // Bob verifies — this TOFU-pins alice's key.
+        let result = protocol.verify_control_message(&signed_msg);
+        assert!(matches!(result, Ok(true)), "First signed message should verify");
+        assert!(
+            protocol.known_peer_public_keys.contains_key("alice"),
+            "Alice's key should be TOFU-pinned"
+        );
+
+        // Now "alice" (or an impersonator) sends an unsigned control message.
+        let unsigned_msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"unsigned\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        assert!(!unsigned_msg.metadata.contains_key(CTRL_SIG_META_KEY));
+
+        // The security gate should reject this as a signature downgrade.
+        let gate_result = protocol.security_gate_control_message(&unsigned_msg);
+        assert!(
+            matches!(gate_result, Some(InternalMessageResult::SecurityRejected)),
+            "Unsigned message from TOFU-pinned peer should be rejected as signature downgrade"
+        );
+    }
+
+    #[test]
+    fn test_second_signed_message_from_tofu_pinned_peer_passes_gate() {
+        // After TOFU-pinning, a subsequent correctly-signed control message
+        // from the same peer (with the same key) should pass the security gate.
+        let mut protocol = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
+        let storage = Arc::new(crate::mls::InMemoryStorage::new());
+        protocol.initialize_mls(storage).unwrap();
+
+        let mut alice = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
+        let storage_a = Arc::new(crate::mls::InMemoryStorage::new());
+        alice.initialize_mls(storage_a).unwrap();
+
+        // First signed message — pins alice's key.
+        let mut msg1 = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"first\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        alice.sign_control_message(&mut msg1).unwrap();
+
+        let gate1 = protocol.security_gate_control_message(&msg1);
+        assert!(
+            gate1.is_none(),
+            "First signed message should pass the security gate"
+        );
+        assert!(protocol.known_peer_public_keys.contains_key("alice"));
+
+        // Second signed message — same key, should also pass.
+        let mut msg2 = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"second\"}}", internal_prefixes::CONN_ACCEPT),
+        );
+        alice.sign_control_message(&mut msg2).unwrap();
+
+        let gate2 = protocol.security_gate_control_message(&msg2);
+        assert!(
+            gate2.is_none(),
+            "Second signed message from same TOFU-pinned peer should pass the security gate"
+        );
+    }
+
+    #[test]
+    fn test_security_rejected_does_not_send_ack() {
+        // Verify that SecurityRejected messages do NOT trigger a delivery ACK,
+        // preventing an attacker from confirming the target is online.
+        let mut bob = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
+        let storage_b = Arc::new(crate::mls::InMemoryStorage::new());
+        bob.initialize_mls(storage_b).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        let transport_handle = mock_transport.clone();
+
+        // Create a spoofed control message: sender says "alice", transport says "eve"
+        let mut spoofed = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"evil\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        spoofed.requires_ack = true;
+        mock_transport.queue_message_from(spoofed, "eve".to_string());
+
+        bob.transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        bob.start().unwrap();
+
+        // Process the message — should be security-rejected
+        let received = bob.receive_message();
+        assert!(received.is_none(), "Spoofed message should not surface");
+
+        // Verify no ACK was sent back
+        let sent = transport_handle.sent_messages();
+        let ack_count = sent
+            .iter()
+            .filter(|m| m.metadata.contains_key(ACK_FOR_KEY))
+            .count();
+        assert_eq!(
+            ack_count, 0,
+            "Security-rejected messages must NOT trigger a delivery ACK"
         );
     }
 }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -182,6 +182,13 @@ const INTERNAL_PREFIXES: &[&str] = &[
 /// contact after restart.
 const MAX_TOFU_PEERS: usize = 1000;
 
+/// Minimum age (in milliseconds) a TOFU entry must have before it can be
+/// evicted by LRU. This prevents a cache-filling attack where an adversary
+/// rapidly registers many fake identities to evict legitimate pinned keys.
+///
+/// Set to 1 hour.
+const TOFU_MIN_EVICTION_AGE_MS: i64 = 3_600_000;
+
 /// Entry in the TOFU key store, pairing the peer's public key with a
 /// last-seen timestamp used for LRU eviction.
 #[derive(Clone, Debug)]
@@ -6397,11 +6404,31 @@ impl OfflineProtocol {
     // CONTROL MESSAGE SIGNING & VERIFICATION
     // ========================================================================
 
+    /// Builds a canonical signing payload using length-prefixed encoding.
+    ///
+    /// Each field is encoded as `<4-byte big-endian length><utf-8 bytes>`,
+    /// making the encoding unambiguous regardless of field content (no
+    /// delimiter-collision risk).
+    fn build_canonical_payload(message: &Message) -> Vec<u8> {
+        let fields: [&str; 4] = [
+            message.sender.as_str(),
+            &message.id.as_str(),
+            message.recipient.as_str(),
+            &message.content,
+        ];
+        let mut buf = Vec::with_capacity(fields.iter().map(|f| 4 + f.len()).sum());
+        for field in &fields {
+            buf.extend_from_slice(&(field.len() as u32).to_be_bytes());
+            buf.extend_from_slice(field.as_bytes());
+        }
+        buf
+    }
+
     /// Signs a control message by adding an Ed25519 signature and the sender's
     /// public key to the message metadata.
     ///
-    /// If MLS is not initialized, the message is sent unsigned. The receiving
-    /// side uses TOFU (Trust-On-First-Use) to pin the public key.
+    /// If MLS is not initialized, the message is sent unsigned and a
+    /// `SecurityWarning` event is emitted so the application layer is aware.
     fn sign_control_message(&self, message: &mut Message) {
         let mls = match self.mls_manager.as_ref() {
             Some(m) => m,
@@ -6413,7 +6440,13 @@ impl OfflineProtocol {
         let manager = match mls.read() {
             Ok(guard) => guard,
             Err(e) => {
-                warn!(error = %e, "MLS lock poisoned — sending unsigned control message");
+                error!(error = %e, "MLS lock poisoned — cannot sign control message");
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::security_warning(
+                        message.sender.as_str().to_string(),
+                        "Control message sent unsigned: MLS lock poisoned".to_string(),
+                    ));
+                }
                 return;
             }
         };
@@ -6421,20 +6454,27 @@ impl OfflineProtocol {
         let public_key = match manager.get_identity_public_key() {
             Ok(pk) => pk,
             Err(e) => {
-                warn!(error = %e, "Failed to get identity public key — sending unsigned control message");
+                error!(error = %e, "Failed to get identity public key — sending unsigned control message");
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::security_warning(
+                        message.sender.as_str().to_string(),
+                        format!("Control message sent unsigned: {}", e),
+                    ));
+                }
                 return;
             }
         };
-        // Sign a canonical payload that includes message ID and recipient
-        // to prevent cross-recipient replay attacks.
-        let canonical = format!(
-            "{}:{}:{}:{}",
-            message.sender, message.id, message.recipient, message.content
-        );
-        let signature = match manager.sign_data(canonical.as_bytes()) {
+        let canonical = Self::build_canonical_payload(message);
+        let signature = match manager.sign_data(&canonical) {
             Ok(sig) => sig,
             Err(e) => {
-                warn!(error = %e, "Failed to sign control message — sending unsigned");
+                error!(error = %e, "Failed to sign control message — sending unsigned");
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::security_warning(
+                        message.sender.as_str().to_string(),
+                        format!("Control message sent unsigned: {}", e),
+                    ));
+                }
                 return;
             }
         };
@@ -6454,11 +6494,11 @@ impl OfflineProtocol {
     /// - `Ok(false)` — no signature present (legacy/unsigned message)
     /// - `Err(..)`   — signature invalid, key mismatch, or TOFU violation
     fn verify_control_message(&mut self, message: &Message) -> Result<bool> {
-        let sig_hex = match message.metadata.get(CTRL_SIG_META_KEY) {
+        let sig_b64 = match message.metadata.get(CTRL_SIG_META_KEY) {
             Some(s) => s,
             None => return Ok(false), // Unsigned — caller decides policy
         };
-        let pk_hex = match message.metadata.get(CTRL_PK_META_KEY) {
+        let pk_b64 = match message.metadata.get(CTRL_PK_META_KEY) {
             Some(s) => s,
             None => {
                 return Err(Error::Other(
@@ -6467,23 +6507,17 @@ impl OfflineProtocol {
             }
         };
 
-        let signature = base64_decode(sig_hex)
+        let signature = base64_decode(sig_b64)
             .map_err(|e| Error::Other(format!("Invalid control signature encoding: {}", e)))?;
-        let public_key = base64_decode(pk_hex)
+        let public_key = base64_decode(pk_b64)
             .map_err(|e| Error::Other(format!("Invalid control public key encoding: {}", e)))?;
 
-        // Verify Ed25519 signature over a canonical payload that includes
-        // message ID and recipient to prevent cross-recipient replay attacks.
-        let canonical = format!(
-            "{}:{}:{}:{}",
-            message.sender, message.id, message.recipient, message.content
-        );
-        let valid = offline_protocol_mls::MlsManager::verify_signature(
-            &public_key,
-            canonical.as_bytes(),
-            &signature,
-        )
-        .map_err(|e| Error::Other(format!("Signature verification error: {}", e)))?;
+        // Verify Ed25519 signature over a length-prefixed canonical payload
+        // that binds sender, message ID, recipient, and content.
+        let canonical = Self::build_canonical_payload(message);
+        let valid =
+            offline_protocol_mls::MlsManager::verify_signature(&public_key, &canonical, &signature)
+                .map_err(|e| Error::Other(format!("Signature verification error: {}", e)))?;
 
         if !valid {
             return Err(Error::Other(
@@ -6492,8 +6526,17 @@ impl OfflineProtocol {
         }
 
         // TOFU: check/pin the public key for this sender
-        let sender = message.sender.as_str();
+        self.tofu_check_or_pin(message.sender.as_str(), public_key)
+    }
+
+    /// Checks a verified public key against the TOFU store, or pins it on
+    /// first contact. Handles bounded-capacity eviction with a minimum age
+    /// threshold to resist cache-filling attacks.
+    ///
+    /// Returns `Ok(true)` on success, `Err(..)` on TOFU key mismatch.
+    fn tofu_check_or_pin(&mut self, sender: &str, public_key: Vec<u8>) -> Result<bool> {
         let now_ms = Utc::now().timestamp_millis();
+
         if let Some(entry) = self.known_peer_public_keys.get_mut(sender) {
             if entry.public_key != public_key {
                 warn!(
@@ -6516,14 +6559,39 @@ impl OfflineProtocol {
         } else {
             // First contact — pin the key (with bounded capacity, LRU eviction)
             if self.known_peer_public_keys.len() >= MAX_TOFU_PEERS {
-                if let Some(evict_key) = self
+                // Only evict entries older than the minimum age to prevent a
+                // cache-filling attack where an adversary rapidly registers
+                // many fake identities to force eviction of legitimate peers.
+                let eviction_cutoff = now_ms - TOFU_MIN_EVICTION_AGE_MS;
+                let evict_key = self
                     .known_peer_public_keys
                     .iter()
+                    .filter(|(_, entry)| entry.last_seen_ms < eviction_cutoff)
                     .min_by_key(|(_, entry)| entry.last_seen_ms)
-                    .map(|(k, _)| k.clone())
-                {
-                    debug!(evicted_peer = %evict_key, "TOFU store full, evicting LRU entry");
-                    self.known_peer_public_keys.remove(&evict_key);
+                    .map(|(k, _)| k.clone());
+
+                match evict_key {
+                    Some(key) => {
+                        debug!(evicted_peer = %key, "TOFU store full, evicting LRU entry");
+                        self.known_peer_public_keys.remove(&key);
+                    }
+                    None => {
+                        warn!(
+                            sender = %sender,
+                            store_size = self.known_peer_public_keys.len(),
+                            "TOFU store full and no entry old enough to evict — \
+                             refusing to pin new peer (possible cache-filling attack)"
+                        );
+                        if let Ok(state) = lock_shared_state(&self.shared_state) {
+                            state.emit_event(Event::security_warning(
+                                sender.to_string(),
+                                "TOFU store full, cannot pin new peer key".to_string(),
+                            ));
+                        }
+                        // Still accept the message (signature was valid) but
+                        // don't pin — the peer will be re-verified each time.
+                        return Ok(true);
+                    }
                 }
             }
             debug!(sender = %sender, "TOFU: pinning public key for new peer");
@@ -6544,8 +6612,8 @@ impl OfflineProtocol {
     /// transport identity is available (best-effort). Returns `false` if
     /// there is a mismatch.
     fn validate_transport_sender(&self, message: &Message) -> bool {
-        if let Some(ref transport_peer) = message.transport_peer_id {
-            if message.sender.as_str() != transport_peer.as_str() {
+        if let Some(transport_peer) = message.transport_peer_id() {
+            if message.sender.as_str() != transport_peer {
                 warn!(
                     claimed_sender = %message.sender,
                     transport_peer = %transport_peer,
@@ -13243,15 +13311,8 @@ pub(crate) mod tests {
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_svc_prefixes_included_in_internal_prefixes() {
-        // Verify all SVC prefixes are covered, including the catch-all
-        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_MESSAGE_PREFIX));
-        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_QUERY));
-        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_RESPONSE));
-        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_REQUEST));
-        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_RESPONSE));
-    }
+    // NOTE: SVC prefix coverage is now verified by
+    // test_internal_prefixes_completeness above.
 
     #[test]
     fn test_is_internal_prefix() {
@@ -13276,7 +13337,7 @@ pub(crate) mod tests {
             AppId::new("test-app").unwrap(),
             "hello",
         );
-        msg.transport_peer_id = Some("alice".to_string());
+        msg.set_transport_peer_id("alice".to_string());
 
         assert!(protocol.validate_transport_sender(&msg));
     }
@@ -13291,7 +13352,7 @@ pub(crate) mod tests {
             AppId::new("test-app").unwrap(),
             "hello",
         );
-        msg.transport_peer_id = Some("eve".to_string());
+        msg.set_transport_peer_id("eve".to_string());
 
         assert!(!protocol.validate_transport_sender(&msg));
     }
@@ -13322,7 +13383,7 @@ pub(crate) mod tests {
             "sender123",
             &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
         );
-        msg.transport_peer_id = Some("eve".to_string());
+        msg.set_transport_peer_id("eve".to_string());
 
         // process_internal_message should consume (drop) the message
         let result = protocol.process_internal_message(&msg);
@@ -13372,38 +13433,25 @@ pub(crate) mod tests {
     fn test_tofu_store_bounded_capacity_with_lru_eviction() {
         let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
 
+        // Use timestamps old enough to be eviction-eligible (beyond the
+        // TOFU_MIN_EVICTION_AGE_MS threshold).
+        let old_base = Utc::now().timestamp_millis() - TOFU_MIN_EVICTION_AGE_MS - 100_000;
+
         // Fill the TOFU store to capacity with ascending last_seen timestamps
         for i in 0..MAX_TOFU_PEERS {
             protocol.known_peer_public_keys.insert(
                 format!("peer_{}", i),
                 TofuEntry {
                     public_key: vec![i as u8; 32],
-                    last_seen_ms: i as i64, // peer_0 has oldest timestamp
+                    last_seen_ms: old_base + i as i64, // peer_0 has oldest timestamp
                 },
             );
         }
         assert_eq!(protocol.known_peer_public_keys.len(), MAX_TOFU_PEERS);
 
-        // Simulate what verify_control_message does when store is full:
-        // LRU eviction should remove the entry with the smallest last_seen_ms.
-        if protocol.known_peer_public_keys.len() >= MAX_TOFU_PEERS {
-            if let Some(evict_key) = protocol
-                .known_peer_public_keys
-                .iter()
-                .min_by_key(|(_, entry)| entry.last_seen_ms)
-                .map(|(k, _)| k.clone())
-            {
-                assert_eq!(evict_key, "peer_0", "Should evict the LRU entry");
-                protocol.known_peer_public_keys.remove(&evict_key);
-            }
-        }
-        protocol.known_peer_public_keys.insert(
-            "new_peer".to_string(),
-            TofuEntry {
-                public_key: vec![99u8; 32],
-                last_seen_ms: MAX_TOFU_PEERS as i64 + 1,
-            },
-        );
+        // tofu_check_or_pin should evict the oldest entry and add the new one.
+        let result = protocol.tofu_check_or_pin("new_peer", vec![99u8; 32]);
+        assert!(result.is_ok());
 
         // Size should still be at the cap
         assert_eq!(protocol.known_peer_public_keys.len(), MAX_TOFU_PEERS);
@@ -13417,6 +13465,40 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_tofu_eviction_refuses_when_all_entries_too_recent() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // Fill with entries that are all recent (within the min eviction age).
+        let recent = Utc::now().timestamp_millis();
+        for i in 0..MAX_TOFU_PEERS {
+            protocol.known_peer_public_keys.insert(
+                format!("recent_peer_{}", i),
+                TofuEntry {
+                    public_key: vec![i as u8; 32],
+                    last_seen_ms: recent - i as i64, // all very recent
+                },
+            );
+        }
+        assert_eq!(protocol.known_peer_public_keys.len(), MAX_TOFU_PEERS);
+
+        // Attempt to pin a new peer — should succeed (signature was valid)
+        // but should NOT evict any entry or pin the new key.
+        let result = protocol.tofu_check_or_pin("attacker_peer", vec![42u8; 32]);
+        assert!(result.is_ok(), "Should accept message despite full store");
+        assert!(
+            !protocol
+                .known_peer_public_keys
+                .contains_key("attacker_peer"),
+            "Should not pin new peer when all entries are too recent to evict"
+        );
+        assert_eq!(
+            protocol.known_peer_public_keys.len(),
+            MAX_TOFU_PEERS,
+            "Store size should be unchanged"
+        );
+    }
+
+    #[test]
     fn test_transport_peer_id_not_serialized() {
         let mut msg = Message::new(
             UserId::new("alice").unwrap(),
@@ -13424,7 +13506,7 @@ pub(crate) mod tests {
             AppId::new("test-app").unwrap(),
             "hello",
         );
-        msg.transport_peer_id = Some("ble-device-42".to_string());
+        msg.set_transport_peer_id("ble-device-42".to_string());
 
         let json = serde_json::to_string(&msg).unwrap();
         assert!(
@@ -13438,7 +13520,7 @@ pub(crate) mod tests {
 
         // Deserialize back — field should be None
         let deserialized: Message = serde_json::from_str(&json).unwrap();
-        assert!(deserialized.transport_peer_id.is_none());
+        assert!(deserialized.transport_peer_id().is_none());
     }
 
     #[test]
@@ -13537,33 +13619,38 @@ pub(crate) mod tests {
     fn test_tofu_lru_eviction_removes_oldest() {
         let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
 
+        // Use timestamps old enough to be eviction-eligible
+        let old_base = Utc::now().timestamp_millis() - TOFU_MIN_EVICTION_AGE_MS - 100_000;
+
         // Insert 3 entries with different timestamps
         protocol.known_peer_public_keys.insert(
             "old_peer".to_string(),
             TofuEntry {
                 public_key: vec![1u8; 32],
-                last_seen_ms: 100,
+                last_seen_ms: old_base,
             },
         );
         protocol.known_peer_public_keys.insert(
             "medium_peer".to_string(),
             TofuEntry {
                 public_key: vec![2u8; 32],
-                last_seen_ms: 200,
+                last_seen_ms: old_base + 100,
             },
         );
         protocol.known_peer_public_keys.insert(
             "new_peer".to_string(),
             TofuEntry {
                 public_key: vec![3u8; 32],
-                last_seen_ms: 300,
+                last_seen_ms: old_base + 200,
             },
         );
 
-        // Find the LRU entry
+        // Find the LRU entry (among eviction-eligible ones)
+        let eviction_cutoff = Utc::now().timestamp_millis() - TOFU_MIN_EVICTION_AGE_MS;
         let lru = protocol
             .known_peer_public_keys
             .iter()
+            .filter(|(_, e)| e.last_seen_ms < eviction_cutoff)
             .min_by_key(|(_, e)| e.last_seen_ms)
             .map(|(k, _)| k.clone())
             .unwrap();
@@ -13575,9 +13662,9 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_canonical_signing_payload_format() {
-        // Verify the canonical payload format used for signing includes
-        // sender, message ID, recipient, and content.
+    fn test_canonical_signing_payload_is_length_prefixed() {
+        // Verify the canonical payload uses length-prefixed encoding, not
+        // delimiter-based, to prevent ambiguity from field contents.
         let msg = Message::new(
             UserId::new("alice").unwrap(),
             UserId::new("bob").unwrap(),
@@ -13585,19 +13672,100 @@ pub(crate) mod tests {
             "__CONN_REQ__payload",
         );
 
-        let canonical = format!(
-            "{}:{}:{}:{}",
-            msg.sender, msg.id, msg.recipient, msg.content
+        let canonical = OfflineProtocol::build_canonical_payload(&msg);
+
+        // Parse back: each field is <4-byte big-endian length><utf-8 bytes>
+        let mut cursor = 0usize;
+        let mut fields = Vec::new();
+        while cursor < canonical.len() {
+            assert!(cursor + 4 <= canonical.len(), "truncated length prefix");
+            let len =
+                u32::from_be_bytes(canonical[cursor..cursor + 4].try_into().unwrap()) as usize;
+            cursor += 4;
+            assert!(cursor + len <= canonical.len(), "truncated field data");
+            let field = std::str::from_utf8(&canonical[cursor..cursor + len]).unwrap();
+            fields.push(field.to_string());
+            cursor += len;
+        }
+
+        assert_eq!(fields.len(), 4, "canonical payload should have 4 fields");
+        assert_eq!(fields[0], "alice");
+        assert_eq!(fields[1], msg.id.as_str());
+        assert_eq!(fields[2], "bob");
+        assert_eq!(fields[3], "__CONN_REQ__payload");
+    }
+
+    #[test]
+    fn test_canonical_payload_no_collision_with_colon_in_sender() {
+        // Regression test: ensure that a sender containing a colon does NOT
+        // produce the same payload as a different sender/id split.
+        let msg_a = Message::new(
+            UserId::new("alice:extra").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "content",
         );
-        assert!(canonical.contains("alice"));
-        assert!(canonical.contains(&msg.id.as_str().to_string()));
-        assert!(canonical.contains("bob"));
-        assert!(canonical.contains("__CONN_REQ__payload"));
-        // Ensure the format has exactly the expected structure
-        let parts: Vec<&str> = canonical.splitn(4, ':').collect();
-        assert_eq!(parts.len(), 4);
-        assert_eq!(parts[0], "alice");
-        assert_eq!(parts[2], "bob");
-        assert_eq!(parts[3], "__CONN_REQ__payload");
+        let msg_b = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "content",
+        );
+
+        let payload_a = OfflineProtocol::build_canonical_payload(&msg_a);
+        let payload_b = OfflineProtocol::build_canonical_payload(&msg_b);
+
+        // Even if content and recipient match, different sender lengths
+        // produce different payloads.
+        assert_ne!(payload_a, payload_b);
+    }
+
+    #[test]
+    fn test_internal_prefixes_completeness() {
+        // Verify that every constant defined in `internal_prefixes` is
+        // registered in INTERNAL_PREFIXES. If a new prefix is added to the
+        // module but not to the array, this test fails.
+        let module_prefixes: Vec<&str> = vec![
+            internal_prefixes::KEY_PACKAGE,
+            internal_prefixes::WELCOME,
+            internal_prefixes::ENCRYPTED,
+            internal_prefixes::SESSION_CONFIRM_PROBE,
+            internal_prefixes::SESSION_CONFIRM_ACK,
+            internal_prefixes::CONN_REQUEST,
+            internal_prefixes::CONN_ACCEPT,
+            internal_prefixes::CONN_REJECT,
+            internal_prefixes::GROUP_CREATED,
+            internal_prefixes::GROUP_MSG,
+            internal_prefixes::GROUP_MEMBER_ADDED,
+            internal_prefixes::GROUP_MEMBER_REMOVED,
+            internal_prefixes::GROUP_INFO,
+            internal_prefixes::USER_GROUPS,
+            internal_prefixes::GROUP_ERROR,
+            internal_prefixes::GROUP_MLS_MSG,
+            internal_prefixes::GROUP_MLS_WELCOME,
+            internal_prefixes::GROUP_MLS_COMMIT,
+            internal_prefixes::GROUP_MLS_LEAVE,
+            internal_prefixes::GROUP_RELAY_REGISTER,
+            internal_prefixes::GROUP_RELAY_BROADCAST,
+            internal_prefixes::PRESENCE,
+            internal_prefixes::TYPING_INDICATOR,
+            internal_prefixes::READ_RECEIPT,
+        ];
+
+        for prefix in &module_prefixes {
+            assert!(
+                INTERNAL_PREFIXES.contains(prefix),
+                "internal_prefixes::{:?} is missing from INTERNAL_PREFIXES array — \
+                 this is a security gap that allows prefix injection for this message type",
+                prefix
+            );
+        }
+
+        // Also verify the SVC catch-all and explicit SVC prefixes
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_MESSAGE_PREFIX));
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_QUERY));
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_RESPONSE));
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_REQUEST));
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_RESPONSE));
     }
 }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -131,6 +131,13 @@ const CTRL_SIG_META_KEY: &str = "__ctrl_sig";
 /// Metadata key for the sender's Ed25519 public key (base64, 32 bytes raw).
 const CTRL_PK_META_KEY: &str = "__ctrl_pk";
 
+/// Domain separator prepended to the canonical signing payload.
+///
+/// Prevents cross-context signature reuse: a signature produced for control
+/// messages cannot be replayed in a future protocol extension that reuses the
+/// same MLS identity key but with a different domain separator.
+const CTRL_SIGN_DOMAIN: &[u8] = b"offline-ctrl-v1";
+
 /// All internal message prefixes used for control messages.
 /// Used to reject user-sent messages that start with these prefixes.
 ///
@@ -5212,12 +5219,10 @@ impl OfflineProtocol {
                     message_id = %message.id,
                     "Dropping control message: sender/transport identity mismatch"
                 );
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::security_warning(
-                        sender.to_string(),
-                        "Control message sender does not match transport peer identity".to_string(),
-                    ));
-                }
+                self.emit_security_warning(
+                    sender,
+                    "Control message sender does not match transport peer identity",
+                );
                 return Some(InternalMessageResult::Consumed);
             }
 
@@ -5236,12 +5241,10 @@ impl OfflineProtocol {
                             message_id = %message.id,
                             "Dropping unsigned control message from TOFU-pinned peer (signature downgrade)"
                         );
-                        if let Ok(state) = lock_shared_state(&self.shared_state) {
-                            state.emit_event(Event::security_warning(
-                                sender.to_string(),
-                                "Unsigned control message from peer with pinned key (possible downgrade attack)".to_string(),
-                            ));
-                        }
+                        self.emit_security_warning(
+                            sender,
+                            "Unsigned control message from peer with pinned key (possible downgrade attack)",
+                        );
                         return Some(InternalMessageResult::Consumed);
                     }
                     debug!(
@@ -5258,12 +5261,10 @@ impl OfflineProtocol {
                         error = %err,
                         "Dropping control message: signature verification failed"
                     );
-                    if let Ok(state) = lock_shared_state(&self.shared_state) {
-                        state.emit_event(Event::security_warning(
-                            sender.to_string(),
-                            format!("Control message rejected: {}", err),
-                        ));
-                    }
+                    self.emit_security_warning(
+                        sender,
+                        format!("Control message rejected: {}", err),
+                    );
                     return Some(InternalMessageResult::Consumed);
                 }
             }
@@ -6416,7 +6417,10 @@ impl OfflineProtocol {
             message.recipient.as_str(),
             &message.content,
         ];
-        let mut buf = Vec::with_capacity(fields.iter().map(|f| 4 + f.len()).sum());
+        let mut buf = Vec::with_capacity(
+            CTRL_SIGN_DOMAIN.len() + fields.iter().map(|f| 4 + f.len()).sum::<usize>(),
+        );
+        buf.extend_from_slice(CTRL_SIGN_DOMAIN);
         for field in &fields {
             buf.extend_from_slice(&(field.len() as u32).to_be_bytes());
             buf.extend_from_slice(field.as_bytes());
@@ -6441,12 +6445,10 @@ impl OfflineProtocol {
             Ok(guard) => guard,
             Err(e) => {
                 error!(error = %e, "MLS lock poisoned — cannot sign control message");
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::security_warning(
-                        message.sender.as_str().to_string(),
-                        "Control message sent unsigned: MLS lock poisoned".to_string(),
-                    ));
-                }
+                self.emit_security_warning(
+                    message.sender.as_str(),
+                    "Control message sent unsigned: MLS lock poisoned",
+                );
                 return;
             }
         };
@@ -6455,12 +6457,10 @@ impl OfflineProtocol {
             Ok(pk) => pk,
             Err(e) => {
                 error!(error = %e, "Failed to get identity public key — sending unsigned control message");
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::security_warning(
-                        message.sender.as_str().to_string(),
-                        format!("Control message sent unsigned: {}", e),
-                    ));
-                }
+                self.emit_security_warning(
+                    message.sender.as_str(),
+                    format!("Control message sent unsigned: {}", e),
+                );
                 return;
             }
         };
@@ -6469,12 +6469,10 @@ impl OfflineProtocol {
             Ok(sig) => sig,
             Err(e) => {
                 error!(error = %e, "Failed to sign control message — sending unsigned");
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::security_warning(
-                        message.sender.as_str().to_string(),
-                        format!("Control message sent unsigned: {}", e),
-                    ));
-                }
+                self.emit_security_warning(
+                    message.sender.as_str(),
+                    format!("Control message sent unsigned: {}", e),
+                );
                 return;
             }
         };
@@ -6543,12 +6541,10 @@ impl OfflineProtocol {
                     sender = %sender,
                     "TOFU key mismatch: peer presented a different public key"
                 );
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::security_warning(
-                        sender.to_string(),
-                        "Public key changed for known peer (possible impersonation)".to_string(),
-                    ));
-                }
+                self.emit_security_warning(
+                    sender,
+                    "Public key changed for known peer (possible impersonation)",
+                );
                 return Err(Error::Other(format!(
                     "TOFU key mismatch for peer '{}'",
                     sender
@@ -6582,12 +6578,10 @@ impl OfflineProtocol {
                             "TOFU store full and no entry old enough to evict — \
                              refusing to pin new peer (possible cache-filling attack)"
                         );
-                        if let Ok(state) = lock_shared_state(&self.shared_state) {
-                            state.emit_event(Event::security_warning(
-                                sender.to_string(),
-                                "TOFU store full, cannot pin new peer key".to_string(),
-                            ));
-                        }
+                        self.emit_security_warning(
+                            sender,
+                            "TOFU store full, cannot pin new peer key",
+                        );
                         // Still accept the message (signature was valid) but
                         // don't pin — the peer will be re-verified each time.
                         return Ok(true);
@@ -6624,6 +6618,11 @@ impl OfflineProtocol {
             }
         }
         true
+    }
+
+    /// Emits a `SecurityWarning` event for the given peer.
+    fn emit_security_warning(&self, peer_id: &str, reason: impl Into<String>) {
+        self.emit_event(Event::security_warning(peer_id.to_string(), reason.into()));
     }
 
     /// Returns `true` if the message content starts with any internal prefix.
@@ -13663,8 +13662,8 @@ pub(crate) mod tests {
 
     #[test]
     fn test_canonical_signing_payload_is_length_prefixed() {
-        // Verify the canonical payload uses length-prefixed encoding, not
-        // delimiter-based, to prevent ambiguity from field contents.
+        // Verify the canonical payload uses a domain separator followed by
+        // length-prefixed encoding to prevent ambiguity and cross-context reuse.
         let msg = Message::new(
             UserId::new("alice").unwrap(),
             UserId::new("bob").unwrap(),
@@ -13674,8 +13673,14 @@ pub(crate) mod tests {
 
         let canonical = OfflineProtocol::build_canonical_payload(&msg);
 
-        // Parse back: each field is <4-byte big-endian length><utf-8 bytes>
-        let mut cursor = 0usize;
+        // Payload must start with the domain separator
+        assert!(
+            canonical.starts_with(CTRL_SIGN_DOMAIN),
+            "canonical payload must start with domain separator"
+        );
+
+        // Parse fields after the domain separator
+        let mut cursor = CTRL_SIGN_DOMAIN.len();
         let mut fields = Vec::new();
         while cursor < canonical.len() {
             assert!(cursor + 4 <= canonical.len(), "truncated length prefix");
@@ -13714,6 +13719,10 @@ pub(crate) mod tests {
 
         let payload_a = OfflineProtocol::build_canonical_payload(&msg_a);
         let payload_b = OfflineProtocol::build_canonical_payload(&msg_b);
+
+        // Both must start with domain separator
+        assert!(payload_a.starts_with(CTRL_SIGN_DOMAIN));
+        assert!(payload_b.starts_with(CTRL_SIGN_DOMAIN));
 
         // Even if content and recipient match, different sender lengths
         // produce different payloads.
@@ -13767,5 +13776,176 @@ pub(crate) mod tests {
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_RESPONSE));
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_REQUEST));
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_RESPONSE));
+    }
+
+    // ========================================================================
+    // SECURITY: end-to-end signing round-trip and edge cases
+    // ========================================================================
+
+    #[test]
+    fn test_sign_and_verify_control_message_roundtrip() {
+        let mut protocol = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
+        let storage = Arc::new(crate::mls::InMemoryStorage::new());
+        protocol.initialize_mls(storage).unwrap();
+
+        // Create a control message from "alice"
+        let mut msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+
+        // Sign it
+        protocol.sign_control_message(&mut msg);
+
+        // Must have signature and public key metadata
+        assert!(
+            msg.metadata.contains_key(CTRL_SIG_META_KEY),
+            "Signed message must contain signature metadata"
+        );
+        assert!(
+            msg.metadata.contains_key(CTRL_PK_META_KEY),
+            "Signed message must contain public key metadata"
+        );
+
+        // Verify it — should succeed and TOFU-pin alice's key
+        let result = protocol.verify_control_message(&msg);
+        assert!(
+            matches!(result, Ok(true)),
+            "Round-trip sign+verify must succeed, got: {:?}",
+            result
+        );
+
+        // Verify again — TOFU-pinned key should match
+        let result2 = protocol.verify_control_message(&msg);
+        assert!(
+            matches!(result2, Ok(true)),
+            "Second verify with same key must succeed"
+        );
+    }
+
+    #[test]
+    fn test_sign_and_verify_rejects_tampered_content() {
+        let mut protocol = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
+        let storage = Arc::new(crate::mls::InMemoryStorage::new());
+        protocol.initialize_mls(storage).unwrap();
+
+        let mut msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!(
+                "{}{{\"data\":\"original\"}}",
+                internal_prefixes::CONN_REQUEST
+            ),
+        );
+
+        protocol.sign_control_message(&mut msg);
+
+        // Tamper with the content after signing
+        msg.content = format!(
+            "{}{{\"data\":\"tampered\"}}",
+            internal_prefixes::CONN_REQUEST
+        );
+
+        // Verification must fail — signature no longer matches content
+        let result = protocol.verify_control_message(&msg);
+        assert!(result.is_err(), "Tampered content must fail verification");
+    }
+
+    #[test]
+    fn test_sign_control_message_without_mls_sends_unsigned() {
+        // No MLS initialization — sign_control_message should gracefully no-op
+        let protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut msg = Message::new(
+            UserId::new("user123").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+
+        protocol.sign_control_message(&mut msg);
+
+        assert!(
+            !msg.metadata.contains_key(CTRL_SIG_META_KEY),
+            "Without MLS, message must remain unsigned"
+        );
+        assert!(
+            !msg.metadata.contains_key(CTRL_PK_META_KEY),
+            "Without MLS, message must not have public key metadata"
+        );
+    }
+
+    #[test]
+    fn test_verify_control_message_malformed_base64_signature() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut msg = pending_test_message(
+            "alice",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        msg.metadata.insert(
+            CTRL_SIG_META_KEY.to_string(),
+            "!!!not-valid-base64!!!".to_string(),
+        );
+        msg.metadata
+            .insert(CTRL_PK_META_KEY.to_string(), base64_encode(&vec![1u8; 32]));
+
+        let result = protocol.verify_control_message(&msg);
+        assert!(
+            result.is_err(),
+            "Malformed base64 signature must be rejected"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Invalid control signature encoding"),
+            "Error should mention invalid encoding, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_verify_control_message_empty_signature() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut msg = pending_test_message(
+            "alice",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        // Empty signature (0 bytes) — Ed25519 expects 64 bytes
+        msg.metadata
+            .insert(CTRL_SIG_META_KEY.to_string(), base64_encode(&[]));
+        msg.metadata
+            .insert(CTRL_PK_META_KEY.to_string(), base64_encode(&vec![1u8; 32]));
+
+        let result = protocol.verify_control_message(&msg);
+        assert!(result.is_err(), "Empty signature must be rejected");
+    }
+
+    #[test]
+    fn test_verify_control_message_signature_without_public_key() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut msg = pending_test_message(
+            "alice",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        // Has signature but no public key
+        msg.metadata
+            .insert(CTRL_SIG_META_KEY.to_string(), base64_encode(&vec![0u8; 64]));
+
+        let result = protocol.verify_control_message(&msg);
+        assert!(
+            result.is_err(),
+            "Signature without public key must be rejected"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("missing public key"),
+            "Error should mention missing public key, got: {}",
+            err_msg
+        );
     }
 }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -168,6 +168,16 @@ const INTERNAL_PREFIXES: &[&str] = &[
 /// Maximum number of TOFU-pinned peer public keys to retain.
 const MAX_TOFU_PEERS: usize = 1000;
 
+/// Entry in the TOFU key store, pairing the peer's public key with a
+/// last-seen timestamp used for LRU eviction.
+#[derive(Clone, Debug)]
+struct TofuEntry {
+    public_key: Vec<u8>,
+    /// Milliseconds since epoch (UTC) when we last verified a signed message
+    /// from this peer.
+    last_seen_ms: i64,
+}
+
 /// Payload for key package exchange.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct KeyPackagePayload {
@@ -691,7 +701,8 @@ pub struct OfflineProtocol {
     /// The first signed control message from a peer pins their public key here.
     /// Subsequent messages from the same peer must present the same key;
     /// a mismatch triggers a security warning and the message is dropped.
-    known_peer_public_keys: HashMap<String, Vec<u8>>,
+    /// Entries track a last-seen timestamp for LRU eviction when the store is full.
+    known_peer_public_keys: HashMap<String, TofuEntry>,
 }
 
 impl OfflineProtocol {
@@ -5195,7 +5206,23 @@ impl OfflineProtocol {
                     // Signed and verified — proceed
                 }
                 Ok(false) => {
-                    // Unsigned (legacy) — log but allow for backward compatibility
+                    // Unsigned (legacy) — but if the sender already has a TOFU-pinned
+                    // key, reject: a known-signed peer going unsigned is a suspicious
+                    // downgrade that could indicate an impersonation attempt.
+                    if self.known_peer_public_keys.contains_key(sender) {
+                        warn!(
+                            sender = %sender,
+                            message_id = %message.id,
+                            "Dropping unsigned control message from TOFU-pinned peer (signature downgrade)"
+                        );
+                        if let Ok(state) = lock_shared_state(&self.shared_state) {
+                            state.emit_event(Event::security_warning(
+                                sender.to_string(),
+                                "Unsigned control message from peer with pinned key (possible downgrade attack)".to_string(),
+                            ));
+                        }
+                        return Some(InternalMessageResult::Consumed);
+                    }
                     debug!(
                         sender = %sender,
                         message_id = %message.id,
@@ -6384,7 +6411,10 @@ impl OfflineProtocol {
                 return;
             }
         };
-        let signature = match manager.sign_data(message.content.as_bytes()) {
+        // Sign a canonical payload that includes message ID and recipient
+        // to prevent cross-recipient replay attacks.
+        let canonical = format!("{}:{}:{}", message.id, message.recipient, message.content);
+        let signature = match manager.sign_data(canonical.as_bytes()) {
             Ok(sig) => sig,
             Err(e) => {
                 warn!(error = %e, "Failed to sign control message — sending unsigned");
@@ -6425,10 +6455,12 @@ impl OfflineProtocol {
         let public_key = base64_decode(pk_hex)
             .map_err(|e| Error::Other(format!("Invalid control public key encoding: {}", e)))?;
 
-        // Verify Ed25519 signature over the content
+        // Verify Ed25519 signature over a canonical payload that includes
+        // message ID and recipient to prevent cross-recipient replay attacks.
+        let canonical = format!("{}:{}:{}", message.id, message.recipient, message.content);
         let valid = offline_protocol_mls::MlsManager::verify_signature(
             &public_key,
-            message.content.as_bytes(),
+            canonical.as_bytes(),
             &signature,
         )
         .map_err(|e| Error::Other(format!("Signature verification error: {}", e)))?;
@@ -6441,8 +6473,9 @@ impl OfflineProtocol {
 
         // TOFU: check/pin the public key for this sender
         let sender = message.sender.as_str();
-        if let Some(known_pk) = self.known_peer_public_keys.get(sender) {
-            if *known_pk != public_key {
+        let now_ms = Utc::now().timestamp_millis();
+        if let Some(entry) = self.known_peer_public_keys.get(sender) {
+            if entry.public_key != public_key {
                 warn!(
                     sender = %sender,
                     "TOFU key mismatch: peer presented a different public key"
@@ -6458,20 +6491,31 @@ impl OfflineProtocol {
                     sender
                 )));
             }
+            // Update last-seen timestamp for LRU tracking
+            if let Some(entry) = self.known_peer_public_keys.get_mut(sender) {
+                entry.last_seen_ms = now_ms;
+            }
         } else {
-            // First contact — pin the key (with bounded capacity)
+            // First contact — pin the key (with bounded capacity, LRU eviction)
             if self.known_peer_public_keys.len() >= MAX_TOFU_PEERS {
-                // Evict an arbitrary entry to stay within bounds.
-                // In a production system this would be LRU; here we remove the first
-                // key returned by the iterator which is effectively random for HashMap.
-                if let Some(evict_key) = self.known_peer_public_keys.keys().next().cloned() {
-                    debug!(evicted_peer = %evict_key, "TOFU store full, evicting oldest entry");
+                if let Some(evict_key) = self
+                    .known_peer_public_keys
+                    .iter()
+                    .min_by_key(|(_, entry)| entry.last_seen_ms)
+                    .map(|(k, _)| k.clone())
+                {
+                    debug!(evicted_peer = %evict_key, "TOFU store full, evicting LRU entry");
                     self.known_peer_public_keys.remove(&evict_key);
                 }
             }
             debug!(sender = %sender, "TOFU: pinning public key for new peer");
-            self.known_peer_public_keys
-                .insert(sender.to_string(), public_key);
+            self.known_peer_public_keys.insert(
+                sender.to_string(),
+                TofuEntry {
+                    public_key,
+                    last_seen_ms: now_ms,
+                },
+            );
         }
 
         Ok(true)
@@ -13273,50 +13317,82 @@ pub(crate) mod tests {
 
         // Pin a key for "alice"
         let fake_pk = vec![1u8; 32];
-        protocol
-            .known_peer_public_keys
-            .insert("alice".to_string(), fake_pk.clone());
+        protocol.known_peer_public_keys.insert(
+            "alice".to_string(),
+            TofuEntry {
+                public_key: fake_pk.clone(),
+                last_seen_ms: 1000,
+            },
+        );
 
         // Verify same key passes TOFU check
         assert_eq!(
-            protocol.known_peer_public_keys.get("alice").unwrap(),
-            &fake_pk
+            protocol
+                .known_peer_public_keys
+                .get("alice")
+                .unwrap()
+                .public_key,
+            fake_pk
         );
 
         // A different key should be detected
         let different_pk = vec![2u8; 32];
         assert_ne!(
-            protocol.known_peer_public_keys.get("alice").unwrap(),
-            &different_pk,
+            protocol
+                .known_peer_public_keys
+                .get("alice")
+                .unwrap()
+                .public_key,
+            different_pk,
         );
     }
 
     #[test]
-    fn test_tofu_store_bounded_capacity() {
+    fn test_tofu_store_bounded_capacity_with_lru_eviction() {
         let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
 
-        // Fill the TOFU store to capacity
+        // Fill the TOFU store to capacity with ascending last_seen timestamps
         for i in 0..MAX_TOFU_PEERS {
-            protocol
-                .known_peer_public_keys
-                .insert(format!("peer_{}", i), vec![i as u8; 32]);
+            protocol.known_peer_public_keys.insert(
+                format!("peer_{}", i),
+                TofuEntry {
+                    public_key: vec![i as u8; 32],
+                    last_seen_ms: i as i64, // peer_0 has oldest timestamp
+                },
+            );
         }
         assert_eq!(protocol.known_peer_public_keys.len(), MAX_TOFU_PEERS);
 
         // Simulate what verify_control_message does when store is full:
-        // it should evict one entry before inserting
+        // LRU eviction should remove the entry with the smallest last_seen_ms.
         if protocol.known_peer_public_keys.len() >= MAX_TOFU_PEERS {
-            if let Some(evict_key) = protocol.known_peer_public_keys.keys().next().cloned() {
+            if let Some(evict_key) = protocol
+                .known_peer_public_keys
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_seen_ms)
+                .map(|(k, _)| k.clone())
+            {
+                assert_eq!(evict_key, "peer_0", "Should evict the LRU entry");
                 protocol.known_peer_public_keys.remove(&evict_key);
             }
         }
-        protocol
-            .known_peer_public_keys
-            .insert("new_peer".to_string(), vec![99u8; 32]);
+        protocol.known_peer_public_keys.insert(
+            "new_peer".to_string(),
+            TofuEntry {
+                public_key: vec![99u8; 32],
+                last_seen_ms: MAX_TOFU_PEERS as i64 + 1,
+            },
+        );
 
         // Size should still be at the cap
         assert_eq!(protocol.known_peer_public_keys.len(), MAX_TOFU_PEERS);
         assert!(protocol.known_peer_public_keys.contains_key("new_peer"));
+        assert!(
+            !protocol.known_peer_public_keys.contains_key("peer_0"),
+            "LRU entry should have been evicted"
+        );
+        // peer_1 should still be present (it wasn't the LRU)
+        assert!(protocol.known_peer_public_keys.contains_key("peer_1"));
     }
 
     #[test]
@@ -13342,5 +13418,160 @@ pub(crate) mod tests {
         // Deserialize back — field should be None
         let deserialized: Message = serde_json::from_str(&json).unwrap();
         assert!(deserialized.transport_peer_id.is_none());
+    }
+
+    #[test]
+    fn test_unsigned_control_message_rejected_when_tofu_pinned() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // Pin a key for "alice" (simulating a prior signed exchange)
+        protocol.known_peer_public_keys.insert(
+            "alice".to_string(),
+            TofuEntry {
+                public_key: vec![1u8; 32],
+                last_seen_ms: 1000,
+            },
+        );
+
+        // Create an unsigned control message from "alice"
+        let msg = pending_test_message(
+            "alice",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        // No __ctrl_sig / __ctrl_pk metadata → unsigned
+
+        // Should be rejected because alice has a TOFU-pinned key
+        let result = protocol.process_internal_message(&msg);
+        assert!(
+            matches!(result, Some(InternalMessageResult::Consumed)),
+            "Unsigned control message from TOFU-pinned peer should be dropped"
+        );
+    }
+
+    #[test]
+    fn test_unsigned_control_message_allowed_from_unknown_peer() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // No TOFU entry for "bob"
+        assert!(!protocol.known_peer_public_keys.contains_key("bob"));
+
+        // Create an unsigned control message from "bob"
+        let msg = pending_test_message(
+            "bob",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+
+        // Should be allowed through (legacy peer, no TOFU key pinned)
+        let result = protocol.process_internal_message(&msg);
+        // CONN_REQUEST handler will attempt to parse the payload — it won't
+        // return None (it will be Consumed by the handler or by parsing logic).
+        // The key point is that it was NOT rejected by the security gate.
+        assert!(
+            result.is_some(),
+            "Unsigned control message from unknown peer should pass the security gate"
+        );
+    }
+
+    #[test]
+    fn test_verify_control_message_tofu_violation() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // We need MLS initialized for signing. Since we can't easily init MLS
+        // in unit tests, we test the verify path directly by constructing a
+        // message with valid-looking but mismatched TOFU state.
+
+        // Pin a key for "alice"
+        let pinned_pk = vec![1u8; 32];
+        protocol.known_peer_public_keys.insert(
+            "alice".to_string(),
+            TofuEntry {
+                public_key: pinned_pk,
+                last_seen_ms: 1000,
+            },
+        );
+
+        // Create a message with a different public key in metadata
+        let different_pk = vec![2u8; 32];
+        let mut msg = pending_test_message(
+            "alice",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        // Put a fake signature and the different public key
+        msg.metadata
+            .insert(CTRL_SIG_META_KEY.to_string(), base64_encode(&vec![0u8; 64]));
+        msg.metadata
+            .insert(CTRL_PK_META_KEY.to_string(), base64_encode(&different_pk));
+
+        // verify_control_message should fail because the signature won't verify
+        // (we used a fake signature), OR it would fail on TOFU mismatch.
+        // Either way it should be an error.
+        let result = protocol.verify_control_message(&msg);
+        assert!(
+            result.is_err(),
+            "Should reject: bad signature or TOFU mismatch"
+        );
+    }
+
+    #[test]
+    fn test_tofu_lru_eviction_removes_oldest() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // Insert 3 entries with different timestamps
+        protocol.known_peer_public_keys.insert(
+            "old_peer".to_string(),
+            TofuEntry {
+                public_key: vec![1u8; 32],
+                last_seen_ms: 100,
+            },
+        );
+        protocol.known_peer_public_keys.insert(
+            "medium_peer".to_string(),
+            TofuEntry {
+                public_key: vec![2u8; 32],
+                last_seen_ms: 200,
+            },
+        );
+        protocol.known_peer_public_keys.insert(
+            "new_peer".to_string(),
+            TofuEntry {
+                public_key: vec![3u8; 32],
+                last_seen_ms: 300,
+            },
+        );
+
+        // Find the LRU entry
+        let lru = protocol
+            .known_peer_public_keys
+            .iter()
+            .min_by_key(|(_, e)| e.last_seen_ms)
+            .map(|(k, _)| k.clone())
+            .unwrap();
+
+        assert_eq!(
+            lru, "old_peer",
+            "LRU eviction should target the oldest entry"
+        );
+    }
+
+    #[test]
+    fn test_canonical_signing_payload_format() {
+        // Verify the canonical payload format used for signing includes
+        // message ID and recipient, not just content.
+        let msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "__CONN_REQ__payload",
+        );
+
+        let canonical = format!("{}:{}:{}", msg.id, msg.recipient, msg.content);
+        assert!(canonical.contains(&msg.id.as_str().to_string()));
+        assert!(canonical.contains("bob"));
+        assert!(canonical.contains("__CONN_REQ__payload"));
+        // Ensure the format has exactly the expected structure
+        let parts: Vec<&str> = canonical.splitn(3, ':').collect();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[1], "bob");
+        assert_eq!(parts[2], "__CONN_REQ__payload");
     }
 }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -133,6 +133,11 @@ const CTRL_PK_META_KEY: &str = "__ctrl_pk";
 
 /// All internal message prefixes used for control messages.
 /// Used to reject user-sent messages that start with these prefixes.
+///
+/// **Maintenance note:** When adding a new control message prefix (in
+/// `internal_prefixes` or `offline-protocol-services`), it MUST be registered
+/// here. The `SVC_MESSAGE_PREFIX` catch-all covers future `__SVC_*` prefixes
+/// automatically, but non-SVC prefixes require an explicit entry.
 const INTERNAL_PREFIXES: &[&str] = &[
     internal_prefixes::KEY_PACKAGE,
     internal_prefixes::WELCOME,
@@ -158,7 +163,11 @@ const INTERNAL_PREFIXES: &[&str] = &[
     internal_prefixes::PRESENCE,
     internal_prefixes::TYPING_INDICATOR,
     internal_prefixes::READ_RECEIPT,
-    // Service discovery and request/response prefixes
+    // Service discovery and request/response prefixes.
+    // NOTE: individual SVC prefixes are listed explicitly so that new service
+    // prefixes added in offline-protocol-services must be registered here too.
+    // The catch-all `SVC_MESSAGE_PREFIX` ("__SVC_") covers any future additions.
+    offline_protocol_services::SVC_MESSAGE_PREFIX,
     offline_protocol_services::SVC_DISCOVER_QUERY,
     offline_protocol_services::SVC_DISCOVER_RESPONSE,
     offline_protocol_services::SVC_REQUEST,
@@ -166,6 +175,11 @@ const INTERNAL_PREFIXES: &[&str] = &[
 ];
 
 /// Maximum number of TOFU-pinned peer public keys to retain.
+///
+/// NOTE: The TOFU store is currently in-memory only — all pinned keys are lost
+/// on process restart. Persisting this store (e.g. via `MlsStorage`) is a
+/// future hardening item. Until then, peers are re-pinned on first signed
+/// contact after restart.
 const MAX_TOFU_PEERS: usize = 1000;
 
 /// Entry in the TOFU key store, pairing the peer's public key with a
@@ -6413,7 +6427,10 @@ impl OfflineProtocol {
         };
         // Sign a canonical payload that includes message ID and recipient
         // to prevent cross-recipient replay attacks.
-        let canonical = format!("{}:{}:{}", message.id, message.recipient, message.content);
+        let canonical = format!(
+            "{}:{}:{}:{}",
+            message.sender, message.id, message.recipient, message.content
+        );
         let signature = match manager.sign_data(canonical.as_bytes()) {
             Ok(sig) => sig,
             Err(e) => {
@@ -6457,7 +6474,10 @@ impl OfflineProtocol {
 
         // Verify Ed25519 signature over a canonical payload that includes
         // message ID and recipient to prevent cross-recipient replay attacks.
-        let canonical = format!("{}:{}:{}", message.id, message.recipient, message.content);
+        let canonical = format!(
+            "{}:{}:{}:{}",
+            message.sender, message.id, message.recipient, message.content
+        );
         let valid = offline_protocol_mls::MlsManager::verify_signature(
             &public_key,
             canonical.as_bytes(),
@@ -6474,7 +6494,7 @@ impl OfflineProtocol {
         // TOFU: check/pin the public key for this sender
         let sender = message.sender.as_str();
         let now_ms = Utc::now().timestamp_millis();
-        if let Some(entry) = self.known_peer_public_keys.get(sender) {
+        if let Some(entry) = self.known_peer_public_keys.get_mut(sender) {
             if entry.public_key != public_key {
                 warn!(
                     sender = %sender,
@@ -6492,9 +6512,7 @@ impl OfflineProtocol {
                 )));
             }
             // Update last-seen timestamp for LRU tracking
-            if let Some(entry) = self.known_peer_public_keys.get_mut(sender) {
-                entry.last_seen_ms = now_ms;
-            }
+            entry.last_seen_ms = now_ms;
         } else {
             // First contact — pin the key (with bounded capacity, LRU eviction)
             if self.known_peer_public_keys.len() >= MAX_TOFU_PEERS {
@@ -13227,7 +13245,8 @@ pub(crate) mod tests {
 
     #[test]
     fn test_svc_prefixes_included_in_internal_prefixes() {
-        // Verify all SVC prefixes are covered
+        // Verify all SVC prefixes are covered, including the catch-all
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_MESSAGE_PREFIX));
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_QUERY));
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_RESPONSE));
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_REQUEST));
@@ -13240,6 +13259,8 @@ pub(crate) mod tests {
         assert!(OfflineProtocol::is_internal_prefix("__CONN_REQ__data"));
         assert!(OfflineProtocol::is_internal_prefix("__SVC_DISC_Q__data"));
         assert!(OfflineProtocol::is_internal_prefix("__SVC_REQ__data"));
+        // Catch-all SVC prefix covers future service message types
+        assert!(OfflineProtocol::is_internal_prefix("__SVC_NEW_THING__data"));
         assert!(!OfflineProtocol::is_internal_prefix("Hello world"));
         assert!(!OfflineProtocol::is_internal_prefix("__UNKNOWN__data"));
         assert!(!OfflineProtocol::is_internal_prefix(""));
@@ -13556,7 +13577,7 @@ pub(crate) mod tests {
     #[test]
     fn test_canonical_signing_payload_format() {
         // Verify the canonical payload format used for signing includes
-        // message ID and recipient, not just content.
+        // sender, message ID, recipient, and content.
         let msg = Message::new(
             UserId::new("alice").unwrap(),
             UserId::new("bob").unwrap(),
@@ -13564,14 +13585,19 @@ pub(crate) mod tests {
             "__CONN_REQ__payload",
         );
 
-        let canonical = format!("{}:{}:{}", msg.id, msg.recipient, msg.content);
+        let canonical = format!(
+            "{}:{}:{}:{}",
+            msg.sender, msg.id, msg.recipient, msg.content
+        );
+        assert!(canonical.contains("alice"));
         assert!(canonical.contains(&msg.id.as_str().to_string()));
         assert!(canonical.contains("bob"));
         assert!(canonical.contains("__CONN_REQ__payload"));
         // Ensure the format has exactly the expected structure
-        let parts: Vec<&str> = canonical.splitn(3, ':').collect();
-        assert_eq!(parts.len(), 3);
-        assert_eq!(parts[1], "bob");
-        assert_eq!(parts[2], "__CONN_REQ__payload");
+        let parts: Vec<&str> = canonical.splitn(4, ':').collect();
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0], "alice");
+        assert_eq!(parts[2], "bob");
+        assert_eq!(parts[3], "__CONN_REQ__payload");
     }
 }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -158,7 +158,15 @@ const INTERNAL_PREFIXES: &[&str] = &[
     internal_prefixes::PRESENCE,
     internal_prefixes::TYPING_INDICATOR,
     internal_prefixes::READ_RECEIPT,
+    // Service discovery and request/response prefixes
+    offline_protocol_services::SVC_DISCOVER_QUERY,
+    offline_protocol_services::SVC_DISCOVER_RESPONSE,
+    offline_protocol_services::SVC_REQUEST,
+    offline_protocol_services::SVC_RESPONSE,
 ];
+
+/// Maximum number of TOFU-pinned peer public keys to retain.
+const MAX_TOFU_PEERS: usize = 1000;
 
 /// Payload for key package exchange.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -4615,6 +4623,14 @@ impl OfflineProtocol {
         let content_str: String = content.into();
         let priority = priority.unwrap_or(MessagePriority::Medium);
 
+        // Reject content that starts with an internal control prefix to prevent
+        // injection of protocol-level messages through the public API.
+        if Self::is_internal_prefix(&content_str) {
+            return Err(Error::Other(
+                "Message content must not start with a reserved internal prefix".to_string(),
+            ));
+        }
+
         // Parse reply_to_msg if provided
         let reply_to_msg_id = reply_to_msg
             .map(|r| MessageId::from_str(&r.into()))
@@ -6348,20 +6364,32 @@ impl OfflineProtocol {
     fn sign_control_message(&self, message: &mut Message) {
         let mls = match self.mls_manager.as_ref() {
             Some(m) => m,
-            None => return, // MLS not initialized — send unsigned
+            None => {
+                debug!("MLS not initialized — sending unsigned control message");
+                return;
+            }
         };
         let manager = match mls.read() {
             Ok(guard) => guard,
-            Err(_) => return, // Lock poisoned — send unsigned
+            Err(e) => {
+                warn!(error = %e, "MLS lock poisoned — sending unsigned control message");
+                return;
+            }
         };
 
         let public_key = match manager.get_identity_public_key() {
             Ok(pk) => pk,
-            Err(_) => return,
+            Err(e) => {
+                warn!(error = %e, "Failed to get identity public key — sending unsigned control message");
+                return;
+            }
         };
         let signature = match manager.sign_data(message.content.as_bytes()) {
             Ok(sig) => sig,
-            Err(_) => return,
+            Err(e) => {
+                warn!(error = %e, "Failed to sign control message — sending unsigned");
+                return;
+            }
         };
 
         message
@@ -6431,7 +6459,16 @@ impl OfflineProtocol {
                 )));
             }
         } else {
-            // First contact — pin the key
+            // First contact — pin the key (with bounded capacity)
+            if self.known_peer_public_keys.len() >= MAX_TOFU_PEERS {
+                // Evict an arbitrary entry to stay within bounds.
+                // In a production system this would be LRU; here we remove the first
+                // key returned by the iterator which is effectively random for HashMap.
+                if let Some(evict_key) = self.known_peer_public_keys.keys().next().cloned() {
+                    debug!(evicted_peer = %evict_key, "TOFU store full, evicting oldest entry");
+                    self.known_peer_public_keys.remove(&evict_key);
+                }
+            }
             debug!(sender = %sender, "TOFU: pinning public key for new peer");
             self.known_peer_public_keys
                 .insert(sender.to_string(), public_key);
@@ -13066,5 +13103,244 @@ pub(crate) mod tests {
 
         // Just verify it doesn't panic and the method is wired correctly
         assert!(protocol.mesh_services().seen_discovery_queries().is_empty());
+    }
+
+    // ========================================================================
+    // SECURITY: prefix injection, transport identity, TOFU key pinning
+    // ========================================================================
+
+    #[test]
+    fn test_send_message_rejects_internal_prefixes() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        protocol.start().unwrap();
+
+        // Every internal prefix must be rejected
+        for prefix in INTERNAL_PREFIXES {
+            let content = format!("{}injected_payload", prefix);
+            let result =
+                protocol.send_message("bob", &content, None::<MessagePriority>, None::<String>);
+            assert!(
+                result.is_err(),
+                "Expected rejection for prefix '{}', but send succeeded",
+                prefix
+            );
+        }
+    }
+
+    #[test]
+    fn test_send_message_via_transport_rejects_internal_prefixes() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        protocol.start().unwrap();
+
+        for prefix in INTERNAL_PREFIXES {
+            let content = format!("{}injected_payload", prefix);
+            let result = protocol.send_message_via_transport(
+                "bob",
+                &content,
+                None::<MessagePriority>,
+                TransportType::BLE,
+                None::<String>,
+            );
+            assert!(
+                result.is_err(),
+                "Expected rejection for prefix '{}' via send_message_via_transport, but send succeeded",
+                prefix
+            );
+        }
+    }
+
+    #[test]
+    fn test_send_message_allows_normal_content() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        protocol.start().unwrap();
+
+        let result = protocol.send_message(
+            "bob",
+            "Hello, this is a normal message!",
+            None::<MessagePriority>,
+            None::<String>,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_svc_prefixes_included_in_internal_prefixes() {
+        // Verify all SVC prefixes are covered
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_QUERY));
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_RESPONSE));
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_REQUEST));
+        assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_RESPONSE));
+    }
+
+    #[test]
+    fn test_is_internal_prefix() {
+        assert!(OfflineProtocol::is_internal_prefix("__MLS_KEY_PKG__data"));
+        assert!(OfflineProtocol::is_internal_prefix("__CONN_REQ__data"));
+        assert!(OfflineProtocol::is_internal_prefix("__SVC_DISC_Q__data"));
+        assert!(OfflineProtocol::is_internal_prefix("__SVC_REQ__data"));
+        assert!(!OfflineProtocol::is_internal_prefix("Hello world"));
+        assert!(!OfflineProtocol::is_internal_prefix("__UNKNOWN__data"));
+        assert!(!OfflineProtocol::is_internal_prefix(""));
+    }
+
+    #[test]
+    fn test_validate_transport_sender_match() {
+        let protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "hello",
+        );
+        msg.transport_peer_id = Some("alice".to_string());
+
+        assert!(protocol.validate_transport_sender(&msg));
+    }
+
+    #[test]
+    fn test_validate_transport_sender_mismatch() {
+        let protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "hello",
+        );
+        msg.transport_peer_id = Some("eve".to_string());
+
+        assert!(!protocol.validate_transport_sender(&msg));
+    }
+
+    #[test]
+    fn test_validate_transport_sender_no_transport_id() {
+        let protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("user123").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "hello",
+        );
+        // No transport_peer_id — should pass (best effort)
+        assert!(protocol.validate_transport_sender(&msg));
+    }
+
+    #[test]
+    fn test_control_message_with_transport_mismatch_is_dropped() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+
+        // Create a control message claiming to be from "alice" but delivered by "eve"
+        let mut msg = pending_test_message(
+            "sender123",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        msg.transport_peer_id = Some("eve".to_string());
+
+        // process_internal_message should consume (drop) the message
+        let result = protocol.process_internal_message(&msg);
+        assert!(
+            matches!(result, Some(InternalMessageResult::Consumed)),
+            "Expected spoofed control message to be dropped"
+        );
+    }
+
+    #[test]
+    fn test_tofu_key_pinning_and_mismatch() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // Pin a key for "alice"
+        let fake_pk = vec![1u8; 32];
+        protocol
+            .known_peer_public_keys
+            .insert("alice".to_string(), fake_pk.clone());
+
+        // Verify same key passes TOFU check
+        assert_eq!(
+            protocol.known_peer_public_keys.get("alice").unwrap(),
+            &fake_pk
+        );
+
+        // A different key should be detected
+        let different_pk = vec![2u8; 32];
+        assert_ne!(
+            protocol.known_peer_public_keys.get("alice").unwrap(),
+            &different_pk,
+        );
+    }
+
+    #[test]
+    fn test_tofu_store_bounded_capacity() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // Fill the TOFU store to capacity
+        for i in 0..MAX_TOFU_PEERS {
+            protocol
+                .known_peer_public_keys
+                .insert(format!("peer_{}", i), vec![i as u8; 32]);
+        }
+        assert_eq!(protocol.known_peer_public_keys.len(), MAX_TOFU_PEERS);
+
+        // Simulate what verify_control_message does when store is full:
+        // it should evict one entry before inserting
+        if protocol.known_peer_public_keys.len() >= MAX_TOFU_PEERS {
+            if let Some(evict_key) = protocol.known_peer_public_keys.keys().next().cloned() {
+                protocol.known_peer_public_keys.remove(&evict_key);
+            }
+        }
+        protocol
+            .known_peer_public_keys
+            .insert("new_peer".to_string(), vec![99u8; 32]);
+
+        // Size should still be at the cap
+        assert_eq!(protocol.known_peer_public_keys.len(), MAX_TOFU_PEERS);
+        assert!(protocol.known_peer_public_keys.contains_key("new_peer"));
+    }
+
+    #[test]
+    fn test_transport_peer_id_not_serialized() {
+        let mut msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "hello",
+        );
+        msg.transport_peer_id = Some("ble-device-42".to_string());
+
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(
+            !json.contains("transport_peer_id"),
+            "transport_peer_id must not appear in serialized output"
+        );
+        assert!(
+            !json.contains("ble-device-42"),
+            "transport peer identity must not leak into serialized output"
+        );
+
+        // Deserialize back — field should be None
+        let deserialized: Message = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.transport_peer_id.is_none());
     }
 }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -5201,74 +5201,15 @@ impl OfflineProtocol {
         message: &Message,
     ) -> Option<InternalMessageResult> {
         let content = &message.content;
-        let sender = message.sender.as_str();
 
-        // --- Security gate: validate sender identity and control message signature ---
-        //
-        // 1. If the transport layer provided a peer identity, verify it matches the
-        //    claimed sender. This prevents a BLE/WiFi/Internet peer from spoofing
-        //    another user's identity.
-        //
-        // 2. Verify the Ed25519 control message signature (if present). This binds
-        //    the message to the sender's cryptographic identity via TOFU.
-        if Self::is_internal_prefix(content) {
-            // Transport-level identity check
-            if !self.validate_transport_sender(message) {
-                warn!(
-                    sender = %sender,
-                    message_id = %message.id,
-                    "Dropping control message: sender/transport identity mismatch"
-                );
-                self.emit_security_warning(
-                    sender,
-                    "Control message sender does not match transport peer identity",
-                );
-                return Some(InternalMessageResult::Consumed);
-            }
-
-            // Cryptographic signature check
-            match self.verify_control_message(message) {
-                Ok(true) => {
-                    // Signed and verified — proceed
-                }
-                Ok(false) => {
-                    // Unsigned (legacy) — but if the sender already has a TOFU-pinned
-                    // key, reject: a known-signed peer going unsigned is a suspicious
-                    // downgrade that could indicate an impersonation attempt.
-                    if self.known_peer_public_keys.contains_key(sender) {
-                        warn!(
-                            sender = %sender,
-                            message_id = %message.id,
-                            "Dropping unsigned control message from TOFU-pinned peer (signature downgrade)"
-                        );
-                        self.emit_security_warning(
-                            sender,
-                            "Unsigned control message from peer with pinned key (possible downgrade attack)",
-                        );
-                        return Some(InternalMessageResult::Consumed);
-                    }
-                    debug!(
-                        sender = %sender,
-                        message_id = %message.id,
-                        "Received unsigned control message (legacy peer)"
-                    );
-                }
-                Err(err) => {
-                    // Signature invalid or TOFU violation — drop
-                    warn!(
-                        sender = %sender,
-                        message_id = %message.id,
-                        error = %err,
-                        "Dropping control message: signature verification failed"
-                    );
-                    self.emit_security_warning(
-                        sender,
-                        format!("Control message rejected: {}", err),
-                    );
-                    return Some(InternalMessageResult::Consumed);
-                }
-            }
+        // Run the security gate for control messages (transport identity +
+        // signature verification). Returns `Some(Consumed)` to drop the
+        // message, or `None` to proceed.
+        if let Some(result) = self.security_gate_control_message(message) {
+            return Some(result);
         }
+
+        let sender = message.sender.as_str();
 
         // Handle key package messages
         if let Some(data) = content.strip_prefix(internal_prefixes::KEY_PACKAGE) {
@@ -6493,12 +6434,24 @@ impl OfflineProtocol {
     ///
     /// Returns:
     /// - `Ok(true)`  — valid signature, TOFU key check passed
-    /// - `Ok(false)` — no signature present (legacy/unsigned message)
-    /// - `Err(..)`   — signature invalid, key mismatch, or TOFU violation
+    /// - `Ok(false)` — no signature metadata at all (legacy/unsigned message)
+    /// - `Err(..)` — signature invalid, key mismatch, TOFU violation, or
+    ///   malformed metadata (e.g. public key present without a signature,
+    ///   or vice versa)
     fn verify_control_message(&mut self, message: &Message) -> Result<bool> {
         let sig_b64 = match message.metadata.get(CTRL_SIG_META_KEY) {
             Some(s) => s,
-            None => return Ok(false), // Unsigned — caller decides policy
+            None => {
+                // If the public key metadata is present without a signature,
+                // treat this as a malformed message rather than unsigned.
+                if message.metadata.contains_key(CTRL_PK_META_KEY) {
+                    return Err(Error::Other(
+                        "Control message has public key but missing signature (malformed)"
+                            .to_string(),
+                    ));
+                }
+                return Ok(false); // Truly unsigned — caller decides policy
+            }
         };
         let pk_b64 = match message.metadata.get(CTRL_PK_META_KEY) {
             Some(s) => s,
@@ -6535,8 +6488,14 @@ impl OfflineProtocol {
     /// first contact. Handles bounded-capacity eviction with a minimum age
     /// threshold to resist cache-filling attacks.
     ///
-    /// Returns `Ok(true)` on success, `Err(..)` on TOFU key mismatch.
+    /// Returns `Ok(true)` on success, `Err(..)` on TOFU key mismatch or
+    /// invalid (empty) public key.
     fn tofu_check_or_pin(&mut self, sender: &str, public_key: Vec<u8>) -> Result<bool> {
+        if public_key.is_empty() {
+            return Err(Error::Other(
+                "Cannot TOFU-pin an empty public key".to_string(),
+            ));
+        }
         let now_ms = Utc::now().timestamp_millis();
 
         if let Some(entry) = self.known_peer_public_keys.get_mut(sender) {
@@ -6603,6 +6562,80 @@ impl OfflineProtocol {
         }
 
         Ok(true)
+    }
+
+    /// Security gate for control messages. Validates transport-level sender
+    /// identity and cryptographic signature before allowing the message to
+    /// proceed through `process_internal_message`.
+    ///
+    /// Returns `Some(InternalMessageResult::Consumed)` to drop the message,
+    /// or `None` to allow it through.
+    fn security_gate_control_message(
+        &mut self,
+        message: &Message,
+    ) -> Option<InternalMessageResult> {
+        let content = &message.content;
+        let sender = message.sender.as_str();
+
+        if !Self::is_internal_prefix(content) {
+            return None; // Not a control message — no gate needed
+        }
+
+        // Transport-level identity check
+        if !self.validate_transport_sender(message) {
+            warn!(
+                sender = %sender,
+                message_id = %message.id,
+                "Dropping control message: sender/transport identity mismatch"
+            );
+            self.emit_security_warning(
+                sender,
+                "Control message sender does not match transport peer identity",
+            );
+            return Some(InternalMessageResult::Consumed);
+        }
+
+        // Cryptographic signature check
+        match self.verify_control_message(message) {
+            Ok(true) => {
+                // Signed and verified — proceed
+            }
+            Ok(false) => {
+                // Unsigned (legacy) — but if the sender already has a TOFU-pinned
+                // key, reject: a known-signed peer going unsigned is a suspicious
+                // downgrade that could indicate an impersonation attempt.
+                if self.known_peer_public_keys.contains_key(sender) {
+                    warn!(
+                        sender = %sender,
+                        message_id = %message.id,
+                        "Dropping unsigned control message from TOFU-pinned peer (signature downgrade)"
+                    );
+                    self.emit_security_warning(
+                        sender,
+                        "Unsigned control message from peer with pinned key (possible downgrade attack)",
+                    );
+                    return Some(InternalMessageResult::Consumed);
+                }
+                debug!(
+                    sender = %sender,
+                    message_id = %message.id,
+                    "Received unsigned control message (legacy peer)"
+                );
+            }
+            Err(err) => {
+                // Signature invalid, TOFU violation, or malformed metadata — drop
+                warn!(
+                    sender = %sender,
+                    message_id = %message.id,
+                    error = %err,
+                    "Dropping control message: signature verification failed"
+                );
+                self.emit_security_warning(sender, format!("Control message rejected: {}", err));
+                return Some(InternalMessageResult::Consumed);
+            }
+        }
+
+        None // Passed the security gate
     }
 
     /// Validates that the claimed `message.sender` matches the transport-level
@@ -13332,8 +13365,15 @@ pub(crate) mod tests {
         assert!(OfflineProtocol::is_internal_prefix("__CONN_REQ__data"));
         assert!(OfflineProtocol::is_internal_prefix("__SVC_DISC_Q__data"));
         assert!(OfflineProtocol::is_internal_prefix("__SVC_REQ__data"));
-        // Catch-all SVC prefix covers future service message types
+        // The `SVC_MESSAGE_PREFIX` ("__SVC_") entry in `INTERNAL_PREFIXES` acts
+        // as a catch-all: any content starting with "__SVC_" matches, even if the
+        // specific sub-prefix (e.g., "__SVC_NEW_THING__") is not explicitly listed.
+        // This ensures future service prefixes are automatically blocked from
+        // user-sent messages without requiring a code change to `INTERNAL_PREFIXES`.
         assert!(OfflineProtocol::is_internal_prefix("__SVC_NEW_THING__data"));
+        assert!(OfflineProtocol::is_internal_prefix(
+            "__SVC_my_legitimate_content"
+        ));
         assert!(!OfflineProtocol::is_internal_prefix("Hello world"));
         assert!(!OfflineProtocol::is_internal_prefix("__UNKNOWN__data"));
         assert!(!OfflineProtocol::is_internal_prefix(""));
@@ -13349,7 +13389,7 @@ pub(crate) mod tests {
             AppId::new("test-app").unwrap(),
             "hello",
         );
-        msg.set_transport_peer_id("alice".to_string());
+        msg.set_transport_peer_id("alice".to_string()).unwrap();
 
         assert!(protocol.validate_transport_sender(&msg));
     }
@@ -13364,7 +13404,7 @@ pub(crate) mod tests {
             AppId::new("test-app").unwrap(),
             "hello",
         );
-        msg.set_transport_peer_id("eve".to_string());
+        msg.set_transport_peer_id("eve".to_string()).unwrap();
 
         assert!(!protocol.validate_transport_sender(&msg));
     }
@@ -13395,7 +13435,7 @@ pub(crate) mod tests {
             "sender123",
             &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
         );
-        msg.set_transport_peer_id("eve".to_string());
+        msg.set_transport_peer_id("eve".to_string()).unwrap();
 
         // process_internal_message should consume (drop) the message
         let result = protocol.process_internal_message(&msg);
@@ -13518,7 +13558,8 @@ pub(crate) mod tests {
             AppId::new("test-app").unwrap(),
             "hello",
         );
-        msg.set_transport_peer_id("ble-device-42".to_string());
+        msg.set_transport_peer_id("ble-device-42".to_string())
+            .unwrap();
 
         let json = serde_json::to_string(&msg).unwrap();
         assert!(
@@ -14074,7 +14115,10 @@ pub(crate) mod tests {
             UserId::new("alice").unwrap(),
             UserId::new("bob").unwrap(),
             AppId::new("test-app").unwrap(),
-            format!("{}{{\"data\":\"relayed\"}}", internal_prefixes::CONN_REQUEST),
+            format!(
+                "{}{{\"data\":\"relayed\"}}",
+                internal_prefixes::CONN_REQUEST
+            ),
         );
         assert!(
             msg.transport_peer_id().is_none(),
@@ -14094,6 +14138,159 @@ pub(crate) mod tests {
         assert!(
             received.is_none(),
             "Unsigned relay message from unknown peer should be consumed by handler"
+        );
+    }
+
+    // ========================================================================
+    // SECURITY: parameterized security gate, edge cases, ACK bypass
+    // ========================================================================
+
+    #[test]
+    fn test_security_gate_rejects_spoofed_transport_for_all_prefixes() {
+        // Verify that the security gate drops control messages with a
+        // transport identity mismatch for EVERY registered internal prefix,
+        // not just CONN_REQUEST.
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        for prefix in INTERNAL_PREFIXES {
+            let mut msg = pending_test_message("sender123", &format!("{}test_payload", prefix));
+            msg.set_transport_peer_id("eve".to_string()).unwrap();
+
+            let result = protocol.process_internal_message(&msg);
+            assert!(
+                matches!(result, Some(InternalMessageResult::Consumed)),
+                "Security gate should drop spoofed message for prefix '{}'",
+                prefix
+            );
+        }
+    }
+
+    #[test]
+    fn test_verify_control_message_pk_without_signature_is_malformed() {
+        // A message with a public key in metadata but no signature should
+        // be treated as malformed (not as unsigned/legacy).
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut msg = pending_test_message(
+            "alice",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        // Public key present but no signature
+        msg.metadata
+            .insert(CTRL_PK_META_KEY.to_string(), base64_encode(&vec![1u8; 32]));
+
+        let result = protocol.verify_control_message(&msg);
+        assert!(
+            result.is_err(),
+            "Public key without signature must be rejected as malformed"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("missing signature"),
+            "Error should mention missing signature, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_security_gate_rejects_pk_only_no_signature() {
+        // Full process_internal_message path: a control message with a
+        // public key but no signature should be dropped by the security gate.
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut msg = pending_test_message(
+            "alice",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        msg.metadata
+            .insert(CTRL_PK_META_KEY.to_string(), base64_encode(&vec![1u8; 32]));
+
+        let result = protocol.process_internal_message(&msg);
+        assert!(
+            matches!(result, Some(InternalMessageResult::Consumed)),
+            "Malformed message (pk without sig) should be dropped by security gate"
+        );
+    }
+
+    #[test]
+    fn test_ack_messages_bypass_security_gate() {
+        // ACK messages do not start with any internal prefix (they have
+        // empty or non-prefixed content), so the security gate must not
+        // interfere with them — even if transport_peer_id mismatches.
+        let protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // ACK-like message: content is just the acked message ID, not an
+        // internal prefix.
+        let msg = pending_test_message("alice", "some-message-id-being-acked");
+        assert!(
+            !OfflineProtocol::is_internal_prefix(&msg.content),
+            "ACK content must not be detected as an internal prefix"
+        );
+
+        // The security gate should return None (pass-through) regardless
+        // of any transport mismatch, because ACKs aren't control messages.
+        assert!(
+            !OfflineProtocol::is_internal_prefix(""),
+            "Empty content must not trigger the security gate"
+        );
+    }
+
+    #[test]
+    fn test_set_transport_peer_id_rejects_empty_string() {
+        let mut msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            "hello",
+        );
+        let result = msg.set_transport_peer_id("".to_string());
+        assert!(result.is_err(), "Empty transport_peer_id must be rejected");
+        assert!(
+            msg.transport_peer_id().is_none(),
+            "transport_peer_id should remain None after rejected empty set"
+        );
+    }
+
+    #[test]
+    fn test_tofu_rejects_empty_public_key() {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let result = protocol.tofu_check_or_pin("alice", vec![]);
+        assert!(
+            result.is_err(),
+            "Empty public key must be rejected by TOFU store"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("empty public key"),
+            "Error should mention empty public key, got: {}",
+            err_msg
+        );
+        assert!(
+            !protocol.known_peer_public_keys.contains_key("alice"),
+            "Empty key must not be pinned"
+        );
+    }
+
+    #[test]
+    fn test_verify_control_message_zero_byte_public_key_rejected() {
+        // Even if someone constructs a message with a valid-looking
+        // signature but a 0-byte public key, Ed25519 parsing should fail.
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        let mut msg = pending_test_message(
+            "alice",
+            &format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        msg.metadata
+            .insert(CTRL_SIG_META_KEY.to_string(), base64_encode(&vec![0u8; 64]));
+        msg.metadata
+            .insert(CTRL_PK_META_KEY.to_string(), base64_encode(&[]));
+
+        let result = protocol.verify_control_message(&msg);
+        assert!(
+            result.is_err(),
+            "Zero-byte public key must be rejected during verification"
         );
     }
 }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -6422,6 +6422,10 @@ impl OfflineProtocol {
         );
         buf.extend_from_slice(CTRL_SIGN_DOMAIN);
         for field in &fields {
+            debug_assert!(
+                field.len() <= u32::MAX as usize,
+                "field too large for canonical payload length prefix"
+            );
             buf.extend_from_slice(&(field.len() as u32).to_be_bytes());
             buf.extend_from_slice(field.as_bytes());
         }
@@ -6605,6 +6609,15 @@ impl OfflineProtocol {
     /// peer identity, if available. Returns `true` if validated or if no
     /// transport identity is available (best-effort). Returns `false` if
     /// there is a mismatch.
+    ///
+    /// # Relay / mesh forwarding
+    ///
+    /// Forwarded messages are re-created via [`send_internal_message`] which
+    /// calls [`create_message`], producing a fresh `Message` with
+    /// `transport_peer_id: None`. Because `transport_peer_id` is
+    /// `#[serde(skip)]`, it is also `None` after deserialization. In both
+    /// cases this method returns `true` (best-effort pass), so relayed
+    /// control messages are never incorrectly rejected by this check.
     fn validate_transport_sender(&self, message: &Message) -> bool {
         if let Some(transport_peer) = message.transport_peer_id() {
             if message.sender.as_str() != transport_peer {
@@ -13946,6 +13959,141 @@ pub(crate) mod tests {
             err_msg.contains("missing public key"),
             "Error should mention missing public key, got: {}",
             err_msg
+        );
+    }
+
+    // ========================================================================
+    // INTEGRATION: full transport → receive → verify → TOFU round-trip
+    // ========================================================================
+
+    #[test]
+    fn test_integration_signed_control_message_via_mock_transport() {
+        // Set up "alice" as the sender with MLS initialized so she can sign.
+        let mut alice = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
+        let storage_a = Arc::new(crate::mls::InMemoryStorage::new());
+        alice.initialize_mls(storage_a).unwrap();
+
+        // Set up "bob" as the receiver with MLS initialized so he can verify.
+        let mut bob = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
+        let storage_b = Arc::new(crate::mls::InMemoryStorage::new());
+        bob.initialize_mls(storage_b).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+
+        // Alice creates and signs a control message destined for bob.
+        let mut msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"hello\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        alice.sign_control_message(&mut msg);
+        assert!(
+            msg.metadata.contains_key(CTRL_SIG_META_KEY),
+            "Alice should have signed the message"
+        );
+
+        // Enqueue the signed message on bob's transport with alice's identity.
+        mock_transport.queue_message_from(msg, "alice".to_string());
+
+        // Wire up bob's transport manager.
+        bob.transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        bob.start().unwrap();
+
+        // Bob receives and processes — the security gate should pass.
+        // receive_message drives the full transport → dedup → process_internal_message path.
+        let received = bob.receive_message();
+        // CONN_REQUEST is consumed internally (not surfaced to the app).
+        assert!(
+            received.is_none(),
+            "Control message should be consumed, not surfaced"
+        );
+
+        // Alice's key should now be TOFU-pinned in bob's store.
+        assert!(
+            bob.known_peer_public_keys.contains_key("alice"),
+            "Bob should have TOFU-pinned alice's public key"
+        );
+    }
+
+    #[test]
+    fn test_integration_spoofed_transport_identity_rejected() {
+        // A signed control message claiming to be from "alice" but delivered
+        // by transport peer "eve" must be rejected.
+        let mut alice = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
+        let storage_a = Arc::new(crate::mls::InMemoryStorage::new());
+        alice.initialize_mls(storage_a).unwrap();
+
+        let mut bob = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
+        let storage_b = Arc::new(crate::mls::InMemoryStorage::new());
+        bob.initialize_mls(storage_b).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+
+        let mut msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"evil\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        alice.sign_control_message(&mut msg);
+
+        // Deliver via "eve" — transport identity mismatch.
+        mock_transport.queue_message_from(msg, "eve".to_string());
+
+        bob.transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        bob.start().unwrap();
+
+        let received = bob.receive_message();
+        assert!(
+            received.is_none(),
+            "Spoofed message should be consumed (dropped)"
+        );
+        assert!(
+            !bob.known_peer_public_keys.contains_key("alice"),
+            "Spoofed message must not TOFU-pin alice's key"
+        );
+    }
+
+    #[test]
+    fn test_integration_relay_forwarded_message_no_transport_peer_id() {
+        // Relay-forwarded messages are created fresh via send_internal_message
+        // and thus have transport_peer_id = None. Verify they pass the
+        // transport sender check (best-effort).
+        let mut bob = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
+
+        let mut mock_transport = MockTransport::new(TransportType::BLE);
+        mock_transport.start().unwrap();
+
+        // Simulate a relay-forwarded control message: no transport_peer_id.
+        let msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!("{}{{\"data\":\"relayed\"}}", internal_prefixes::CONN_REQUEST),
+        );
+        assert!(
+            msg.transport_peer_id().is_none(),
+            "Relay-forwarded message should have no transport_peer_id"
+        );
+
+        // Enqueue without transport identity (using queue_message, not queue_message_from).
+        mock_transport.queue_message(msg);
+
+        bob.transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock_transport));
+        bob.start().unwrap();
+
+        // Should pass the transport sender check and reach the handler
+        // (CONN_REQUEST handler will consume it).
+        let received = bob.receive_message();
+        assert!(
+            received.is_none(),
+            "Unsigned relay message from unknown peer should be consumed by handler"
         );
     }
 }

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -138,8 +138,9 @@ const CTRL_PK_META_KEY: &str = "__ctrl_pk";
 /// same MLS identity key but with a different domain separator.
 const CTRL_SIGN_DOMAIN: &[u8] = b"offline-ctrl-v1";
 
-/// All internal message prefixes used for control messages.
-/// Used to reject user-sent messages that start with these prefixes.
+/// All internal message prefixes — used to reject user-sent messages that
+/// start with a reserved prefix via the public `send_message` /
+/// `send_message_via_transport` APIs (injection prevention).
 ///
 /// **Maintenance note:** When adding a new control message prefix (in
 /// `internal_prefixes` or `offline-protocol-services`), it MUST be registered
@@ -174,6 +175,48 @@ const INTERNAL_PREFIXES: &[&str] = &[
     // NOTE: individual SVC prefixes are listed explicitly so that new service
     // prefixes added in offline-protocol-services must be registered here too.
     // The catch-all `SVC_MESSAGE_PREFIX` ("__SVC_") covers any future additions.
+    offline_protocol_services::SVC_MESSAGE_PREFIX,
+    offline_protocol_services::SVC_DISCOVER_QUERY,
+    offline_protocol_services::SVC_DISCOVER_RESPONSE,
+    offline_protocol_services::SVC_REQUEST,
+    offline_protocol_services::SVC_RESPONSE,
+];
+
+/// Control-plane prefixes that require signature verification and TOFU
+/// enforcement in the security gate. Data-plane prefixes like `__MLS_ENC__`
+/// are deliberately excluded because they are MLS-encrypted (MLS provides
+/// its own authentication) and are sent via `send_message`, not
+/// `send_internal_message`, so they are never signed outbound.
+///
+/// **Maintenance note:** Only add prefixes here that are sent via
+/// `send_internal_message` (which calls `sign_control_message`). Data-plane
+/// messages that rely on MLS for authentication must NOT be listed here,
+/// or they will be rejected as "unsigned" once the sender's key is
+/// TOFU-pinned from a prior signed control message.
+const SECURITY_GATED_PREFIXES: &[&str] = &[
+    internal_prefixes::KEY_PACKAGE,
+    internal_prefixes::WELCOME,
+    internal_prefixes::SESSION_CONFIRM_PROBE,
+    internal_prefixes::SESSION_CONFIRM_ACK,
+    internal_prefixes::CONN_REQUEST,
+    internal_prefixes::CONN_ACCEPT,
+    internal_prefixes::CONN_REJECT,
+    internal_prefixes::GROUP_CREATED,
+    internal_prefixes::GROUP_MSG,
+    internal_prefixes::GROUP_MEMBER_ADDED,
+    internal_prefixes::GROUP_MEMBER_REMOVED,
+    internal_prefixes::GROUP_INFO,
+    internal_prefixes::USER_GROUPS,
+    internal_prefixes::GROUP_ERROR,
+    internal_prefixes::GROUP_MLS_MSG,
+    internal_prefixes::GROUP_MLS_WELCOME,
+    internal_prefixes::GROUP_MLS_COMMIT,
+    internal_prefixes::GROUP_MLS_LEAVE,
+    internal_prefixes::GROUP_RELAY_REGISTER,
+    internal_prefixes::GROUP_RELAY_BROADCAST,
+    internal_prefixes::PRESENCE,
+    internal_prefixes::TYPING_INDICATOR,
+    internal_prefixes::READ_RECEIPT,
     offline_protocol_services::SVC_MESSAGE_PREFIX,
     offline_protocol_services::SVC_DISCOVER_QUERY,
     offline_protocol_services::SVC_DISCOVER_RESPONSE,
@@ -1390,7 +1433,7 @@ impl OfflineProtocol {
         }
 
         let mut message = self.create_message(recipient, content, Some(priority), None)?;
-        self.sign_control_message(&mut message);
+        self.sign_control_message(&mut message)?;
         let message_id = message.id.clone();
 
         if self.deduplicator.is_duplicate(&message_id) {
@@ -2181,7 +2224,7 @@ impl OfflineProtocol {
         let content = format!("{}{}", internal_prefixes::WELCOME, serialized);
         let mut message =
             self.create_message(recipient, content, Some(MessagePriority::High), None)?;
-        self.sign_control_message(&mut message);
+        self.sign_control_message(&mut message)?;
         let group_id = welcome.group_id.as_str().to_string();
 
         self.upsert_welcome_lifecycle(recipient, &group_id, message, "welcome_created")?;
@@ -4287,7 +4330,7 @@ impl OfflineProtocol {
 
         let mut message =
             self.create_message(peer_id, content, Some(MessagePriority::Low), None)?;
-        self.sign_control_message(&mut message);
+        self.sign_control_message(&mut message)?;
 
         match self.transport_manager.send(&message) {
             Ok(()) => {
@@ -6351,7 +6394,7 @@ impl OfflineProtocol {
     /// Each field is encoded as `<4-byte big-endian length><utf-8 bytes>`,
     /// making the encoding unambiguous regardless of field content (no
     /// delimiter-collision risk).
-    fn build_canonical_payload(message: &Message) -> Vec<u8> {
+    fn build_canonical_payload(message: &Message) -> Result<Vec<u8>> {
         let fields: [&str; 4] = [
             message.sender.as_str(),
             &message.id.as_str(),
@@ -6363,62 +6406,60 @@ impl OfflineProtocol {
         );
         buf.extend_from_slice(CTRL_SIGN_DOMAIN);
         for field in &fields {
-            debug_assert!(
-                field.len() <= u32::MAX as usize,
-                "field too large for canonical payload length prefix"
-            );
-            buf.extend_from_slice(&(field.len() as u32).to_be_bytes());
+            let len: u32 = field.len().try_into().map_err(|_| {
+                Error::Other(format!(
+                    "Field too large for canonical payload length prefix: {} bytes",
+                    field.len()
+                ))
+            })?;
+            buf.extend_from_slice(&len.to_be_bytes());
             buf.extend_from_slice(field.as_bytes());
         }
-        buf
+        Ok(buf)
     }
 
     /// Signs a control message by adding an Ed25519 signature and the sender's
     /// public key to the message metadata.
     ///
-    /// If MLS is not initialized, the message is sent unsigned and a
-    /// `SecurityWarning` event is emitted so the application layer is aware.
-    fn sign_control_message(&self, message: &mut Message) {
+    /// Returns `Ok(())` on success (or when MLS is not initialized — unsigned
+    /// messages are acceptable for backward compatibility with pre-MLS peers).
+    /// Returns `Err` when MLS is initialized but signing fails, so the caller
+    /// can decide whether to abort the send.
+    fn sign_control_message(&self, message: &mut Message) -> Result<()> {
         let mls = match self.mls_manager.as_ref() {
             Some(m) => m,
             None => {
                 debug!("MLS not initialized — sending unsigned control message");
-                return;
+                return Ok(());
             }
         };
         let manager = match mls.read() {
             Ok(guard) => guard,
             Err(e) => {
+                let reason = format!("MLS lock poisoned — cannot sign control message: {}", e);
                 error!(error = %e, "MLS lock poisoned — cannot sign control message");
-                self.emit_security_warning(
-                    message.sender.as_str(),
-                    "Control message sent unsigned: MLS lock poisoned",
-                );
-                return;
+                self.emit_security_warning(message.sender.as_str(), &reason);
+                return Err(Error::Other(reason));
             }
         };
 
         let public_key = match manager.get_identity_public_key() {
             Ok(pk) => pk,
             Err(e) => {
-                error!(error = %e, "Failed to get identity public key — sending unsigned control message");
-                self.emit_security_warning(
-                    message.sender.as_str(),
-                    format!("Control message sent unsigned: {}", e),
-                );
-                return;
+                let reason = format!("Failed to get identity public key: {}", e);
+                error!(error = %e, "Failed to get identity public key — cannot sign control message");
+                self.emit_security_warning(message.sender.as_str(), &reason);
+                return Err(Error::Other(reason));
             }
         };
-        let canonical = Self::build_canonical_payload(message);
+        let canonical = Self::build_canonical_payload(message)?;
         let signature = match manager.sign_data(&canonical) {
             Ok(sig) => sig,
             Err(e) => {
-                error!(error = %e, "Failed to sign control message — sending unsigned");
-                self.emit_security_warning(
-                    message.sender.as_str(),
-                    format!("Control message sent unsigned: {}", e),
-                );
-                return;
+                let reason = format!("Failed to sign control message: {}", e);
+                error!(error = %e, "Failed to sign control message");
+                self.emit_security_warning(message.sender.as_str(), &reason);
+                return Err(Error::Other(reason));
             }
         };
 
@@ -6428,6 +6469,7 @@ impl OfflineProtocol {
         message
             .metadata
             .insert(CTRL_PK_META_KEY.to_string(), base64_encode(&public_key));
+        Ok(())
     }
 
     /// Verifies a control message's Ed25519 signature from metadata.
@@ -6469,7 +6511,7 @@ impl OfflineProtocol {
 
         // Verify Ed25519 signature over a length-prefixed canonical payload
         // that binds sender, message ID, recipient, and content.
-        let canonical = Self::build_canonical_payload(message);
+        let canonical = Self::build_canonical_payload(message)?;
         let valid =
             offline_protocol_mls::MlsManager::verify_signature(&public_key, &canonical, &signature)
                 .map_err(|e| Error::Other(format!("Signature verification error: {}", e)))?;
@@ -6577,8 +6619,8 @@ impl OfflineProtocol {
         let content = &message.content;
         let sender = message.sender.as_str();
 
-        if !Self::is_internal_prefix(content) {
-            return None; // Not a control message — no gate needed
+        if !Self::is_security_gated_prefix(content) {
+            return None; // Not a security-gated control message — no gate needed
         }
 
         // Transport-level identity check
@@ -6672,8 +6714,19 @@ impl OfflineProtocol {
     }
 
     /// Returns `true` if the message content starts with any internal prefix.
+    /// Used for injection prevention on the public send APIs.
     fn is_internal_prefix(content: &str) -> bool {
         INTERNAL_PREFIXES.iter().any(|p| content.starts_with(p))
+    }
+
+    /// Returns `true` if the message content starts with a control-plane
+    /// prefix that requires security gate enforcement (transport identity +
+    /// signature verification + TOFU). Data-plane prefixes like `__MLS_ENC__`
+    /// are excluded because MLS provides its own authentication layer.
+    fn is_security_gated_prefix(content: &str) -> bool {
+        SECURITY_GATED_PREFIXES
+            .iter()
+            .any(|p| content.starts_with(p))
     }
 
     /// Cleans up expired entries from deduplicator, retry queue, outbox, and ack manager.
@@ -13725,7 +13778,7 @@ pub(crate) mod tests {
             "__CONN_REQ__payload",
         );
 
-        let canonical = OfflineProtocol::build_canonical_payload(&msg);
+        let canonical = OfflineProtocol::build_canonical_payload(&msg).unwrap();
 
         // Payload must start with the domain separator
         assert!(
@@ -13771,8 +13824,8 @@ pub(crate) mod tests {
             "content",
         );
 
-        let payload_a = OfflineProtocol::build_canonical_payload(&msg_a);
-        let payload_b = OfflineProtocol::build_canonical_payload(&msg_b);
+        let payload_a = OfflineProtocol::build_canonical_payload(&msg_a).unwrap();
+        let payload_b = OfflineProtocol::build_canonical_payload(&msg_b).unwrap();
 
         // Both must start with domain separator
         assert!(payload_a.starts_with(CTRL_SIGN_DOMAIN));
@@ -13830,6 +13883,29 @@ pub(crate) mod tests {
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_DISCOVER_RESPONSE));
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_REQUEST));
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_RESPONSE));
+
+        // Every SECURITY_GATED_PREFIXES entry must also be in INTERNAL_PREFIXES
+        // (security-gated messages are a subset of internal messages).
+        for prefix in SECURITY_GATED_PREFIXES {
+            assert!(
+                INTERNAL_PREFIXES.contains(prefix),
+                "SECURITY_GATED_PREFIXES entry {:?} is missing from INTERNAL_PREFIXES — \
+                 the security-gated set must be a subset of the injection-prevention set",
+                prefix
+            );
+        }
+
+        // __MLS_ENC__ must be in INTERNAL_PREFIXES (injection prevention) but
+        // NOT in SECURITY_GATED_PREFIXES (it's a data-plane message).
+        assert!(
+            INTERNAL_PREFIXES.contains(&internal_prefixes::ENCRYPTED),
+            "__MLS_ENC__ must be in INTERNAL_PREFIXES for injection prevention"
+        );
+        assert!(
+            !SECURITY_GATED_PREFIXES.contains(&internal_prefixes::ENCRYPTED),
+            "__MLS_ENC__ must NOT be in SECURITY_GATED_PREFIXES — \
+             MLS provides its own authentication for encrypted messages"
+        );
     }
 
     // ========================================================================
@@ -13851,7 +13927,7 @@ pub(crate) mod tests {
         );
 
         // Sign it
-        protocol.sign_control_message(&mut msg);
+        protocol.sign_control_message(&mut msg).unwrap();
 
         // Must have signature and public key metadata
         assert!(
@@ -13895,7 +13971,7 @@ pub(crate) mod tests {
             ),
         );
 
-        protocol.sign_control_message(&mut msg);
+        protocol.sign_control_message(&mut msg).unwrap();
 
         // Tamper with the content after signing
         msg.content = format!(
@@ -13920,7 +13996,7 @@ pub(crate) mod tests {
             format!("{}{{\"data\":\"test\"}}", internal_prefixes::CONN_REQUEST),
         );
 
-        protocol.sign_control_message(&mut msg);
+        protocol.sign_control_message(&mut msg).unwrap();
 
         assert!(
             !msg.metadata.contains_key(CTRL_SIG_META_KEY),
@@ -14029,7 +14105,7 @@ pub(crate) mod tests {
             AppId::new("test-app").unwrap(),
             format!("{}{{\"data\":\"hello\"}}", internal_prefixes::CONN_REQUEST),
         );
-        alice.sign_control_message(&mut msg);
+        alice.sign_control_message(&mut msg).unwrap();
         assert!(
             msg.metadata.contains_key(CTRL_SIG_META_KEY),
             "Alice should have signed the message"
@@ -14080,7 +14156,7 @@ pub(crate) mod tests {
             AppId::new("test-app").unwrap(),
             format!("{}{{\"data\":\"evil\"}}", internal_prefixes::CONN_REQUEST),
         );
-        alice.sign_control_message(&mut msg);
+        alice.sign_control_message(&mut msg).unwrap();
 
         // Deliver via "eve" — transport identity mismatch.
         mock_transport.queue_message_from(msg, "eve".to_string());
@@ -14141,18 +14217,145 @@ pub(crate) mod tests {
         );
     }
 
+    #[test]
+    fn test_integration_encrypted_message_survives_security_gate_after_tofu_pin() {
+        // Critical regression test: after a signed control message exchange
+        // TOFU-pins the sender's key, subsequent __MLS_ENC__ (data-plane)
+        // messages from that sender must NOT be rejected as "signature
+        // downgrade". MLS provides its own authentication for encrypted
+        // messages; they are not signed with the control-plane Ed25519 key.
+        //
+        // Without the SECURITY_GATED_PREFIXES / INTERNAL_PREFIXES split,
+        // this test would fail because the security gate would treat
+        // __MLS_ENC__ as a control message and reject it for being unsigned
+        // from a TOFU-pinned peer.
+
+        use crate::mls::InMemoryStorage;
+
+        // --- Set up Alice (sender) with MLS ---
+        let mut alice_config = create_test_config_for_user("alice");
+        alice_config.encryption.enabled = true;
+        alice_config.encryption.store_pending = true;
+        let mut alice = OfflineProtocol::new(alice_config).unwrap();
+        alice
+            .initialize_mls(Arc::new(InMemoryStorage::new()))
+            .unwrap();
+
+        let mut alice_transport = MockTransport::new(TransportType::BLE);
+        alice_transport.start().unwrap();
+        let alice_transport_handle = alice_transport.clone();
+        alice
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(alice_transport));
+        alice.start().unwrap();
+
+        // --- Set up Bob (receiver) with MLS ---
+        let mut bob_config = create_test_config_for_user("bob");
+        bob_config.encryption.enabled = true;
+        bob_config.encryption.store_pending = true;
+        let mut bob = OfflineProtocol::new(bob_config).unwrap();
+        bob.initialize_mls(Arc::new(InMemoryStorage::new()))
+            .unwrap();
+
+        let mut bob_transport = MockTransport::new(TransportType::BLE);
+        bob_transport.start().unwrap();
+        let bob_transport_handle = bob_transport.clone();
+        bob.transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(bob_transport));
+        bob.start().unwrap();
+
+        // --- Step 1: Alice sends a signed control message (key package) ---
+        // Manually create and sign a CONN_REQUEST from Alice to Bob.
+        let mut ctrl_msg = Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            format!(
+                "{}{{\"sender_name\":\"alice\",\"timestamp_ms\":1234}}",
+                internal_prefixes::CONN_REQUEST
+            ),
+        );
+        alice.sign_control_message(&mut ctrl_msg).unwrap();
+        assert!(
+            ctrl_msg.metadata.contains_key(CTRL_SIG_META_KEY),
+            "Control message should be signed"
+        );
+
+        // Bob receives it — this will TOFU-pin Alice's public key.
+        bob_transport_handle.queue_message_from(ctrl_msg, "alice".to_string());
+        let _ = bob.receive_message(); // consumed internally
+
+        // Verify Alice's key is now TOFU-pinned at Bob.
+        assert!(
+            bob.known_peer_public_keys.contains_key("alice"),
+            "Alice's key should be TOFU-pinned at Bob after signed control message"
+        );
+
+        // --- Step 2: Set up MLS session directly (shortcut) ---
+        let bob_key_package = {
+            let manager = bob.mls_manager.as_ref().unwrap().read().unwrap();
+            manager.get_or_create_key_package().unwrap()
+        };
+        {
+            let manager = alice.mls_manager.as_ref().unwrap().read().unwrap();
+            manager
+                .import_key_package("bob", &bob_key_package.key_package_data)
+                .unwrap();
+            let welcome = manager.create_session("bob").unwrap();
+            let bob_manager = bob.mls_manager.as_ref().unwrap().read().unwrap();
+            bob_manager.join_session(&welcome).unwrap();
+        }
+        alice.confirm_session_state("bob", "test_setup").unwrap();
+        bob.confirm_session_state("alice", "test_setup").unwrap();
+
+        // --- Step 3: Alice sends an encrypted message ---
+        alice
+            .send_message(
+                "bob",
+                "hello after TOFU pin",
+                None::<MessagePriority>,
+                None::<String>,
+            )
+            .unwrap();
+
+        let encrypted_wire = alice_transport_handle
+            .sent_messages()
+            .last()
+            .expect("expected encrypted message from alice")
+            .clone();
+        assert!(
+            encrypted_wire
+                .content
+                .starts_with(internal_prefixes::ENCRYPTED),
+            "Message should be MLS-encrypted"
+        );
+
+        // --- Step 4: Bob receives the encrypted message ---
+        // This is the critical assertion: the __MLS_ENC__ message must NOT
+        // be rejected by the security gate, even though Alice has a
+        // TOFU-pinned key and this message is unsigned.
+        bob_transport_handle.queue_message(encrypted_wire);
+        let received = bob
+            .receive_message()
+            .expect("Encrypted message must NOT be dropped by security gate after TOFU pin");
+        assert_eq!(received.content, "hello after TOFU pin");
+        assert_eq!(
+            received.metadata.get("encrypted").map(String::as_str),
+            Some("true")
+        );
+    }
+
     // ========================================================================
     // SECURITY: parameterized security gate, edge cases, ACK bypass
     // ========================================================================
 
     #[test]
-    fn test_security_gate_rejects_spoofed_transport_for_all_prefixes() {
+    fn test_security_gate_rejects_spoofed_transport_for_all_gated_prefixes() {
         // Verify that the security gate drops control messages with a
-        // transport identity mismatch for EVERY registered internal prefix,
-        // not just CONN_REQUEST.
+        // transport identity mismatch for EVERY security-gated prefix.
         let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
 
-        for prefix in INTERNAL_PREFIXES {
+        for prefix in SECURITY_GATED_PREFIXES {
             let mut msg = pending_test_message("sender123", &format!("{}test_payload", prefix));
             msg.set_transport_peer_id("eve".to_string()).unwrap();
 
@@ -14163,6 +14366,35 @@ pub(crate) mod tests {
                 prefix
             );
         }
+    }
+
+    #[test]
+    fn test_data_plane_prefixes_bypass_security_gate() {
+        // __MLS_ENC__ messages are data-plane (MLS provides its own
+        // authentication) and must NOT be rejected by the security gate,
+        // even when the sender has a TOFU-pinned key.
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+        // First, TOFU-pin a key for "alice" to simulate a prior signed
+        // control message exchange.
+        protocol.tofu_check_or_pin("alice", vec![1u8; 32]).unwrap();
+        assert!(protocol.known_peer_public_keys.contains_key("alice"));
+
+        // Now send an unsigned __MLS_ENC__ message from alice — this is the
+        // normal data path after MLS session establishment.
+        let msg = pending_test_message(
+            "alice",
+            &format!(
+                "{}{{\"group_id\":\"session:alice:bob\",\"message_type\":\"Application\",\"epoch\":0,\"ciphertext\":[1,2,3],\"sender_id\":\"alice\",\"timestamp_ms\":12345}}",
+                internal_prefixes::ENCRYPTED
+            ),
+        );
+
+        let result = protocol.security_gate_control_message(&msg);
+        assert!(
+            result.is_none(),
+            "Security gate must NOT block __MLS_ENC__ messages — MLS provides its own authentication"
+        );
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -126,6 +126,40 @@ const MEDIA_TRANSFER_STALE_TIMEOUT_SECS: u64 = 300;
 /// Maximum number of tracked known peers for service discovery.
 const MAX_KNOWN_PEERS: usize = 1000;
 
+/// Metadata key for the Ed25519 signature over the control message content (base64).
+const CTRL_SIG_META_KEY: &str = "__ctrl_sig";
+/// Metadata key for the sender's Ed25519 public key (base64, 32 bytes raw).
+const CTRL_PK_META_KEY: &str = "__ctrl_pk";
+
+/// All internal message prefixes used for control messages.
+/// Used to reject user-sent messages that start with these prefixes.
+const INTERNAL_PREFIXES: &[&str] = &[
+    internal_prefixes::KEY_PACKAGE,
+    internal_prefixes::WELCOME,
+    internal_prefixes::ENCRYPTED,
+    internal_prefixes::SESSION_CONFIRM_PROBE,
+    internal_prefixes::SESSION_CONFIRM_ACK,
+    internal_prefixes::CONN_REQUEST,
+    internal_prefixes::CONN_ACCEPT,
+    internal_prefixes::CONN_REJECT,
+    internal_prefixes::GROUP_CREATED,
+    internal_prefixes::GROUP_MSG,
+    internal_prefixes::GROUP_MEMBER_ADDED,
+    internal_prefixes::GROUP_MEMBER_REMOVED,
+    internal_prefixes::GROUP_INFO,
+    internal_prefixes::USER_GROUPS,
+    internal_prefixes::GROUP_ERROR,
+    internal_prefixes::GROUP_MLS_MSG,
+    internal_prefixes::GROUP_MLS_WELCOME,
+    internal_prefixes::GROUP_MLS_COMMIT,
+    internal_prefixes::GROUP_MLS_LEAVE,
+    internal_prefixes::GROUP_RELAY_REGISTER,
+    internal_prefixes::GROUP_RELAY_BROADCAST,
+    internal_prefixes::PRESENCE,
+    internal_prefixes::TYPING_INDICATOR,
+    internal_prefixes::READ_RECEIPT,
+];
+
 /// Payload for key package exchange.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct KeyPackagePayload {
@@ -643,6 +677,13 @@ pub struct OfflineProtocol {
 
     /// Bundled state for mesh group messaging (member cache, dedup, pending commits).
     pub(crate) group_mesh: crate::group_mesh::GroupMeshState,
+
+    /// TOFU (Trust-On-First-Use) key store for peer Ed25519 public keys.
+    ///
+    /// The first signed control message from a peer pins their public key here.
+    /// Subsequent messages from the same peer must present the same key;
+    /// a mismatch triggers a security warning and the message is dropped.
+    known_peer_public_keys: HashMap<String, Vec<u8>>,
 }
 
 impl OfflineProtocol {
@@ -706,6 +747,7 @@ impl OfflineProtocol {
             outbound_media_windows: HashMap::new(),
             mesh_services: MeshServices::new(),
             group_mesh: crate::group_mesh::GroupMeshState::default(),
+            known_peer_public_keys: HashMap::new(),
             config,
         })
     }
@@ -1300,7 +1342,8 @@ impl OfflineProtocol {
             }
         }
 
-        let message = self.create_message(recipient, content, Some(priority), None)?;
+        let mut message = self.create_message(recipient, content, Some(priority), None)?;
+        self.sign_control_message(&mut message);
         let message_id = message.id.clone();
 
         if self.deduplicator.is_duplicate(&message_id) {
@@ -1370,6 +1413,14 @@ impl OfflineProtocol {
         let recipient_str: String = recipient.into();
         let content_str: String = content.into();
         let priority = priority.unwrap_or(MessagePriority::Medium);
+
+        // Reject content that starts with an internal control prefix to prevent
+        // injection of protocol-level messages through the public API.
+        if Self::is_internal_prefix(&content_str) {
+            return Err(Error::Other(
+                "Message content must not start with a reserved internal prefix".to_string(),
+            ));
+        }
 
         // Parse reply_to_msg if provided
         let reply_to_msg_id = reply_to_msg
@@ -2081,7 +2132,9 @@ impl OfflineProtocol {
         let serialized =
             serde_json::to_string(welcome).map_err(|e| Error::Serialization(e.to_string()))?;
         let content = format!("{}{}", internal_prefixes::WELCOME, serialized);
-        let message = self.create_message(recipient, content, Some(MessagePriority::High), None)?;
+        let mut message =
+            self.create_message(recipient, content, Some(MessagePriority::High), None)?;
+        self.sign_control_message(&mut message);
         let group_id = welcome.group_id.as_str().to_string();
 
         self.upsert_welcome_lifecycle(recipient, &group_id, message, "welcome_created")?;
@@ -4185,7 +4238,9 @@ impl OfflineProtocol {
             serde_json::to_string(&payload).map_err(|e| Error::Serialization(e.to_string()))?;
         let content = format!("{}{}", internal_prefixes::KEY_PACKAGE, serialized);
 
-        let message = self.create_message(peer_id, content, Some(MessagePriority::Low), None)?;
+        let mut message =
+            self.create_message(peer_id, content, Some(MessagePriority::Low), None)?;
+        self.sign_control_message(&mut message);
 
         match self.transport_manager.send(&message) {
             Ok(()) => {
@@ -5092,6 +5147,63 @@ impl OfflineProtocol {
     ) -> Option<InternalMessageResult> {
         let content = &message.content;
         let sender = message.sender.as_str();
+
+        // --- Security gate: validate sender identity and control message signature ---
+        //
+        // 1. If the transport layer provided a peer identity, verify it matches the
+        //    claimed sender. This prevents a BLE/WiFi/Internet peer from spoofing
+        //    another user's identity.
+        //
+        // 2. Verify the Ed25519 control message signature (if present). This binds
+        //    the message to the sender's cryptographic identity via TOFU.
+        if Self::is_internal_prefix(content) {
+            // Transport-level identity check
+            if !self.validate_transport_sender(message) {
+                warn!(
+                    sender = %sender,
+                    message_id = %message.id,
+                    "Dropping control message: sender/transport identity mismatch"
+                );
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::security_warning(
+                        sender.to_string(),
+                        "Control message sender does not match transport peer identity".to_string(),
+                    ));
+                }
+                return Some(InternalMessageResult::Consumed);
+            }
+
+            // Cryptographic signature check
+            match self.verify_control_message(message) {
+                Ok(true) => {
+                    // Signed and verified — proceed
+                }
+                Ok(false) => {
+                    // Unsigned (legacy) — log but allow for backward compatibility
+                    debug!(
+                        sender = %sender,
+                        message_id = %message.id,
+                        "Received unsigned control message (legacy peer)"
+                    );
+                }
+                Err(err) => {
+                    // Signature invalid or TOFU violation — drop
+                    warn!(
+                        sender = %sender,
+                        message_id = %message.id,
+                        error = %err,
+                        "Dropping control message: signature verification failed"
+                    );
+                    if let Ok(state) = lock_shared_state(&self.shared_state) {
+                        state.emit_event(Event::security_warning(
+                            sender.to_string(),
+                            format!("Control message rejected: {}", err),
+                        ));
+                    }
+                    return Some(InternalMessageResult::Consumed);
+                }
+            }
+        }
 
         // Handle key package messages
         if let Some(data) = content.strip_prefix(internal_prefixes::KEY_PACKAGE) {
@@ -6222,6 +6334,134 @@ impl OfflineProtocol {
             .ok_or_else(|| Error::Other("MLS not initialized".to_string()))?;
         mls.read()
             .map_err(|_| Error::Other("MLS lock poisoned".to_string()))
+    }
+
+    // ========================================================================
+    // CONTROL MESSAGE SIGNING & VERIFICATION
+    // ========================================================================
+
+    /// Signs a control message by adding an Ed25519 signature and the sender's
+    /// public key to the message metadata.
+    ///
+    /// If MLS is not initialized, the message is sent unsigned. The receiving
+    /// side uses TOFU (Trust-On-First-Use) to pin the public key.
+    fn sign_control_message(&self, message: &mut Message) {
+        let mls = match self.mls_manager.as_ref() {
+            Some(m) => m,
+            None => return, // MLS not initialized — send unsigned
+        };
+        let manager = match mls.read() {
+            Ok(guard) => guard,
+            Err(_) => return, // Lock poisoned — send unsigned
+        };
+
+        let public_key = match manager.get_identity_public_key() {
+            Ok(pk) => pk,
+            Err(_) => return,
+        };
+        let signature = match manager.sign_data(message.content.as_bytes()) {
+            Ok(sig) => sig,
+            Err(_) => return,
+        };
+
+        message
+            .metadata
+            .insert(CTRL_SIG_META_KEY.to_string(), base64_encode(&signature));
+        message
+            .metadata
+            .insert(CTRL_PK_META_KEY.to_string(), base64_encode(&public_key));
+    }
+
+    /// Verifies a control message's Ed25519 signature from metadata.
+    ///
+    /// Returns:
+    /// - `Ok(true)`  — valid signature, TOFU key check passed
+    /// - `Ok(false)` — no signature present (legacy/unsigned message)
+    /// - `Err(..)`   — signature invalid, key mismatch, or TOFU violation
+    fn verify_control_message(&mut self, message: &Message) -> Result<bool> {
+        let sig_hex = match message.metadata.get(CTRL_SIG_META_KEY) {
+            Some(s) => s,
+            None => return Ok(false), // Unsigned — caller decides policy
+        };
+        let pk_hex = match message.metadata.get(CTRL_PK_META_KEY) {
+            Some(s) => s,
+            None => {
+                return Err(Error::Other(
+                    "Control message has signature but missing public key".to_string(),
+                ));
+            }
+        };
+
+        let signature = base64_decode(sig_hex)
+            .map_err(|e| Error::Other(format!("Invalid control signature encoding: {}", e)))?;
+        let public_key = base64_decode(pk_hex)
+            .map_err(|e| Error::Other(format!("Invalid control public key encoding: {}", e)))?;
+
+        // Verify Ed25519 signature over the content
+        let valid = offline_protocol_mls::MlsManager::verify_signature(
+            &public_key,
+            message.content.as_bytes(),
+            &signature,
+        )
+        .map_err(|e| Error::Other(format!("Signature verification error: {}", e)))?;
+
+        if !valid {
+            return Err(Error::Other(
+                "Control message signature verification failed".to_string(),
+            ));
+        }
+
+        // TOFU: check/pin the public key for this sender
+        let sender = message.sender.as_str();
+        if let Some(known_pk) = self.known_peer_public_keys.get(sender) {
+            if *known_pk != public_key {
+                warn!(
+                    sender = %sender,
+                    "TOFU key mismatch: peer presented a different public key"
+                );
+                if let Ok(state) = lock_shared_state(&self.shared_state) {
+                    state.emit_event(Event::security_warning(
+                        sender.to_string(),
+                        "Public key changed for known peer (possible impersonation)".to_string(),
+                    ));
+                }
+                return Err(Error::Other(format!(
+                    "TOFU key mismatch for peer '{}'",
+                    sender
+                )));
+            }
+        } else {
+            // First contact — pin the key
+            debug!(sender = %sender, "TOFU: pinning public key for new peer");
+            self.known_peer_public_keys
+                .insert(sender.to_string(), public_key);
+        }
+
+        Ok(true)
+    }
+
+    /// Validates that the claimed `message.sender` matches the transport-level
+    /// peer identity, if available. Returns `true` if validated or if no
+    /// transport identity is available (best-effort). Returns `false` if
+    /// there is a mismatch.
+    fn validate_transport_sender(&self, message: &Message) -> bool {
+        if let Some(ref transport_peer) = message.transport_peer_id {
+            if message.sender.as_str() != transport_peer.as_str() {
+                warn!(
+                    claimed_sender = %message.sender,
+                    transport_peer = %transport_peer,
+                    message_id = %message.id,
+                    "Sender identity mismatch: claimed sender does not match transport peer"
+                );
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Returns `true` if the message content starts with any internal prefix.
+    fn is_internal_prefix(content: &str) -> bool {
+        INTERNAL_PREFIXES.iter().any(|p| content.starts_with(p))
     }
 
     /// Cleans up expired entries from deduplicator, retry queue, outbox, and ack manager.

--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -182,54 +182,34 @@ const INTERNAL_PREFIXES: &[&str] = &[
     offline_protocol_services::SVC_RESPONSE,
 ];
 
-/// Control-plane prefixes that require signature verification and TOFU
-/// enforcement in the security gate. Data-plane prefixes like `__MLS_ENC__`
-/// are deliberately excluded because they are MLS-encrypted (MLS provides
-/// its own authentication) and are sent via `send_message`, not
-/// `send_internal_message`, so they are never signed outbound.
+/// Data-plane prefixes that are **excluded** from the security gate.
 ///
-/// **Maintenance note:** Only add prefixes here that are sent via
-/// `send_internal_message` (which calls `sign_control_message`). Data-plane
-/// messages that rely on MLS for authentication must NOT be listed here,
-/// or they will be rejected as "unsigned" once the sender's key is
-/// TOFU-pinned from a prior signed control message.
-const SECURITY_GATED_PREFIXES: &[&str] = &[
-    internal_prefixes::KEY_PACKAGE,
-    internal_prefixes::WELCOME,
-    internal_prefixes::SESSION_CONFIRM_PROBE,
-    internal_prefixes::SESSION_CONFIRM_ACK,
-    internal_prefixes::CONN_REQUEST,
-    internal_prefixes::CONN_ACCEPT,
-    internal_prefixes::CONN_REJECT,
-    internal_prefixes::GROUP_CREATED,
-    internal_prefixes::GROUP_MSG,
-    internal_prefixes::GROUP_MEMBER_ADDED,
-    internal_prefixes::GROUP_MEMBER_REMOVED,
-    internal_prefixes::GROUP_INFO,
-    internal_prefixes::USER_GROUPS,
-    internal_prefixes::GROUP_ERROR,
-    internal_prefixes::GROUP_MLS_MSG,
-    internal_prefixes::GROUP_MLS_WELCOME,
-    internal_prefixes::GROUP_MLS_COMMIT,
-    internal_prefixes::GROUP_MLS_LEAVE,
-    internal_prefixes::GROUP_RELAY_REGISTER,
-    internal_prefixes::GROUP_RELAY_BROADCAST,
-    internal_prefixes::PRESENCE,
-    internal_prefixes::TYPING_INDICATOR,
-    internal_prefixes::READ_RECEIPT,
-    offline_protocol_services::SVC_MESSAGE_PREFIX,
-    offline_protocol_services::SVC_DISCOVER_QUERY,
-    offline_protocol_services::SVC_DISCOVER_RESPONSE,
-    offline_protocol_services::SVC_REQUEST,
-    offline_protocol_services::SVC_RESPONSE,
+/// These prefixes rely on MLS for authentication (not Ed25519 control-message
+/// signing) and are sent via `send_message`, not `send_internal_message`, so
+/// they are never signed outbound. Listing them here rather than maintaining a
+/// separate `SECURITY_GATED_PREFIXES` array ensures that any new prefix added
+/// to `INTERNAL_PREFIXES` is automatically security-gated unless explicitly
+/// excluded here.
+///
+/// **Maintenance note:** Only add prefixes here if they are MLS-authenticated
+/// data-plane messages. All other internal prefixes are control-plane and
+/// require signature verification + TOFU enforcement.
+const DATA_PLANE_PREFIXES: &[&str] = &[
+    internal_prefixes::ENCRYPTED,
 ];
 
 /// Maximum number of TOFU-pinned peer public keys to retain.
 ///
-/// NOTE: The TOFU store is currently in-memory only — all pinned keys are lost
-/// on process restart. Persisting this store (e.g. via `MlsStorage`) is a
-/// future hardening item. Until then, peers are re-pinned on first signed
-/// contact after restart.
+/// // TODO(security): The TOFU store is currently in-memory only — all pinned
+/// // keys are lost on process restart. This allows key-substitution attacks
+/// // during the re-pinning window after restart. Persist the TOFU store via
+/// // `MlsStorage` to close this gap.
+///
+/// // TODO(security): There is no mechanism for legitimate key rotation. A peer
+/// // who re-initializes MLS (getting a new identity key) will be permanently
+/// // rejected by all peers who have TOFU-pinned the old key, until process
+/// // restart clears the in-memory store. Implement a key rotation protocol
+/// // (e.g. signed key-update messages) or a manual TOFU reset API.
 const MAX_TOFU_PEERS: usize = 1000;
 
 /// Minimum age (in milliseconds) a TOFU entry must have before it can be
@@ -773,6 +753,9 @@ pub struct OfflineProtocol {
     /// Subsequent messages from the same peer must present the same key;
     /// a mismatch triggers a security warning and the message is dropped.
     /// Entries track a last-seen timestamp for LRU eviction when the store is full.
+    ///
+    // TODO(security): persist via MlsStorage; see MAX_TOFU_PEERS doc.
+    // TODO(security): support key rotation; see MAX_TOFU_PEERS doc.
     known_peer_public_keys: HashMap<String, TofuEntry>,
 }
 
@@ -6721,12 +6704,18 @@ impl OfflineProtocol {
 
     /// Returns `true` if the message content starts with a control-plane
     /// prefix that requires security gate enforcement (transport identity +
-    /// signature verification + TOFU). Data-plane prefixes like `__MLS_ENC__`
-    /// are excluded because MLS provides its own authentication layer.
+    /// signature verification + TOFU). Data-plane prefixes listed in
+    /// `DATA_PLANE_PREFIXES` (e.g. `__MLS_ENC__`) are excluded because MLS
+    /// provides its own authentication layer.
     fn is_security_gated_prefix(content: &str) -> bool {
-        SECURITY_GATED_PREFIXES
-            .iter()
-            .any(|p| content.starts_with(p))
+        // A prefix is security-gated if it is an internal prefix AND not a
+        // data-plane prefix. This derives the gated set from INTERNAL_PREFIXES
+        // minus DATA_PLANE_PREFIXES, so any new internal prefix is automatically
+        // gated unless explicitly excluded.
+        Self::is_internal_prefix(content)
+            && !DATA_PLANE_PREFIXES
+                .iter()
+                .any(|p| content.starts_with(p))
     }
 
     /// Cleans up expired entries from deduplicator, retry queue, outbox, and ack manager.
@@ -13884,27 +13873,33 @@ pub(crate) mod tests {
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_REQUEST));
         assert!(INTERNAL_PREFIXES.contains(&offline_protocol_services::SVC_RESPONSE));
 
-        // Every SECURITY_GATED_PREFIXES entry must also be in INTERNAL_PREFIXES
-        // (security-gated messages are a subset of internal messages).
-        for prefix in SECURITY_GATED_PREFIXES {
+        // Every DATA_PLANE_PREFIXES entry must also be in INTERNAL_PREFIXES
+        // (data-plane messages still need injection prevention).
+        for prefix in DATA_PLANE_PREFIXES {
             assert!(
                 INTERNAL_PREFIXES.contains(prefix),
-                "SECURITY_GATED_PREFIXES entry {:?} is missing from INTERNAL_PREFIXES — \
-                 the security-gated set must be a subset of the injection-prevention set",
+                "DATA_PLANE_PREFIXES entry {:?} is missing from INTERNAL_PREFIXES — \
+                 data-plane messages must still be protected from injection",
                 prefix
             );
         }
 
-        // __MLS_ENC__ must be in INTERNAL_PREFIXES (injection prevention) but
-        // NOT in SECURITY_GATED_PREFIXES (it's a data-plane message).
-        assert!(
-            INTERNAL_PREFIXES.contains(&internal_prefixes::ENCRYPTED),
-            "__MLS_ENC__ must be in INTERNAL_PREFIXES for injection prevention"
-        );
-        assert!(
-            !SECURITY_GATED_PREFIXES.contains(&internal_prefixes::ENCRYPTED),
-            "__MLS_ENC__ must NOT be in SECURITY_GATED_PREFIXES — \
-             MLS provides its own authentication for encrypted messages"
+        // Only DATA_PLANE_PREFIXES entries should be excluded from security
+        // gating. Any internal prefix NOT in DATA_PLANE_PREFIXES is
+        // automatically security-gated (signature + TOFU). If this assertion
+        // fails, a new prefix was added to INTERNAL_PREFIXES but also needs to
+        // be evaluated: should it be in DATA_PLANE_PREFIXES (MLS-authenticated)
+        // or remain security-gated (control-plane, Ed25519-signed)?
+        let excluded: Vec<&&str> = INTERNAL_PREFIXES
+            .iter()
+            .filter(|p| !OfflineProtocol::is_security_gated_prefix(p))
+            .collect();
+        let expected_excluded: Vec<&&str> = DATA_PLANE_PREFIXES.iter().collect();
+        assert_eq!(
+            excluded, expected_excluded,
+            "Only DATA_PLANE_PREFIXES entries should be excluded from security gating. \
+             If a new internal prefix was added, decide whether it is data-plane \
+             (MLS-authenticated) or control-plane (Ed25519-signed) and update accordingly."
         );
     }
 
@@ -14225,10 +14220,10 @@ pub(crate) mod tests {
         // downgrade". MLS provides its own authentication for encrypted
         // messages; they are not signed with the control-plane Ed25519 key.
         //
-        // Without the SECURITY_GATED_PREFIXES / INTERNAL_PREFIXES split,
-        // this test would fail because the security gate would treat
-        // __MLS_ENC__ as a control message and reject it for being unsigned
-        // from a TOFU-pinned peer.
+        // Without the DATA_PLANE_PREFIXES exclusion in
+        // `is_security_gated_prefix`, this test would fail because the
+        // security gate would treat __MLS_ENC__ as a control message and
+        // reject it for being unsigned from a TOFU-pinned peer.
 
         use crate::mls::InMemoryStorage;
 
@@ -14352,10 +14347,20 @@ pub(crate) mod tests {
     #[test]
     fn test_security_gate_rejects_spoofed_transport_for_all_gated_prefixes() {
         // Verify that the security gate drops control messages with a
-        // transport identity mismatch for EVERY security-gated prefix.
+        // transport identity mismatch for EVERY security-gated prefix
+        // (all INTERNAL_PREFIXES except DATA_PLANE_PREFIXES).
         let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
 
-        for prefix in SECURITY_GATED_PREFIXES {
+        let gated_prefixes: Vec<&&str> = INTERNAL_PREFIXES
+            .iter()
+            .filter(|p| !DATA_PLANE_PREFIXES.contains(p))
+            .collect();
+        assert!(
+            !gated_prefixes.is_empty(),
+            "There must be at least one security-gated prefix"
+        );
+
+        for prefix in gated_prefixes {
             let mut msg = pending_test_message("sender123", &format!("{}test_payload", prefix));
             msg.set_transport_peer_id("eve".to_string()).unwrap();
 


### PR DESCRIPTION


Mitigate cache-poisoning-class vulnerabilities by adding three security layers: transport-level sender identity binding, Ed25519 control message signing with TOFU key pinning, and internal prefix injection prevention.