### PR TITLE
Fix MLS session confirmation blocked by Welcome delivery state gate

### DIFF
--- a/crates/offline-protocol/src/protocol.rs
+++ b/crates/offline-protocol/src/protocol.rs
@@ -1566,7 +1566,7 @@ impl OfflineProtocol {
         }
 
         match self.welcome_lifecycles.get(peer_id) {
-            Some(record) => matches!(record.state, WelcomeDeliveryState::Sent),
+            Some(record) => matches!(record.state, WelcomeDeliveryState::Sent | WelcomeDeliveryState::SendAttempted),
             None => matches!(
                 source_event,
                 // Compatibility path for sessions created before welcome lifecycle


### PR DESCRIPTION
## Summary
- One-line fix in `can_confirm_from_source()` to accept `SendAttempted` Welcome state for session confirmation
- Fixes encrypted messages silently queuing with no events over BLE

## Problem
When sending encrypted messages over BLE:
1. SDK creates MLS session and sends Welcome message to recipient
2. Welcome delivery state = `SendAttempted` (BLE doesn't immediately confirm to `Sent`)
3. Recipient receives Welcome, joins session, replies successfully
4. Sender decrypts reply (`decrypt_success`) but `can_confirm_from_source()` returns `false` because Welcome is `SendAttempted`, not `Sent`
5. Session stays unconfirmed → queued messages never flush → no `message_sent`/`message_delivered` events

## Fix
Allow `SendAttempted` as a valid Welcome state for `decrypt_success` confirmation. If the recipient decrypted our Welcome and replied, the session is established.

```rust
// Before:
Some(record) => matches!(record.state, WelcomeDeliveryState::Sent),
// After:
Some(record) => matches!(record.state, WelcomeDeliveryState::Sent | WelcomeDeliveryState::SendAttempted),
```

## Test plan
- [ ] Encrypted messages deliver over BLE between two devices
- [ ] `message_sent` and `message_delivered` events fire
- [ ] Unencrypted path still works (no regression)