### PR TITLE
fix: address 14 bugs found during full codebase audit

### DIFF
--- a/crates/offline-protocol-core/src/types.rs
+++ b/crates/offline-protocol-core/src/types.rs
@@ -282,8 +282,18 @@ impl Default for Timestamp {
 /// if message B was sent after receiving message A, then B's clock > A's clock.
 ///
 /// Use this — not wall-clock timestamps — for sorting messages.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct LamportClock(u64);
+
+impl<'de> serde::Deserialize<'de> for LamportClock {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = u64::deserialize(deserializer)?;
+        Ok(Self(raw.min(LAMPORT_CLOCK_MAX)))
+    }
+}
 
 /// Upper bound for accepted Lamport clock values.
 /// Rejects absurdly large values from malicious or buggy peers.

--- a/crates/offline-protocol-mls/src/lib.rs
+++ b/crates/offline-protocol-mls/src/lib.rs
@@ -29,6 +29,7 @@
 //! let ciphertext = manager.encrypt_for_user("bob", b"Hello, Bob!")?;
 //! ```
 
+#![deny(unsafe_code)]
 #![warn(missing_docs)]
 
 pub mod error;

--- a/crates/offline-protocol-reliability/src/ack_optimization.rs
+++ b/crates/offline-protocol-reliability/src/ack_optimization.rs
@@ -257,24 +257,31 @@ impl AckOptimizer {
         }
 
         // Get pending ACKs for this destination
-        let acks = self.flush_pending_acks(message_destination)?;
+        let mut acks = self.flush_pending_acks(message_destination)?;
         if acks.is_empty() {
             return None;
         }
 
-        // Limit size for piggybacking
-        let limited_acks: Vec<_> = acks
-            .into_iter()
-            .take(self.estimate_piggyback_limit())
-            .collect();
+        // Limit size for piggybacking; return overflow back to the queue
+        let limit = self.estimate_piggyback_limit();
+        if acks.len() > limit {
+            let overflow = acks.split_off(limit);
+            self.pending_acks
+                .insert(message_destination.to_string(), overflow);
+            // Preserve pending_since so the overflow batch retains its age
+            // (it was already removed by flush_pending_acks; re-set to now
+            // so the overflow doesn't immediately time-out on the next tick).
+            self.pending_since
+                .insert(message_destination.to_string(), Utc::now());
+        }
 
-        if limited_acks.is_empty() {
+        if acks.is_empty() {
             return None;
         }
 
         Some(PiggybackAckData {
             destination: message_destination.to_string(),
-            acks: limited_acks,
+            acks,
             first_added_at: Utc::now(),
         })
     }

--- a/crates/offline-protocol-reliability/src/retry_queue.rs
+++ b/crates/offline-protocol-reliability/src/retry_queue.rs
@@ -105,7 +105,7 @@ impl Eq for RetryEntry {}
 
 impl PartialEq for RetryEntry {
     fn eq(&self, other: &Self) -> bool {
-        self.message.id == other.message.id
+        self.retry_at == other.retry_at && self.message.priority == other.message.priority
     }
 }
 
@@ -144,6 +144,11 @@ impl RetryQueue {
     pub fn enqueue(&mut self, message: Message, retry_count: u32) -> crate::Result<()> {
         if retry_count >= self.config.max_retries {
             return Err(crate::Error::MaxRetriesExceeded);
+        }
+
+        // Prevent duplicate entries for the same message
+        if self.index.contains_key(&message.id.as_str()) {
+            return Ok(());
         }
 
         // Calculate retry delay with exponential backoff
@@ -273,6 +278,7 @@ impl RetryQueue {
         RetryQueueStats {
             total_count: self.len(),
             ready_count,
+            critical_priority_count: priority_counts[&MessagePriority::Critical],
             high_priority_count: priority_counts[&MessagePriority::High],
             medium_priority_count: priority_counts[&MessagePriority::Medium],
             low_priority_count: priority_counts[&MessagePriority::Low],
@@ -307,6 +313,8 @@ pub struct RetryQueueStats {
     pub total_count: usize,
     /// Number of messages ready for retry.
     pub ready_count: usize,
+    /// Number of critical priority messages.
+    pub critical_priority_count: usize,
     /// Number of high priority messages.
     pub high_priority_count: usize,
     /// Number of medium priority messages.

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -688,7 +688,7 @@ impl TransportSelector {
 
         // Lower hop count = higher score
         // If message just started (hop_count = 0), give high score
-        if hop_count == 0 {
+        if hop_count == 0 || ttl == 0 {
             100.0
         } else {
             // Score decreases as hop count increases

--- a/crates/offline-protocol-router/src/router.rs
+++ b/crates/offline-protocol-router/src/router.rs
@@ -180,7 +180,15 @@ impl GradientRoutingTable {
                     })
                     .then_with(|| a.hop_count.cmp(&b.hop_count))
             });
-            routes.pop();
+            if let Some(evicted) = routes.pop() {
+                // Remove evicted route from reverse mapping
+                if let Some(dests) = self.neighbor_destinations.get_mut(&evicted.next_hop) {
+                    dests.retain(|d| d != destination);
+                    if dests.is_empty() {
+                        self.neighbor_destinations.remove(&evicted.next_hop);
+                    }
+                }
+            }
         }
 
         routes.push(RouteEntry {
@@ -191,11 +199,14 @@ impl GradientRoutingTable {
             sequence_number,
         });
 
-        // Update reverse mapping
-        self.neighbor_destinations
+        // Update reverse mapping (only add if not already present)
+        let dests = self
+            .neighbor_destinations
             .entry(next_hop.to_string())
-            .or_default()
-            .push(destination.to_string());
+            .or_default();
+        if !dests.contains(&destination.to_string()) {
+            dests.push(destination.to_string());
+        }
 
         // Enforce table size limit
         self.enforce_size_limit();
@@ -314,6 +325,13 @@ impl GradientRoutingTable {
                     routes.retain(|r| r.next_hop != next_hop);
                     if routes.is_empty() {
                         self.routes.remove(&dest);
+                    }
+                }
+                // Update reverse mapping
+                if let Some(dests) = self.neighbor_destinations.get_mut(&next_hop) {
+                    dests.retain(|d| d != &dest);
+                    if dests.is_empty() {
+                        self.neighbor_destinations.remove(&next_hop);
                     }
                 }
             } else {

--- a/crates/offline-protocol-transport/src/mock.rs
+++ b/crates/offline-protocol-transport/src/mock.rs
@@ -2,6 +2,7 @@
 
 use crate::{Result, Transport, TransportMetrics, TransportStatus, TransportType};
 use offline_protocol_core::Message;
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 /// Mock transport for testing purposes.
@@ -12,7 +13,7 @@ pub struct MockTransport {
     transport_type: TransportType,
     status: Arc<Mutex<TransportStatus>>,
     sent_messages: Arc<Mutex<Vec<Message>>>,
-    receive_queue: Arc<Mutex<Vec<Message>>>,
+    receive_queue: Arc<Mutex<VecDeque<Message>>>,
     metrics: Arc<Mutex<TransportMetrics>>,
     /// When > 0, next send() calls fail this many times (for escalation/fallback tests).
     fail_next_sends: Arc<Mutex<usize>>,
@@ -33,7 +34,7 @@ impl MockTransport {
             transport_type,
             status: Arc::new(Mutex::new(TransportStatus::Unavailable)),
             sent_messages: Arc::new(Mutex::new(Vec::new())),
-            receive_queue: Arc::new(Mutex::new(Vec::new())),
+            receive_queue: Arc::new(Mutex::new(VecDeque::new())),
             metrics: Arc::new(Mutex::new(TransportMetrics::default())),
             fail_next_sends: Arc::new(Mutex::new(0)),
         }
@@ -47,7 +48,7 @@ impl MockTransport {
     /// Adds a message to the receive queue for testing.
     pub fn queue_message(&self, message: Message) {
         let mut queue = self.receive_queue.lock().unwrap();
-        queue.push(message);
+        queue.push_back(message);
     }
 
     /// Adds a message to the receive queue with a transport-verified peer identity.
@@ -56,7 +57,7 @@ impl MockTransport {
             .set_transport_peer_id(peer_id)
             .expect("test must provide non-empty peer_id");
         let mut queue = self.receive_queue.lock().unwrap();
-        queue.push(message);
+        queue.push_back(message);
     }
 
     /// Returns all messages that were sent through this transport.
@@ -130,7 +131,7 @@ impl Transport for MockTransport {
 
     fn receive(&self) -> Result<Option<Message>> {
         let mut queue = self.receive_queue.lock().unwrap();
-        Ok(queue.pop())
+        Ok(queue.pop_front())
     }
 
     fn start(&mut self) -> Result<()> {

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -201,13 +201,13 @@ impl CoreMlsStorage for MlsStorageWrapper {
             .load(key_type.to_string(), key_id.to_string())
             .map_err(|e| match e {
                 MlsStorageError::StoreFailed => {
-                    CoreStorageError::LoadFailed("Storage failed".to_string())
+                    CoreStorageError::StoreFailed("Store failed".to_string())
                 }
                 MlsStorageError::LoadFailed => {
                     CoreStorageError::LoadFailed("Load failed".to_string())
                 }
                 MlsStorageError::DeleteFailed => {
-                    CoreStorageError::LoadFailed("Delete failed".to_string())
+                    CoreStorageError::DeleteFailed("Delete failed".to_string())
                 }
                 MlsStorageError::KeyNotFound => CoreStorageError::KeyNotFound(key_id.to_string()),
                 MlsStorageError::CorruptedData => {
@@ -248,13 +248,13 @@ impl CoreMlsStorage for MlsStorageWrapper {
             .list_keys(key_type.to_string())
             .map_err(|e| match e {
                 MlsStorageError::StoreFailed => {
-                    CoreStorageError::LoadFailed("Storage failed".to_string())
+                    CoreStorageError::StoreFailed("Store failed".to_string())
                 }
                 MlsStorageError::LoadFailed => {
                     CoreStorageError::LoadFailed("Load failed".to_string())
                 }
                 MlsStorageError::DeleteFailed => {
-                    CoreStorageError::LoadFailed("Delete failed".to_string())
+                    CoreStorageError::DeleteFailed("Delete failed".to_string())
                 }
                 MlsStorageError::KeyNotFound => CoreStorageError::KeyNotFound("".to_string()),
                 MlsStorageError::CorruptedData => {
@@ -970,8 +970,11 @@ impl OfflineProtocol {
         protocol.on_event(move |event| {
             // Convert event to JSON
             if let Ok(event_json) = event.to_json() {
-                // Call the event callback if set
-                if let Some(callback) = event_callback_clone.read().unwrap().as_ref() {
+                // Clone callback Arc outside the lock to avoid holding the
+                // RwLock during callback invocation (prevents deadlock if the
+                // callback re-enters the protocol).
+                let callback_arc = event_callback_clone.read().unwrap().as_ref().cloned();
+                if let Some(callback) = callback_arc {
                     callback.on_event(event_json.clone());
                 }
 

--- a/crates/offline-protocol/src/file_transfer.rs
+++ b/crates/offline-protocol/src/file_transfer.rs
@@ -124,6 +124,12 @@ impl FileChunk {
         buf
     }
 
+    /// Maximum allowed length for a string field (file_id, file_name, checksum)
+    /// in the binary wire format. Prevents allocation bombs from crafted payloads.
+    const MAX_STRING_FIELD_LEN: usize = 4096;
+    /// Maximum allowed chunk data length in the binary wire format.
+    const MAX_CHUNK_DATA_LEN: usize = 128 * 1024 * 1024; // 128 MB
+
     /// Deserializes from the compact binary format produced by `to_bytes`.
     pub fn from_bytes(data: &[u8]) -> Result<Self, String> {
         let mut pos = 0;
@@ -156,10 +162,24 @@ impl FileChunk {
         };
 
         let file_id_len = read_u32(&mut pos)? as usize;
+        if file_id_len > Self::MAX_STRING_FIELD_LEN {
+            return Err(format!(
+                "file_id_len {} exceeds maximum {}",
+                file_id_len,
+                Self::MAX_STRING_FIELD_LEN
+            ));
+        }
         let file_id = String::from_utf8(read_bytes(&mut pos, file_id_len)?)
             .map_err(|e| format!("invalid file_id UTF-8: {}", e))?;
 
         let file_name_len = read_u32(&mut pos)? as usize;
+        if file_name_len > Self::MAX_STRING_FIELD_LEN {
+            return Err(format!(
+                "file_name_len {} exceeds maximum {}",
+                file_name_len,
+                Self::MAX_STRING_FIELD_LEN
+            ));
+        }
         let file_name = String::from_utf8(read_bytes(&mut pos, file_name_len)?)
             .map_err(|e| format!("invalid file_name UTF-8: {}", e))?;
 
@@ -168,9 +188,23 @@ impl FileChunk {
         let chunk_index = read_u32(&mut pos)?;
 
         let chunk_data_len = read_u32(&mut pos)? as usize;
+        if chunk_data_len > Self::MAX_CHUNK_DATA_LEN {
+            return Err(format!(
+                "chunk_data_len {} exceeds maximum {}",
+                chunk_data_len,
+                Self::MAX_CHUNK_DATA_LEN
+            ));
+        }
         let chunk_data = read_bytes(&mut pos, chunk_data_len)?;
 
         let checksum_len = read_u32(&mut pos)? as usize;
+        if checksum_len > Self::MAX_STRING_FIELD_LEN {
+            return Err(format!(
+                "checksum_len {} exceeds maximum {}",
+                checksum_len,
+                Self::MAX_STRING_FIELD_LEN
+            ));
+        }
         let file_checksum = String::from_utf8(read_bytes(&mut pos, checksum_len)?)
             .map_err(|e| format!("invalid checksum UTF-8: {}", e))?;
 
@@ -422,18 +456,31 @@ impl FileTransferManager {
 
     /// Finalizes a file transfer and returns the complete file data.
     ///
+    /// Verifies the SHA256 checksum of the reassembled file before returning.
+    ///
     /// # Arguments
     ///
     /// * `file_id` - File identifier
     ///
     /// # Returns
     ///
-    /// Returns `Some(Vec<u8>)` if file is complete, `None` otherwise.
+    /// Returns `Some(Vec<u8>)` if file is complete and checksum matches, `None` otherwise.
     pub fn finalize_file(&mut self, file_id: &str) -> Option<Vec<u8>> {
-        let file_data = self
-            .active_assemblies
-            .get(file_id)
-            .and_then(FileAssembly::reassemble)?;
+        let assembly = self.active_assemblies.get(file_id)?;
+        let file_data = assembly.reassemble()?;
+
+        // Verify checksum before returning
+        let actual_checksum = format!("{:x}", Sha256::digest(&file_data));
+        if actual_checksum != assembly.file_checksum {
+            tracing::warn!(
+                file_id = %file_id,
+                expected = %assembly.file_checksum,
+                actual = %actual_checksum,
+                "File checksum mismatch — corrupted or tampered transfer"
+            );
+            self.active_assemblies.remove(file_id);
+            return None;
+        }
 
         self.active_assemblies.remove(file_id);
         Some(file_data)

--- a/crates/offline-protocol/src/protocol/pending_queue.rs
+++ b/crates/offline-protocol/src/protocol/pending_queue.rs
@@ -76,7 +76,7 @@ impl OfflineProtocol {
                         self.persist_lamport_clock();
 
                         if let Ok(mut state) = lock_shared_state(&self.shared_state) {
-                            state.received_messages.push(decrypted_msg.clone());
+                            state.received_messages.push_back(decrypted_msg.clone());
                             let event = Event::MessageReceived {
                                 message_id: decrypted_msg.id.as_str().to_string(),
                                 sender: decrypted_msg.sender.as_str().to_string(),

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -21,7 +21,7 @@ impl OfflineProtocol {
         let protocol_running = state.state == ProtocolState::Running;
 
         if !state.received_messages.is_empty() {
-            return Some(state.received_messages.remove(0));
+            return state.received_messages.pop_front();
         }
 
         drop(state);

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use offline_protocol_core::{ContentType, MediaMetadata, Message, MessageId, MessagePriority};
 use offline_protocol_transport::TransportType;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -367,7 +367,7 @@ pub(crate) struct SharedState {
     pub(crate) event_handlers: Vec<EventCallback>,
 
     /// Received messages queue.
-    pub(crate) received_messages: Vec<Message>,
+    pub(crate) received_messages: VecDeque<Message>,
 }
 
 impl SharedState {
@@ -375,7 +375,7 @@ impl SharedState {
         Self {
             state: ProtocolState::Stopped,
             event_handlers: Vec::new(),
-            received_messages: Vec::new(),
+            received_messages: VecDeque::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Full codebase audit across all 8 crates uncovered 14 bugs. This PR fixes them all in a single pass — 12 files changed, 132 insertions, 37 deletions.

### High severity
- **ACK loss in piggyback**: `get_piggyback_acks()` flushed *all* pending ACKs then `.take(limit)`, silently dropping the overflow. Now returns overflow to the queue.
- **File transfer memory bomb**: `FileChunk::from_bytes()` allocated whatever a u32 length prefix said with zero bounds. Crafted payload = 4GB alloc. Added hard caps (4KB strings, 128MB chunks).
- **Missing checksum verification**: `finalize_file()` reassembled chunks without ever checking the SHA256 checksum. Now verifies before returning.
- **LamportClock deserialization bypass**: `#[derive(Deserialize)]` bypassed `LAMPORT_CLOCK_MAX` clamping. Malicious peer could inflate clock past safety boundary. Custom `Deserialize` impl now clamps.
- **Wrong UniFFI error mappings**: `MlsStorageWrapper` mapped `DeleteFailed`→`LoadFailed` and `StoreFailed`→`LoadFailed`. Fixed to preserve actual error semantics.

### Medium severity
- **RetryEntry Eq/Ord violation**: `PartialEq` compared message IDs, `Ord` compared `retry_at`+`priority` — breaks BinaryHeap contract. Fixed PartialEq to match Ord.
- **RetryQueue duplicate enqueue**: No dup check in `enqueue()`. Added index guard.
- **Routing table reverse index leak**: `neighbor_destinations` never cleaned on eviction or size limit enforcement. Now updated on every removal path.
- **DORS div-by-zero**: Proximity score divided by TTL=0 → NaN propagation. Added guard.
- **MockTransport LIFO queue**: Used `Vec`+`pop()` (LIFO) while real transports use FIFO. Switched to `VecDeque`.
- **UniFFI event callback deadlock risk**: Callback invoked while holding RwLock. Clone Arc first, drop guard, then invoke.

### Low severity
- **O(n) receive queue**: `Vec::remove(0)` → `VecDeque::pop_front()`
- **Missing Critical priority stat**: `RetryQueueStats` now includes `critical_priority_count`
- **MLS crate missing `deny(unsafe_code)`**: Added the attribute

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes clean
- [x] `cargo test --workspace` — 766 tests pass, 0 failures
- [x] No formatting regressions in changed files