### PR TITLE
fix(protocol): add missing dedup to commit, Welcome, and leave handlers

### DIFF
--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -364,7 +364,7 @@ impl OfflineProtocol {
     }
 
     /// Handles an incoming MLS Welcome message (group invite).
-    pub(crate) fn handle_group_mls_welcome(&mut self, sender: &str, data: &str) {
+    pub(crate) fn handle_group_mls_welcome(&mut self, message_id: &str, sender: &str, data: &str) {
         let payload = match serde_json::from_str::<GroupMlsWelcomePayload>(data) {
             Ok(p) => p,
             Err(_) => {
@@ -374,6 +374,20 @@ impl OfflineProtocol {
         };
 
         info!(group_id = %payload.group_id, "Received mesh group Welcome");
+
+        // Dedup check — prevents double-join when the same Welcome arrives via
+        // multiple transports nearly simultaneously (TOCTOU race on members cache).
+        let dedup_key = message_id.to_string();
+        if self.group_mesh.message_dedup.contains_key(&dedup_key) {
+            debug!(group_id = %payload.group_id, msg_id = %dedup_key, "Duplicate Welcome message, skipping");
+            return;
+        }
+        self.group_mesh
+            .message_dedup
+            .insert(dedup_key, Instant::now());
+        if self.group_mesh.message_dedup.len() > MAX_GROUP_MESSAGE_DEDUP_ENTRIES {
+            self.cleanup_group_message_dedup();
+        }
 
         // Skip duplicate Welcome — we're already a member
         if self.group_mesh.members.contains_key(&payload.group_id) {
@@ -433,7 +447,23 @@ impl OfflineProtocol {
     /// If decryption fails (e.g., due to out-of-order delivery in a mesh network),
     /// the commit is buffered for deferred retry. When a subsequent commit for the
     /// same group succeeds, buffered commits are drained and retried.
-    pub(crate) fn handle_group_mls_commit(&mut self, sender: &str, data: &str) {
+    pub(crate) fn handle_group_mls_commit(&mut self, message_id: &str, sender: &str, data: &str) {
+        // Dedup check — prevents processing the same commit twice when it
+        // arrives via multiple transports. Without this, the second copy fails
+        // at MLS (wrong epoch) and gets buffered as a "retriable" pending
+        // commit, wasting space and potentially triggering false fork detection.
+        let dedup_key = message_id.to_string();
+        if self.group_mesh.message_dedup.contains_key(&dedup_key) {
+            debug!(msg_id = %dedup_key, "Duplicate commit message, skipping");
+            return;
+        }
+        self.group_mesh
+            .message_dedup
+            .insert(dedup_key, Instant::now());
+        if self.group_mesh.message_dedup.len() > MAX_GROUP_MESSAGE_DEDUP_ENTRIES {
+            self.cleanup_group_message_dedup();
+        }
+
         match self.process_commit_core(sender, data) {
             CommitOutcome::Success(group_id) => {
                 self.drain_pending_commits(&group_id);
@@ -804,7 +834,7 @@ impl OfflineProtocol {
     ///
     /// For fully adversarial environments, consider requiring admin-only removal
     /// or adding an MLS application-message-signed leave proof.
-    pub(crate) fn handle_group_mls_leave(&mut self, sender: &str, data: &str) {
+    pub(crate) fn handle_group_mls_leave(&mut self, message_id: &str, sender: &str, data: &str) {
         let payload = match serde_json::from_str::<GroupMlsLeavePayload>(data) {
             Ok(p) => p,
             Err(_) => {
@@ -812,6 +842,24 @@ impl OfflineProtocol {
                 return;
             }
         };
+
+        // Dedup check — prevents duplicate leave notifications from resetting
+        // the election timer or triggering redundant remove-commit attempts.
+        let dedup_key = message_id.to_string();
+        if self.group_mesh.message_dedup.contains_key(&dedup_key) {
+            debug!(
+                group_id = %payload.group_id,
+                msg_id = %dedup_key,
+                "Duplicate leave notification, skipping"
+            );
+            return;
+        }
+        self.group_mesh
+            .message_dedup
+            .insert(dedup_key, Instant::now());
+        if self.group_mesh.message_dedup.len() > MAX_GROUP_MESSAGE_DEDUP_ENTRIES {
+            self.cleanup_group_message_dedup();
+        }
 
         // Verify sender matches the claimed leaving member to prevent spoofing
         if payload.leaving_member != sender {

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -3115,7 +3115,7 @@ fn test_epoch_fork_cleared_on_successful_commit() {
     let data = serde_json::to_string(&commit_payload).unwrap();
 
     // Process through the protocol layer — this calls process_commit_core
-    alice.handle_group_mls_commit("bob", &data);
+    alice.handle_group_mls_commit("commit-fork-clear-1", "bob", &data);
 
     // Fork should be cleared after successful commit processing
     assert!(
@@ -3988,7 +3988,7 @@ fn test_pending_leave_elections_size_cap_eviction() {
     let data = serde_json::to_string(&leave_payload).unwrap();
 
     // test_user is not the lex-first remaining member (alice is), so it records a pending election
-    protocol.handle_group_mls_leave(new_leaver, &data);
+    protocol.handle_group_mls_leave("leave-evict-1", new_leaver, &data);
 
     // Should still be at cap (one old evicted, one new added)
     assert!(
@@ -4083,7 +4083,7 @@ fn test_non_key_update_commit_does_not_clear_fork_state() {
     let data = serde_json::to_string(&add_commit_payload).unwrap();
 
     // Process through alice — the MLS commit succeeds but commit_type is Add
-    alice.handle_group_mls_commit("bob", &data);
+    alice.handle_group_mls_commit("commit-add-no-clear-1", "bob", &data);
 
     // Fork state should still exist because this was an Add commit, not KeyUpdate
     assert!(
@@ -4122,7 +4122,7 @@ fn test_key_update_commit_clears_fork_state() {
     };
     let data = serde_json::to_string(&ku_commit_payload).unwrap();
 
-    alice.handle_group_mls_commit("bob", &data);
+    alice.handle_group_mls_commit("commit-ku-clear-1", "bob", &data);
 
     assert!(
         !alice.group_mesh.epoch_forks.contains_key(&group_id),
@@ -4473,7 +4473,7 @@ fn test_handle_group_mls_leave_records_pending_election_for_non_elected() {
     };
     let data = serde_json::to_string(&leave_payload).unwrap();
 
-    protocol.handle_group_mls_leave("bob", &data);
+    protocol.handle_group_mls_leave("leave-else-1", "bob", &data);
 
     let key = (group_id.clone(), "bob".to_string());
     assert!(
@@ -4502,7 +4502,7 @@ fn test_handle_group_mls_leave_elected_does_not_record_election() {
     let data = serde_json::to_string(&leave_payload).unwrap();
 
     // alice < bob, so alice is elected → should handle immediately
-    alice.handle_group_mls_leave("bob", &data);
+    alice.handle_group_mls_leave("leave-elected-1", "bob", &data);
 
     let key = (group_id.clone(), "bob".to_string());
     assert!(
@@ -4907,7 +4907,7 @@ fn test_duplicate_welcome_ignored() {
     );
     // Strip the prefix to get just the JSON, since handle_group_mls_welcome expects raw JSON
     let json_data = &data[internal_prefixes::GROUP_MLS_WELCOME.len()..];
-    bob.handle_group_mls_welcome("alice", json_data);
+    bob.handle_group_mls_welcome("welcome-dup-1", "alice", json_data);
 
     let evts = events.lock().unwrap();
     let add_events: Vec<_> = evts

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -1003,17 +1003,20 @@ impl OfflineProtocol {
         }
 
         if let Some(data) = content.strip_prefix(internal_prefixes::GROUP_MLS_WELCOME) {
-            self.handle_group_mls_welcome(sender, data);
+            let mid = message.id.as_str();
+            self.handle_group_mls_welcome(&mid, sender, data);
             return Some(InternalMessageResult::Consumed);
         }
 
         if let Some(data) = content.strip_prefix(internal_prefixes::GROUP_MLS_COMMIT) {
-            self.handle_group_mls_commit(sender, data);
+            let mid = message.id.as_str();
+            self.handle_group_mls_commit(&mid, sender, data);
             return Some(InternalMessageResult::Consumed);
         }
 
         if let Some(data) = content.strip_prefix(internal_prefixes::GROUP_MLS_LEAVE) {
-            self.handle_group_mls_leave(sender, data);
+            let mid = message.id.as_str();
+            self.handle_group_mls_leave(&mid, sender, data);
             return Some(InternalMessageResult::Consumed);
         }
 


### PR DESCRIPTION
It turns out that handle_group_mls_commit, handle_group_mls_welcome, and handle_group_mls_leave had *no* deduplication — even though handle_group_mls_msg (the application message handler) has had it since 889bf9b. In a multi-transport environment where the same message arrives via BLE and WiFi Direct, confusion ensues.

The commit handler was the worst offender: the duplicate arrives, MLS rejects it (wrong epoch), it gets buffered as "retriable," and when it eventually expires, drain_pending_commits flags a phantom epoch fork. So we get false fork detection from a message we already processed successfully. Not great.

For Welcome, two copies arriving before the members cache populates both attempt join_group — the second fails at MLS but wastes a crypto operation. For leave, a duplicate resets the election timer by overwriting the PendingLeaveElection entry, delaying removal.

Add message_id: &str to all three handlers and insert into the existing message_dedup table before any MLS work. The dedup lives at the transport entry point, not inside process_commit_core, so drain_pending_commits retries are unaffected.