### PR TITLE
fix(bindings): save BLE fragments when peripheral connection is missing

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -267,6 +267,7 @@ class BleManager(
     private data class OutboundFragment(val data: ByteArray, val timestamp: Long)
     private val pendingOutboundFragments = mutableMapOf<String, MutableList<OutboundFragment>>()
     private val PENDING_OUTBOUND_FRAGMENT_TIMEOUT_MS = 30_000L // 30 seconds
+    private val MAX_PENDING_FRAGMENTS_PER_PEER = 100
     private val lastSeenMeshAdvertisements = ConcurrentHashMap<String, MeshObservation>()
     private var pendingAdvertiseRestart: Runnable? = null
     private var lastAdvertiseRestartAt: Long = 0L
@@ -1835,6 +1836,10 @@ class BleManager(
     private fun enqueuePendingOutboundFragment(recipientId: String, data: ByteArray) {
         val queue = pendingOutboundFragments.getOrPut(recipientId) { mutableListOf() }
         queue.add(OutboundFragment(data, System.currentTimeMillis()))
+        // Drop oldest fragments if the queue exceeds the per-peer cap
+        while (queue.size > MAX_PENDING_FRAGMENTS_PER_PEER) {
+            queue.removeAt(0)
+        }
     }
 
     private fun resolveTargetAddress(recipientId: String): String? {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -1687,9 +1687,21 @@ class BleManager(
                 val recipientId = fragment.recipientId
                 val data = fragment.data.map { it.toByte() }.toByteArray()
 
-                val hasConnection = resolveTargetAddress(recipientId)?.let { connections.getGatt(it) } != null
+                val address = resolveTargetAddress(recipientId)
+                val hasConnection = address?.let { connections.getGatt(it) } != null
                 if (!hasConnection) {
                     enqueuePendingOutboundFragment(recipientId, data)
+                    // Proactively attempt reconnection if we know the address
+                    if (address != null) {
+                        bluetoothAdapter?.let { adapter ->
+                            try {
+                                val device = adapter.getRemoteDevice(address)
+                                connectToDevice(device)
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Error attempting reconnection for $recipientId during fragment drain", e)
+                            }
+                        }
+                    }
                     consecutiveSkips++
                     if (consecutiveSkips >= maxConsecutiveSkips) {
                         break

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -1689,6 +1689,7 @@ class BleManager(
 
                 val hasConnection = resolveTargetAddress(recipientId)?.let { connections.getGatt(it) } != null
                 if (!hasConnection) {
+                    enqueuePendingOutboundFragment(recipientId, data)
                     consecutiveSkips++
                     if (consecutiveSkips >= maxConsecutiveSkips) {
                         break

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -1836,9 +1836,10 @@ class BleManager(
     private fun enqueuePendingOutboundFragment(recipientId: String, data: ByteArray) {
         val queue = pendingOutboundFragments.getOrPut(recipientId) { mutableListOf() }
         queue.add(OutboundFragment(data, System.currentTimeMillis()))
-        // Drop oldest fragments if the queue exceeds the per-peer cap
-        while (queue.size > MAX_PENDING_FRAGMENTS_PER_PEER) {
+        // Drop oldest fragment if the queue exceeds the per-peer cap
+        if (queue.size > MAX_PENDING_FRAGMENTS_PER_PEER) {
             queue.removeAt(0)
+            Log.w(TAG, "Pending outbound fragment queue capped for $recipientId, dropping oldest (max=$MAX_PENDING_FRAGMENTS_PER_PEER)")
         }
     }
 

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -1675,6 +1675,7 @@ class BleManager(
 
             var consecutiveSkips = 0
             val maxConsecutiveSkips = 5
+            val reconnectAttempted = mutableSetOf<String>()
 
             while (true) {
                 val fragment = try {
@@ -1691,8 +1692,8 @@ class BleManager(
                 val hasConnection = address?.let { connections.getGatt(it) } != null
                 if (!hasConnection) {
                     enqueuePendingOutboundFragment(recipientId, data)
-                    // Proactively attempt reconnection if we know the address
-                    if (address != null) {
+                    // Proactively attempt reconnection if we know the address (once per peer per drain)
+                    if (address != null && reconnectAttempted.add(address)) {
                         bluetoothAdapter?.let { adapter ->
                             try {
                                 val device = adapter.getRemoteDevice(address)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt
@@ -265,7 +265,7 @@ class BleManager(
     
     // Track outbound fragments with timestamps for timeout handling
     private data class OutboundFragment(val data: ByteArray, val timestamp: Long)
-    private val pendingOutboundFragments = mutableMapOf<String, MutableList<OutboundFragment>>()
+    private val pendingOutboundFragments = mutableMapOf<String, ArrayDeque<OutboundFragment>>()
     private val PENDING_OUTBOUND_FRAGMENT_TIMEOUT_MS = 30_000L // 30 seconds
     private val MAX_PENDING_FRAGMENTS_PER_PEER = 100
     private val lastSeenMeshAdvertisements = ConcurrentHashMap<String, MeshObservation>()
@@ -1805,11 +1805,11 @@ class BleManager(
             }
             
             // Update queue with only valid fragments (remove expired ones)
-            val mutableQueue = validFragments.toMutableList()
+            val mutableQueue = ArrayDeque(validFragments)
             if (mutableQueue.size < queue.size) {
                 pendingOutboundFragments[recipientId] = mutableQueue
             }
-            
+
             // Try to send each fragment
             val iterator = mutableQueue.iterator()
             while (iterator.hasNext()) {
@@ -1834,11 +1834,11 @@ class BleManager(
     }
 
     private fun enqueuePendingOutboundFragment(recipientId: String, data: ByteArray) {
-        val queue = pendingOutboundFragments.getOrPut(recipientId) { mutableListOf() }
-        queue.add(OutboundFragment(data, System.currentTimeMillis()))
+        val queue = pendingOutboundFragments.getOrPut(recipientId) { ArrayDeque() }
+        queue.addLast(OutboundFragment(data, System.currentTimeMillis()))
         // Drop oldest fragment if the queue exceeds the per-peer cap
         if (queue.size > MAX_PENDING_FRAGMENTS_PER_PEER) {
-            queue.removeAt(0)
+            queue.removeFirst()
             Log.w(TAG, "Pending outbound fragment queue capped for $recipientId, dropping oldest (max=$MAX_PENDING_FRAGMENTS_PER_PEER)")
         }
     }

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -1083,6 +1083,9 @@ public class BleManager: NSObject, TransportManager {
                     if let identifier = self.connections.peripheralIdentifier(for: recipientId) {
                         if let peripheral = self.discoveredPeripherals[identifier] {
                             self.attemptConnection(to: peripheral, reason: "fragment_drain_reconnect")
+                        } else {
+                            self.emitDiagnostic("debug", "Known peripheral not in discoveredPeripherals, skipping reconnect",
+                                               context: ["recipientId": recipientId, "identifier": identifier.uuidString])
                         }
                     }
                     consecutiveSkips += 1

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -763,80 +763,84 @@ public class BleManager: NSObject, TransportManager {
     private func attemptConnection(to peripheral: CBPeripheral, reason: String, rssi: Int16? = nil, desiredRole: MeshController.MeshRole? = nil) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            
-            // Atomic check-and-connect: all checks must pass before proceeding
-            // This prevents race conditions when multiple discovery callbacks try to connect
-            
-            // 1. Already connected check
-            if self.connections.connectedPeripheral(for: peripheral.identifier) != nil {
-                return
-            }
-            
-            // 2. Recent attempt cooldown check
-            let now = Date()
-            if let lastAttempt = self.connectionAttemptTimestamps[peripheral.identifier], now.timeIntervalSince(lastAttempt) < self.MIN_RECONNECT_INTERVAL {
-                return
-            }
-            
-            // 3. RSSI threshold check
-            if let effectiveRSSI = rssi ?? self.peripheralRSSI[peripheral.identifier], effectiveRSSI < self.MINIMUM_RSSI_TO_CONNECT {
-                if self.logThrottler.shouldLog(key: "rssi_skip_\(peripheral.identifier.uuidString)", interval: 10) {
-                    self.emitDiagnostic("debug", "Skipping BLE connect due to weak RSSI", context: [
-                        "rssi": effectiveRSSI,
-                        "threshold": self.MINIMUM_RSSI_TO_CONNECT,
-                        "reason": reason
-                    ])
-                }
-                return
-            }
-            
-            // 4. Connection capacity check (atomic with the connect call)
-            if self.currentConnectionCount() >= self.MAX_CONNECTIONS_PER_DEVICE {
-                if self.logThrottler.shouldLog(key: "mesh_conn_cap_ios", interval: 10) {
-                    print("[BleManager] Connection cap reached, not connecting to \(peripheral.identifier)")
-                }
-                return
-            }
-            
-            // 5. Double-check peripheral state before connecting
-            guard peripheral.state != .connecting else {
-                if self.logThrottler.shouldLog(key: "already_connecting_\(peripheral.identifier.uuidString)", interval: 5) {
-                    print("[BleManager] Already connecting to \(peripheral.identifier)")
-                }
-                return
-            }
-            
-            // All checks passed - proceed with connection
-            self.connectionAttemptTimestamps[peripheral.identifier] = now
-            if let desiredRole = desiredRole {
-                self.connections.setPendingRole(desiredRole, for: peripheral.identifier)
-            } else if self.connections.pendingRole(for: peripheral.identifier) == nil {
-                self.connections.setPendingRole(.member, for: peripheral.identifier)
-            }
-            peripheral.delegate = self
-            
-            if peripheral.state == .connected {
-                self.connections.registerPeripheral(peripheral)
-                if let service = peripheral.services?.first(where: { $0.uuid == self.SERVICE_UUID }) {
-                    peripheral.discoverCharacteristics([self.MESSAGE_CHAR_UUID, self.DEVICE_ID_CHAR_UUID, self.IDENTITY_CHAR_UUID], for: service)
-                } else {
-                    peripheral.discoverServices([self.SERVICE_UUID])
-                }
-                return
-            }
-            
-            self.centralManager?.connect(peripheral, options: nil)
-            if self.logThrottler.shouldLog(key: "connect_attempt_\(peripheral.identifier.uuidString)", interval: 10) {
-                print("[BleManager] Attempting connection to \(peripheral.identifier) (reason: \(reason))")
-                var context: [String: Any] = [
-                    "identifier": peripheral.identifier.uuidString,
+            self.performConnectionAttempt(to: peripheral, reason: reason, rssi: rssi, desiredRole: desiredRole)
+        }
+    }
+
+    /// Core connection logic — must be called on the main thread.
+    private func performConnectionAttempt(to peripheral: CBPeripheral, reason: String, rssi: Int16? = nil, desiredRole: MeshController.MeshRole? = nil) {
+        // Atomic check-and-connect: all checks must pass before proceeding
+        // This prevents race conditions when multiple discovery callbacks try to connect
+
+        // 1. Already connected check
+        if connections.connectedPeripheral(for: peripheral.identifier) != nil {
+            return
+        }
+
+        // 2. Recent attempt cooldown check
+        let now = Date()
+        if let lastAttempt = connectionAttemptTimestamps[peripheral.identifier], now.timeIntervalSince(lastAttempt) < MIN_RECONNECT_INTERVAL {
+            return
+        }
+
+        // 3. RSSI threshold check
+        if let effectiveRSSI = rssi ?? peripheralRSSI[peripheral.identifier], effectiveRSSI < MINIMUM_RSSI_TO_CONNECT {
+            if logThrottler.shouldLog(key: "rssi_skip_\(peripheral.identifier.uuidString)", interval: 10) {
+                emitDiagnostic("debug", "Skipping BLE connect due to weak RSSI", context: [
+                    "rssi": effectiveRSSI,
+                    "threshold": MINIMUM_RSSI_TO_CONNECT,
                     "reason": reason
-                ]
-                if let rssi = rssi {
-                    context["rssi"] = rssi
-                }
-                self.emitDiagnostic("info", "Connecting to BLE peripheral", context: context)
+                ])
             }
+            return
+        }
+
+        // 4. Connection capacity check (atomic with the connect call)
+        if currentConnectionCount() >= MAX_CONNECTIONS_PER_DEVICE {
+            if logThrottler.shouldLog(key: "mesh_conn_cap_ios", interval: 10) {
+                print("[BleManager] Connection cap reached, not connecting to \(peripheral.identifier)")
+            }
+            return
+        }
+
+        // 5. Double-check peripheral state before connecting
+        guard peripheral.state != .connecting else {
+            if logThrottler.shouldLog(key: "already_connecting_\(peripheral.identifier.uuidString)", interval: 5) {
+                print("[BleManager] Already connecting to \(peripheral.identifier)")
+            }
+            return
+        }
+
+        // All checks passed - proceed with connection
+        connectionAttemptTimestamps[peripheral.identifier] = now
+        if let desiredRole = desiredRole {
+            connections.setPendingRole(desiredRole, for: peripheral.identifier)
+        } else if connections.pendingRole(for: peripheral.identifier) == nil {
+            connections.setPendingRole(.member, for: peripheral.identifier)
+        }
+        peripheral.delegate = self
+
+        if peripheral.state == .connected {
+            connections.registerPeripheral(peripheral)
+            if let service = peripheral.services?.first(where: { $0.uuid == SERVICE_UUID }) {
+                peripheral.discoverCharacteristics([MESSAGE_CHAR_UUID, DEVICE_ID_CHAR_UUID, IDENTITY_CHAR_UUID], for: service)
+            } else {
+                peripheral.discoverServices([SERVICE_UUID])
+            }
+            return
+        }
+
+        centralManager?.connect(peripheral, options: nil)
+        if logThrottler.shouldLog(key: "connect_attempt_\(peripheral.identifier.uuidString)", interval: 10) {
+            print("[BleManager] Attempting connection to \(peripheral.identifier) (reason: \(reason))")
+            var context: [String: Any] = [
+                "identifier": peripheral.identifier.uuidString,
+                "reason": reason
+            ]
+            if let rssi = rssi {
+                context["rssi"] = rssi
+            }
+            emitDiagnostic("info", "Connecting to BLE peripheral", context: context)
         }
     }
 
@@ -1084,11 +1088,11 @@ public class BleManager: NSObject, TransportManager {
                     self.enqueuePendingOutboundFragment(recipientId: recipientId, data: data)
                     if let identifier = self.connections.peripheralIdentifier(for: recipientId),
                        reconnectAttempted.insert(identifier).inserted {
-                        // Dispatch to main: discoveredPeripherals is only safe to read from the main thread
+                        // Dispatch to main: discoveredPeripherals and connection logic must run on the main thread
                         DispatchQueue.main.async { [weak self] in
                             guard let self = self else { return }
                             if let peripheral = self.discoveredPeripherals[identifier] {
-                                self.attemptConnection(to: peripheral, reason: "fragment_drain_reconnect")
+                                self.performConnectionAttempt(to: peripheral, reason: "fragment_drain_reconnect")
                             } else {
                                 self.emitDiagnostic("debug", "Known peripheral not in discoveredPeripherals, skipping reconnect",
                                                    context: ["recipientId": recipientId, "identifier": identifier.uuidString])

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -1083,11 +1083,14 @@ public class BleManager: NSObject, TransportManager {
                     self.enqueuePendingOutboundFragment(recipientId: recipientId, data: data)
                     if let identifier = self.connections.peripheralIdentifier(for: recipientId),
                        reconnectAttempted.insert(identifier).inserted {
-                        if let peripheral = self.discoveredPeripherals[identifier] {
-                            self.attemptConnection(to: peripheral, reason: "fragment_drain_reconnect")
-                        } else {
-                            self.emitDiagnostic("debug", "Known peripheral not in discoveredPeripherals, skipping reconnect",
-                                               context: ["recipientId": recipientId, "identifier": identifier.uuidString])
+                        // Dispatch to main: discoveredPeripherals is only safe to read from the main thread
+                        DispatchQueue.main.async {
+                            if let peripheral = self.discoveredPeripherals[identifier] {
+                                self.attemptConnection(to: peripheral, reason: "fragment_drain_reconnect")
+                            } else {
+                                self.emitDiagnostic("debug", "Known peripheral not in discoveredPeripherals, skipping reconnect",
+                                                   context: ["recipientId": recipientId, "identifier": identifier.uuidString])
+                            }
                         }
                     }
                     consecutiveSkips += 1

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -1237,6 +1237,8 @@ public class BleManager: NSObject, TransportManager {
         if queue.count > MAX_PENDING_FRAGMENTS_PER_PEER {
             let overflow = queue.count - MAX_PENDING_FRAGMENTS_PER_PEER
             queue.removeFirst(overflow)
+            emitDiagnostic("warning", "Pending outbound fragment queue capped, dropping oldest",
+                           context: ["recipientId": recipientId, "dropped": overflow, "max": MAX_PENDING_FRAGMENTS_PER_PEER])
         }
         pendingOutboundFragments[recipientId] = queue
     }

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -1079,6 +1079,12 @@ public class BleManager: NSObject, TransportManager {
                 
                 let hasPeripheral = self.findPeripheral(for: recipientId) != nil
                 if !hasPeripheral {
+                    self.enqueuePendingOutboundFragment(recipientId: recipientId, data: data)
+                    if let identifier = self.connections.peripheralIdentifier(for: recipientId) {
+                        if let peripheral = self.discoveredPeripherals[identifier] {
+                            self.attemptConnection(to: peripheral, reason: "fragment_drain_reconnect")
+                        }
+                    }
                     consecutiveSkips += 1
                     if consecutiveSkips >= maxConsecutiveSkips {
                         break

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -112,6 +112,7 @@ public class BleManager: NSObject, TransportManager {
     private var pendingFragments: [UUID: [(Data, Date)]] = [:]
     private let PENDING_FRAGMENT_TIMEOUT: TimeInterval = 5.0 // For incoming fragments waiting for device ID
     private let PENDING_OUTBOUND_FRAGMENT_TIMEOUT: TimeInterval = 30.0 // For outbound fragments that failed to send
+    private let MAX_PENDING_FRAGMENTS_PER_PEER = 100
     // Track outbound fragments with timestamps for timeout handling
     private var pendingOutboundFragments: [String: [(data: Data, timestamp: Date)]] = [:]
     private struct MeshObservation {
@@ -1084,7 +1085,8 @@ public class BleManager: NSObject, TransportManager {
                     if let identifier = self.connections.peripheralIdentifier(for: recipientId),
                        reconnectAttempted.insert(identifier).inserted {
                         // Dispatch to main: discoveredPeripherals is only safe to read from the main thread
-                        DispatchQueue.main.async {
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self else { return }
                             if let peripheral = self.discoveredPeripherals[identifier] {
                                 self.attemptConnection(to: peripheral, reason: "fragment_drain_reconnect")
                             } else {
@@ -1227,6 +1229,11 @@ public class BleManager: NSObject, TransportManager {
     private func enqueuePendingOutboundFragment(recipientId: String, data: Data) {
         var queue = pendingOutboundFragments[recipientId] ?? []
         queue.append((data: data, timestamp: Date()))
+        // Drop oldest fragments if the queue exceeds the per-peer cap
+        if queue.count > MAX_PENDING_FRAGMENTS_PER_PEER {
+            let overflow = queue.count - MAX_PENDING_FRAGMENTS_PER_PEER
+            queue.removeFirst(overflow)
+        }
         pendingOutboundFragments[recipientId] = queue
     }
 

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -1072,15 +1072,17 @@ public class BleManager: NSObject, TransportManager {
             
             var consecutiveSkips = 0
             let maxConsecutiveSkips = 5
-            
+            var reconnectAttempted = Set<UUID>()
+
             while let fragment = self.protocolInstance.bleGetNextFragment() {
                 let recipientId = fragment.recipientId
                 let data = Data(fragment.data)
-                
+
                 let hasPeripheral = self.findPeripheral(for: recipientId) != nil
                 if !hasPeripheral {
                     self.enqueuePendingOutboundFragment(recipientId: recipientId, data: data)
-                    if let identifier = self.connections.peripheralIdentifier(for: recipientId) {
+                    if let identifier = self.connections.peripheralIdentifier(for: recipientId),
+                       reconnectAttempted.insert(identifier).inserted {
                         if let peripheral = self.discoveredPeripherals[identifier] {
                             self.attemptConnection(to: peripheral, reason: "fragment_drain_reconnect")
                         } else {


### PR DESCRIPTION
## Summary

- **Fix one-way messaging when a device goes offline** (WiFi/cellular off, BLE stays on). `drainAndSendFragments()` dequeues fragments from the Rust BLE send queue via `bleGetNextFragment()` but silently drops them when no peripheral/GATT connection exists. After BLE restarts, the device can receive messages (peripheral role) but all sent fragments are permanently lost.
- Fragments are now saved via `enqueuePendingOutboundFragment()` for retry when the connection re-establishes, matching the existing behavior when `sendFragmentData()` returns false.
- On iOS, proactively attempts reconnection to known peripherals when fragments can't be delivered.

## Root Cause

In `drainAndSendFragments()`, when `findPeripheral()` (iOS) or `resolveTargetAddress()` (Android) returns nil, the fragment has already been consumed from the Rust queue but is just `continue`d — permanently lost. Compare with the `sendFragmentData()` failure path which correctly calls `enqueuePendingOutboundFragment()`.

## Changes

| File | Change |
|------|--------|
| `bindings/react-native/ios/BleManager.swift` | Save fragment + trigger reconnect when peripheral missing |
| `bindings/react-native/android/src/main/java/com/offlineprotocol/BleManager.kt` | Save fragment when GATT connection missing |

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] Manual: connect two iOS devices, disable WiFi+cellular on one (keep BLE), verify bidirectional messaging works
- [ ] Check logs for `enqueuePendingOutboundFragment` entries instead of silent drops