### PR TITLE
fix(reliability): decouple transport retries from ACK retries

### DIFF
--- a/crates/offline-protocol-reliability/src/constants.rs
+++ b/crates/offline-protocol-reliability/src/constants.rs
@@ -1,13 +1,13 @@
 //! Reliability layer constants.
 
 /// Default ACK timeout in milliseconds.
-pub const DEFAULT_ACK_TIMEOUT_MS: u64 = 5000;
+pub const DEFAULT_ACK_TIMEOUT_MS: u64 = 10000;
 
 /// Maximum number of pending ACKs to track.
 pub const DEFAULT_MAX_PENDING_ACKS: usize = 1000;
 
 /// Default maximum number of retries per message.
-pub const DEFAULT_MAX_RETRIES: u32 = 3;
+pub const DEFAULT_MAX_RETRIES: u32 = 10;
 
 /// Initial retry delay in milliseconds.
 pub const DEFAULT_INITIAL_DELAY_MS: u64 = 1000;

--- a/crates/offline-protocol-reliability/src/error.rs
+++ b/crates/offline-protocol-reliability/src/error.rs
@@ -12,10 +12,6 @@ pub enum Error {
     #[error("ACK timeout for message {0}")]
     AckTimeout(String),
 
-    /// Maximum retries exceeded.
-    #[error("Maximum retries exceeded")]
-    MaxRetriesExceeded,
-
     /// Core error.
     #[error("Core error: {0}")]
     Core(#[from] offline_protocol_core::Error),

--- a/crates/offline-protocol-reliability/src/retry_queue.rs
+++ b/crates/offline-protocol-reliability/src/retry_queue.rs
@@ -133,14 +133,19 @@ impl RetryQueue {
 
     /// Adds a message to the retry queue.
     ///
+    /// The retry queue is a pure scheduling mechanism — it does not enforce a
+    /// retry limit.  ACK-level retry limits are enforced by the ACK manager in
+    /// the protocol layer.
+    ///
     /// # Arguments
     ///
     /// * `message` - The message to queue for retry
-    /// * `retry_count` - Current retry count (0 for first retry)
+    /// * `retry_count` - Current retry count (used for backoff calculation)
     ///
     /// # Returns
     ///
-    /// Returns `Ok(())` if queued, `Err` if max retries exceeded.
+    /// Returns `Ok(())` if queued. Duplicate messages (same ID already in
+    /// queue) are silently ignored.
     pub fn enqueue(&mut self, message: Message, retry_count: u32) -> crate::Result<()> {
         // Prevent duplicate entries for the same message
         if self.index.contains_key(&message.id.as_str()) {

--- a/crates/offline-protocol-reliability/src/retry_queue.rs
+++ b/crates/offline-protocol-reliability/src/retry_queue.rs
@@ -89,8 +89,9 @@ impl Ord for RetryEntry {
     fn cmp(&self, other: &Self) -> Ordering {
         // Reverse comparison for min-heap (earliest retry_at first)
         other.retry_at.cmp(&self.retry_at).then_with(|| {
-            // Tie-breaker: higher priority messages first
-            other.message.priority.cmp(&self.message.priority)
+            // Tie-breaker: higher priority messages first (non-reversed,
+            // so High > Low makes High pop first from the max-heap)
+            self.message.priority.cmp(&other.message.priority)
         })
     }
 }
@@ -261,11 +262,16 @@ impl RetryQueue {
 
     /// Drains all entries from the queue, ignoring `retry_at` timing.
     ///
-    /// Returns all entries and clears the queue. Used for immediate flush
-    /// when transport becomes available.
+    /// Returns entries in priority order (earliest `retry_at` first, then
+    /// highest message priority). Used for immediate flush when transport
+    /// becomes available.
     pub fn drain_all(&mut self) -> Vec<RetryEntry> {
         self.index.clear();
-        self.queue.drain().collect()
+        let mut entries = Vec::with_capacity(self.queue.len());
+        while let Some(entry) = self.queue.pop() {
+            entries.push(entry);
+        }
+        entries
     }
 
     /// Gets the time until the next retry is ready.
@@ -452,7 +458,8 @@ mod tests {
         assert!(queue.dequeue_ready().is_none());
         assert_eq!(queue.len(), 3);
 
-        // drain_all returns everything regardless of timing
+        // drain_all returns everything regardless of timing, in heap order
+        // (earliest retry_at first, priority as tiebreaker)
         let entries = queue.drain_all();
         assert_eq!(entries.len(), 3);
         assert!(queue.is_empty());
@@ -487,6 +494,37 @@ mod tests {
             .iter()
             .any(|e| e.message.priority == MessagePriority::High);
         assert!(has_high);
+    }
+
+    #[test]
+    fn test_priority_tiebreaker_ordering() {
+        // Verify that when retry_at is identical, higher priority pops first.
+        // We construct entries directly to ensure identical timestamps.
+        let now = Utc::now();
+        let make_entry = |priority: MessagePriority| {
+            let mut msg = create_test_message(priority);
+            // Force same priority into message
+            msg.priority = priority;
+            RetryEntry {
+                message: msg,
+                retry_count: 0,
+                added_at: now,
+                retry_at: now,
+                current_delay_ms: 1000,
+            }
+        };
+
+        let mut heap = BinaryHeap::new();
+        heap.push(make_entry(MessagePriority::Low));
+        heap.push(make_entry(MessagePriority::High));
+        heap.push(make_entry(MessagePriority::Medium));
+
+        assert_eq!(heap.pop().unwrap().message.priority, MessagePriority::High);
+        assert_eq!(
+            heap.pop().unwrap().message.priority,
+            MessagePriority::Medium
+        );
+        assert_eq!(heap.pop().unwrap().message.priority, MessagePriority::Low);
     }
 
     #[test]

--- a/crates/offline-protocol-reliability/src/retry_queue.rs
+++ b/crates/offline-protocol-reliability/src/retry_queue.rs
@@ -138,19 +138,16 @@ impl RetryQueue {
     /// retry limit.  ACK-level retry limits are enforced by the ACK manager in
     /// the protocol layer.
     ///
+    /// Duplicate messages (same ID already in queue) are silently ignored.
+    ///
     /// # Arguments
     ///
     /// * `message` - The message to queue for retry
     /// * `retry_count` - Current retry count (used for backoff calculation)
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok(())` if queued. Duplicate messages (same ID already in
-    /// queue) are silently ignored.
-    pub fn enqueue(&mut self, message: Message, retry_count: u32) -> crate::Result<()> {
+    pub fn enqueue(&mut self, message: Message, retry_count: u32) {
         // Prevent duplicate entries for the same message
         if self.index.contains_key(&message.id.as_str()) {
-            return Ok(());
+            return;
         }
 
         // Calculate retry delay with exponential backoff
@@ -178,8 +175,6 @@ impl RetryQueue {
 
         self.index.insert(message.id.as_str(), ());
         self.queue.push(entry);
-
-        Ok(())
     }
 
     /// Dequeues the next message that is ready for retry.
@@ -370,7 +365,7 @@ mod tests {
         let mut queue = RetryQueue::with_config(config);
 
         let msg = create_test_message(MessagePriority::Medium);
-        queue.enqueue(msg.clone(), 0).unwrap();
+        queue.enqueue(msg.clone(), 0);
 
         assert_eq!(queue.len(), 1);
         assert!(queue.contains(&msg.id.as_str()));
@@ -425,17 +420,17 @@ mod tests {
 
         // enqueue no longer rejects based on max_retries — it's a pure
         // scheduling mechanism. ACK timeouts govern permanent failure.
-        assert!(queue.enqueue(msg.clone(), 0).is_ok());
+        queue.enqueue(msg.clone(), 0);
         queue.dequeue_ready(); // Clear queue
 
-        assert!(queue.enqueue(msg.clone(), 1).is_ok());
+        queue.enqueue(msg.clone(), 1);
         queue.dequeue_ready();
 
         // Previously this would fail; now it should succeed
-        assert!(queue.enqueue(msg.clone(), 2).is_ok());
+        queue.enqueue(msg.clone(), 2);
         queue.dequeue_ready();
 
-        assert!(queue.enqueue(msg.clone(), 100).is_ok());
+        queue.enqueue(msg.clone(), 100);
     }
 
     #[test]
@@ -450,9 +445,9 @@ mod tests {
         let msg2 = create_test_message(MessagePriority::Low);
         let msg3 = create_test_message(MessagePriority::Medium);
 
-        queue.enqueue(msg1.clone(), 0).unwrap();
-        queue.enqueue(msg2.clone(), 0).unwrap();
-        queue.enqueue(msg3.clone(), 0).unwrap();
+        queue.enqueue(msg1.clone(), 0);
+        queue.enqueue(msg2.clone(), 0);
+        queue.enqueue(msg3.clone(), 0);
 
         // Nothing should be ready (long delay)
         assert!(queue.dequeue_ready().is_none());
@@ -479,9 +474,9 @@ mod tests {
         let high = create_test_message(MessagePriority::High);
         let medium = create_test_message(MessagePriority::Medium);
 
-        queue.enqueue(low.clone(), 0).unwrap();
-        queue.enqueue(high.clone(), 0).unwrap();
-        queue.enqueue(medium.clone(), 0).unwrap();
+        queue.enqueue(low.clone(), 0);
+        queue.enqueue(high.clone(), 0);
+        queue.enqueue(medium.clone(), 0);
 
         thread::sleep(Duration::from_millis(60));
 
@@ -532,7 +527,7 @@ mod tests {
         let mut queue = RetryQueue::new();
         let msg = create_test_message(MessagePriority::Medium);
 
-        queue.enqueue(msg.clone(), 0).unwrap();
+        queue.enqueue(msg.clone(), 0);
         assert!(queue.contains(&msg.id.as_str()));
 
         assert!(queue.remove(&msg.id.as_str()));
@@ -549,7 +544,7 @@ mod tests {
         let mut queue = RetryQueue::with_config(config);
 
         let msg = create_test_message(MessagePriority::Medium);
-        queue.enqueue(msg, 0).unwrap();
+        queue.enqueue(msg, 0);
 
         // Wait for expiration
         thread::sleep(Duration::from_millis(150));
@@ -567,18 +562,10 @@ mod tests {
         };
         let mut queue = RetryQueue::with_config(config);
 
-        queue
-            .enqueue(create_test_message(MessagePriority::High), 0)
-            .unwrap();
-        queue
-            .enqueue(create_test_message(MessagePriority::High), 0)
-            .unwrap();
-        queue
-            .enqueue(create_test_message(MessagePriority::Medium), 0)
-            .unwrap();
-        queue
-            .enqueue(create_test_message(MessagePriority::Low), 0)
-            .unwrap();
+        queue.enqueue(create_test_message(MessagePriority::High), 0);
+        queue.enqueue(create_test_message(MessagePriority::High), 0);
+        queue.enqueue(create_test_message(MessagePriority::Medium), 0);
+        queue.enqueue(create_test_message(MessagePriority::Low), 0);
 
         let stats = queue.stats();
         assert_eq!(stats.total_count, 4);

--- a/crates/offline-protocol-reliability/src/retry_queue.rs
+++ b/crates/offline-protocol-reliability/src/retry_queue.rs
@@ -142,21 +142,21 @@ impl RetryQueue {
     ///
     /// Returns `Ok(())` if queued, `Err` if max retries exceeded.
     pub fn enqueue(&mut self, message: Message, retry_count: u32) -> crate::Result<()> {
-        if retry_count >= self.config.max_retries {
-            return Err(crate::Error::MaxRetriesExceeded);
-        }
-
         // Prevent duplicate entries for the same message
         if self.index.contains_key(&message.id.as_str()) {
             return Ok(());
         }
 
         // Calculate retry delay with exponential backoff
+        // Cap exponent at 20 to prevent overflow with large retry counts
         let delay_ms = if retry_count == 0 {
             self.config.initial_delay_ms
         } else {
             let base_delay = self.config.initial_delay_ms
-                * (self.config.backoff_multiplier.powi(retry_count as i32) as u64);
+                * (self
+                    .config
+                    .backoff_multiplier
+                    .powi(retry_count.min(20) as i32) as u64);
             base_delay.min(self.config.max_delay_ms)
         };
 
@@ -252,6 +252,15 @@ impl RetryQueue {
     /// Checks if a message is in the queue.
     pub fn contains(&self, message_id: &str) -> bool {
         self.index.contains_key(message_id)
+    }
+
+    /// Drains all entries from the queue, ignoring `retry_at` timing.
+    ///
+    /// Returns all entries and clears the queue. Used for immediate flush
+    /// when transport becomes available.
+    pub fn drain_all(&mut self) -> Vec<RetryEntry> {
+        self.index.clear();
+        self.queue.drain().collect()
     }
 
     /// Gets the time until the next retry is ready.
@@ -394,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn test_max_retries() {
+    fn test_enqueue_accepts_high_retry_count() {
         let config = RetryConfig {
             max_retries: 2,
             ..Default::default()
@@ -403,15 +412,46 @@ mod tests {
 
         let msg = create_test_message(MessagePriority::Medium);
 
-        // Should succeed for retry 0 and 1
+        // enqueue no longer rejects based on max_retries — it's a pure
+        // scheduling mechanism. ACK timeouts govern permanent failure.
         assert!(queue.enqueue(msg.clone(), 0).is_ok());
         queue.dequeue_ready(); // Clear queue
 
         assert!(queue.enqueue(msg.clone(), 1).is_ok());
         queue.dequeue_ready();
 
-        // Should fail for retry 2 (max_retries = 2)
-        assert!(queue.enqueue(msg.clone(), 2).is_err());
+        // Previously this would fail; now it should succeed
+        assert!(queue.enqueue(msg.clone(), 2).is_ok());
+        queue.dequeue_ready();
+
+        assert!(queue.enqueue(msg.clone(), 100).is_ok());
+    }
+
+    #[test]
+    fn test_drain_all() {
+        let config = RetryConfig {
+            initial_delay_ms: 60_000, // Long delay so nothing is "ready"
+            ..Default::default()
+        };
+        let mut queue = RetryQueue::with_config(config);
+
+        let msg1 = create_test_message(MessagePriority::High);
+        let msg2 = create_test_message(MessagePriority::Low);
+        let msg3 = create_test_message(MessagePriority::Medium);
+
+        queue.enqueue(msg1.clone(), 0).unwrap();
+        queue.enqueue(msg2.clone(), 0).unwrap();
+        queue.enqueue(msg3.clone(), 0).unwrap();
+
+        // Nothing should be ready (long delay)
+        assert!(queue.dequeue_ready().is_none());
+        assert_eq!(queue.len(), 3);
+
+        // drain_all returns everything regardless of timing
+        let entries = queue.drain_all();
+        assert_eq!(entries.len(), 3);
+        assert!(queue.is_empty());
+        assert!(!queue.contains(&msg1.id.as_str()));
     }
 
     #[test]

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -1782,15 +1782,11 @@ impl OfflineProtocol {
             }
         }
 
-        // When reconnecting after disconnection, trigger outbox flush
-        // This ensures pending messages are retried immediately
+        // When reconnecting after disconnection, immediately flush all pending
+        // outbox messages (bypasses backoff timers)
         if is_connected && !was_connected {
-            // Process pending retries to flush outbox
             let mut protocol = self.lock_inner()?;
-            if let Err(e) = protocol.process() {
-                // Log but don't fail - outbox flush is best-effort
-                tracing::warn!(error = %e, "Failed to flush outbox on reconnect");
-            }
+            protocol.flush_outbox_all();
         }
 
         // Emit connection event

--- a/crates/offline-protocol/src/config.rs
+++ b/crates/offline-protocol/src/config.rs
@@ -588,8 +588,8 @@ mod tests {
     #[test]
     fn test_reliability_config_default() {
         let reliability = ReliabilityConfig::default();
-        assert_eq!(reliability.ack.default_timeout_ms, 5000);
-        assert_eq!(reliability.retry.max_retries, 3);
+        assert_eq!(reliability.ack.default_timeout_ms, 10000);
+        assert_eq!(reliability.retry.max_retries, 10);
         assert_eq!(reliability.dedup.max_tracked_messages, 1000);
     }
 

--- a/crates/offline-protocol/src/constants.rs
+++ b/crates/offline-protocol/src/constants.rs
@@ -72,6 +72,10 @@ pub const ORIGINAL_CONTENT_TYPE_KEY: &str = "original_content_type";
 /// forwarding chains from malicious or buggy clients.
 pub const MAX_FORWARD_COUNT: u32 = 100;
 
+/// Maximum messages to send in a single flush operation.
+/// Prevents blocking the process loop when many messages are pending.
+pub const FLUSH_BATCH_LIMIT: usize = 20;
+
 /// Default route quality assigned when learning a route from a relayed message.
 /// Conservative (0.5) because the transport layer doesn't expose the immediate
 /// peer identity, so the route may be sub-optimal for multi-hop return paths.

--- a/crates/offline-protocol/src/protocol/config_accessors.rs
+++ b/crates/offline-protocol/src/protocol/config_accessors.rs
@@ -118,6 +118,12 @@ impl OfflineProtocol {
         self.retry_queue.len()
     }
 
+    /// Returns a mutable reference to the retry queue (test-only).
+    #[cfg(test)]
+    pub(crate) fn retry_queue_mut(&mut self) -> &mut offline_protocol_reliability::RetryQueue {
+        &mut self.retry_queue
+    }
+
     /// Cleans up expired entries from deduplicator, retry queue, outbox, and ack manager.
     /// Also checks for Internet availability transitions to sync groups with relay.
     pub(crate) fn cleanup_expired_entries(&mut self) {

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -455,6 +455,9 @@ impl OfflineProtocol {
             debug!(peer_id = %peer_id, cap = MAX_KNOWN_PEERS, "Known peers at capacity, not tracking new peer");
         }
 
+        // Flush any pending outbox messages destined for this peer
+        self.flush_outbox_for_peer(peer_id);
+
         // Only send key package if encryption is enabled and auto key exchange is on
         if !self.config.encryption.enabled || !self.config.encryption.auto_key_exchange {
             return;
@@ -472,6 +475,148 @@ impl OfflineProtocol {
 
         if let Err(e) = self.send_key_package_to(peer_id, false) {
             warn!(error = %e, peer_id = %peer_id, "Failed to send key package on discovery");
+        }
+    }
+
+    /// Immediately attempts to send all pending outbox messages destined for a specific peer.
+    ///
+    /// Called when a peer is discovered to flush messages that were queued while
+    /// the peer was unreachable, bypassing backoff timers.
+    fn flush_outbox_for_peer(&mut self, peer_id: &str) {
+        // Collect matching messages from outbox + media_outbox
+        let mut to_send: Vec<(Message, u32)> = Vec::new();
+
+        for entry in self.outbox.values() {
+            if entry.message.recipient.as_str() == peer_id {
+                to_send.push((entry.message.clone(), entry.attempt_count));
+            }
+        }
+        for entry in self.media_outbox.values() {
+            if entry.message.recipient.as_str() == peer_id {
+                to_send.push((entry.message.clone(), entry.attempt_count));
+            }
+        }
+
+        if to_send.is_empty() {
+            return;
+        }
+
+        let batch_limit = 20;
+        let count = to_send.len().min(batch_limit);
+        debug!(peer_id = %peer_id, count = count, "Flushing outbox for discovered peer");
+
+        for (message, attempt_count) in to_send.into_iter().take(batch_limit) {
+            // Remove from retry queue since we're sending immediately
+            self.retry_queue.remove(&message.id.as_str());
+
+            let forced_transport = self.pinned_media_transport_for_message(&message.id);
+            let send_result = if let Some(transport) = forced_transport {
+                self.transport_manager
+                    .send_via_transport(&message, transport)
+            } else {
+                self.transport_manager.send(&message)
+            };
+            let current_transport =
+                forced_transport.or_else(|| self.transport_manager.current_transport());
+
+            match send_result {
+                Ok(()) => {
+                    if let Err(e) = self.ensure_ack_registration(&message) {
+                        warn!(message_id = %message.id, error = %e, "ACK registration failed during flush");
+                    }
+                    self.mark_message_sent(
+                        &message,
+                        current_transport,
+                        Some(attempt_count.saturating_add(1)),
+                    );
+                    debug!(message_id = %message.id, "Flush send succeeded for peer");
+                }
+                Err(e) => {
+                    // Re-enqueue to retry queue with current attempt count for backoff
+                    if let Err(eq_err) = self.retry_queue.enqueue(message.clone(), attempt_count) {
+                        warn!(message_id = %message.id, error = %eq_err, "Failed to re-enqueue after flush failure");
+                    }
+                    debug!(message_id = %message.id, error = %e, "Flush send failed, re-enqueued");
+                }
+            }
+        }
+    }
+
+    /// Immediately attempts to send all pending outbox messages across all peers.
+    ///
+    /// Called when a transport becomes available (e.g. internet reconnects) to
+    /// flush all queued messages, bypassing backoff timers.
+    pub fn flush_outbox_all(&mut self) {
+        // Drain all entries from the retry queue (ignores timing)
+        let retry_entries = self.retry_queue.drain_all();
+
+        // Also collect outbox entries NOT in the retry queue (stranded after
+        // previous max_retries rejection)
+        let mut all_messages: Vec<(Message, u32)> = retry_entries
+            .into_iter()
+            .map(|e| (e.message, e.retry_count))
+            .collect();
+
+        // Add outbox entries that weren't in the retry queue
+        let retry_ids: std::collections::HashSet<String> =
+            all_messages.iter().map(|(m, _)| m.id.as_str()).collect();
+
+        for entry in self.outbox.values() {
+            if !retry_ids.contains(&entry.message.id.as_str()) {
+                all_messages.push((entry.message.clone(), entry.attempt_count));
+            }
+        }
+        for entry in self.media_outbox.values() {
+            if !retry_ids.contains(&entry.message.id.as_str()) {
+                all_messages.push((entry.message.clone(), entry.attempt_count));
+            }
+        }
+
+        if all_messages.is_empty() {
+            return;
+        }
+
+        let batch_limit = 20;
+        let count = all_messages.len().min(batch_limit);
+        debug!(
+            count = count,
+            total = all_messages.len(),
+            "Flushing all outbox messages"
+        );
+
+        for (message, attempt_count) in all_messages.into_iter().take(batch_limit) {
+            self.ensure_outbox_entry(&message);
+
+            let forced_transport = self.pinned_media_transport_for_message(&message.id);
+            let send_result = if let Some(transport) = forced_transport {
+                self.transport_manager
+                    .send_via_transport(&message, transport)
+            } else {
+                self.transport_manager.send(&message)
+            };
+            let current_transport =
+                forced_transport.or_else(|| self.transport_manager.current_transport());
+
+            match send_result {
+                Ok(()) => {
+                    if let Err(e) = self.ensure_ack_registration(&message) {
+                        warn!(message_id = %message.id, error = %e, "ACK registration failed during flush");
+                    }
+                    self.mark_message_sent(
+                        &message,
+                        current_transport,
+                        Some(attempt_count.saturating_add(1)),
+                    );
+                    debug!(message_id = %message.id, "Flush send succeeded");
+                }
+                Err(e) => {
+                    // Re-enqueue with current attempt count for backoff
+                    if let Err(eq_err) = self.retry_queue.enqueue(message.clone(), attempt_count) {
+                        warn!(message_id = %message.id, error = %eq_err, "Failed to re-enqueue after flush failure");
+                    }
+                    debug!(message_id = %message.id, error = %e, "Flush send failed, re-enqueued");
+                }
+            }
         }
     }
 
@@ -1067,6 +1212,7 @@ impl OfflineProtocol {
         drop(state);
 
         self.handle_outbound_media_chunk_failed(message_id, "max retries exceeded");
+        self.retry_queue.remove(&message_id.as_str());
         self.ack_manager.remove_ack(message_id);
         if let Some(entry) = self.remove_outbox_entry(message_id) {
             if let Some(transport) = entry.last_transport {

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -577,7 +577,7 @@ impl OfflineProtocol {
 
         // Re-enqueue any messages beyond the batch limit so they aren't lost
         for (message, attempt_count) in iter {
-            let _ = self.retry_queue.enqueue(message, attempt_count);
+            self.retry_queue.enqueue(message, attempt_count);
         }
     }
 
@@ -613,9 +613,7 @@ impl OfflineProtocol {
                 debug!(message_id = %message.id, "Flush send succeeded");
             }
             Err(e) => {
-                if let Err(eq_err) = self.retry_queue.enqueue(message.clone(), attempt_count) {
-                    warn!(message_id = %message.id, error = %eq_err, "Failed to re-enqueue after flush failure");
-                }
+                self.retry_queue.enqueue(message.clone(), attempt_count);
                 debug!(message_id = %message.id, error = %e, "Flush send failed, re-enqueued");
             }
         }
@@ -1092,7 +1090,7 @@ impl OfflineProtocol {
     /// - Properly tracks retry counts and transport failures
     fn process_retry_queue(&mut self) -> Result<()> {
         // Limit batch size to prevent blocking on large queues
-        let max_batch_size = 20;
+        let max_batch_size = crate::constants::FLUSH_BATCH_LIMIT;
         let mut processed = 0;
 
         while processed < max_batch_size {
@@ -1140,19 +1138,9 @@ impl OfflineProtocol {
                     );
                 }
                 Err(e) => {
-                    // Re-enqueue with incremented retry count
-                    // If this fails (max retries), the message remains in outbox
-                    if self
-                        .retry_queue
-                        .enqueue(entry.message.clone(), entry.retry_count + 1)
-                        .is_err()
-                    {
-                        warn!(
-                            message_id = %entry.message.id,
-                            retry_count = entry.retry_count,
-                            "Max retries exceeded, message remains in outbox for recovery"
-                        );
-                    }
+                    // Re-enqueue with incremented retry count for backoff
+                    self.retry_queue
+                        .enqueue(entry.message.clone(), entry.retry_count + 1);
 
                     if let Some(transport) = forced_transport.or(previous_transport) {
                         self.transport_manager.record_retry_failure(transport);
@@ -1234,7 +1222,7 @@ impl OfflineProtocol {
             let last_transport = entry.last_transport;
 
             // enqueue is infallible (retry queue has no attempt limit)
-            let _ = self.retry_queue.enqueue(message_clone, retry_count);
+            self.retry_queue.enqueue(message_clone, retry_count);
             if let Some(transport) = last_transport {
                 self.transport_manager.record_retry_failure(transport);
             }

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -532,17 +532,24 @@ impl OfflineProtocol {
             .map(|e| (e.message, e.retry_count))
             .collect();
 
-        // Add outbox entries that weren't in the retry queue
+        // Add outbox entries that weren't in the retry queue (stranded) AND
+        // aren't already waiting for an ACK (successfully sent, just awaiting
+        // confirmation). Without the ACK check, a prior flush that succeeded
+        // would cause these messages to be re-sent unnecessarily.
         let retry_ids: std::collections::HashSet<String> =
             all_messages.iter().map(|(m, _)| m.id.as_str()).collect();
 
         for entry in self.outbox.values() {
-            if !retry_ids.contains(&entry.message.id.as_str()) {
+            if !retry_ids.contains(&entry.message.id.as_str())
+                && !self.ack_manager.is_waiting_for_ack(&entry.message.id)
+            {
                 all_messages.push((entry.message.clone(), entry.attempt_count));
             }
         }
         for entry in self.media_outbox.values() {
-            if !retry_ids.contains(&entry.message.id.as_str()) {
+            if !retry_ids.contains(&entry.message.id.as_str())
+                && !self.ack_manager.is_waiting_for_ack(&entry.message.id)
+            {
                 all_messages.push((entry.message.clone(), entry.attempt_count));
             }
         }

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -501,44 +501,16 @@ impl OfflineProtocol {
             return;
         }
 
-        let batch_limit = 20;
-        let count = to_send.len().min(batch_limit);
+        let count = to_send.len().min(crate::constants::FLUSH_BATCH_LIMIT);
         debug!(peer_id = %peer_id, count = count, "Flushing outbox for discovered peer");
 
-        for (message, attempt_count) in to_send.into_iter().take(batch_limit) {
+        for (message, attempt_count) in to_send
+            .into_iter()
+            .take(crate::constants::FLUSH_BATCH_LIMIT)
+        {
             // Remove from retry queue since we're sending immediately
             self.retry_queue.remove(&message.id.as_str());
-
-            let forced_transport = self.pinned_media_transport_for_message(&message.id);
-            let send_result = if let Some(transport) = forced_transport {
-                self.transport_manager
-                    .send_via_transport(&message, transport)
-            } else {
-                self.transport_manager.send(&message)
-            };
-            let current_transport =
-                forced_transport.or_else(|| self.transport_manager.current_transport());
-
-            match send_result {
-                Ok(()) => {
-                    if let Err(e) = self.ensure_ack_registration(&message) {
-                        warn!(message_id = %message.id, error = %e, "ACK registration failed during flush");
-                    }
-                    self.mark_message_sent(
-                        &message,
-                        current_transport,
-                        Some(attempt_count.saturating_add(1)),
-                    );
-                    debug!(message_id = %message.id, "Flush send succeeded for peer");
-                }
-                Err(e) => {
-                    // Re-enqueue to retry queue with current attempt count for backoff
-                    if let Err(eq_err) = self.retry_queue.enqueue(message.clone(), attempt_count) {
-                        warn!(message_id = %message.id, error = %eq_err, "Failed to re-enqueue after flush failure");
-                    }
-                    debug!(message_id = %message.id, error = %e, "Flush send failed, re-enqueued");
-                }
-            }
+            self.try_flush_send(message, attempt_count);
         }
     }
 
@@ -576,46 +548,55 @@ impl OfflineProtocol {
             return;
         }
 
-        let batch_limit = 20;
-        let count = all_messages.len().min(batch_limit);
+        let count = all_messages.len().min(crate::constants::FLUSH_BATCH_LIMIT);
         debug!(
             count = count,
             total = all_messages.len(),
             "Flushing all outbox messages"
         );
 
-        for (message, attempt_count) in all_messages.into_iter().take(batch_limit) {
+        for (message, attempt_count) in all_messages
+            .into_iter()
+            .take(crate::constants::FLUSH_BATCH_LIMIT)
+        {
             self.ensure_outbox_entry(&message);
+            self.try_flush_send(message, attempt_count);
+        }
+    }
 
-            let forced_transport = self.pinned_media_transport_for_message(&message.id);
-            let send_result = if let Some(transport) = forced_transport {
-                self.transport_manager
-                    .send_via_transport(&message, transport)
-            } else {
-                self.transport_manager.send(&message)
-            };
-            let current_transport =
-                forced_transport.or_else(|| self.transport_manager.current_transport());
+    /// Attempts to send a single message as part of a flush operation.
+    ///
+    /// On success, registers ACK tracking and updates the outbox entry.
+    /// On failure, re-enqueues the message to the retry queue with its
+    /// current attempt count so backoff resumes.
+    fn try_flush_send(&mut self, message: Message, attempt_count: u32) {
+        let forced_transport = self.pinned_media_transport_for_message(&message.id);
+        let send_result = if let Some(transport) = forced_transport {
+            self.transport_manager
+                .send_via_transport(&message, transport)
+        } else {
+            self.transport_manager.send(&message)
+        };
+        let current_transport =
+            forced_transport.or_else(|| self.transport_manager.current_transport());
 
-            match send_result {
-                Ok(()) => {
-                    if let Err(e) = self.ensure_ack_registration(&message) {
-                        warn!(message_id = %message.id, error = %e, "ACK registration failed during flush");
-                    }
-                    self.mark_message_sent(
-                        &message,
-                        current_transport,
-                        Some(attempt_count.saturating_add(1)),
-                    );
-                    debug!(message_id = %message.id, "Flush send succeeded");
+        match send_result {
+            Ok(()) => {
+                if let Err(e) = self.ensure_ack_registration(&message) {
+                    warn!(message_id = %message.id, error = %e, "ACK registration failed during flush");
                 }
-                Err(e) => {
-                    // Re-enqueue with current attempt count for backoff
-                    if let Err(eq_err) = self.retry_queue.enqueue(message.clone(), attempt_count) {
-                        warn!(message_id = %message.id, error = %eq_err, "Failed to re-enqueue after flush failure");
-                    }
-                    debug!(message_id = %message.id, error = %e, "Flush send failed, re-enqueued");
+                self.mark_message_sent(
+                    &message,
+                    current_transport,
+                    Some(attempt_count.saturating_add(1)),
+                );
+                debug!(message_id = %message.id, "Flush send succeeded");
+            }
+            Err(e) => {
+                if let Err(eq_err) = self.retry_queue.enqueue(message.clone(), attempt_count) {
+                    warn!(message_id = %message.id, error = %eq_err, "Failed to re-enqueue after flush failure");
                 }
+                debug!(message_id = %message.id, error = %e, "Flush send failed, re-enqueued");
             }
         }
     }
@@ -1232,48 +1213,13 @@ impl OfflineProtocol {
             let message_clone = entry.message.clone();
             let last_transport = entry.last_transport;
 
-            match self.retry_queue.enqueue(message_clone, retry_count) {
-                Ok(()) => {
-                    if let Some(transport) = last_transport {
-                        self.transport_manager.record_retry_failure(transport);
-                    }
-                }
-                Err(_) => {
-                    self.handle_retry_queue_unavailable(message_id, retry_count)?;
-                }
+            // enqueue is infallible (retry queue has no attempt limit)
+            let _ = self.retry_queue.enqueue(message_clone, retry_count);
+            if let Some(transport) = last_transport {
+                self.transport_manager.record_retry_failure(transport);
             }
         } else {
             self.handle_missing_outbox_entry(message_id, retry_count)?;
-        }
-        Ok(())
-    }
-
-    /// Handles the case when retry queue is unavailable.
-    fn handle_retry_queue_unavailable(
-        &mut self,
-        message_id: &MessageId,
-        retry_count: u32,
-    ) -> Result<()> {
-        let state = lock_shared_state(&self.shared_state).map_err(|e| {
-            error!(
-                "Failed to lock shared state for retry queue error event: {}",
-                e
-            );
-            e
-        })?;
-        state.emit_event(Event::message_failed(
-            message_id.clone(),
-            "Retry queue unavailable".to_string(),
-            retry_count,
-        ));
-        drop(state);
-
-        self.handle_outbound_media_chunk_failed(message_id, "retry queue unavailable");
-        self.ack_manager.remove_ack(message_id);
-        if let Some(entry) = self.remove_outbox_entry(message_id) {
-            if let Some(transport) = entry.last_transport {
-                self.transport_manager.record_delivery_failure(transport);
-            }
         }
         Ok(())
     }

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -504,6 +504,9 @@ impl OfflineProtocol {
         let count = to_send.len().min(crate::constants::FLUSH_BATCH_LIMIT);
         debug!(peer_id = %peer_id, count = count, "Flushing outbox for discovered peer");
 
+        // Only process up to FLUSH_BATCH_LIMIT messages. Overflow messages
+        // are not removed from the retry queue, so they retain their backoff
+        // timers and will be picked up on the next process() tick or flush.
         for (message, attempt_count) in to_send
             .into_iter()
             .take(crate::constants::FLUSH_BATCH_LIMIT)

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -559,17 +559,19 @@ impl OfflineProtocol {
             .into_iter()
             .take(crate::constants::FLUSH_BATCH_LIMIT)
         {
-            self.ensure_outbox_entry(&message);
             self.try_flush_send(message, attempt_count);
         }
     }
 
     /// Attempts to send a single message as part of a flush operation.
     ///
-    /// On success, registers ACK tracking and updates the outbox entry.
-    /// On failure, re-enqueues the message to the retry queue with its
-    /// current attempt count so backoff resumes.
+    /// Ensures the outbox entry exists before sending (it may have been evicted
+    /// by capacity limits while the message sat in the retry queue). On success,
+    /// registers ACK tracking and updates the outbox entry. On failure,
+    /// re-enqueues the message to the retry queue with its current attempt count
+    /// so backoff resumes.
     fn try_flush_send(&mut self, message: Message, attempt_count: u32) {
+        self.ensure_outbox_entry(&message);
         let forced_transport = self.pinned_media_transport_for_message(&message.id);
         let send_result = if let Some(transport) = forced_transport {
             self.transport_manager
@@ -1237,6 +1239,12 @@ impl OfflineProtocol {
     #[cfg(test)]
     pub(crate) fn outbox_messages(&self) -> impl Iterator<Item = &Message> {
         self.outbox.values().map(|e| &e.message)
+    }
+
+    /// Returns the total number of entries across outbox and media_outbox (test-only).
+    #[cfg(test)]
+    pub(crate) fn outbox_entry_count(&self) -> usize {
+        self.outbox.len() + self.media_outbox.len()
     }
 
     /// Clears all outbox entries (test-only).

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -555,11 +555,15 @@ impl OfflineProtocol {
             "Flushing all outbox messages"
         );
 
-        for (message, attempt_count) in all_messages
-            .into_iter()
-            .take(crate::constants::FLUSH_BATCH_LIMIT)
-        {
+        let mut iter = all_messages.into_iter();
+
+        for (message, attempt_count) in iter.by_ref().take(crate::constants::FLUSH_BATCH_LIMIT) {
             self.try_flush_send(message, attempt_count);
+        }
+
+        // Re-enqueue any messages beyond the batch limit so they aren't lost
+        for (message, attempt_count) in iter {
+            let _ = self.retry_queue.enqueue(message, attempt_count);
         }
     }
 

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -487,12 +487,16 @@ impl OfflineProtocol {
         let mut to_send: Vec<(Message, u32)> = Vec::new();
 
         for entry in self.outbox.values() {
-            if entry.message.recipient.as_str() == peer_id {
+            if entry.message.recipient.as_str() == peer_id
+                && !self.ack_manager.is_waiting_for_ack(&entry.message.id)
+            {
                 to_send.push((entry.message.clone(), entry.attempt_count));
             }
         }
         for entry in self.media_outbox.values() {
-            if entry.message.recipient.as_str() == peer_id {
+            if entry.message.recipient.as_str() == peer_id
+                && !self.ack_manager.is_waiting_for_ack(&entry.message.id)
+            {
                 to_send.push((entry.message.clone(), entry.attempt_count));
             }
         }

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -1417,25 +1417,8 @@ impl OfflineProtocol {
         // Ensure message is persisted to outbox for recovery
         self.ensure_outbox_entry(message);
 
-        // Schedule retry. If queuing fails, treat this as a terminal failure.
-        if let Err(e) = self.retry_queue.enqueue(message.clone(), 0) {
-            warn!(
-                message_id = %message.id,
-                error = %e,
-                "Failed to enqueue message for retry"
-            );
-            if message.content_type == ContentType::FileChunk {
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::message_failed(
-                        message.id.clone(),
-                        "Retry queue unavailable".to_string(),
-                        0,
-                    ));
-                }
-                self.handle_outbound_media_chunk_failed(&message.id, "retry queue unavailable");
-                self.remove_outbox_entry(&message.id);
-            }
-        }
+        // Schedule retry (enqueue is infallible — no attempt limit)
+        let _ = self.retry_queue.enqueue(message.clone(), 0);
 
         warn!(
             message_id = %message.id,

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -1341,6 +1341,7 @@ impl OfflineProtocol {
             if let Some(transport) = last_transport {
                 self.transport_manager.record_delivery_failure(transport);
             }
+            self.retry_queue.remove(&message_id.as_str());
             self.outbox.remove(&message_id);
             self.handle_outbound_media_chunk_failed(&message_id, "outbox lifetime exceeded");
         }
@@ -1360,6 +1361,7 @@ impl OfflineProtocol {
             if let Some(transport) = last_transport {
                 self.transport_manager.record_delivery_failure(transport);
             }
+            self.retry_queue.remove(&message_id.as_str());
             self.media_outbox.remove(&message_id);
             self.handle_outbound_media_chunk_failed(&message_id, "outbox lifetime exceeded");
         }

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -142,10 +142,13 @@ impl OfflineProtocol {
                     error = %err,
                     "Send failed, message deferred"
                 );
-                Err(Error::Other(format!(
-                    "Send failed (message {} deferred for retry): {}",
-                    message.id, err
-                )))
+                self.emit_event(Event::message_deferred(
+                    message.id.clone(),
+                    format!("Transport send failed: {}", err),
+                    0,
+                    None,
+                ));
+                Ok(message_id)
             }
         }
     }
@@ -261,10 +264,13 @@ impl OfflineProtocol {
                     error = %err,
                     "Send failed, message deferred"
                 );
-                Err(Error::Other(format!(
-                    "Send failed (message {} deferred for retry): {}",
-                    message.id, err
-                )))
+                self.emit_event(Event::message_deferred(
+                    message.id.clone(),
+                    format!("Transport send failed: {}", err),
+                    0,
+                    None,
+                ));
+                Ok(message_id)
             }
         }
     }
@@ -420,10 +426,13 @@ impl OfflineProtocol {
                     error = %err,
                     "Send via forced transport failed, message deferred"
                 );
-                Err(Error::Other(format!(
-                    "Send via {:?} failed (message {} deferred for retry): {}",
-                    transport, message.id, err
-                )))
+                self.emit_event(Event::message_deferred(
+                    message.id.clone(),
+                    format!("Send via {:?} failed: {}", transport, err),
+                    0,
+                    None,
+                ));
+                Ok(message_id)
             }
         }
     }
@@ -1674,6 +1683,7 @@ impl OfflineProtocol {
                         hop_count,
                     );
                     self.handle_outbound_media_chunk_delivered(&message_id);
+                    self.retry_queue.remove(&message_id.as_str());
                     self.remove_outbox_entry(&message_id);
                 }
             }

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -1420,7 +1420,7 @@ impl OfflineProtocol {
         self.ensure_outbox_entry(message);
 
         // Schedule retry (enqueue is infallible — no attempt limit)
-        let _ = self.retry_queue.enqueue(message.clone(), 0);
+        self.retry_queue.enqueue(message.clone(), 0);
 
         warn!(
             message_id = %message.id,

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -9346,3 +9346,42 @@ fn test_flush_outbox_all_includes_media_outbox() {
         "Stranded media outbox message should be sent by flush_outbox_all"
     );
 }
+
+#[test]
+fn test_flush_outbox_for_peer_skips_messages_awaiting_ack() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    let mock_clone = mock.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    protocol.start().unwrap();
+
+    // Send a message — succeeds, enters ACK tracking
+    let _msg_id = protocol
+        .send_message("bob", "Hello!", None::<MessagePriority>, None::<String>)
+        .unwrap();
+
+    // Message was sent successfully: it should be in outbox (awaiting ACK)
+    // but NOT in the retry queue
+    assert_eq!(protocol.retry_queue_size(), 0);
+    assert!(protocol.outbox_entry_count() > 0);
+
+    let sent_before = mock_clone.sent_messages().len();
+
+    // Discovering the peer again should NOT re-send the message because it
+    // already has a pending ACK
+    protocol.on_neighbor_discovered("bob");
+
+    let sent_after = mock_clone.sent_messages().len();
+    assert_eq!(
+        sent_before, sent_after,
+        "flush_outbox_for_peer should not re-send messages awaiting ACK"
+    );
+}

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -9010,7 +9010,7 @@ fn test_ack_receipt_cleans_up_retry_queue() {
 
     // Manually enqueue into retry queue to simulate a retry-in-flight scenario
     let msg = protocol.outbox_messages().next().unwrap().clone();
-    let _ = protocol.retry_queue_mut().enqueue(msg, 1);
+    protocol.retry_queue_mut().enqueue(msg, 1);
     assert!(protocol.retry_queue_size() > 0);
 
     // Simulate receiving an ACK from bob for this message
@@ -9207,7 +9207,12 @@ fn test_cleanup_outbox_removes_retry_queue_entry() {
 
     // Send a message — deferred, enters outbox + retry queue
     let _ = protocol
-        .send_message("bob", "will expire", None::<MessagePriority>, None::<String>)
+        .send_message(
+            "bob",
+            "will expire",
+            None::<MessagePriority>,
+            None::<String>,
+        )
         .unwrap();
     assert_eq!(protocol.retry_queue_size(), 1);
     assert!(protocol.outbox_entry_count() > 0);
@@ -9274,7 +9279,7 @@ fn test_flush_outbox_for_peer_includes_media_outbox() {
     );
 
     // Also enqueue in retry queue
-    let _ = protocol.retry_queue_mut().enqueue(media_msg, 0);
+    protocol.retry_queue_mut().enqueue(media_msg, 0);
     assert_eq!(protocol.retry_queue_size(), 1);
 
     // Discover the peer — should flush the media outbox message too
@@ -9283,7 +9288,10 @@ fn test_flush_outbox_for_peer_includes_media_outbox() {
     // The media message should have been sent
     let sent = mock_clone.sent_messages();
     let found = sent.iter().any(|m| m.id == media_msg_id);
-    assert!(found, "Media outbox message should be sent on peer discovery");
+    assert!(
+        found,
+        "Media outbox message should be sent on peer discovery"
+    );
 
     // Retry queue should be empty
     assert_eq!(

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -9148,3 +9148,201 @@ fn test_flush_send_failure_re_enqueues_message() {
         "Outbox entry should survive flush send failure"
     );
 }
+
+#[test]
+fn test_flush_outbox_all_skips_messages_awaiting_ack() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    let mock_clone = mock.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    protocol.start().unwrap();
+
+    // Send a message — succeeds, enters ACK tracking
+    let _msg_id = protocol
+        .send_message("bob", "Hello!", None::<MessagePriority>, None::<String>)
+        .unwrap();
+
+    // Message was sent successfully: it should be in outbox (awaiting ACK)
+    // but NOT in the retry queue
+    assert_eq!(protocol.retry_queue_size(), 0);
+    assert!(protocol.outbox_entry_count() > 0);
+
+    let sent_before = mock_clone.sent_messages().len();
+
+    // flush_outbox_all should NOT re-send this message because it already
+    // has a pending ACK
+    protocol.flush_outbox_all();
+
+    let sent_after = mock_clone.sent_messages().len();
+    assert_eq!(
+        sent_before, sent_after,
+        "flush_outbox_all should not re-send messages awaiting ACK"
+    );
+}
+
+#[test]
+fn test_cleanup_outbox_removes_retry_queue_entry() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    // Very short outbox lifetime so entries expire immediately
+    config.reliability.retry.outbox_max_lifetime_ms = 1;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Start with a transport that always fails
+    let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+
+    protocol.start().unwrap();
+
+    // Send a message — deferred, enters outbox + retry queue
+    let _ = protocol
+        .send_message("bob", "will expire", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    assert_eq!(protocol.retry_queue_size(), 1);
+    assert!(protocol.outbox_entry_count() > 0);
+
+    // Wait a tiny bit for the outbox lifetime to expire
+    std::thread::sleep(Duration::from_millis(5));
+
+    // Run cleanup — should remove both outbox entry AND retry queue entry
+    protocol.cleanup_expired_entries();
+
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        0,
+        "Outbox entry should be cleaned up after expiry"
+    );
+    assert_eq!(
+        protocol.retry_queue_size(),
+        0,
+        "Retry queue entry should be cleaned up when outbox entry expires"
+    );
+}
+
+#[test]
+fn test_flush_outbox_for_peer_includes_media_outbox() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Start with a working transport
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    let mock_clone = mock.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    protocol.start().unwrap();
+
+    // Manually insert a FileChunk message into media_outbox to simulate
+    // a media chunk that was deferred while the peer was unreachable
+    let media_msg = Message::builder(
+        UserId::new("user123").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+    )
+    .content(String::new())
+    .content_type(ContentType::FileChunk)
+    .requires_ack(true)
+    .build();
+
+    let media_msg_id = media_msg.id.clone();
+
+    // Insert into media_outbox
+    protocol.media_outbox.insert(
+        media_msg.id.clone(),
+        OutboxEntry {
+            message: media_msg.clone(),
+            attempt_count: 0,
+            first_sent_at: chrono::Utc::now(),
+            last_sent_at: chrono::Utc::now(),
+            last_transport: None,
+        },
+    );
+
+    // Also enqueue in retry queue
+    let _ = protocol.retry_queue_mut().enqueue(media_msg, 0);
+    assert_eq!(protocol.retry_queue_size(), 1);
+
+    // Discover the peer — should flush the media outbox message too
+    protocol.on_neighbor_discovered("bob");
+
+    // The media message should have been sent
+    let sent = mock_clone.sent_messages();
+    let found = sent.iter().any(|m| m.id == media_msg_id);
+    assert!(found, "Media outbox message should be sent on peer discovery");
+
+    // Retry queue should be empty
+    assert_eq!(
+        protocol.retry_queue_size(),
+        0,
+        "Retry queue should be empty after flushing media message"
+    );
+}
+
+#[test]
+fn test_flush_outbox_all_includes_media_outbox() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Start with a working transport
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    let mock_clone = mock.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    protocol.start().unwrap();
+
+    // Insert a stranded FileChunk in media_outbox (not in retry queue)
+    let media_msg = Message::builder(
+        UserId::new("user123").unwrap(),
+        UserId::new("alice").unwrap(),
+        AppId::new("test-app").unwrap(),
+    )
+    .content(String::new())
+    .content_type(ContentType::FileChunk)
+    .requires_ack(true)
+    .build();
+
+    let media_msg_id = media_msg.id.clone();
+
+    protocol.media_outbox.insert(
+        media_msg.id.clone(),
+        OutboxEntry {
+            message: media_msg,
+            attempt_count: 1,
+            first_sent_at: chrono::Utc::now(),
+            last_sent_at: chrono::Utc::now(),
+            last_transport: None,
+        },
+    );
+
+    // No retry queue entry — simulates a stranded media outbox entry
+
+    // flush_outbox_all should pick up the stranded media entry
+    protocol.flush_outbox_all();
+
+    let sent = mock_clone.sent_messages();
+    let found = sent.iter().any(|m| m.id == media_msg_id);
+    assert!(
+        found,
+        "Stranded media outbox message should be sent by flush_outbox_all"
+    );
+}

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -8888,3 +8888,212 @@ fn test_flush_batch_limit_caps_sends() {
         protocol.retry_queue_size()
     );
 }
+
+#[test]
+fn test_flush_outbox_all_on_internet_reconnect() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Start with a transport that always fails
+    let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+
+    protocol.start().unwrap();
+
+    // Queue several messages to different peers
+    for peer in &["alice", "bob", "carol"] {
+        let _ = protocol.send_message(*peer, "hello", None::<MessagePriority>, None::<String>);
+    }
+    assert_eq!(protocol.retry_queue_size(), 3);
+
+    // Replace with a working transport
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    let observed_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let observed_clone = observed_events.clone();
+    protocol.on_event(move |event| {
+        observed_clone.lock().unwrap().push(event);
+    });
+
+    // Simulate internet reconnect — flush all
+    protocol.flush_outbox_all();
+
+    // All messages should have been flushed from the retry queue
+    assert_eq!(
+        protocol.retry_queue_size(),
+        0,
+        "Retry queue should be empty after flush_outbox_all"
+    );
+}
+
+#[test]
+fn test_flush_outbox_all_collects_stranded_outbox_entries() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Start with a transport that always fails
+    let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+
+    protocol.start().unwrap();
+
+    // Queue a message — goes to outbox AND retry queue
+    let msg_id = protocol
+        .send_message("bob", "stranded", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    assert_eq!(protocol.retry_queue_size(), 1);
+    assert!(protocol.outbox_entry_count() > 0);
+
+    // Manually remove from retry queue to simulate a "stranded" outbox entry
+    // (e.g., from a prior max_retries rejection in the old code path)
+    protocol.retry_queue_mut().remove(&msg_id.as_str());
+    assert_eq!(protocol.retry_queue_size(), 0);
+    // Outbox entry still exists
+    assert!(protocol.outbox_entry_count() > 0);
+
+    // Replace with a working transport
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    let mock_clone = mock.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    // flush_outbox_all should pick up the stranded outbox entry
+    protocol.flush_outbox_all();
+
+    // The stranded message should have been sent
+    let sent = mock_clone.sent_messages();
+    assert!(
+        !sent.is_empty(),
+        "Expected stranded outbox message to be sent"
+    );
+}
+
+#[test]
+fn test_ack_receipt_cleans_up_retry_queue() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock.clone()));
+
+    let observed_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let observed_clone = observed_events.clone();
+    protocol.on_event(move |event| {
+        observed_clone.lock().unwrap().push(event);
+    });
+
+    protocol.start().unwrap();
+
+    // Send a message — succeeds, enters ACK tracking
+    let msg_id = protocol
+        .send_message("bob", "Hello!", None::<MessagePriority>, None::<String>)
+        .unwrap();
+
+    // Manually enqueue into retry queue to simulate a retry-in-flight scenario
+    let msg = protocol.outbox_messages().next().unwrap().clone();
+    let _ = protocol.retry_queue_mut().enqueue(msg, 1);
+    assert!(protocol.retry_queue_size() > 0);
+
+    // Simulate receiving an ACK from bob for this message
+    let ack_message = Message::builder(
+        UserId::new("bob").unwrap(),
+        UserId::new("user123").unwrap(),
+        AppId::new("test-app").unwrap(),
+    )
+    .content(String::new())
+    .requires_ack(false)
+    .metadata(ACK_FOR_KEY, msg_id.as_str())
+    .metadata("ack_hop_count", "0")
+    .metadata("ack_transport", "ble")
+    .build();
+
+    // Queue the ACK so it's received on next process
+    mock.queue_message(ack_message);
+    let _ = protocol.receive_message();
+
+    // The retry queue should be empty after ACK receipt
+    assert_eq!(
+        protocol.retry_queue_size(),
+        0,
+        "Retry queue should be cleaned up after ACK"
+    );
+
+    // Outbox should also be cleaned up
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        0,
+        "Outbox should be cleaned up after ACK"
+    );
+
+    // MessageDelivered event should have been emitted
+    let events = observed_events.lock().unwrap();
+    let delivered = events
+        .iter()
+        .find(|e| matches!(e, Event::MessageDelivered { .. }));
+    assert!(
+        delivered.is_some(),
+        "Expected MessageDelivered event, got: {:?}",
+        *events
+    );
+}
+
+#[test]
+fn test_flush_send_failure_re_enqueues_message() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Start with a transport that always fails
+    let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+
+    protocol.start().unwrap();
+
+    // Queue a message — deferred
+    let _ = protocol
+        .send_message(
+            "bob",
+            "will fail again",
+            None::<MessagePriority>,
+            None::<String>,
+        )
+        .unwrap();
+    assert_eq!(protocol.retry_queue_size(), 1);
+
+    // Flush for peer — transport still fails, so message should be re-enqueued
+    protocol.on_neighbor_discovered("bob");
+
+    assert_eq!(
+        protocol.retry_queue_size(),
+        1,
+        "Message should be re-enqueued after flush send failure"
+    );
+
+    // Outbox entry should still exist
+    assert!(
+        protocol.outbox_entry_count() > 0,
+        "Outbox entry should survive flush send failure"
+    );
+}

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -9057,6 +9057,57 @@ fn test_ack_receipt_cleans_up_retry_queue() {
 }
 
 #[test]
+fn test_flush_outbox_all_re_enqueues_overflow_beyond_batch_limit() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Start with a transport that always fails to fill the outbox
+    let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+
+    protocol.start().unwrap();
+
+    // Queue more messages than the batch limit across different peers
+    let total = crate::constants::FLUSH_BATCH_LIMIT + 10;
+    for i in 0..total {
+        let _ = protocol.send_message(
+            &format!("peer-{}", i),
+            &format!("msg-{}", i),
+            None::<MessagePriority>,
+            None::<String>,
+        );
+    }
+    assert_eq!(protocol.retry_queue_size(), total);
+
+    // Replace with a working transport
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    // Flush all — should send FLUSH_BATCH_LIMIT and re-enqueue the rest
+    protocol.flush_outbox_all();
+
+    // The overflow messages must still be in the retry queue, not lost
+    assert_eq!(
+        protocol.retry_queue_size(),
+        10,
+        "Overflow messages beyond batch limit should be re-enqueued"
+    );
+
+    // Outbox entries for overflowed messages should still exist
+    assert!(
+        protocol.outbox_entry_count() >= 10,
+        "Outbox entries for overflow messages should survive"
+    );
+}
+
+#[test]
 fn test_flush_send_failure_re_enqueues_message() {
     let mut config = create_test_config();
     config.reliability.retry.initial_delay_ms = 60_000;

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -8752,3 +8752,139 @@ fn test_forward_message_rejects_excessive_forward_count() {
         err_msg
     );
 }
+
+#[test]
+fn test_send_message_returns_ok_and_emits_deferred_when_transport_fails() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000; // long delay so nothing retries during test
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Use a FlakyTransport that always fails
+    let mut flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    flaky.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+
+    let observed_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let observed_clone = observed_events.clone();
+    protocol.on_event(move |event| {
+        observed_clone.lock().unwrap().push(event);
+    });
+
+    protocol.start().unwrap();
+
+    // send_message should return Ok even though the transport fails
+    let result = protocol.send_message("bob", "Hello!", None::<MessagePriority>, None::<String>);
+    assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+
+    // Should have emitted a MessageDeferred event
+    let events = observed_events.lock().unwrap();
+    let deferred = events
+        .iter()
+        .find(|e| matches!(e, Event::MessageDeferred { .. }));
+    assert!(
+        deferred.is_some(),
+        "Expected MessageDeferred event, got: {:?}",
+        *events
+    );
+
+    // Message should be in the outbox for retry
+    assert!(
+        protocol.retry_queue_size() > 0,
+        "Expected message in retry queue"
+    );
+}
+
+#[test]
+fn test_flush_outbox_for_peer_on_discovery() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000; // long delay
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Start with a transport that always fails
+    let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    // Don't start it — transport is unavailable so sends go to outbox
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+
+    protocol.start().unwrap();
+
+    // Send a message — it will be deferred
+    let _msg_id = protocol
+        .send_message("bob", "queued msg", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    assert!(protocol.retry_queue_size() > 0);
+
+    // Now replace with a working transport
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    let observed_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let observed_clone = observed_events.clone();
+    protocol.on_event(move |event| {
+        observed_clone.lock().unwrap().push(event);
+    });
+
+    // Discover the peer — should flush the pending message
+    protocol.on_neighbor_discovered("bob");
+
+    // The message should have been flushed from the retry queue
+    assert_eq!(
+        protocol.retry_queue_size(),
+        0,
+        "Retry queue should be empty after flush"
+    );
+}
+
+#[test]
+fn test_flush_batch_limit_caps_sends() {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Start with a transport that always fails to fill the outbox
+    let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+
+    protocol.start().unwrap();
+
+    // Queue more messages than the batch limit
+    let total = crate::constants::FLUSH_BATCH_LIMIT + 5;
+    for i in 0..total {
+        let _ = protocol.send_message(
+            "bob",
+            &format!("msg-{}", i),
+            None::<MessagePriority>,
+            None::<String>,
+        );
+    }
+    assert_eq!(protocol.retry_queue_size(), total);
+
+    // Replace with a working transport
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    // Flush for peer — should send at most FLUSH_BATCH_LIMIT
+    protocol.on_neighbor_discovered("bob");
+
+    // Remaining messages should still be in the outbox (not in retry queue
+    // since they weren't attempted and thus stay in outbox only)
+    assert!(
+        protocol.retry_queue_size() <= 5,
+        "Expected at most 5 remaining in retry queue, got: {}",
+        protocol.retry_queue_size()
+    );
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 |-------|-------------|
 | [DORS Deep Dive](dors.md) | How the transport selection engine works (scoring, switching, escalation) |
 | [DORS Configuration](dors-configuration.md) | Tuning DORS for different use cases with parameter reference |
+| [Message Delivery](message-delivery.md) | Delivery lifecycle, retry/ACK system, flush triggers, and client-side persistence |
 | [Mesh Networking](mesh.md) | Peer discovery, connection management, message delivery, and routing |
 | [MLS Encryption](mls-integration.md) | End-to-end encryption with auto-encryption and manual MLS APIs |
 | [Service Discovery](service-discovery.md) | Decentralized service registration, discovery, and request/response |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -330,7 +330,7 @@ Rust migration note:
 **Dedup Config**:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `maxTrackedMessages` | number | 10000 | Max message IDs to track |
+| `maxTrackedMessages` | number | 1000 | Max message IDs to track |
 | `retentionTimeSecs` | number | 3600 | Retention time (1 hour) |
 
 ### Network Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,13 +315,13 @@ Rust migration note:
 **ACK Config**:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `defaultTimeoutMs` | number | 5000 | ACK timeout (milliseconds) |
+| `defaultTimeoutMs` | number | 10000 | ACK timeout (milliseconds) |
 | `maxPendingAcks` | number | 1000 | Max pending ACKs |
 
 **Retry Config**:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `maxRetries` | number | 3 | Max retry attempts |
+| `maxRetries` | number | 10 | Max ACK retry attempts (transport retries are unlimited) |
 | `initialDelayMs` | number | 1000 | Initial retry delay |
 | `maxDelayMs` | number | 30000 | Max retry delay |
 | `backoffMultiplier` | number | 2.0 | Backoff multiplier |

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -260,19 +260,19 @@ Messages awaiting acknowledgment are stored in an in-memory outbox:
 
 Without deduplication, the same message could be processed multiple times. The deduplicator tracks seen message IDs.
 
-### Bloom Filter Mode (Default)
+### HashMap Mode (Default)
+Exact tracking with no false positives:
+- **Capacity**: 1,000 message IDs (configurable)
+- **Retention**: 1 hour (configurable)
+- **Eviction**: LRU when capacity is reached
+
+### Bloom Filter Mode
 For high-volume scenarios, a space-efficient bloom filter tracks message IDs:
 - **Memory**: ~1MB per filter (constant regardless of message count)
 - **False Positive Rate**: ~1% with default settings
 - **Rotation**: Filters rotate every 15 minutes for automatic expiration
 
-Bloom filters trade perfect accuracy for constant memory usage, making them suitable for resource-constrained devices.
-
-### HashMap Mode
-For exact tracking (no false positives):
-- **Capacity**: 10,000 message IDs (configurable)
-- **Retention**: 1 hour (configurable)
-- **Eviction**: FIFO when capacity is reached
+Bloom filters trade perfect accuracy for constant memory usage, making them suitable for resource-constrained devices. Enable with `useBloomFilter: true`.
 
 ### Deduplication Behavior
 When a message arrives:
@@ -700,17 +700,17 @@ const config = {
   
   reliability: {
     ack: {
-      defaultTimeoutMs: 5000,    // Wait 5s for ACK
+      defaultTimeoutMs: 10000,   // Wait 10s for ACK
     },
     retry: {
-      maxRetries: 5,             // Max retry attempts
+      maxRetries: 10,            // Max ACK retry attempts
       initialDelayMs: 1000,      // First retry after 1s
       maxDelayMs: 30000,         // Cap delay at 30s
       backoffFactor: 2.0,        // Double delay each retry
     },
     dedup: {
-      useBloomFilter: true,      // Use bloom filter mode
-      maxTrackedMessages: 10000, // HashMap mode capacity
+      useBloomFilter: false,     // HashMap mode (default); set true for bloom filter
+      maxTrackedMessages: 1000,  // HashMap mode capacity
       retentionTimeSecs: 3600,   // 1 hour retention
     },
   },

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -220,21 +220,25 @@ The reliability layer ensures messages are delivered despite the inherent unreli
 
 ### Acknowledgment (ACK) Management
 Messages that require acknowledgment are tracked:
-- **Timeout**: Default 5 seconds to wait for ACK
+- **Timeout**: Default 10 seconds to wait for ACK
 - **Tracking**: Message ID, recipient, timestamp, retry count
-- **Events**: `MessageDelivered` when ACK received, `MessageFailed` after max retries
+- **Events**: `MessageDelivered` when ACK received, `MessageFailed` after max ACK retries
 
 When an ACK is received, the sender:
 1. Marks the message as delivered
 2. Emits a `MessageDelivered` event
-3. Cancels any pending retries
+3. Removes the message from both the retry queue and outbox
 
 ### Retry Queue
 Failed messages are queued for retry with exponential backoff:
 - **Initial Delay**: 1 second
 - **Backoff Factor**: 2x each retry (1s → 2s → 4s → 8s...)
 - **Maximum Delay**: 30 seconds
-- **Maximum Retries**: 5 attempts (configurable)
+- **No attempt limit**: The retry queue is a pure scheduling mechanism. Only ACK timeouts (not transport failures) count toward the retry limit (default: 10).
+
+When a transport becomes available (peer discovered, internet reconnects), pending messages are flushed immediately — bypassing backoff timers.
+
+For the full delivery lifecycle including client-side persistence patterns, see [Message Delivery & Reliability](message-delivery.md).
 
 ### Priority Ordering
 The retry queue processes messages by priority:
@@ -245,11 +249,12 @@ The retry queue processes messages by priority:
 
 Within the same priority, older messages go first.
 
-### Outbox Persistence
-Messages awaiting acknowledgment are stored in an outbox:
-- Survives temporary transport failures
-- Automatically cleaned up after successful delivery or max retries
-- Configurable maximum lifetime
+### Outbox
+Messages awaiting acknowledgment are stored in an in-memory outbox:
+- Survives temporary transport failures within the process lifetime
+- Automatically cleaned up after successful delivery or max ACK retries
+- Configurable maximum lifetime (default: 1 hour)
+- Does not survive process restarts — see [Client-Side Persistence](message-delivery.md#client-side-persistence)
 
 ## Deduplication
 

--- a/docs/message-delivery.md
+++ b/docs/message-delivery.md
@@ -1,0 +1,306 @@
+# Message Delivery & Reliability
+
+## Overview
+
+The Offline Protocol SDK is designed for environments where connectivity is intermittent or absent for extended periods. The delivery system ensures that messages persist until delivered (or expired), and are sent immediately when any transport becomes available.
+
+This guide explains how messages move through the system, how failures are handled, and how client applications should integrate with the delivery lifecycle.
+
+## Message Lifecycle
+
+```
+send_message()
+    │
+    ├─ Transport available ──► Send ──► ACK tracking ──► MessageDelivered
+    │                                       │
+    │                                       └─ ACK timeout ──► Retry via queue
+    │                                                              │
+    │                                                              ├─ Send succeeds ──► ACK tracking
+    │                                                              └─ Max ACK retries ──► MessageFailed
+    │
+    └─ Transport unavailable ──► Outbox + Retry Queue ──► MessageDeferred
+                                        │
+                                        ├─ Backoff timer fires ──► Retry send
+                                        ├─ Peer discovered ──► Immediate flush
+                                        └─ Internet reconnects ──► Immediate flush
+```
+
+### Successful Send
+
+1. `send_message()` creates the message and attempts transport delivery via DORS
+2. On success, the message is registered for ACK tracking
+3. When the recipient sends an ACK, a `MessageDelivered` event fires
+4. The message is removed from outbox and retry queue
+
+### Deferred Send
+
+1. `send_message()` returns `Ok(message_id)` even when the transport send fails
+2. The message is persisted to the outbox and enqueued in the retry queue
+3. A `MessageDeferred` event fires with the reason
+4. The retry queue will attempt redelivery on its next cycle
+
+The caller always receives the message ID. A deferred message is not a failure — it's queued for delivery.
+
+## Retry System
+
+### Two Independent Retry Paths
+
+The system has two distinct retry mechanisms that serve different purposes:
+
+**Transport Retries** (retry queue):
+- Fires when no transport can deliver the message right now
+- The retry queue is a pure scheduling mechanism with no attempt limit
+- Uses exponential backoff: 1s → 2s → 4s → 8s → ... → 30s (capped)
+- Messages stay in the queue indefinitely as long as the process runs
+- Processed in batches of 20 during each `process()` tick
+
+**ACK Retries** (ACK manager):
+- Fires when a message was sent but no acknowledgment arrived
+- Limited to `max_retries` attempts (default: 10)
+- After exhausting retries, the message permanently fails with `MessageFailed`
+- This is the only path to permanent failure
+
+This separation is critical: a message that can't reach any transport should not be permanently failed. Only messages that were sent but never acknowledged count toward the retry limit.
+
+### Exponential Backoff
+
+```
+Retry 0:  1s     (initial_delay_ms)
+Retry 1:  2s     (1000 × 2^1)
+Retry 2:  4s     (1000 × 2^2)
+Retry 3:  8s     (1000 × 2^3)
+Retry 4:  16s    (1000 × 2^4)
+Retry 5+: 30s    (capped at max_delay_ms)
+```
+
+The backoff exponent is capped at 20 to prevent arithmetic overflow in the intermediate calculation. In practice, `max_delay_ms` (30s) kicks in much earlier.
+
+### Priority Ordering
+
+The retry queue is a priority-based min-heap. When multiple messages are ready:
+
+1. Earlier `retry_at` times are dequeued first
+2. Among messages with the same retry time, higher priority wins
+3. Within the same priority, order is arbitrary
+
+## Transport-Triggered Flush
+
+When a transport becomes available, pending messages are sent immediately — they don't wait for their backoff timer to expire.
+
+### Peer Discovery Flush
+
+When `on_neighbor_discovered()` is called (a BLE or Wi-Fi Direct peer appears):
+
+1. The outbox is scanned for messages addressed to that peer
+2. Matching messages are removed from the retry queue
+3. Each message is sent immediately (batch limit: 20)
+4. Failed sends are re-enqueued with their current attempt count
+
+This means a message queued while a peer was unreachable will be delivered as soon as that peer reappears, without waiting for the next backoff cycle.
+
+### Internet Reconnect Flush
+
+When `internet_status_changed(true)` is called after a disconnection:
+
+1. All entries are drained from the retry queue (ignoring timing)
+2. Outbox entries not in the retry queue are also collected (stranded messages)
+3. Each message is sent immediately (batch limit: 20)
+4. Failed sends are re-enqueued
+
+### Batch Limits
+
+Both flush methods cap at 20 messages per invocation to prevent blocking. If more messages are pending, the remainder stays in the retry queue and will be picked up on the next `process()` tick or the next flush.
+
+## Outbox
+
+The outbox persists messages that require acknowledgment. It serves as the source of truth for "what messages are in flight."
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Max entries | 1000 | Regular messages |
+| Max media entries | 100 | File chunk messages |
+| Max lifetime | 1 hour | `outbox_max_lifetime_ms` |
+
+When the outbox is full, the oldest entry is evicted. When a message exceeds its lifetime and has no pending ACK, it is cleaned up.
+
+**Important**: The outbox is in-memory only. It does not survive process restarts. See [Client-Side Persistence](#client-side-persistence) for how to handle this.
+
+## ACK Cleanup
+
+When an ACK is received for a message:
+
+1. `MessageDelivered` event is emitted with latency and hop count
+2. The message is removed from the retry queue (prevents ghost re-sends)
+3. The message is removed from the outbox
+4. Transport delivery metrics are updated
+
+When a message exceeds max ACK retries:
+
+1. `MessageFailed` event is emitted
+2. The message is removed from the retry queue
+3. The ACK tracking is removed
+4. The outbox entry is removed
+
+## Configuration
+
+### Reliability Parameters
+
+```typescript
+const config = {
+  reliability: {
+    ack: {
+      defaultTimeoutMs: 10000,  // 10s ACK timeout (default)
+      maxPendingAcks: 1000,
+    },
+    retry: {
+      maxRetries: 10,              // ACK retry limit (default)
+      initialDelayMs: 1000,        // First backoff delay
+      maxDelayMs: 30000,           // Backoff ceiling (30s)
+      backoffMultiplier: 2.0,      // Exponential factor
+      outboxMaxLifetimeMs: 3600000, // 1 hour outbox lifetime
+    },
+  },
+};
+```
+
+### Tuning for Different Scenarios
+
+**High-reliability (field operations, disaster response)**:
+```typescript
+reliability: {
+  ack: { defaultTimeoutMs: 15000 },
+  retry: {
+    maxRetries: 20,
+    outboxMaxLifetimeMs: 86400000,  // 24 hours
+  },
+}
+```
+
+**Low-latency (real-time chat with good connectivity)**:
+```typescript
+reliability: {
+  ack: { defaultTimeoutMs: 5000 },
+  retry: {
+    maxRetries: 5,
+    maxDelayMs: 10000,
+  },
+}
+```
+
+**Battery-constrained (IoT sensors)**:
+```typescript
+reliability: {
+  retry: {
+    maxRetries: 3,
+    initialDelayMs: 5000,
+    maxDelayMs: 60000,  // Longer backoff to save power
+  },
+}
+```
+
+## Events
+
+The delivery system emits events at each stage of the message lifecycle:
+
+| Event | When | Key Fields |
+|-------|------|------------|
+| `MessageSent` | Message accepted and sent via transport | `message_id`, `recipient`, `priority` |
+| `MessageDeferred` | Message queued for retry (transport unavailable) | `message_id`, `reason`, `retry_count` |
+| `MessageDelivered` | ACK received from recipient | `message_id`, `latency_ms`, `hop_count`, `transport` |
+| `MessageFailed` | Permanent failure (max ACK retries exceeded) | `message_id`, `reason`, `retry_count` |
+
+### Event Flow Examples
+
+**Immediate delivery**:
+```
+MessageSent → MessageDelivered
+```
+
+**Deferred then delivered**:
+```
+MessageDeferred → (transport becomes available) → MessageDelivered
+```
+
+**Permanent failure**:
+```
+MessageSent → (ACK timeout) → (retry) → ... → MessageFailed
+```
+
+## Client-Side Persistence
+
+The SDK's retry system operates in-memory. If the app process is killed (common on mobile), pending messages are lost. Client applications should implement their own persistence layer to survive restarts.
+
+### Recommended Pattern
+
+```
+┌─────────────────────────────────────┐
+│           Client App                │
+│                                     │
+│  ┌───────────┐   ┌──────────────┐  │
+│  │ Local DB  │   │  Message UI  │  │
+│  │ (SQLite)  │   │              │  │
+│  └─────┬─────┘   └──────────────┘  │
+│        │                            │
+│  Store message    Read events       │
+│  with status      and update        │
+│        │          status            │
+│        ▼                            │
+│  ┌──────────────────────────────┐   │
+│  │     Offline Protocol SDK     │   │
+│  │  (in-memory retry + outbox)  │   │
+│  └──────────────────────────────┘   │
+└─────────────────────────────────────┘
+```
+
+### Implementation Steps
+
+1. **On send**: Store the message in local DB with `status: pending`
+
+```typescript
+// Send the message
+const messageId = protocol.sendMessage(recipient, content, priority);
+
+// Persist locally
+db.insert({
+  id: messageId,
+  recipient,
+  content,
+  priority,
+  status: 'pending',
+  createdAt: Date.now(),
+});
+```
+
+2. **On delivery**: Update status when ACK arrives
+
+```typescript
+protocol.onEvent((event) => {
+  if (event.type === 'message_delivered') {
+    db.update(event.message_id, { status: 'delivered' });
+  }
+  if (event.type === 'message_failed') {
+    db.update(event.message_id, { status: 'failed' });
+  }
+});
+```
+
+3. **On app restart**: Re-send pending messages
+
+```typescript
+const pending = db.query({ status: 'pending' });
+for (const msg of pending) {
+  // Optional: skip messages older than your retention policy
+  if (Date.now() - msg.createdAt > 7 * 24 * 3600 * 1000) {
+    db.update(msg.id, { status: 'expired' });
+    continue;
+  }
+  protocol.sendMessage(msg.recipient, msg.content, msg.priority);
+}
+```
+
+### Considerations
+
+- **Duplicate delivery**: If the original send succeeded but the app was killed before receiving the ACK, re-sending creates a duplicate. The receiver's deduplicator catches duplicates by message ID, but re-sends generate a *new* message ID. Consider content-level dedup in the UI if this matters for your use case.
+- **Message ordering**: Re-sent messages get new timestamps and Lamport clocks. If strict ordering matters, the client should track sequence numbers.
+- **Retention policy**: Decide how long to keep unsent messages. A disaster-response app might keep them for days; a chat app might expire after hours.
+- **Storage limits**: Cap the local pending queue to prevent unbounded growth during extended offline periods.

--- a/docs/message-delivery.md
+++ b/docs/message-delivery.md
@@ -117,7 +117,7 @@ The outbox persists messages that require acknowledgment. It serves as the sourc
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| Max entries | 1000 | Regular messages |
+| Max entries | 500 | Regular messages |
 | Max media entries | 100 | File chunk messages |
 | Max lifetime | 1 hour | `outbox_max_lifetime_ms` |
 
@@ -224,6 +224,38 @@ MessageDeferred → (transport becomes available) → MessageDelivered
 **Permanent failure**:
 ```
 MessageSent → (ACK timeout) → (retry) → ... → MessageFailed
+```
+
+## Breaking Changes
+
+This version introduces the following breaking changes to the delivery system:
+
+### `send_message()` now returns `Ok` on transport failure
+
+Previously, `send_message()` returned `Err` when no transport could deliver the message immediately. Now it returns `Ok(message_id)` and emits a `MessageDeferred` event instead. The message is queued for automatic retry.
+
+**Migration**: If your code matches on `Err` from `send_message()` to detect "no transport available," switch to listening for `MessageDeferred` events instead. An `Err` from `send_message()` now only indicates a true failure (e.g., invalid recipient, protocol not started).
+
+### `Error::MaxRetriesExceeded` removed
+
+The `MaxRetriesExceeded` variant was removed from the reliability crate's error type. The retry queue no longer enforces a retry limit — only ACK timeouts count toward permanent failure.
+
+**Migration**: Remove any match arms for `Error::MaxRetriesExceeded`. If you need to detect permanent failure, listen for the `MessageFailed` event.
+
+### Default constants changed
+
+| Parameter | Old Default | New Default |
+|-----------|-------------|-------------|
+| ACK timeout | 5,000 ms | 10,000 ms |
+| Max ACK retries | 3 | 10 |
+
+Messages will take longer to permanently fail (up to ~100 seconds worst-case vs ~15 seconds before). Configure lower values if you need faster failure detection:
+
+```typescript
+reliability: {
+  ack: { defaultTimeoutMs: 5000 },
+  retry: { maxRetries: 3 },
+}
 ```
 
 ## Client-Side Persistence

--- a/docs/message-delivery.md
+++ b/docs/message-delivery.md
@@ -205,7 +205,7 @@ The delivery system emits events at each stage of the message lifecycle:
 | Event | When | Key Fields |
 |-------|------|------------|
 | `MessageSent` | Message accepted and sent via transport | `message_id`, `recipient`, `priority` |
-| `MessageDeferred` | Message queued for retry (transport unavailable) | `message_id`, `reason`, `retry_count` |
+| `MessageDeferred` | Message queued for retry (transport unavailable) | `message_id`, `reason`, `retry_count`, `next_retry_at` |
 | `MessageDelivered` | ACK received from recipient | `message_id`, `latency_ms`, `hop_count`, `transport` |
 | `MessageFailed` | Permanent failure (max ACK retries exceeded) | `message_id`, `reason`, `retry_count` |
 


### PR DESCRIPTION
## Summary

- **Decouple transport retries from ACK retries** — `RetryQueue.enqueue()` no longer rejects messages based on `max_retries`. The retry queue is now a pure scheduling mechanism; only ACK timeouts in `process_timed_out_acks` govern permanent failure. Previously, a message permanently failed after ~7s when no transport was available.
- **Add transport-availability-triggered flush** — new `flush_outbox_for_peer()` (called on `on_neighbor_discovered`) and `flush_outbox_all()` (called on internet reconnect) bypass backoff timers to send pending messages immediately when connectivity returns.
- **Fix retry_queue cleanup on ACK receipt and max-retry failure** — `handle_ack_message()` and `handle_max_retries_exceeded()` now remove entries from `retry_queue`, preventing ghost re-sends of already-ACKed or permanently-failed messages.
- **Return Ok for deferred messages** — `send_message()`, `dispatch_prepared_message()`, and `send_message_via_transport()` now return `Ok(message_id)` when a message is safely queued for retry, instead of misleading `Err`. Emits `MessageDeferred` event for observability.
- **Bump defaults** — `DEFAULT_MAX_RETRIES` 3→10, `DEFAULT_ACK_TIMEOUT_MS` 5000→10000 to accommodate slow mesh paths.

## Test plan

- [x] `cargo build --workspace` compiles
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` — all 799 tests pass (0 failures)
- [x] Updated `test_max_retries` → `test_enqueue_accepts_high_retry_count` to reflect new enqueue behavior
- [x] Added `test_drain_all` unit test for new `RetryQueue::drain_all()`
- [x] Updated `test_reliability_config_default` for new default values