### PR TITLE
feat(protocol): add user-level message forwarding with attribution

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -625,6 +625,31 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun forwardMessage(originalMessageJson: String, newRecipient: String, priority: Int?, promise: Promise) {
+        try {
+            val proto = protocol ?: throw IllegalStateException("Protocol not initialized")
+            val msgPriority = priority?.let {
+                when (it) {
+                    0 -> MessagePriority.LOW
+                    1 -> MessagePriority.MEDIUM
+                    2 -> MessagePriority.HIGH
+                    3 -> MessagePriority.CRITICAL
+                    else -> null
+                }
+            }
+            val messageId = proto.forwardMessage(originalMessageJson, newRecipient, msgPriority)
+            promise.resolve(messageId)
+        } catch (e: Exception) {
+            val mapped = mapProtocolBridgeError(e)
+            if (mapped != null) {
+                promise.reject(mapped.code, mapped.message, e)
+            } else {
+                promise.reject("ERROR_FORWARD", "Failed to forward message: ${e.message}", e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun sendConnectionRequest(recipient: String, senderName: String, keyPackage: ReadableArray?, promise: Promise) {
         try {
             val proto = protocol ?: throw IllegalStateException("Protocol not initialized")
@@ -2854,6 +2879,31 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
             promise.resolve(result)
         } catch (e: Exception) {
             promise.reject("ERROR_MESH_GROUP", "Failed to send mesh group message: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Forward a message to all members of a mesh group with forwarding attribution.
+     */
+    @ReactMethod
+    fun meshForwardMessageToGroup(originalMessageJson: String, groupId: String, priority: String?, promise: Promise) {
+        try {
+            val proto = protocol ?: throw IllegalStateException("Protocol not initialized")
+            val msgPriority = priority?.let {
+                when (it.lowercase()) {
+                    "low" -> MessagePriority.LOW
+                    "medium" -> MessagePriority.MEDIUM
+                    "high" -> MessagePriority.HIGH
+                    "critical" -> MessagePriority.CRITICAL
+                    else -> null
+                }
+            }
+            val messageIds = proto.forwardMessageToGroup(originalMessageJson, groupId, msgPriority)
+            val result = Arguments.createArray()
+            messageIds.forEach { result.pushString(it) }
+            promise.resolve(result)
+        } catch (e: Exception) {
+            promise.reject("ERROR_MESH_GROUP", "Failed to forward message to group: ${e.message}", e)
         }
     }
 

--- a/bindings/react-native/ios/OfflineProtocolModule.m
+++ b/bindings/react-native/ios/OfflineProtocolModule.m
@@ -34,6 +34,12 @@ RCT_EXTERN_METHOD(sendMessage:(NSString *)recipient
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(forwardMessage:(NSString *)originalMessageJson
+                  newRecipient:(NSString *)newRecipient
+                  priority:(NSNumber *)priority
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(sendConnectionRequest:(NSString *)recipient
                   senderName:(NSString *)senderName
                   keyPackage:(NSArray *)keyPackage
@@ -475,6 +481,12 @@ RCT_EXTERN_METHOD(meshSendGroupMessage:(NSString *)groupId
                   content:(NSString *)content
                   priority:(NSString * _Nullable)priority
                   replyToMsg:(NSString * _Nullable)replyToMsg
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(meshForwardMessageToGroup:(NSString *)originalMessageJson
+                  groupId:(NSString *)groupId
+                  priority:(NSString * _Nullable)priority
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -716,6 +716,40 @@ class OfflineProtocolModule: RCTEventEmitter {
         }
     }
 
+    /// Forwards a message to a new recipient with original sender attribution.
+    @objc func forwardMessage(_ originalMessageJson: String,
+                              newRecipient: String,
+                              priority: NSNumber?,
+                              resolver: @escaping RCTPromiseResolveBlock,
+                              rejecter: @escaping RCTPromiseRejectBlock) {
+        do {
+            guard let proto = protocolInstance else {
+                throw NSError(domain: "OfflineProtocol", code: -1,
+                            userInfo: [NSLocalizedDescriptionKey: "Protocol not initialized"])
+            }
+
+            var msgPriority: MessagePriority? = nil
+            if let p = priority {
+                switch p.intValue {
+                case 0: msgPriority = .low
+                case 1: msgPriority = .medium
+                case 2: msgPriority = .high
+                case 3: msgPriority = .critical
+                default: break
+                }
+            }
+
+            let messageId = try proto.forwardMessage(originalMessageJson: originalMessageJson, newRecipient: newRecipient, priority: msgPriority)
+            resolver(messageId)
+        } catch {
+            if let mapped = mapProtocolBridgeError(error) {
+                rejecter(mapped.code, mapped.message, error)
+            } else {
+                rejecter("ERROR_FORWARD", "Failed to forward message: \(error.localizedDescription)", error)
+            }
+        }
+    }
+
     @objc func sendConnectionRequest(_ recipient: String,
                                      senderName: String,
                                      keyPackage: [NSNumber]?,
@@ -2988,6 +3022,40 @@ class OfflineProtocolModule: RCTEventEmitter {
             resolver(messageIds)
         } catch {
             rejecter("ERROR_MESH_GROUP", "Failed to send mesh group message: \(error.localizedDescription)", error)
+        }
+    }
+
+    /// Forward a message to all members of a group with forwarding attribution.
+    @objc func meshForwardMessageToGroup(_ originalMessageJson: String,
+                                         groupId: String,
+                                         priority: String?,
+                                         resolver: @escaping RCTPromiseResolveBlock,
+                                         rejecter: @escaping RCTPromiseRejectBlock) {
+        guard let proto = protocolInstance else {
+            rejecter("ERROR_MESH_GROUP", "Protocol not initialized", nil)
+            return
+        }
+        do {
+            var msgPriority: MessagePriority? = nil
+            if let priorityStr = priority {
+                switch priorityStr.lowercased() {
+                case "low":
+                    msgPriority = .low
+                case "medium":
+                    msgPriority = .medium
+                case "high":
+                    msgPriority = .high
+                case "critical":
+                    msgPriority = .critical
+                default:
+                    rejecter("ERROR_MESH_GROUP", "Invalid priority: \(priorityStr). Must be low, medium, high, or critical.", nil)
+                    return
+                }
+            }
+            let messageIds = try proto.forwardMessageToGroup(originalMessageJson: originalMessageJson, groupId: groupId, priority: msgPriority)
+            resolver(messageIds)
+        } catch {
+            rejecter("ERROR_MESH_GROUP", "Failed to forward message to group: \(error.localizedDescription)", error)
         }
     }
 

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -8,6 +8,8 @@ import { NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-na
 import type {
   ProtocolConfig,
   SendMessageParams,
+  ForwardMessageParams,
+  ForwardMessageToGroupParams,
   SendConnectionRequestParams,
   AcceptConnectionRequestParams,
   RejectConnectionRequestParams,
@@ -708,6 +710,26 @@ export class OfflineProtocol {
       params.content,
       priority,
       params.replyToMsg ?? null
+    );
+    return messageId;
+  }
+
+  /**
+   * Forwards a message to a new recipient with original sender attribution.
+   *
+   * Creates a new message with the original content and attaches forwarding
+   * metadata tracking the original sender, message ID, timestamp, and forward count.
+   *
+   * @param params - Forward message parameters
+   * @returns New message ID
+   * @throws Error if forwarding fails
+   */
+  async forwardMessage(params: ForwardMessageParams): Promise<string> {
+    const priority = params.priority ?? null;
+    const messageId = await OfflineProtocolNativeModule.forwardMessage(
+      params.originalMessageJson,
+      params.newRecipient,
+      priority
     );
     return messageId;
   }
@@ -2240,6 +2262,33 @@ export class OfflineProtocol {
       content,
       priority || null,
       replyToMsg || null
+    );
+  }
+
+  /**
+   * Forwards a message to all members of a group with forwarding attribution.
+   *
+   * The message content is encrypted via MLS for the group and fan-out follows
+   * the same path as regular group messages.
+   *
+   * @param params - Forward to group parameters
+   * @returns Array of per-member message IDs
+   */
+  async meshForwardMessageToGroup(params: ForwardMessageToGroupParams): Promise<string[]> {
+    let priorityStr: string | null = null;
+    if (params.priority != null) {
+      const map: Record<number, string> = {
+        [MessagePriority.Low]: 'low',
+        [MessagePriority.Medium]: 'medium',
+        [MessagePriority.High]: 'high',
+        [MessagePriority.Critical]: 'critical',
+      };
+      priorityStr = map[params.priority] ?? null;
+    }
+    return await OfflineProtocolNativeModule.meshForwardMessageToGroup(
+      params.originalMessageJson,
+      params.groupId,
+      priorityStr
     );
   }
 

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -320,6 +320,47 @@ export interface ProtocolConfig {
 export type TransportType = 'ble' | 'internet' | 'wifiDirect';
 
 /**
+ * Forwarding attribution (present when a message was forwarded).
+ *
+ * **Trust model:** This is a display-level hint, not a cryptographic proof.
+ * UI layers should not rely on it for access-control or security decisions.
+ */
+export interface ForwardInfo {
+  /** The original sender's user ID. */
+  original_sender: string;
+  /** The original message ID. */
+  original_message_id: string;
+  /** The original timestamp (wall-clock ms). */
+  original_timestamp: number;
+  /** Number of times this message has been forwarded. */
+  forward_count: number;
+}
+
+/**
+ * Parameters for forwarding a message to a new recipient
+ */
+export interface ForwardMessageParams {
+  /** The original message JSON (as received from the protocol) */
+  originalMessageJson: string;
+  /** New recipient's user ID */
+  newRecipient: string;
+  /** Message priority (optional, defaults to Medium) */
+  priority?: MessagePriority;
+}
+
+/**
+ * Parameters for forwarding a message to a group
+ */
+export interface ForwardMessageToGroupParams {
+  /** The original message JSON (as received from the protocol) */
+  originalMessageJson: string;
+  /** Group ID to forward to */
+  groupId: string;
+  /** Message priority (optional, defaults to Medium) */
+  priority?: MessagePriority;
+}
+
+/**
  * Parameters for sending a message
  */
 export interface SendMessageParams {
@@ -420,6 +461,8 @@ export interface MessageSentEvent extends BaseEvent {
   timestamp: number;
   /** Lamport logical clock value for causal ordering (0 for legacy messages). */
   lamport_clock: number;
+  /** Forwarding attribution (present when this is a forwarded message). */
+  forward_info?: ForwardInfo;
 }
 
 /**
@@ -450,6 +493,8 @@ export interface MessageReceivedEvent extends BaseEvent {
     height?: number;
     thumbnail_base64?: string;
   };
+  /** Forwarding attribution (present when this is a forwarded message). */
+  forward_info?: ForwardInfo;
 }
 
 /**
@@ -721,6 +766,8 @@ export interface GroupMessageReceivedEvent extends BaseEvent {
   timestamp: string;
   message_id: string;
   reply_to_msg?: string;
+  /** Forwarding attribution (present when this is a forwarded message). */
+  forward_info?: ForwardInfo;
 }
 
 /**

--- a/crates/offline-protocol-core/src/lib.rs
+++ b/crates/offline-protocol-core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod service;
 pub mod types;
 
 pub use error::{Error, Result};
-pub use message::{ContentType, MediaMetadata, Message, MessageId, MessagePriority};
+pub use message::{ContentType, ForwardInfo, MediaMetadata, Message, MessageId, MessagePriority};
 pub use service::{ServiceDescriptor, ServiceId};
 pub use types::{
     AppId, HopCount, LamportClock, LocalInstant, Timestamp, UserId, WallClockTimestamp, TTL,

--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -139,7 +139,7 @@ pub struct MediaMetadata {
 }
 
 /// Information about a forwarded message.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ForwardInfo {
     /// The original sender of the message.
     pub original_sender: UserId,
@@ -149,6 +149,30 @@ pub struct ForwardInfo {
     pub original_timestamp: Timestamp,
     /// Number of times this message has been forwarded.
     pub forward_count: u32,
+}
+
+impl ForwardInfo {
+    /// Creates `ForwardInfo` from a message being forwarded.
+    ///
+    /// If the message was already forwarded, the original attribution is preserved
+    /// and `forward_count` is incremented. Otherwise, the message's sender becomes
+    /// the original sender with `forward_count = 1`.
+    pub fn from_message(message: &Message) -> Self {
+        match &message.forwarded_from {
+            Some(existing) => ForwardInfo {
+                original_sender: existing.original_sender.clone(),
+                original_message_id: existing.original_message_id.clone(),
+                original_timestamp: existing.original_timestamp,
+                forward_count: existing.forward_count + 1,
+            },
+            None => ForwardInfo {
+                original_sender: message.sender.clone(),
+                original_message_id: message.id.clone(),
+                original_timestamp: message.timestamp,
+                forward_count: 1,
+            },
+        }
+    }
 }
 
 /// Message priority levels.
@@ -651,29 +675,34 @@ mod tests {
 
     #[test]
     fn test_forward_chain_increment() {
-        use crate::types::Timestamp;
+        // Simulate: Alice sends original → Bob forwards (count=1) → Charlie forwards (count=2)
+        let original_msg = Message::builder(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+        )
+        .content("Hello from Alice")
+        .build();
 
-        // Simulate: Alice → Bob → Charlie (forward count goes 1 → 2)
-        let original_id = MessageId::new();
-        let original_ts = Timestamp::now();
-
-        let first_forward = ForwardInfo {
-            original_sender: UserId::new("alice").unwrap(),
-            original_message_id: original_id.clone(),
-            original_timestamp: original_ts,
-            forward_count: 1,
-        };
+        // Bob forwards to Charlie — ForwardInfo::from_message creates attribution
+        let first_forward = ForwardInfo::from_message(&original_msg);
+        assert_eq!(first_forward.original_sender.as_str(), "alice");
+        assert_eq!(first_forward.original_message_id, original_msg.id);
+        assert_eq!(first_forward.forward_count, 1);
 
         // Charlie forwards to Dave — should carry original_sender and increment count
-        let second_forward = ForwardInfo {
-            original_sender: first_forward.original_sender.clone(),
-            original_message_id: first_forward.original_message_id.clone(),
-            original_timestamp: first_forward.original_timestamp,
-            forward_count: first_forward.forward_count + 1,
-        };
+        let forwarded_msg = Message::builder(
+            UserId::new("bob").unwrap(),
+            UserId::new("charlie").unwrap(),
+            AppId::new("test-app").unwrap(),
+        )
+        .content("Hello from Alice")
+        .forwarded_from(first_forward)
+        .build();
 
+        let second_forward = ForwardInfo::from_message(&forwarded_msg);
         assert_eq!(second_forward.original_sender.as_str(), "alice");
         assert_eq!(second_forward.forward_count, 2);
-        assert_eq!(second_forward.original_message_id, original_id);
+        assert_eq!(second_forward.original_message_id, original_msg.id);
     }
 }

--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -139,6 +139,11 @@ pub struct MediaMetadata {
 }
 
 /// Information about a forwarded message.
+///
+/// **Trust model:** `ForwardInfo` is an unverified attribution hint, not a
+/// cryptographic proof. A malicious client can forge the `original_sender` or
+/// reset `forward_count`. UI layers should treat this as a display-level hint
+/// and must not rely on it for access-control or security decisions.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ForwardInfo {
     /// The original sender of the message.

--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -138,6 +138,19 @@ pub struct MediaMetadata {
     pub thumbnail_base64: Option<String>,
 }
 
+/// Information about a forwarded message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForwardInfo {
+    /// The original sender of the message.
+    pub original_sender: UserId,
+    /// The original message ID.
+    pub original_message_id: MessageId,
+    /// The original timestamp (wall-clock, for display).
+    pub original_timestamp: Timestamp,
+    /// Number of times this message has been forwarded.
+    pub forward_count: u32,
+}
+
 /// Message priority levels.
 #[derive(
     Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
@@ -227,6 +240,10 @@ pub struct Message {
     #[serde(default)]
     pub reply_to_msg: Option<MessageId>,
 
+    /// Forwarding attribution (present when this message was forwarded from another user).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forwarded_from: Option<ForwardInfo>,
+
     /// Transport-verified peer identity.
     ///
     /// Set by the transport layer when a message is received, binding the message
@@ -282,6 +299,7 @@ impl Message {
             metadata: HashMap::new(),
             requires_ack: true,
             reply_to_msg: None,
+            forwarded_from: None,
             transport_peer_id: None,
         }
     }
@@ -392,6 +410,7 @@ pub struct MessageBuilder {
     metadata: HashMap<String, String>,
     requires_ack: bool,
     reply_to_msg: Option<MessageId>,
+    forwarded_from: Option<ForwardInfo>,
 }
 
 impl MessageBuilder {
@@ -410,6 +429,7 @@ impl MessageBuilder {
             metadata: HashMap::new(),
             requires_ack: true,
             reply_to_msg: None,
+            forwarded_from: None,
         }
     }
 
@@ -461,6 +481,12 @@ impl MessageBuilder {
         self
     }
 
+    /// Sets forwarding attribution on the message.
+    pub fn forwarded_from(mut self, info: ForwardInfo) -> Self {
+        self.forwarded_from = Some(info);
+        self
+    }
+
     /// Sets the Lamport clock value for this message.
     pub fn lamport_clock(mut self, clock: LamportClock) -> Self {
         self.lamport_clock = clock;
@@ -486,6 +512,7 @@ impl MessageBuilder {
             metadata: self.metadata,
             requires_ack: self.requires_ack,
             reply_to_msg: self.reply_to_msg,
+            forwarded_from: self.forwarded_from,
             transport_peer_id: None,
         }
     }
@@ -574,5 +601,79 @@ mod tests {
         assert_eq!(MessagePriority::Medium.score(), 2);
         assert_eq!(MessagePriority::High.score(), 3);
         assert_eq!(MessagePriority::Critical.score(), 4);
+    }
+
+    #[test]
+    fn test_forward_info_serialization() {
+        use crate::types::Timestamp;
+
+        let info = ForwardInfo {
+            original_sender: UserId::new("alice").unwrap(),
+            original_message_id: MessageId::new(),
+            original_timestamp: Timestamp::now(),
+            forward_count: 1,
+        };
+
+        let msg = Message::builder(
+            UserId::new("bob").unwrap(),
+            UserId::new("charlie").unwrap(),
+            AppId::new("test-app").unwrap(),
+        )
+        .content("Forwarded message")
+        .forwarded_from(info.clone())
+        .build();
+
+        assert!(msg.forwarded_from.is_some());
+        let fwd = msg.forwarded_from.as_ref().unwrap();
+        assert_eq!(fwd.original_sender.as_str(), "alice");
+        assert_eq!(fwd.forward_count, 1);
+
+        // Round-trip through JSON
+        let json = msg.to_json().unwrap();
+        let deserialized = Message::from_json(&json).unwrap();
+        let fwd2 = deserialized.forwarded_from.as_ref().unwrap();
+        assert_eq!(fwd2.original_sender.as_str(), "alice");
+        assert_eq!(fwd2.forward_count, 1);
+    }
+
+    #[test]
+    fn test_backward_compat_no_forwarded_from() {
+        // Old messages without forwarded_from should deserialize with None
+        let msg = create_test_message();
+        let json = msg.to_json().unwrap();
+
+        // Verify forwarded_from is not in the JSON (skip_serializing_if = None)
+        assert!(!json.contains("forwarded_from"));
+
+        let deserialized = Message::from_json(&json).unwrap();
+        assert!(deserialized.forwarded_from.is_none());
+    }
+
+    #[test]
+    fn test_forward_chain_increment() {
+        use crate::types::Timestamp;
+
+        // Simulate: Alice → Bob → Charlie (forward count goes 1 → 2)
+        let original_id = MessageId::new();
+        let original_ts = Timestamp::now();
+
+        let first_forward = ForwardInfo {
+            original_sender: UserId::new("alice").unwrap(),
+            original_message_id: original_id.clone(),
+            original_timestamp: original_ts,
+            forward_count: 1,
+        };
+
+        // Charlie forwards to Dave — should carry original_sender and increment count
+        let second_forward = ForwardInfo {
+            original_sender: first_forward.original_sender.clone(),
+            original_message_id: first_forward.original_message_id.clone(),
+            original_timestamp: first_forward.original_timestamp,
+            forward_count: first_forward.forward_count + 1,
+        };
+
+        assert_eq!(second_forward.original_sender.as_str(), "alice");
+        assert_eq!(second_forward.forward_count, 2);
+        assert_eq!(second_forward.original_message_id, original_id);
     }
 }

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -1371,12 +1371,7 @@ impl OfflineProtocol {
                     e
                 ))
             })?;
-        let core_priority = priority.map(|p| match p {
-            MessagePriority::Low => CorePriority::Low,
-            MessagePriority::Medium => CorePriority::Medium,
-            MessagePriority::High => CorePriority::High,
-            MessagePriority::Critical => CorePriority::Critical,
-        });
+        let core_priority = priority.map(|p| p.into());
         let mut protocol = self.lock_inner()?;
         let message_id = protocol
             .forward_message(&original, &new_recipient, core_priority)
@@ -3417,12 +3412,7 @@ impl OfflineProtocol {
         priority: Option<MessagePriority>,
         reply_to_msg: Option<String>,
     ) -> Result<Vec<String>, ProtocolError> {
-        let core_priority = priority.map(|p| match p {
-            MessagePriority::Low => CorePriority::Low,
-            MessagePriority::Medium => CorePriority::Medium,
-            MessagePriority::High => CorePriority::High,
-            MessagePriority::Critical => CorePriority::Critical,
-        });
+        let core_priority = priority.map(|p| p.into());
         let mut guard = self.lock_inner()?;
         guard
             .send_group_message(&group_id, &content, core_priority, reply_to_msg.as_deref())
@@ -3444,12 +3434,7 @@ impl OfflineProtocol {
                     e
                 ))
             })?;
-        let core_priority = priority.map(|p| match p {
-            MessagePriority::Low => CorePriority::Low,
-            MessagePriority::Medium => CorePriority::Medium,
-            MessagePriority::High => CorePriority::High,
-            MessagePriority::Critical => CorePriority::Critical,
-        });
+        let core_priority = priority.map(|p| p.into());
         let mut guard = self.lock_inner()?;
         guard
             .forward_message_to_group(&original, &group_id, core_priority)

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -73,6 +73,15 @@ fn recover_rwlock_write<'a, T>(
     })
 }
 
+/// Forwarding attribution for forwarded messages (UniFFI dictionary).
+#[derive(Debug, Clone)]
+pub struct ForwardInfo {
+    pub original_sender: String,
+    pub original_message_id: String,
+    pub original_timestamp: i64,
+    pub forward_count: u32,
+}
+
 /// Per-peer establishment state (for SessionNotReady and get_establishment_state).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EstablishmentState {
@@ -1348,12 +1357,39 @@ impl OfflineProtocol {
         Ok(message_id.as_str())
     }
 
+    /// Forwards a message to a new recipient with original sender attribution.
+    pub fn forward_message(
+        &self,
+        original_message_json: String,
+        new_recipient: String,
+        priority: Option<MessagePriority>,
+    ) -> Result<String, ProtocolError> {
+        let original: offline_protocol_core::Message = serde_json::from_str(&original_message_json)
+            .map_err(|e| {
+                ProtocolError::InvalidConfiguration(format!(
+                    "Failed to parse original message JSON: {}",
+                    e
+                ))
+            })?;
+        let core_priority = priority.map(|p| match p {
+            MessagePriority::Low => CorePriority::Low,
+            MessagePriority::Medium => CorePriority::Medium,
+            MessagePriority::High => CorePriority::High,
+            MessagePriority::Critical => CorePriority::Critical,
+        });
+        let mut protocol = self.lock_inner()?;
+        let message_id = protocol
+            .forward_message(&original, &new_recipient, core_priority)
+            .map_err(ProtocolError::from)?;
+        Ok(message_id.as_str())
+    }
+
     /// Receives the next message (returns JSON string or None)
     pub fn receive_message(&self) -> Option<String> {
         let mut protocol = recover_mutex(&self.inner, "inner");
         protocol.receive_message().and_then(|msg| {
             let msg_id = msg.id.as_str().to_string();
-            match serde_json::to_string(&serde_json::json!({
+            let mut json_value = serde_json::json!({
                 "id": msg.id.as_str(),
                 "sender": msg.sender.as_str(),
                 "recipient": msg.recipient.as_str(),
@@ -1362,7 +1398,16 @@ impl OfflineProtocol {
                 "lamport_clock": msg.lamport_clock.value(),
                 "hop_count": msg.hop_count.value(),
                 "priority": format!("{:?}", msg.priority),
-            })) {
+            });
+            if let Some(ref fwd) = msg.forwarded_from {
+                json_value["forwarded_from"] = serde_json::json!({
+                    "original_sender": fwd.original_sender.as_str(),
+                    "original_message_id": fwd.original_message_id.as_str(),
+                    "original_timestamp": fwd.original_timestamp.as_millis(),
+                    "forward_count": fwd.forward_count,
+                });
+            }
+            match serde_json::to_string(&json_value) {
                 Ok(json) => Some(json),
                 Err(e) => {
                     tracing::error!(
@@ -3381,6 +3426,33 @@ impl OfflineProtocol {
         let mut guard = self.lock_inner()?;
         guard
             .send_group_message(&group_id, &content, core_priority, reply_to_msg.as_deref())
+            .map(|ids| ids.into_iter().map(|id| id.as_str().to_string()).collect())
+            .map_err(|e| ProtocolError::SendFailed(e.to_string()))
+    }
+
+    /// Forward a message to all members of a group with forwarding attribution.
+    pub fn forward_message_to_group(
+        &self,
+        original_message_json: String,
+        group_id: String,
+        priority: Option<MessagePriority>,
+    ) -> Result<Vec<String>, ProtocolError> {
+        let original: offline_protocol_core::Message = serde_json::from_str(&original_message_json)
+            .map_err(|e| {
+                ProtocolError::InvalidConfiguration(format!(
+                    "Failed to parse original message JSON: {}",
+                    e
+                ))
+            })?;
+        let core_priority = priority.map(|p| match p {
+            MessagePriority::Low => CorePriority::Low,
+            MessagePriority::Medium => CorePriority::Medium,
+            MessagePriority::High => CorePriority::High,
+            MessagePriority::Critical => CorePriority::Critical,
+        });
+        let mut guard = self.lock_inner()?;
+        guard
+            .forward_message_to_group(&original, &group_id, core_priority)
             .map(|ids| ids.into_iter().map(|id| id.as_str().to_string()).collect())
             .map_err(|e| ProtocolError::SendFailed(e.to_string()))
     }

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -73,15 +73,6 @@ fn recover_rwlock_write<'a, T>(
     })
 }
 
-/// Forwarding attribution for forwarded messages (UniFFI dictionary).
-#[derive(Debug, Clone)]
-pub struct ForwardInfo {
-    pub original_sender: String,
-    pub original_message_id: String,
-    pub original_timestamp: i64,
-    pub forward_count: u32,
-}
-
 /// Per-peer establishment state (for SessionNotReady and get_establishment_state).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EstablishmentState {

--- a/crates/offline-protocol-uniffi/src/offline_protocol.udl
+++ b/crates/offline-protocol-uniffi/src/offline_protocol.udl
@@ -80,6 +80,14 @@ dictionary MlsGroupInfo {
     u64 last_activity_ms;
 };
 
+// Forwarding attribution for forwarded messages
+dictionary ForwardInfo {
+    string original_sender;
+    string original_message_id;
+    i64 original_timestamp;
+    u32 forward_count;
+};
+
 // Establishment state for a peer (for SessionNotReady and get_establishment_state)
 enum EstablishmentState {
     "NoKeyPackage",
@@ -427,9 +435,13 @@ interface OfflineProtocol {
     // Messaging
     [Throws=ProtocolError]
     string send_message(string recipient, string content, MessagePriority priority, string? reply_to_msg);
-    
+
+    // Forward a message to a new recipient (preserves original sender attribution)
+    [Throws=ProtocolError]
+    string forward_message(string original_message_json, string new_recipient, MessagePriority? priority);
+
     string? receive_message();
-    
+
     // Connection requests (transport-agnostic, routed via DORS)
     [Throws=ProtocolError]
     string send_connection_request(string recipient, string sender_name, sequence<u8>? key_package);
@@ -812,6 +824,10 @@ interface OfflineProtocol {
     // Send an MLS-encrypted message to all group members
     [Throws=ProtocolError]
     sequence<string> send_group_message(string group_id, string content, MessagePriority? priority, string? reply_to_msg);
+
+    // Forward a message to all members of a group (preserves original sender attribution)
+    [Throws=ProtocolError]
+    sequence<string> forward_message_to_group(string original_message_json, string group_id, MessagePriority? priority);
 
     // Invite a user to an MLS group
     [Throws=ProtocolError]

--- a/crates/offline-protocol-uniffi/src/offline_protocol.udl
+++ b/crates/offline-protocol-uniffi/src/offline_protocol.udl
@@ -80,14 +80,6 @@ dictionary MlsGroupInfo {
     u64 last_activity_ms;
 };
 
-// Forwarding attribution for forwarded messages
-dictionary ForwardInfo {
-    string original_sender;
-    string original_message_id;
-    i64 original_timestamp;
-    u32 forward_count;
-};
-
 // Establishment state for a peer (for SessionNotReady and get_establishment_state)
 enum EstablishmentState {
     "NoKeyPackage",

--- a/crates/offline-protocol/src/constants.rs
+++ b/crates/offline-protocol/src/constants.rs
@@ -68,6 +68,10 @@ pub const TRANSPORT_PREFERENCE_INTERNET: &str = "internet";
 /// Metadata key carrying the original content type on file-chunk messages.
 pub const ORIGINAL_CONTENT_TYPE_KEY: &str = "original_content_type";
 
+/// Maximum number of times a message may be forwarded. Prevents unbounded
+/// forwarding chains from malicious or buggy clients.
+pub const MAX_FORWARD_COUNT: u32 = 100;
+
 /// Default route quality assigned when learning a route from a relayed message.
 /// Conservative (0.5) because the transport layer doesn't expose the immediate
 /// peer identity, so the route may be sub-optimal for multi-hop return paths.

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -167,6 +167,17 @@ pub struct ForwardInfoEvent {
     pub forward_count: u32,
 }
 
+impl From<&offline_protocol_core::ForwardInfo> for ForwardInfoEvent {
+    fn from(fwd: &offline_protocol_core::ForwardInfo) -> Self {
+        Self {
+            original_sender: fwd.original_sender.as_str().to_string(),
+            original_message_id: fwd.original_message_id.as_str(),
+            original_timestamp: fwd.original_timestamp.as_millis(),
+            forward_count: fwd.forward_count,
+        }
+    }
+}
+
 /// Events that can occur in the protocol.
 ///
 /// Note: This type implements a custom Debug that redacts sensitive fields
@@ -531,8 +542,11 @@ pub enum Event {
         /// Unique message identifier.
         message_id: String,
         /// Optional reply-to message ID.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         reply_to_msg: Option<String>,
+        /// Forwarding attribution (present when this is a forwarded message).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        forward_info: Option<ForwardInfoEvent>,
     },
 
     /// A member was added to a group (from relay).
@@ -831,12 +845,7 @@ impl Event {
             MessagePriority::Critical => "critical",
         };
 
-        let forward_info = message.forwarded_from.as_ref().map(|fwd| ForwardInfoEvent {
-            original_sender: fwd.original_sender.as_str().to_string(),
-            original_message_id: fwd.original_message_id.as_str(),
-            original_timestamp: fwd.original_timestamp.as_millis(),
-            forward_count: fwd.forward_count,
-        });
+        let forward_info = message.forwarded_from.as_ref().map(ForwardInfoEvent::from);
 
         Self::MessageSent {
             message_id: message.id.as_str(),
@@ -1211,6 +1220,7 @@ impl Event {
         timestamp: String,
         message_id: String,
         reply_to_msg: Option<String>,
+        forward_info: Option<ForwardInfoEvent>,
     ) -> Self {
         Self::GroupMessageReceived {
             group_id,
@@ -1219,6 +1229,7 @@ impl Event {
             timestamp,
             message_id,
             reply_to_msg,
+            forward_info,
         }
     }
 
@@ -1888,12 +1899,14 @@ impl fmt::Debug for Event {
                 group_id,
                 sender: _,
                 content,
+                forward_info,
                 ..
             } => f
                 .debug_struct("GroupMessageReceived")
                 .field("group_id", group_id)
                 .field("sender", &"[REDACTED]")
                 .field("content", &format!("[REDACTED {} bytes]", content.len()))
+                .field("forward_info", &forward_info.is_some())
                 .finish(),
             Self::GroupMemberAdded {
                 group_id,

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -154,6 +154,19 @@ pub enum DecryptionFailureCode {
     Unknown,
 }
 
+/// Forwarding attribution in events (mirrors `ForwardInfo` from core).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForwardInfoEvent {
+    /// The original sender of the message.
+    pub original_sender: String,
+    /// The original message ID.
+    pub original_message_id: String,
+    /// The original timestamp (wall-clock ms).
+    pub original_timestamp: i64,
+    /// Number of times this message has been forwarded.
+    pub forward_count: u32,
+}
+
 /// Events that can occur in the protocol.
 ///
 /// Note: This type implements a custom Debug that redacts sensitive fields
@@ -180,6 +193,9 @@ pub enum Event {
         /// Lamport logical clock value for causal ordering.
         #[serde(default)]
         lamport_clock: u64,
+        /// Forwarding attribution (present when this is a forwarded message).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        forward_info: Option<ForwardInfoEvent>,
     },
 
     /// A message was received.
@@ -210,6 +226,9 @@ pub enum Event {
         /// Media metadata (present for non-text content).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         media_metadata: Option<MediaMetadata>,
+        /// Forwarding attribution (present when this is a forwarded message).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        forward_info: Option<ForwardInfoEvent>,
     },
 
     /// A message was successfully delivered (ACK received).
@@ -812,6 +831,13 @@ impl Event {
             MessagePriority::Critical => "critical",
         };
 
+        let forward_info = message.forwarded_from.as_ref().map(|fwd| ForwardInfoEvent {
+            original_sender: fwd.original_sender.as_str().to_string(),
+            original_message_id: fwd.original_message_id.as_str(),
+            original_timestamp: fwd.original_timestamp.as_millis(),
+            forward_count: fwd.forward_count,
+        });
+
         Self::MessageSent {
             message_id: message.id.as_str(),
             sender: message.sender.as_str().to_string(),
@@ -821,6 +847,7 @@ impl Event {
             requires_ack: message.requires_ack,
             timestamp: message.timestamp.as_millis(),
             lamport_clock: message.lamport_clock.value(),
+            forward_info,
         }
     }
 
@@ -1510,6 +1537,7 @@ impl fmt::Debug for Event {
                 requires_ack,
                 timestamp,
                 lamport_clock,
+                forward_info,
             } => f
                 .debug_struct("MessageSent")
                 .field("message_id", message_id)
@@ -1520,6 +1548,7 @@ impl fmt::Debug for Event {
                 .field("requires_ack", requires_ack)
                 .field("timestamp", timestamp)
                 .field("lamport_clock", lamport_clock)
+                .field("forward_info", &forward_info.is_some())
                 .finish(),
             Self::MessageReceived {
                 message_id,
@@ -1533,6 +1562,7 @@ impl fmt::Debug for Event {
                 reply_to_msg: _,
                 content_type,
                 media_metadata: _,
+                forward_info,
             } => f
                 .debug_struct("MessageReceived")
                 .field("message_id", message_id)
@@ -1545,6 +1575,7 @@ impl fmt::Debug for Event {
                 .field("lamport_clock", lamport_clock)
                 .field("reply_to_msg", &"[REDACTED]")
                 .field("content_type", content_type)
+                .field("forward_info", &forward_info.is_some())
                 .finish(),
             Self::MessageDelivered {
                 message_id,
@@ -2083,6 +2114,7 @@ mod tests {
                 requires_ack,
                 timestamp,
                 lamport_clock,
+                forward_info,
             } => {
                 assert_eq!(message_id, message.id.as_str());
                 assert_eq!(sender, message.sender.as_str());
@@ -2092,6 +2124,7 @@ mod tests {
                 assert!(requires_ack);
                 assert_eq!(timestamp, message.timestamp.as_millis());
                 assert_eq!(lamport_clock, message.lamport_clock.value());
+                assert!(forward_info.is_none());
             }
             _ => panic!("Wrong event type"),
         }

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -1275,6 +1275,14 @@ impl OfflineProtocol {
 
         let forward_info = ForwardInfo::from_message(original_message);
 
+        if forward_info.forward_count > crate::constants::MAX_FORWARD_COUNT {
+            return Err(Error::Other(format!(
+                "Forward count {} exceeds maximum of {}",
+                forward_info.forward_count,
+                crate::constants::MAX_FORWARD_COUNT,
+            )));
+        }
+
         self.send_group_message_inner(
             group_id,
             original_message.content.as_bytes(),
@@ -1963,6 +1971,7 @@ impl OfflineProtocol {
     /// from the relay server for a group we have MLS state for. If MLS
     /// decryption fails or the content is not ciphertext, falls back to
     /// emitting the raw content.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn handle_relay_group_message_with_mls(
         &mut self,
         group_id: &str,
@@ -1971,7 +1980,12 @@ impl OfflineProtocol {
         timestamp: &str,
         message_id: &str,
         reply_to_msg: Option<String>,
+        forward_info: Option<offline_protocol_core::ForwardInfo>,
     ) {
+        let forward_info_event = forward_info
+            .as_ref()
+            .map(crate::events::ForwardInfoEvent::from);
+
         // Attempt base64 decode — if it fails, the content is plaintext (legacy)
         let ciphertext_bytes = match base64_decode(content) {
             Ok(bytes) => bytes,
@@ -1984,7 +1998,7 @@ impl OfflineProtocol {
                     timestamp.to_string(),
                     message_id.to_string(),
                     reply_to_msg,
-                    None,
+                    forward_info_event,
                 ));
                 return;
             }
@@ -2003,7 +2017,7 @@ impl OfflineProtocol {
                         timestamp.to_string(),
                         message_id.to_string(),
                         reply_to_msg,
-                        None,
+                        forward_info_event,
                     ));
                     return;
                 }
@@ -2036,7 +2050,7 @@ impl OfflineProtocol {
                     timestamp.to_string(),
                     message_id.to_string(),
                     reply_to_msg,
-                    None,
+                    forward_info_event,
                 ));
             }
             None => {
@@ -2051,7 +2065,7 @@ impl OfflineProtocol {
                     timestamp.to_string(),
                     message_id.to_string(),
                     reply_to_msg,
-                    None,
+                    forward_info_event,
                 ));
             }
         }

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -12,7 +12,7 @@
 use crate::protocol::{base64_decode, base64_encode, internal_prefixes, OfflineProtocol};
 use crate::{Error, Event, Result};
 use chrono::Utc;
-use offline_protocol_core::{Message, MessageId, MessagePriority};
+use offline_protocol_core::{ForwardInfo, Message, MessageId, MessagePriority};
 use offline_protocol_transport::TransportType;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -1355,6 +1355,142 @@ impl OfflineProtocol {
                 succeeded_members,
             ));
         }
+
+        Ok(message_ids)
+    }
+
+    /// Forwards a message to all members of a group with forwarding attribution.
+    ///
+    /// Similar to `send_group_message` but attaches `ForwardInfo` to preserve
+    /// the original sender and forward count. The message content is encrypted
+    /// via MLS for the group and fan-out follows the same path as regular
+    /// group messages.
+    pub fn forward_message_to_group(
+        &mut self,
+        original_message: &Message,
+        group_id: &str,
+        priority: Option<MessagePriority>,
+    ) -> Result<Vec<MessageId>> {
+        let priority = priority.unwrap_or(MessagePriority::Medium);
+
+        // Build ForwardInfo
+        let forward_info = match &original_message.forwarded_from {
+            Some(existing) => ForwardInfo {
+                original_sender: existing.original_sender.clone(),
+                original_message_id: existing.original_message_id.clone(),
+                original_timestamp: existing.original_timestamp,
+                forward_count: existing.forward_count + 1,
+            },
+            None => ForwardInfo {
+                original_sender: original_message.sender.clone(),
+                original_message_id: original_message.id.clone(),
+                original_timestamp: original_message.timestamp,
+                forward_count: 1,
+            },
+        };
+
+        // Encrypt content for the group
+        let encrypted = {
+            let mls_guard = self.read_mls_guard()?;
+            let gid = offline_protocol_mls::GroupId::new(group_id);
+            mls_guard.encrypt_for_group(&gid, original_message.content.as_bytes())?
+        };
+
+        let members = match self.group_mesh.members.get(group_id) {
+            Some(m) => m.clone(),
+            None => {
+                let mls_guard = self.read_mls_guard()?;
+                let gid = offline_protocol_mls::GroupId::new(group_id);
+                let info = mls_guard
+                    .get_group_info(&gid)?
+                    .ok_or_else(|| Error::Other(format!("Group not found: {}", group_id)))?;
+                info.members.clone()
+            }
+        };
+
+        if !self.group_mesh.members.contains_key(group_id) {
+            self.group_mesh
+                .members
+                .insert(group_id.to_string(), members.clone());
+        }
+
+        let ciphertext_b64 = base64_encode(&encrypted.ciphertext);
+        let epoch = encrypted.epoch;
+        let self_id = self.config.user_id.clone();
+
+        // Attach forward_info as JSON in the payload metadata
+        let forward_info_json = serde_json::to_string(&forward_info)
+            .map_err(|e| Error::Other(format!("Serialize forward info: {}", e)))?;
+
+        let msg_payload = GroupMlsMessagePayload {
+            group_id: group_id.to_string(),
+            ciphertext: ciphertext_b64,
+            epoch,
+            reply_to: None,
+        };
+        let base_content = format!(
+            "{}{}",
+            internal_prefixes::GROUP_MLS_MSG,
+            serde_json::to_string(&msg_payload)
+                .map_err(|e| Error::Other(format!("Serialize group message: {}", e)))?
+        );
+
+        let mut message_ids = Vec::new();
+        let mut failed_members = Vec::new();
+        let mut succeeded_members = Vec::new();
+
+        for member in &members {
+            if member == &self_id {
+                continue;
+            }
+            match self.send_internal_message(member, base_content.clone(), priority) {
+                Ok(mid) => {
+                    message_ids.push(mid);
+                    succeeded_members.push(member.clone());
+                }
+                Err(e) => {
+                    warn!(
+                        group_id = %group_id,
+                        member = %member,
+                        error = %e,
+                        "Failed to forward group message to member"
+                    );
+                    failed_members.push(member.clone());
+                }
+            }
+        }
+
+        let member_count = succeeded_members.len() as u32;
+        let had_recipients = members.iter().any(|m| m != &self_id);
+        if had_recipients && message_ids.is_empty() {
+            self.emit_event(Event::group_message_partial_failure(
+                group_id.to_string(),
+                failed_members,
+                succeeded_members,
+            ));
+            return Err(Error::Other(
+                "All group forward message sends failed".to_string(),
+            ));
+        }
+
+        if failed_members.is_empty() {
+            self.emit_event(Event::group_message_sent(
+                group_id.to_string(),
+                message_ids.iter().map(|m| m.as_str().to_string()).collect(),
+                member_count,
+            ));
+        } else {
+            self.emit_event(Event::group_message_partial_failure(
+                group_id.to_string(),
+                failed_members,
+                succeeded_members,
+            ));
+        }
+
+        // Note: forward_info is embedded in the encrypted group payload metadata.
+        // The receiving side will see it when decrypting the group message.
+        // For now, the forward_info_json is kept for future per-member metadata support.
+        let _ = forward_info_json;
 
         Ok(message_ids)
     }

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -111,8 +111,11 @@ pub(crate) struct GroupMlsMessagePayload {
     /// MLS epoch at which the message was encrypted.
     pub(crate) epoch: u64,
     /// Optional reply-to message ID.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) reply_to: Option<String>,
+    /// Optional forwarding attribution (present when message was forwarded).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) forward_info: Option<offline_protocol_core::ForwardInfo>,
 }
 
 /// Payload for MLS Welcome messages (group invites) sent via mesh.
@@ -341,6 +344,10 @@ impl OfflineProtocol {
             let msg_id = message.id.as_str().to_string();
             let timestamp = chrono::Utc::now().to_rfc3339();
             info!(group_id = %payload.group_id, "Decrypted mesh group message");
+            let forward_info_event = payload
+                .forward_info
+                .as_ref()
+                .map(crate::events::ForwardInfoEvent::from);
             self.emit_event(Event::group_message_received(
                 payload.group_id,
                 sender.to_string(),
@@ -348,6 +355,7 @@ impl OfflineProtocol {
                 timestamp,
                 msg_id,
                 payload.reply_to,
+                forward_info_event,
             ));
         }
     }
@@ -1292,6 +1300,7 @@ impl OfflineProtocol {
             ciphertext: ciphertext_b64,
             epoch,
             reply_to: reply_to_msg.map(|s| s.to_string()),
+            forward_info: None,
         };
         let base_content = format!(
             "{}{}",
@@ -1373,21 +1382,16 @@ impl OfflineProtocol {
     ) -> Result<Vec<MessageId>> {
         let priority = priority.unwrap_or(MessagePriority::Medium);
 
+        // Reject content that starts with an internal control prefix to prevent
+        // injection of protocol-level messages through the forwarding API.
+        if Self::is_internal_prefix(&original_message.content) {
+            return Err(Error::Other(
+                "Cannot forward a message with reserved internal prefix content".to_string(),
+            ));
+        }
+
         // Build ForwardInfo
-        let forward_info = match &original_message.forwarded_from {
-            Some(existing) => ForwardInfo {
-                original_sender: existing.original_sender.clone(),
-                original_message_id: existing.original_message_id.clone(),
-                original_timestamp: existing.original_timestamp,
-                forward_count: existing.forward_count + 1,
-            },
-            None => ForwardInfo {
-                original_sender: original_message.sender.clone(),
-                original_message_id: original_message.id.clone(),
-                original_timestamp: original_message.timestamp,
-                forward_count: 1,
-            },
-        };
+        let forward_info = ForwardInfo::from_message(original_message);
 
         // Encrypt content for the group
         let encrypted = {
@@ -1418,15 +1422,12 @@ impl OfflineProtocol {
         let epoch = encrypted.epoch;
         let self_id = self.config.user_id.clone();
 
-        // Attach forward_info as JSON in the payload metadata
-        let forward_info_json = serde_json::to_string(&forward_info)
-            .map_err(|e| Error::Other(format!("Serialize forward info: {}", e)))?;
-
         let msg_payload = GroupMlsMessagePayload {
             group_id: group_id.to_string(),
             ciphertext: ciphertext_b64,
             epoch,
             reply_to: None,
+            forward_info: Some(forward_info),
         };
         let base_content = format!(
             "{}{}",
@@ -1486,11 +1487,6 @@ impl OfflineProtocol {
                 succeeded_members,
             ));
         }
-
-        // Note: forward_info is embedded in the encrypted group payload metadata.
-        // The receiving side will see it when decrypting the group message.
-        // For now, the forward_info_json is kept for future per-member metadata support.
-        let _ = forward_info_json;
 
         Ok(message_ids)
     }
@@ -2052,6 +2048,7 @@ impl OfflineProtocol {
                     timestamp.to_string(),
                     message_id.to_string(),
                     reply_to_msg,
+                    None,
                 ));
                 return;
             }
@@ -2070,6 +2067,7 @@ impl OfflineProtocol {
                         timestamp.to_string(),
                         message_id.to_string(),
                         reply_to_msg,
+                        None,
                     ));
                     return;
                 }
@@ -2102,6 +2100,7 @@ impl OfflineProtocol {
                     timestamp.to_string(),
                     message_id.to_string(),
                     reply_to_msg,
+                    None,
                 ));
             }
             None => {
@@ -2116,6 +2115,7 @@ impl OfflineProtocol {
                     timestamp.to_string(),
                     message_id.to_string(),
                     reply_to_msg,
+                    None,
                 ));
             }
         }

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -203,8 +203,11 @@ pub(crate) struct RelayGroupBroadcastPayload {
     /// MLS epoch at which the message was encrypted.
     pub(crate) epoch: u64,
     /// Optional reply-to message ID.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) reply_to: Option<String>,
+    /// Optional forwarding attribution (present when message was forwarded).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) forward_info: Option<offline_protocol_core::ForwardInfo>,
 }
 
 /// A commit that arrived out-of-order and is waiting to be processed.
@@ -1241,14 +1244,64 @@ impl OfflineProtocol {
         priority: Option<MessagePriority>,
         reply_to_msg: Option<&str>,
     ) -> Result<Vec<MessageId>> {
-        let priority = priority.unwrap_or(MessagePriority::Medium);
+        self.send_group_message_inner(
+            group_id,
+            content.as_bytes(),
+            priority.unwrap_or(MessagePriority::Medium),
+            reply_to_msg,
+            None,
+        )
+    }
 
+    /// Forwards a message to all members of a group with forwarding attribution.
+    ///
+    /// Similar to `send_group_message` but attaches `ForwardInfo` to preserve
+    /// the original sender and forward count. The message content is encrypted
+    /// via MLS for the group and fan-out follows the same path as regular
+    /// group messages (including relay broadcast when available).
+    pub fn forward_message_to_group(
+        &mut self,
+        original_message: &Message,
+        group_id: &str,
+        priority: Option<MessagePriority>,
+    ) -> Result<Vec<MessageId>> {
+        // Reject content that starts with an internal control prefix to prevent
+        // injection of protocol-level messages through the forwarding API.
+        if Self::is_internal_prefix(&original_message.content) {
+            return Err(Error::Other(
+                "Cannot forward a message with reserved internal prefix content".to_string(),
+            ));
+        }
+
+        let forward_info = ForwardInfo::from_message(original_message);
+
+        self.send_group_message_inner(
+            group_id,
+            original_message.content.as_bytes(),
+            priority.unwrap_or(MessagePriority::Medium),
+            None,
+            Some(forward_info),
+        )
+    }
+
+    /// Shared implementation for sending and forwarding group messages.
+    ///
+    /// Handles MLS encryption, member list caching, relay broadcast attempt,
+    /// per-member fan-out, and event emission.
+    fn send_group_message_inner(
+        &mut self,
+        group_id: &str,
+        content_bytes: &[u8],
+        priority: MessagePriority,
+        reply_to_msg: Option<&str>,
+        forward_info: Option<ForwardInfo>,
+    ) -> Result<Vec<MessageId>> {
         // Encrypt via MLS — release the guard immediately after encryption
         // to minimize lock contention during the fan-out phase.
         let encrypted = {
             let mls_guard = self.read_mls_guard()?;
             let gid = offline_protocol_mls::GroupId::new(group_id);
-            mls_guard.encrypt_for_group(&gid, content.as_bytes())?
+            mls_guard.encrypt_for_group(&gid, content_bytes)?
         };
 
         // Read member list from cache, falling back to MLS on cache miss.
@@ -1280,9 +1333,13 @@ impl OfflineProtocol {
         // If Internet is the primary transport and the group is registered,
         // a single relay broadcast is O(1) instead of O(N) individual sends.
         if self.group_mesh.relay_synced.contains(group_id) {
-            if let Ok(mid) =
-                self.try_relay_broadcast(group_id, &ciphertext_b64, epoch, reply_to_msg)
-            {
+            if let Ok(mid) = self.try_relay_broadcast(
+                group_id,
+                &ciphertext_b64,
+                epoch,
+                reply_to_msg,
+                forward_info.clone(),
+            ) {
                 let member_count = members.iter().filter(|m| m.as_str() != self_id).count() as u32;
                 self.emit_event(Event::group_message_sent(
                     group_id.to_string(),
@@ -1294,13 +1351,13 @@ impl OfflineProtocol {
             // Relay broadcast failed — fall through to per-member fan-out
         }
 
-        // Build the internal message payload with reply_to as a proper field
+        // Build the internal message payload
         let msg_payload = GroupMlsMessagePayload {
             group_id: group_id.to_string(),
             ciphertext: ciphertext_b64,
             epoch,
             reply_to: reply_to_msg.map(|s| s.to_string()),
-            forward_info: None,
+            forward_info,
         };
         let base_content = format!(
             "{}{}",
@@ -1351,129 +1408,6 @@ impl OfflineProtocol {
         }
 
         // Emit appropriate event
-        if failed_members.is_empty() {
-            self.emit_event(Event::group_message_sent(
-                group_id.to_string(),
-                message_ids.iter().map(|m| m.as_str().to_string()).collect(),
-                member_count,
-            ));
-        } else {
-            self.emit_event(Event::group_message_partial_failure(
-                group_id.to_string(),
-                failed_members,
-                succeeded_members,
-            ));
-        }
-
-        Ok(message_ids)
-    }
-
-    /// Forwards a message to all members of a group with forwarding attribution.
-    ///
-    /// Similar to `send_group_message` but attaches `ForwardInfo` to preserve
-    /// the original sender and forward count. The message content is encrypted
-    /// via MLS for the group and fan-out follows the same path as regular
-    /// group messages.
-    pub fn forward_message_to_group(
-        &mut self,
-        original_message: &Message,
-        group_id: &str,
-        priority: Option<MessagePriority>,
-    ) -> Result<Vec<MessageId>> {
-        let priority = priority.unwrap_or(MessagePriority::Medium);
-
-        // Reject content that starts with an internal control prefix to prevent
-        // injection of protocol-level messages through the forwarding API.
-        if Self::is_internal_prefix(&original_message.content) {
-            return Err(Error::Other(
-                "Cannot forward a message with reserved internal prefix content".to_string(),
-            ));
-        }
-
-        // Build ForwardInfo
-        let forward_info = ForwardInfo::from_message(original_message);
-
-        // Encrypt content for the group
-        let encrypted = {
-            let mls_guard = self.read_mls_guard()?;
-            let gid = offline_protocol_mls::GroupId::new(group_id);
-            mls_guard.encrypt_for_group(&gid, original_message.content.as_bytes())?
-        };
-
-        let members = match self.group_mesh.members.get(group_id) {
-            Some(m) => m.clone(),
-            None => {
-                let mls_guard = self.read_mls_guard()?;
-                let gid = offline_protocol_mls::GroupId::new(group_id);
-                let info = mls_guard
-                    .get_group_info(&gid)?
-                    .ok_or_else(|| Error::Other(format!("Group not found: {}", group_id)))?;
-                info.members.clone()
-            }
-        };
-
-        if !self.group_mesh.members.contains_key(group_id) {
-            self.group_mesh
-                .members
-                .insert(group_id.to_string(), members.clone());
-        }
-
-        let ciphertext_b64 = base64_encode(&encrypted.ciphertext);
-        let epoch = encrypted.epoch;
-        let self_id = self.config.user_id.clone();
-
-        let msg_payload = GroupMlsMessagePayload {
-            group_id: group_id.to_string(),
-            ciphertext: ciphertext_b64,
-            epoch,
-            reply_to: None,
-            forward_info: Some(forward_info),
-        };
-        let base_content = format!(
-            "{}{}",
-            internal_prefixes::GROUP_MLS_MSG,
-            serde_json::to_string(&msg_payload)
-                .map_err(|e| Error::Other(format!("Serialize group message: {}", e)))?
-        );
-
-        let mut message_ids = Vec::new();
-        let mut failed_members = Vec::new();
-        let mut succeeded_members = Vec::new();
-
-        for member in &members {
-            if member == &self_id {
-                continue;
-            }
-            match self.send_internal_message(member, base_content.clone(), priority) {
-                Ok(mid) => {
-                    message_ids.push(mid);
-                    succeeded_members.push(member.clone());
-                }
-                Err(e) => {
-                    warn!(
-                        group_id = %group_id,
-                        member = %member,
-                        error = %e,
-                        "Failed to forward group message to member"
-                    );
-                    failed_members.push(member.clone());
-                }
-            }
-        }
-
-        let member_count = succeeded_members.len() as u32;
-        let had_recipients = members.iter().any(|m| m != &self_id);
-        if had_recipients && message_ids.is_empty() {
-            self.emit_event(Event::group_message_partial_failure(
-                group_id.to_string(),
-                failed_members,
-                succeeded_members,
-            ));
-            return Err(Error::Other(
-                "All group forward message sends failed".to_string(),
-            ));
-        }
-
         if failed_members.is_empty() {
             self.emit_event(Event::group_message_sent(
                 group_id.to_string(),
@@ -1607,12 +1541,14 @@ impl OfflineProtocol {
         ciphertext_b64: &str,
         epoch: u64,
         reply_to: Option<&str>,
+        forward_info: Option<ForwardInfo>,
     ) -> Result<MessageId> {
         let payload = RelayGroupBroadcastPayload {
             group_id: group_id.to_string(),
             ciphertext: ciphertext_b64.to_string(),
             epoch,
             reply_to: reply_to.map(|s| s.to_string()),
+            forward_info,
         };
         let content = format!(
             "{}{}",

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -2677,6 +2677,7 @@ fn test_handle_relay_group_message_plaintext_passthrough() {
         "2026-03-13T00:00:00Z",
         "msg-relay-001",
         None,
+        None,
     );
 
     let events = events.lock().unwrap();
@@ -2721,6 +2722,7 @@ fn test_handle_relay_group_message_mls_decrypt() {
         "2026-03-13T00:00:00Z",
         "msg-relay-mls-001",
         None,
+        None,
     );
 
     // Verify decrypted content
@@ -2754,6 +2756,7 @@ fn test_handle_relay_group_message_mls_unavailable_emits_raw() {
         &raw_content,
         "2026-03-13T00:00:00Z",
         "msg-relay-no-mls",
+        None,
         None,
     );
 

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -401,6 +401,7 @@ fn test_group_mls_payload_serialization_roundtrip() {
         ciphertext: "dGVzdA==".to_string(),
         epoch: 42,
         reply_to: Some("msg-123".to_string()),
+        forward_info: None,
     };
     let json = serde_json::to_string(&msg_payload).unwrap();
     let parsed: GroupMlsMessagePayload = serde_json::from_str(&json).unwrap();
@@ -415,6 +416,7 @@ fn test_group_mls_payload_serialization_roundtrip() {
         ciphertext: "dGVzdA==".to_string(),
         epoch: 1,
         reply_to: None,
+        forward_info: None,
     };
     let json_no_reply = serde_json::to_string(&msg_no_reply).unwrap();
     assert!(!json_no_reply.contains("reply_to"));
@@ -509,6 +511,7 @@ fn test_group_mls_full_lifecycle_create_invite_send_decrypt() {
         ciphertext: base64_encode(&encrypted.ciphertext),
         epoch: encrypted.epoch,
         reply_to: None,
+        forward_info: None,
     };
     let content = format!(
         "{}{}",
@@ -647,6 +650,7 @@ fn test_group_mls_message_after_leaving() {
         ciphertext: base64_encode(b"encrypted-content"),
         epoch: 1,
         reply_to: None,
+        forward_info: None,
     };
     let content = format!(
         "{}{}",
@@ -680,6 +684,7 @@ fn test_group_mls_oversized_payload_rejected() {
         ciphertext: oversized,
         epoch: 1,
         reply_to: None,
+        forward_info: None,
     };
     let content = format!(
         "{}{}",
@@ -723,6 +728,7 @@ fn test_group_mls_duplicate_message_rejected() {
         ciphertext: base64_encode(&encrypted.ciphertext),
         epoch: encrypted.epoch,
         reply_to: None,
+        forward_info: None,
     };
     let content = format!(
         "{}{}",
@@ -1082,6 +1088,7 @@ fn test_group_mls_dedup_inserted_before_decrypt_attempt() {
         ciphertext: base64_encode(b"definitely-not-valid-mls-ciphertext"),
         epoch: 1,
         reply_to: None,
+        forward_info: None,
     };
     let content = format!(
         "{}{}",
@@ -2338,6 +2345,7 @@ fn test_group_mls_dedup_independent_per_message_id() {
             ciphertext: base64_encode(&encrypted.ciphertext),
             epoch: encrypted.epoch,
             reply_to: None,
+            forward_info: None,
         };
         let content = format!(
             "{}{}",

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -659,6 +659,7 @@ impl OfflineProtocol {
                             payload.timestamp,
                             payload.message_id,
                             payload.reply_to_msg,
+                            None,
                         ));
                     }
                 }

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -648,6 +648,7 @@ impl OfflineProtocol {
                         &payload.timestamp,
                         &payload.message_id,
                         payload.reply_to_msg,
+                        payload.forward_info,
                     );
                 } else {
                     // Legacy relay-only group — emit raw content

--- a/crates/offline-protocol/src/protocol/pending_queue.rs
+++ b/crates/offline-protocol/src/protocol/pending_queue.rs
@@ -92,6 +92,14 @@ impl OfflineProtocol {
                                     .map(|id| id.as_str().to_string()),
                                 content_type: decrypted_msg.content_type.to_string(),
                                 media_metadata: decrypted_msg.media_metadata.clone(),
+                                forward_info: decrypted_msg.forwarded_from.as_ref().map(|fwd| {
+                                    crate::events::ForwardInfoEvent {
+                                        original_sender: fwd.original_sender.as_str().to_string(),
+                                        original_message_id: fwd.original_message_id.as_str(),
+                                        original_timestamp: fwd.original_timestamp.as_millis(),
+                                        forward_count: fwd.forward_count,
+                                    }
+                                }),
                             };
                             state.emit_event(event);
                         }

--- a/crates/offline-protocol/src/protocol/pending_queue.rs
+++ b/crates/offline-protocol/src/protocol/pending_queue.rs
@@ -92,14 +92,10 @@ impl OfflineProtocol {
                                     .map(|id| id.as_str().to_string()),
                                 content_type: decrypted_msg.content_type.to_string(),
                                 media_metadata: decrypted_msg.media_metadata.clone(),
-                                forward_info: decrypted_msg.forwarded_from.as_ref().map(|fwd| {
-                                    crate::events::ForwardInfoEvent {
-                                        original_sender: fwd.original_sender.as_str().to_string(),
-                                        original_message_id: fwd.original_message_id.as_str(),
-                                        original_timestamp: fwd.original_timestamp.as_millis(),
-                                        forward_count: fwd.forward_count,
-                                    }
-                                }),
+                                forward_info: decrypted_msg
+                                    .forwarded_from
+                                    .as_ref()
+                                    .map(crate::events::ForwardInfoEvent::from),
                             };
                             state.emit_event(event);
                         }

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -151,14 +151,10 @@ impl OfflineProtocol {
                         continue;
                     }
 
-                    let forward_info = message.forwarded_from.as_ref().map(|fwd| {
-                        crate::events::ForwardInfoEvent {
-                            original_sender: fwd.original_sender.as_str().to_string(),
-                            original_message_id: fwd.original_message_id.as_str(),
-                            original_timestamp: fwd.original_timestamp.as_millis(),
-                            forward_count: fwd.forward_count,
-                        }
-                    });
+                    let forward_info = message
+                        .forwarded_from
+                        .as_ref()
+                        .map(crate::events::ForwardInfoEvent::from);
 
                     let event = Event::MessageReceived {
                         message_id: message.id.as_str(),

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -151,6 +151,15 @@ impl OfflineProtocol {
                         continue;
                     }
 
+                    let forward_info = message.forwarded_from.as_ref().map(|fwd| {
+                        crate::events::ForwardInfoEvent {
+                            original_sender: fwd.original_sender.as_str().to_string(),
+                            original_message_id: fwd.original_message_id.as_str(),
+                            original_timestamp: fwd.original_timestamp.as_millis(),
+                            forward_count: fwd.forward_count,
+                        }
+                    });
+
                     let event = Event::MessageReceived {
                         message_id: message.id.as_str(),
                         sender: message.sender.as_str().to_string(),
@@ -166,6 +175,7 @@ impl OfflineProtocol {
                             .map(|id| id.as_str().to_string()),
                         content_type: message.content_type.to_string(),
                         media_metadata: message.media_metadata.clone(),
+                        forward_info,
                     };
 
                     let Ok(state) = lock_shared_state(&self.shared_state) else {

--- a/crates/offline-protocol/src/protocol/security.rs
+++ b/crates/offline-protocol/src/protocol/security.rs
@@ -380,7 +380,7 @@ impl OfflineProtocol {
 
     /// Returns `true` if the message content starts with any internal prefix.
     /// Used for injection prevention on the public send APIs.
-    pub(super) fn is_internal_prefix(content: &str) -> bool {
+    pub(crate) fn is_internal_prefix(content: &str) -> bool {
         INTERNAL_PREFIXES.iter().any(|p| content.starts_with(p))
     }
 

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -6,7 +6,9 @@ use super::{
     OutboxEntry, PendingMessage, PresencePayload, ProtocolState, ReadReceiptPayload,
     TypingIndicatorPayload, WelcomeDeliveryState, MAX_READ_RECEIPT_IDS,
 };
-use crate::constants::{ACK_FOR_KEY, ACK_HOP_COUNT_KEY, ACK_TRANSPORT_KEY, MAX_OUTBOX_ENTRIES};
+use crate::constants::{
+    ACK_FOR_KEY, ACK_HOP_COUNT_KEY, ACK_TRANSPORT_KEY, MAX_FORWARD_COUNT, MAX_OUTBOX_ENTRIES,
+};
 use crate::events::{DecryptionFailureCode, Event, PresenceStatus};
 use crate::file_transfer::{FileChunk, OutboundTransferState};
 use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsOperationContext};
@@ -193,6 +195,13 @@ impl OfflineProtocol {
         // Build ForwardInfo: preserve original attribution, increment count
         let forward_info = ForwardInfo::from_message(original_message);
 
+        if forward_info.forward_count > MAX_FORWARD_COUNT {
+            return Err(Error::Other(format!(
+                "Forward count {} exceeds maximum of {}",
+                forward_info.forward_count, MAX_FORWARD_COUNT,
+            )));
+        }
+
         // Prepare content (may encrypt). ForwardInfo is threaded through so
         // it survives the pending-message queue if the session isn't ready.
         let final_content = match self.prepare_outbound_content(
@@ -242,6 +251,68 @@ impl OfflineProtocol {
                 );
                 Err(Error::Other(format!(
                     "Forward failed (message {} deferred for retry): {}",
+                    message.id, err
+                )))
+            }
+        }
+    }
+
+    /// Sends a forwarded message with a pre-built `ForwardInfo`, skipping re-derivation.
+    ///
+    /// Used by `flush_pending_messages` to avoid double-incrementing `forward_count`
+    /// when resending a queued forwarded message.
+    fn send_forwarded_message_direct(
+        &mut self,
+        recipient: &str,
+        content: &str,
+        forward_info: ForwardInfo,
+        priority: MessagePriority,
+    ) -> Result<MessageId> {
+        // Prepare content (may encrypt). ForwardInfo is threaded through so
+        // it survives re-queue if the session still isn't ready.
+        let final_content = match self.prepare_outbound_content(
+            recipient,
+            content,
+            priority,
+            None,
+            Some(forward_info.clone()),
+            "forward_message_flush_pending",
+        )? {
+            OutboundSendPreparation::Ready(c) => c,
+            OutboundSendPreparation::Queued(message_id) => return Ok(message_id),
+        };
+
+        let mut message = self.create_message(recipient, final_content, Some(priority), None)?;
+        message.forwarded_from = Some(forward_info);
+
+        let message_id = message.id.clone();
+
+        if self.deduplicator.is_duplicate(&message_id) {
+            return Err(crate::Error::Other("Duplicate message".to_string()));
+        }
+
+        self.deduplicator.mark_seen(message_id.clone());
+
+        let previous_transport = self.transport_manager.current_transport();
+        let send_result = self.transport_manager.send(&message);
+        let current_transport = self.transport_manager.current_transport();
+
+        match send_result {
+            Ok(()) => {
+                self.handle_send_success(&message, current_transport)?;
+                self.emit_transport_switch_event(previous_transport, current_transport)?;
+                self.emit_message_sent_event(&message)?;
+                Ok(message_id)
+            }
+            Err(err) => {
+                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
+                warn!(
+                    message_id = %message.id,
+                    error = %err,
+                    "Forward flush send failed, message deferred"
+                );
+                Err(Error::Other(format!(
+                    "Forward flush failed (message {} deferred for retry): {}",
                     message.id, err
                 )))
             }
@@ -841,21 +912,16 @@ impl OfflineProtocol {
 
             for msg in pending {
                 let reply_to_str = msg.reply_to_msg.as_ref().map(|id| id.as_str().to_string());
-                let result = if msg.forwarded_from.is_some() {
-                    // Re-send as a forwarded message to preserve attribution.
-                    // Build a minimal Message with the stored content and
-                    // ForwardInfo so forward_message can re-derive attribution.
-                    let app_id = AppId::new(&self.config.app_id)
-                        .map_err(|e| Error::Other(format!("Invalid app_id in config: {}", e)))?;
-                    let sender = UserId::new(&self.config.user_id)
-                        .map_err(|e| Error::Other(format!("Invalid user_id in config: {}", e)))?;
-                    let recip = UserId::new(recipient)
-                        .map_err(|e| Error::Other(format!("Invalid recipient: {}", e)))?;
-                    let mut stub = Message::builder(sender, recip, app_id)
-                        .content(&msg.content)
-                        .build();
-                    stub.forwarded_from = msg.forwarded_from.clone();
-                    self.forward_message(&stub, recipient, Some(msg.priority))
+                let result = if let Some(forward_info) = msg.forwarded_from.clone() {
+                    // Re-send with the stored ForwardInfo directly (don't
+                    // re-derive via forward_message to avoid double-incrementing
+                    // forward_count).
+                    self.send_forwarded_message_direct(
+                        recipient,
+                        &msg.content,
+                        forward_info,
+                        msg.priority,
+                    )
                 } else {
                     self.send_message(
                         recipient,

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -902,19 +902,14 @@ impl OfflineProtocol {
                         }
                     };
 
-                    let mut message = self.create_message(
-                        recipient,
-                        final_content,
-                        Some(msg.priority),
-                        None,
-                    )?;
+                    let mut message =
+                        self.create_message(recipient, final_content, Some(msg.priority), None)?;
                     message.forwarded_from = msg.forwarded_from.clone();
                     message.content_type = msg.content_type;
                     message.media_metadata = msg.media_metadata.clone();
                     self.dispatch_prepared_message(message)
                 } else {
-                    let reply_to_str =
-                        msg.reply_to_msg.as_ref().map(|id| id.as_str().to_string());
+                    let reply_to_str = msg.reply_to_msg.as_ref().map(|id| id.as_str().to_string());
                     self.send_message(
                         recipient,
                         msg.content.clone(),

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -95,6 +95,8 @@ impl OfflineProtocol {
             priority,
             reply_to_msg_id.clone(),
             None,
+            ContentType::default(),
+            None,
             "send_message_session_pending",
         )? {
             OutboundSendPreparation::Ready(content) => content,
@@ -210,81 +212,29 @@ impl OfflineProtocol {
             priority,
             None,
             Some(forward_info.clone()),
+            original_message.content_type,
+            original_message.media_metadata.clone(),
             "forward_message_session_pending",
         )? {
             OutboundSendPreparation::Ready(content) => content,
             OutboundSendPreparation::Queued(message_id) => return Ok(message_id),
         };
 
-        // Create new message with forwarded content
+        // Create and dispatch the forwarded message
         let mut message =
             self.create_message(&recipient_str, final_content, Some(priority), None)?;
         message.forwarded_from = Some(forward_info);
         message.content_type = original_message.content_type;
         message.media_metadata = original_message.media_metadata.clone();
 
-        let message_id = message.id.clone();
-
-        if self.deduplicator.is_duplicate(&message_id) {
-            return Err(crate::Error::Other("Duplicate message".to_string()));
-        }
-
-        self.deduplicator.mark_seen(message_id.clone());
-
-        let previous_transport = self.transport_manager.current_transport();
-        let send_result = self.transport_manager.send(&message);
-        let current_transport = self.transport_manager.current_transport();
-
-        match send_result {
-            Ok(()) => {
-                self.handle_send_success(&message, current_transport)?;
-                self.emit_transport_switch_event(previous_transport, current_transport)?;
-                self.emit_message_sent_event(&message)?;
-                Ok(message_id)
-            }
-            Err(err) => {
-                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
-                warn!(
-                    message_id = %message.id,
-                    error = %err,
-                    "Forward send failed, message deferred"
-                );
-                Err(Error::Other(format!(
-                    "Forward failed (message {} deferred for retry): {}",
-                    message.id, err
-                )))
-            }
-        }
+        self.dispatch_prepared_message(message)
     }
 
-    /// Sends a forwarded message with a pre-built `ForwardInfo`, skipping re-derivation.
+    /// Shared send path: dedup, transport send, success/failure handling, event emission.
     ///
-    /// Used by `flush_pending_messages` to avoid double-incrementing `forward_count`
-    /// when resending a queued forwarded message.
-    fn send_forwarded_message_direct(
-        &mut self,
-        recipient: &str,
-        content: &str,
-        forward_info: ForwardInfo,
-        priority: MessagePriority,
-    ) -> Result<MessageId> {
-        // Prepare content (may encrypt). ForwardInfo is threaded through so
-        // it survives re-queue if the session still isn't ready.
-        let final_content = match self.prepare_outbound_content(
-            recipient,
-            content,
-            priority,
-            None,
-            Some(forward_info.clone()),
-            "forward_message_flush_pending",
-        )? {
-            OutboundSendPreparation::Ready(c) => c,
-            OutboundSendPreparation::Queued(message_id) => return Ok(message_id),
-        };
-
-        let mut message = self.create_message(recipient, final_content, Some(priority), None)?;
-        message.forwarded_from = Some(forward_info);
-
+    /// Used by `forward_message`, `flush_pending_messages` (for forwarded messages),
+    /// and any path that has a fully-constructed `Message` ready to send.
+    fn dispatch_prepared_message(&mut self, message: Message) -> Result<MessageId> {
         let message_id = message.id.clone();
 
         if self.deduplicator.is_duplicate(&message_id) {
@@ -309,10 +259,10 @@ impl OfflineProtocol {
                 warn!(
                     message_id = %message.id,
                     error = %err,
-                    "Forward flush send failed, message deferred"
+                    "Send failed, message deferred"
                 );
                 Err(Error::Other(format!(
-                    "Forward flush failed (message {} deferred for retry): {}",
+                    "Send failed (message {} deferred for retry): {}",
                     message.id, err
                 )))
             }
@@ -416,6 +366,8 @@ impl OfflineProtocol {
             &content_str,
             priority,
             reply_to_msg_id.clone(),
+            None,
+            ContentType::default(),
             None,
             "send_message_via_transport_session_pending",
         )? {
@@ -767,6 +719,7 @@ impl OfflineProtocol {
         Ok(format!("{}{}", internal_prefixes::ENCRYPTED, serialized))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn prepare_outbound_content(
         &mut self,
         recipient: &str,
@@ -774,6 +727,8 @@ impl OfflineProtocol {
         priority: MessagePriority,
         reply_to_msg_id: Option<MessageId>,
         forwarded_from: Option<ForwardInfo>,
+        content_type: ContentType,
+        media_metadata: Option<MediaMetadata>,
         reconciliation_reason: &'static str,
     ) -> Result<OutboundSendPreparation> {
         if self.should_auto_encrypt() {
@@ -790,6 +745,8 @@ impl OfflineProtocol {
                             priority,
                             reply_to_msg_id,
                             forwarded_from,
+                            content_type,
+                            media_metadata,
                             reconciliation_reason,
                         )?;
                         return Ok(OutboundSendPreparation::Queued(queued_id));
@@ -811,6 +768,8 @@ impl OfflineProtocol {
                         priority,
                         reply_to_msg_id,
                         forwarded_from,
+                        content_type,
+                        media_metadata,
                         reconciliation_reason,
                     )?;
                     Ok(OutboundSendPreparation::Queued(queued_id))
@@ -830,6 +789,7 @@ impl OfflineProtocol {
     // PENDING / FLUSH
     // ========================================================================
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn queue_message_for_session_establishment(
         &mut self,
         recipient: &str,
@@ -837,6 +797,8 @@ impl OfflineProtocol {
         priority: MessagePriority,
         reply_to_msg_id: Option<MessageId>,
         forwarded_from: Option<ForwardInfo>,
+        content_type: ContentType,
+        media_metadata: Option<MediaMetadata>,
         reconciliation_reason: &'static str,
     ) -> Result<MessageId> {
         // Generate an ID without ticking the Lamport clock.
@@ -856,6 +818,8 @@ impl OfflineProtocol {
             message_id.clone(),
             reply_to_msg_id,
             forwarded_from,
+            content_type,
+            media_metadata,
         );
         self.kick_pending_session_reconciliation(reconciliation_reason);
         if self.has_terminal_welcome_failure(recipient) {
@@ -873,6 +837,7 @@ impl OfflineProtocol {
     }
 
     /// Queues a message with a specific message ID for later sending when session is established.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn queue_pending_message(
         &mut self,
         recipient: &str,
@@ -881,6 +846,8 @@ impl OfflineProtocol {
         message_id: MessageId,
         reply_to_msg: Option<MessageId>,
         forwarded_from: Option<ForwardInfo>,
+        content_type: ContentType,
+        media_metadata: Option<MediaMetadata>,
     ) {
         let message_id_str = message_id.as_str().to_string();
         let pending = PendingMessage {
@@ -889,6 +856,8 @@ impl OfflineProtocol {
             message_id,
             reply_to_msg,
             forwarded_from,
+            content_type,
+            media_metadata,
             queued_at: Utc::now(),
         };
 
@@ -911,18 +880,41 @@ impl OfflineProtocol {
             let mut remaining = Vec::new();
 
             for msg in pending {
-                let reply_to_str = msg.reply_to_msg.as_ref().map(|id| id.as_str().to_string());
-                let result = if let Some(forward_info) = msg.forwarded_from.clone() {
+                let result = if msg.forwarded_from.is_some() {
                     // Re-send with the stored ForwardInfo directly (don't
                     // re-derive via forward_message to avoid double-incrementing
-                    // forward_count).
-                    self.send_forwarded_message_direct(
+                    // forward_count). Also restore content_type and media_metadata.
+                    let final_content = match self.prepare_outbound_content(
                         recipient,
                         &msg.content,
-                        forward_info,
                         msg.priority,
-                    )
+                        None,
+                        msg.forwarded_from.clone(),
+                        msg.content_type,
+                        msg.media_metadata.clone(),
+                        "forward_message_flush_pending",
+                    )? {
+                        OutboundSendPreparation::Ready(c) => c,
+                        OutboundSendPreparation::Queued(message_id) => {
+                            // Re-queued for later (session still not ready).
+                            debug!(original_id = %msg.message_id, new_id = %message_id, "Forwarded pending message re-queued");
+                            continue;
+                        }
+                    };
+
+                    let mut message = self.create_message(
+                        recipient,
+                        final_content,
+                        Some(msg.priority),
+                        None,
+                    )?;
+                    message.forwarded_from = msg.forwarded_from.clone();
+                    message.content_type = msg.content_type;
+                    message.media_metadata = msg.media_metadata.clone();
+                    self.dispatch_prepared_message(message)
                 } else {
+                    let reply_to_str =
+                        msg.reply_to_msg.as_ref().map(|id| id.as_str().to_string());
                     self.send_message(
                         recipient,
                         msg.content.clone(),

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -181,21 +181,16 @@ impl OfflineProtocol {
             return Err(Error::UserBlocked(recipient_str));
         }
 
+        // Reject content that starts with an internal control prefix to prevent
+        // injection of protocol-level messages through the forwarding API.
+        if Self::is_internal_prefix(&original_message.content) {
+            return Err(Error::Other(
+                "Cannot forward a message with reserved internal prefix content".to_string(),
+            ));
+        }
+
         // Build ForwardInfo: preserve original attribution, increment count
-        let forward_info = match &original_message.forwarded_from {
-            Some(existing) => ForwardInfo {
-                original_sender: existing.original_sender.clone(),
-                original_message_id: existing.original_message_id.clone(),
-                original_timestamp: existing.original_timestamp,
-                forward_count: existing.forward_count + 1,
-            },
-            None => ForwardInfo {
-                original_sender: original_message.sender.clone(),
-                original_message_id: original_message.id.clone(),
-                original_timestamp: original_message.timestamp,
-                forward_count: 1,
-            },
-        };
+        let forward_info = ForwardInfo::from_message(original_message);
 
         // Prepare content (may encrypt)
         let final_content = match self.prepare_outbound_content(

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -92,6 +92,7 @@ impl OfflineProtocol {
             &content_str,
             priority,
             reply_to_msg_id.clone(),
+            None,
             "send_message_session_pending",
         )? {
             OutboundSendPreparation::Ready(content) => content,
@@ -192,12 +193,14 @@ impl OfflineProtocol {
         // Build ForwardInfo: preserve original attribution, increment count
         let forward_info = ForwardInfo::from_message(original_message);
 
-        // Prepare content (may encrypt)
+        // Prepare content (may encrypt). ForwardInfo is threaded through so
+        // it survives the pending-message queue if the session isn't ready.
         let final_content = match self.prepare_outbound_content(
             &recipient_str,
             &original_message.content,
             priority,
             None,
+            Some(forward_info.clone()),
             "forward_message_session_pending",
         )? {
             OutboundSendPreparation::Ready(content) => content,
@@ -342,6 +345,7 @@ impl OfflineProtocol {
             &content_str,
             priority,
             reply_to_msg_id.clone(),
+            None,
             "send_message_via_transport_session_pending",
         )? {
             OutboundSendPreparation::Ready(content) => content,
@@ -698,6 +702,7 @@ impl OfflineProtocol {
         content: &str,
         priority: MessagePriority,
         reply_to_msg_id: Option<MessageId>,
+        forwarded_from: Option<ForwardInfo>,
         reconciliation_reason: &'static str,
     ) -> Result<OutboundSendPreparation> {
         if self.should_auto_encrypt() {
@@ -713,6 +718,7 @@ impl OfflineProtocol {
                             content,
                             priority,
                             reply_to_msg_id,
+                            forwarded_from,
                             reconciliation_reason,
                         )?;
                         return Ok(OutboundSendPreparation::Queued(queued_id));
@@ -733,6 +739,7 @@ impl OfflineProtocol {
                         content,
                         priority,
                         reply_to_msg_id,
+                        forwarded_from,
                         reconciliation_reason,
                     )?;
                     Ok(OutboundSendPreparation::Queued(queued_id))
@@ -758,6 +765,7 @@ impl OfflineProtocol {
         content: &str,
         priority: MessagePriority,
         reply_to_msg_id: Option<MessageId>,
+        forwarded_from: Option<ForwardInfo>,
         reconciliation_reason: &'static str,
     ) -> Result<MessageId> {
         // Generate an ID without ticking the Lamport clock.
@@ -776,6 +784,7 @@ impl OfflineProtocol {
             priority,
             message_id.clone(),
             reply_to_msg_id,
+            forwarded_from,
         );
         self.kick_pending_session_reconciliation(reconciliation_reason);
         if self.has_terminal_welcome_failure(recipient) {
@@ -800,6 +809,7 @@ impl OfflineProtocol {
         priority: MessagePriority,
         message_id: MessageId,
         reply_to_msg: Option<MessageId>,
+        forwarded_from: Option<ForwardInfo>,
     ) {
         let message_id_str = message_id.as_str().to_string();
         let pending = PendingMessage {
@@ -807,6 +817,7 @@ impl OfflineProtocol {
             priority,
             message_id,
             reply_to_msg,
+            forwarded_from,
             queued_at: Utc::now(),
         };
 
@@ -829,15 +840,31 @@ impl OfflineProtocol {
             let mut remaining = Vec::new();
 
             for msg in pending {
-                // Re-attempt to send each pending message
-                // Use the stored message ID by passing reply_to_msg if it exists
                 let reply_to_str = msg.reply_to_msg.as_ref().map(|id| id.as_str().to_string());
-                match self.send_message(
-                    recipient,
-                    msg.content.clone(),
-                    Some(msg.priority),
-                    reply_to_str,
-                ) {
+                let result = if msg.forwarded_from.is_some() {
+                    // Re-send as a forwarded message to preserve attribution.
+                    // Build a minimal Message with the stored content and
+                    // ForwardInfo so forward_message can re-derive attribution.
+                    let app_id = AppId::new(&self.config.app_id)
+                        .map_err(|e| Error::Other(format!("Invalid app_id in config: {}", e)))?;
+                    let sender = UserId::new(&self.config.user_id)
+                        .map_err(|e| Error::Other(format!("Invalid user_id in config: {}", e)))?;
+                    let recip = UserId::new(recipient)
+                        .map_err(|e| Error::Other(format!("Invalid recipient: {}", e)))?;
+                    let mut stub = Message::builder(sender, recip, app_id)
+                        .content(&msg.content)
+                        .build();
+                    stub.forwarded_from = msg.forwarded_from.clone();
+                    self.forward_message(&stub, recipient, Some(msg.priority))
+                } else {
+                    self.send_message(
+                        recipient,
+                        msg.content.clone(),
+                        Some(msg.priority),
+                        reply_to_str,
+                    )
+                };
+                match result {
                     Ok(id) => {
                         // Note: The new message will have a new ID, but the original ID was already returned to the caller
                         debug!(original_id = %msg.message_id, new_id = %id, "Sent pending message");

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -13,7 +13,8 @@ use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsOpera
 use crate::{Error, Result};
 use chrono::{Duration as ChronoDuration, Utc};
 use offline_protocol_core::{
-    AppId, ContentType, MediaMetadata, Message, MessageId, MessagePriority, UserId, TTL,
+    AppId, ContentType, ForwardInfo, MediaMetadata, Message, MessageId, MessagePriority, UserId,
+    TTL,
 };
 use offline_protocol_mls::MlsManager;
 use offline_protocol_transport::TransportType;
@@ -138,6 +139,111 @@ impl OfflineProtocol {
                 );
                 Err(Error::Other(format!(
                     "Send failed (message {} deferred for retry): {}",
+                    message.id, err
+                )))
+            }
+        }
+    }
+
+    /// Forwards a message to a new recipient with attribution to the original sender.
+    ///
+    /// Creates a new message with the original content and attaches `ForwardInfo`
+    /// tracking the original sender, message ID, timestamp, and forward count.
+    /// If the message was already forwarded, the original attribution is preserved
+    /// and `forward_count` is incremented.
+    ///
+    /// # Arguments
+    ///
+    /// * `original_message` - The message to forward
+    /// * `new_recipient` - Recipient's user ID
+    /// * `priority` - Message priority (optional, defaults to Medium)
+    ///
+    /// # Returns
+    ///
+    /// Returns the new message ID if successful.
+    pub fn forward_message(
+        &mut self,
+        original_message: &Message,
+        new_recipient: impl Into<String>,
+        priority: Option<MessagePriority>,
+    ) -> Result<MessageId> {
+        {
+            let state = lock_shared_state(&self.shared_state)?;
+            if state.state != ProtocolState::Running {
+                return Err(Error::NotStarted);
+            }
+        }
+
+        let recipient_str: String = new_recipient.into();
+        let priority = priority.unwrap_or(MessagePriority::Medium);
+
+        if self.is_user_blocked(&recipient_str) {
+            return Err(Error::UserBlocked(recipient_str));
+        }
+
+        // Build ForwardInfo: preserve original attribution, increment count
+        let forward_info = match &original_message.forwarded_from {
+            Some(existing) => ForwardInfo {
+                original_sender: existing.original_sender.clone(),
+                original_message_id: existing.original_message_id.clone(),
+                original_timestamp: existing.original_timestamp,
+                forward_count: existing.forward_count + 1,
+            },
+            None => ForwardInfo {
+                original_sender: original_message.sender.clone(),
+                original_message_id: original_message.id.clone(),
+                original_timestamp: original_message.timestamp,
+                forward_count: 1,
+            },
+        };
+
+        // Prepare content (may encrypt)
+        let final_content = match self.prepare_outbound_content(
+            &recipient_str,
+            &original_message.content,
+            priority,
+            None,
+            "forward_message_session_pending",
+        )? {
+            OutboundSendPreparation::Ready(content) => content,
+            OutboundSendPreparation::Queued(message_id) => return Ok(message_id),
+        };
+
+        // Create new message with forwarded content
+        let mut message =
+            self.create_message(&recipient_str, final_content, Some(priority), None)?;
+        message.forwarded_from = Some(forward_info);
+        message.content_type = original_message.content_type;
+        message.media_metadata = original_message.media_metadata.clone();
+
+        let message_id = message.id.clone();
+
+        if self.deduplicator.is_duplicate(&message_id) {
+            return Err(crate::Error::Other("Duplicate message".to_string()));
+        }
+
+        self.deduplicator.mark_seen(message_id.clone());
+
+        let previous_transport = self.transport_manager.current_transport();
+        let send_result = self.transport_manager.send(&message);
+        let current_transport = self.transport_manager.current_transport();
+
+        match send_result {
+            Ok(()) => {
+                self.handle_send_success(&message, current_transport)?;
+                self.emit_transport_switch_event(previous_transport, current_transport)?;
+                self.emit_message_sent_event(&message)?;
+                Ok(message_id)
+            }
+            Err(err) => {
+                self.handle_send_failure(&message, current_transport.or(previous_transport))?;
+                warn!(
+                    message_id = %message.id,
+                    error = %err,
+                    "Forward send failed, message deferred"
+                );
+                Err(Error::Other(format!(
+                    "Forward failed (message {} deferred for retry): {}",
                     message.id, err
                 )))
             }

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -1686,6 +1686,7 @@ fn test_pending_message_queue() {
         MessagePriority::High,
         MessageId::new(),
         None,
+        None,
     );
     protocol.queue_pending_message(
         "bob",
@@ -1693,12 +1694,14 @@ fn test_pending_message_queue() {
         MessagePriority::Medium,
         MessageId::new(),
         None,
+        None,
     );
     protocol.queue_pending_message(
         "alice",
         "Hello Alice!",
         MessagePriority::Low,
         MessageId::new(),
+        None,
         None,
     );
 
@@ -3717,6 +3720,7 @@ fn test_restore_session_state_keeps_missing_state_pending_when_queue_exists() {
         MessagePriority::Medium,
         MessageId::new(),
         None,
+        None,
     );
     assert!(protocol.load_session_state_entry("bob").unwrap().is_none());
 
@@ -3766,6 +3770,7 @@ fn test_start_flushes_restored_pending_messages_for_confirmed_session() {
         "queued-before-crash",
         MessagePriority::Medium,
         MessageId::new(),
+        None,
         None,
     );
 
@@ -4434,12 +4439,14 @@ fn test_receive_poll_drives_pending_session_reconciliation_without_process_or_ne
         MessagePriority::Medium,
         MessageId::new(),
         None,
+        None,
     );
     bob.queue_pending_message(
         "alice",
         "queued-before-restart-b2a",
         MessagePriority::Medium,
         MessageId::new(),
+        None,
         None,
     );
 

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -8626,3 +8626,113 @@ fn test_local_message_not_relayed() {
         "Local message should not emit MessageRelayed"
     );
 }
+
+#[test]
+fn test_pending_forwarded_message_preserves_forward_count() {
+    // Verifies that a forwarded message queued in the pending queue does NOT
+    // double-increment forward_count when flushed.
+    use offline_protocol_core::ForwardInfo;
+
+    let config = create_test_config();
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    let original_sender = UserId::new("alice").unwrap();
+    let original_msg_id = MessageId::new();
+    let forward_info = ForwardInfo {
+        original_sender: original_sender.clone(),
+        original_message_id: original_msg_id.clone(),
+        original_timestamp: offline_protocol_core::Timestamp::now(),
+        forward_count: 1,
+    };
+
+    // Queue a forwarded message with forward_count = 1
+    protocol.queue_pending_message(
+        "bob",
+        "Hello from Alice",
+        MessagePriority::Medium,
+        MessageId::new(),
+        None,
+        Some(forward_info),
+    );
+
+    // Verify the stored forward_count is 1
+    let bob_pending = protocol.pending_encrypted_messages.get("bob").unwrap();
+    assert_eq!(bob_pending.len(), 1);
+    let stored = bob_pending[0].forwarded_from.as_ref().unwrap();
+    assert_eq!(stored.forward_count, 1);
+    assert_eq!(stored.original_sender, original_sender);
+    assert_eq!(stored.original_message_id, original_msg_id);
+}
+
+#[test]
+fn test_forward_message_rejects_internal_prefix_content() {
+    use crate::protocol::internal_prefixes;
+
+    let config = create_test_config();
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    let mut transport = MockTransport::new(TransportType::BLE);
+    transport.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(transport));
+    protocol.start().unwrap();
+
+    // Build a message whose content starts with an internal prefix
+    let malicious_content = format!("{}evil-payload", internal_prefixes::KEY_PACKAGE);
+    let original = offline_protocol_core::Message::builder(
+        UserId::new("attacker").unwrap(),
+        UserId::new("user123").unwrap(),
+        AppId::new("test-app").unwrap(),
+    )
+    .content(&malicious_content)
+    .build();
+
+    let result = protocol.forward_message(&original, "bob", None);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("reserved internal prefix"),
+        "Expected prefix injection error, got: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn test_forward_message_rejects_excessive_forward_count() {
+    use offline_protocol_core::ForwardInfo;
+
+    let config = create_test_config();
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    let mut transport = MockTransport::new(TransportType::BLE);
+    transport.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(transport));
+    protocol.start().unwrap();
+
+    // Build a message that has already been forwarded MAX_FORWARD_COUNT times
+    let forward_info = ForwardInfo {
+        original_sender: UserId::new("alice").unwrap(),
+        original_message_id: MessageId::new(),
+        original_timestamp: offline_protocol_core::Timestamp::now(),
+        forward_count: crate::constants::MAX_FORWARD_COUNT,
+    };
+    let original = offline_protocol_core::Message::builder(
+        UserId::new("bob").unwrap(),
+        UserId::new("user123").unwrap(),
+        AppId::new("test-app").unwrap(),
+    )
+    .content("Hello")
+    .forwarded_from(forward_info)
+    .build();
+
+    // from_message will increment to MAX_FORWARD_COUNT + 1, which should be rejected
+    let result = protocol.forward_message(&original, "charlie", None);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("exceeds maximum"),
+        "Expected forward count cap error, got: {}",
+        err_msg
+    );
+}

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -4,7 +4,7 @@ use crate::events::{DecryptionFailureCode, PresenceStatus};
 #[cfg(feature = "mls-observability")]
 use crate::mls_observability::MlsLifecycleEvent;
 use chrono::Duration as ChronoDuration;
-use offline_protocol_core::{AppId, MessagePriority, ServiceDescriptor, UserId};
+use offline_protocol_core::{AppId, ContentType, MessagePriority, ServiceDescriptor, UserId};
 use offline_protocol_transport::{
     mock::MockTransport, Transport, TransportMetrics, TransportStatus, TransportType,
 };
@@ -1687,6 +1687,8 @@ fn test_pending_message_queue() {
         MessageId::new(),
         None,
         None,
+        ContentType::default(),
+        None,
     );
     protocol.queue_pending_message(
         "bob",
@@ -1695,6 +1697,8 @@ fn test_pending_message_queue() {
         MessageId::new(),
         None,
         None,
+        ContentType::default(),
+        None,
     );
     protocol.queue_pending_message(
         "alice",
@@ -1702,6 +1706,8 @@ fn test_pending_message_queue() {
         MessagePriority::Low,
         MessageId::new(),
         None,
+        None,
+        ContentType::default(),
         None,
     );
 
@@ -3721,6 +3727,8 @@ fn test_restore_session_state_keeps_missing_state_pending_when_queue_exists() {
         MessageId::new(),
         None,
         None,
+        ContentType::default(),
+        None,
     );
     assert!(protocol.load_session_state_entry("bob").unwrap().is_none());
 
@@ -3771,6 +3779,8 @@ fn test_start_flushes_restored_pending_messages_for_confirmed_session() {
         MessagePriority::Medium,
         MessageId::new(),
         None,
+        None,
+        ContentType::default(),
         None,
     );
 
@@ -4440,6 +4450,8 @@ fn test_receive_poll_drives_pending_session_reconciliation_without_process_or_ne
         MessageId::new(),
         None,
         None,
+        ContentType::default(),
+        None,
     );
     bob.queue_pending_message(
         "alice",
@@ -4447,6 +4459,8 @@ fn test_receive_poll_drives_pending_session_reconciliation_without_process_or_ne
         MessagePriority::Medium,
         MessageId::new(),
         None,
+        None,
+        ContentType::default(),
         None,
     );
 
@@ -8653,6 +8667,8 @@ fn test_pending_forwarded_message_preserves_forward_count() {
         MessageId::new(),
         None,
         Some(forward_info),
+        ContentType::default(),
+        None,
     );
 
     // Verify the stored forward_count is 1

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -3,7 +3,9 @@
 use crate::events::{Event, EventCallback, PresenceStatus};
 use crate::Error;
 use chrono::{DateTime, Utc};
-use offline_protocol_core::{ContentType, MediaMetadata, Message, MessageId, MessagePriority};
+use offline_protocol_core::{
+    ContentType, ForwardInfo, MediaMetadata, Message, MessageId, MessagePriority,
+};
 use offline_protocol_transport::TransportType;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashSet, VecDeque};
@@ -269,6 +271,9 @@ pub(crate) struct PendingMessage {
     pub(crate) message_id: MessageId,
     /// Reply-to message ID if applicable.
     pub(crate) reply_to_msg: Option<MessageId>,
+    /// Forwarding attribution (preserved so it survives the pending queue).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) forwarded_from: Option<ForwardInfo>,
     /// When the message was queued (for future TTL/expiry support).
     pub(crate) queued_at: DateTime<Utc>,
 }

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -277,6 +277,12 @@ pub(crate) struct PendingMessage {
     /// Forwarding attribution (preserved so it survives the pending queue).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) forwarded_from: Option<ForwardInfo>,
+    /// Content type of the original message (preserved for forwarded non-text messages).
+    #[serde(default)]
+    pub(crate) content_type: ContentType,
+    /// Media metadata (preserved for forwarded media messages).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) media_metadata: Option<MediaMetadata>,
     /// When the message was queued (for future TTL/expiry support).
     pub(crate) queued_at: DateTime<Utc>,
 }

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -183,8 +183,11 @@ pub(crate) struct GroupMessageReceivedPayload {
     pub(crate) content: String,
     pub(crate) timestamp: String,
     pub(crate) message_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) reply_to_msg: Option<String>,
+    /// Forwarding attribution (present when the group message was forwarded).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) forward_info: Option<offline_protocol_core::ForwardInfo>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- Add first-class `ForwardInfo` on `Message` — tracks original sender, message ID, timestamp, and forward count with flat attribution (re-forwarding preserves the original author and increments count)
- Add `forward_message()` for 1:1 forwarding and `forward_message_to_group()` for group forwarding on `OfflineProtocol`
- Surface `forward_info` on `MessageSent`/`MessageReceived` events and in `receive_message()` JSON output
- Full UniFFI bindings (`ForwardInfo` dictionary, `forward_message`, `forward_message_to_group`)

## Design decisions

- **Flat attribution, not a chain**: only stores original sender + forward count. Alice → Bob → Charlie → Dave shows `original_sender: Alice, forward_count: 2` for Dave. Simple, WhatsApp-style.
- **New message ID per forward**: forwarded messages are new messages with attribution metadata, not clones.
- **Backward-compatible**: `#[serde(default, skip_serializing_if = "Option::is_none")]` on `forwarded_from` — old messages deserialize cleanly with `None`.
- **Encryption just works**: forwarder already has plaintext; `forward_message()` re-encrypts via existing outbound pipeline.

## Files changed (9)

| File | Change |
|------|--------|
| `crates/offline-protocol-core/src/message.rs` | `ForwardInfo` struct, `forwarded_from` field on `Message`, builder method, 3 tests |
| `crates/offline-protocol-core/src/lib.rs` | Export `ForwardInfo` |
| `crates/offline-protocol/src/protocol/send.rs` | `forward_message()` method |
| `crates/offline-protocol/src/group_mesh.rs` | `forward_message_to_group()` method |
| `crates/offline-protocol/src/events.rs` | `ForwardInfoEvent` struct, `forward_info` on `MessageSent`/`MessageReceived` |
| `crates/offline-protocol/src/protocol/receive.rs` | Populate `forward_info` in receive event |
| `crates/offline-protocol/src/protocol/pending_queue.rs` | Populate `forward_info` in delayed-decrypt event |
| `crates/offline-protocol-uniffi/src/offline_protocol.udl` | `ForwardInfo` dictionary + methods |
| `crates/offline-protocol-uniffi/src/lib.rs` | Binding impls + `receive_message` JSON update |

## Test plan

- [x] `cargo build --workspace` — compiles clean
- [x] `cargo clippy --workspace -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — formatted
- [x] `cargo test --workspace` — all 795 tests pass (0 failures)
- [x] New unit tests: `test_forward_info_serialization`, `test_backward_compat_no_forwarded_from`, `test_forward_chain_increment`