### PR TITLE
fix(protocol): allow session confirmation when Welcome is in SendAttempted state

### DIFF
--- a/crates/offline-protocol/src/protocol/session.rs
+++ b/crates/offline-protocol/src/protocol/session.rs
@@ -467,7 +467,7 @@ impl OfflineProtocol {
         }
 
         match self.welcome_lifecycles.get(peer_id) {
-            Some(record) => matches!(record.state, WelcomeDeliveryState::Sent),
+            Some(record) => matches!(record.state, WelcomeDeliveryState::Sent | WelcomeDeliveryState::SendAttempted),
             None => matches!(
                 source_event,
                 // Compatibility path for sessions created before welcome lifecycle


### PR DESCRIPTION
## Summary
One-line fix in `can_confirm_from_source()` to accept `SendAttempted` Welcome state for session confirmation, fixing encrypted messages silently queuing over BLE.

## Problem
When sending encrypted messages over BLE, the Welcome message delivery state stays in `SendAttempted` (BLE hasn't confirmed delivery yet). The `can_confirm_from_source()` gate only accepted `Sent`, blocking `decrypt_success` confirmations. This caused:
- Queued messages never flushing
- No `message_sent` / `message_delivered` events
- Unencrypted messages worked fine (93ms delivery, 0 hops)

## Fix
```rust
// Before:
Some(record) => matches!(record.state, WelcomeDeliveryState::Sent),
// After:
Some(record) => matches!(record.state, WelcomeDeliveryState::Sent | WelcomeDeliveryState::SendAttempted),
```

If the recipient decrypted our Welcome and replied successfully, the session is clearly established — no need to wait for transport-level delivery confirmation.

## Test plan
- [ ] Encrypted messages deliver over BLE between two devices
- [ ] `message_sent` and `message_delivered` events fire with encryption enabled
- [ ] Unencrypted path still works (no regression)