### PR TITLE
fix(protocol): allow session confirmation when welcome is in SendAttempted state

### DIFF
--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -98,7 +98,7 @@ impl OfflineProtocol {
                 if !self.can_confirm_from_source(&sender_owned, "confirmation_probe_received") {
                     debug!(
                         sender = %sender_owned,
-                        "Skipping probe confirmation until welcome delivery is sent"
+                        "Skipping probe confirmation until welcome send is at least attempted"
                     );
                 } else {
                     match self.confirm_session_state(&sender_owned, "confirmation_probe_received") {
@@ -152,7 +152,7 @@ impl OfflineProtocol {
                 if !self.can_confirm_from_source(&sender_owned, "confirmation_ack_received") {
                     debug!(
                         sender = %sender_owned,
-                        "Skipping ack confirmation until welcome delivery is sent"
+                        "Skipping ack confirmation until welcome send is at least attempted"
                     );
                 } else {
                     match self.confirm_session_state(&sender_owned, "confirmation_ack_received") {
@@ -408,7 +408,7 @@ impl OfflineProtocol {
                     if !self.can_confirm_from_source(&sender_owned, "decrypt_success") {
                         debug!(
                             sender = %sender_owned,
-                            "Skipping decrypt-based confirmation until welcome delivery is sent"
+                            "Skipping decrypt-based confirmation until welcome send is at least attempted"
                         );
                         Some(InternalMessageResult::Decrypted(text))
                     } else {

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -1473,11 +1473,10 @@ impl OfflineProtocol {
             ));
         }
 
-        // Now that the welcome is confirmed as sent, the can_confirm_from_source
-        // gate is open. Send a confirmation probe immediately so the session can
-        // be confirmed without waiting for the next process() tick. Any earlier
-        // probe/ack exchanges were blocked because the welcome was still
-        // SendAttempted — we need a fresh round-trip.
+        // The welcome is now confirmed as sent. Send a confirmation probe
+        // immediately so the session can be confirmed without waiting for the
+        // next process() tick — an optimistic fast-path for the common case
+        // where the transport confirms promptly.
         self.send_session_confirmation_probe(&peer_id, "transport_confirmed");
 
         Ok(())

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -1466,12 +1466,20 @@ impl OfflineProtocol {
             .ok_or_else(|| Error::Other(format!("Missing welcome lifecycle for {}", peer_id)))?;
         if let Ok(state) = lock_shared_state(&self.shared_state) {
             state.emit_event(Event::welcome_send_succeeded(
-                peer_id,
+                peer_id.clone(),
                 sent_snapshot.welcome_message.id.as_str().to_string(),
                 sent_snapshot.group_id,
                 sent_snapshot.attempt,
             ));
         }
+
+        // Now that the welcome is confirmed as sent, the can_confirm_from_source
+        // gate is open. Send a confirmation probe immediately so the session can
+        // be confirmed without waiting for the next process() tick. Any earlier
+        // probe/ack exchanges were blocked because the welcome was still
+        // SendAttempted — we need a fresh round-trip.
+        self.send_session_confirmation_probe(&peer_id, "transport_confirmed");
+
         Ok(())
     }
 

--- a/crates/offline-protocol/src/protocol/session.rs
+++ b/crates/offline-protocol/src/protocol/session.rs
@@ -467,7 +467,10 @@ impl OfflineProtocol {
         }
 
         match self.welcome_lifecycles.get(peer_id) {
-            Some(record) => matches!(record.state, WelcomeDeliveryState::Sent),
+            Some(record) => matches!(
+                record.state,
+                WelcomeDeliveryState::Sent | WelcomeDeliveryState::SendAttempted
+            ),
             None => matches!(
                 source_event,
                 // Compatibility path for sessions created before welcome lifecycle

--- a/crates/offline-protocol/src/protocol/session.rs
+++ b/crates/offline-protocol/src/protocol/session.rs
@@ -429,7 +429,7 @@ impl OfflineProtocol {
             if !self.can_confirm_from_source(&peer_id, "confirmation_retry") {
                 debug!(
                     peer_id = %peer_id,
-                    "Skipping confirmation retry until welcome delivery is sent"
+                    "Skipping confirmation retry until welcome send is at least attempted"
                 );
                 continue;
             }

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -3110,6 +3110,76 @@ fn test_welcome_internet_requires_async_confirmation_before_sent() {
 }
 
 #[test]
+fn test_on_transport_send_confirmed_sends_immediate_probe() {
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.store_pending = true;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    let mut internet = MockTransport::new(TransportType::Internet);
+    internet.start().unwrap();
+    let transport_handle = internet.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::Internet, Box::new(internet));
+    protocol.start().unwrap();
+
+    let bob_storage = Arc::new(InMemoryStorage::new());
+    let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+    let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+    protocol.pending_key_packages.insert(
+        "bob".to_string(),
+        ReceivedKeyPackage {
+            key_package_data: bob_key_package.key_package_data,
+            local_expires_at_ms: Utc::now().timestamp_millis() as u64 + 60_000,
+        },
+    );
+
+    let _ = protocol
+        .send_message(
+            "bob",
+            "probe-after-confirm",
+            None::<MessagePriority>,
+            None::<String>,
+        )
+        .unwrap();
+
+    let welcome_message_id = protocol
+        .welcome_lifecycles
+        .get("bob")
+        .unwrap()
+        .welcome_message
+        .id
+        .as_str()
+        .to_string();
+
+    // Count messages before transport confirmation
+    let messages_before = transport_handle.sent_messages().len();
+
+    protocol
+        .on_transport_send_confirmed(&welcome_message_id)
+        .unwrap();
+
+    // After transport confirmation, a confirmation probe should be sent immediately
+    let messages_after = transport_handle.sent_messages();
+    assert!(
+        messages_after.len() > messages_before,
+        "Expected a confirmation probe to be sent after on_transport_send_confirmed"
+    );
+    let probe_msg = messages_after.last().unwrap();
+    assert!(
+        probe_msg
+            .content
+            .starts_with(internal_prefixes::SESSION_CONFIRM_PROBE),
+        "Expected last message to be a session confirmation probe, got: {}",
+        &probe_msg.content[..probe_msg.content.len().min(40)]
+    );
+}
+
+#[test]
 fn test_welcome_terminal_lifecycle_can_be_overwritten() {
     let mut config = create_test_config();
     config.encryption.enabled = true;
@@ -3505,6 +3575,84 @@ fn test_welcome_dropped_confirmation_expires_with_explicit_failure_events() {
     assert!(!captured
         .iter()
         .any(|event| matches!(event, Event::SecureSessionEstablished { .. })));
+}
+
+#[test]
+fn test_session_confirms_via_ack_when_welcome_is_send_attempted() {
+    // Reproduces the BLE issue: welcome lifecycle stays SendAttempted
+    // (e.g., DORS fell back to Internet), but the peer received the welcome
+    // and sent a confirmation ack. Session should confirm despite the
+    // welcome not being in Sent state.
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.store_pending = true;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    let mut transport = MockTransport::new(TransportType::BLE);
+    transport.start().unwrap();
+    let transport_handle = transport.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(transport));
+    protocol.start().unwrap();
+
+    // Set up Bob's MLS session
+    let bob_storage = Arc::new(InMemoryStorage::new());
+    let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+    let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+    {
+        let manager = protocol.mls_manager.as_ref().unwrap().read().unwrap();
+        manager
+            .import_key_package("bob", &bob_key_package.key_package_data)
+            .unwrap();
+        manager.create_session("bob").unwrap();
+    }
+    protocol
+        .ensure_session_state_entry("bob", "test_setup")
+        .unwrap();
+
+    // Simulate: welcome lifecycle is stuck at SendAttempted (DORS fell back to
+    // Internet, or BLE delivery not confirmed yet).
+    let welcome_msg =
+        protocol.create_message("bob", "placeholder", Some(MessagePriority::High), None).unwrap();
+    protocol
+        .upsert_welcome_lifecycle("bob", "session:bob:user123", welcome_msg, "test_setup")
+        .unwrap();
+    protocol
+        .transition_welcome_state("bob", WelcomeDeliveryState::SendAttempted, "test_setup")
+        .unwrap();
+
+    // Queue a message — it should be pending because session is not confirmed
+    let msg_id = protocol
+        .send_message("bob", "hello-over-ble", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    assert!(
+        protocol.pending_encrypted_messages.contains_key("bob"),
+        "Message should be queued pending session establishment"
+    );
+
+    // Simulate: Bob received our welcome and sends a confirmation ack
+    let ack_msg = Message::new(
+        UserId::new("bob").unwrap(),
+        UserId::new("user123").unwrap(),
+        AppId::new("test-app").unwrap(),
+        internal_prefixes::SESSION_CONFIRM_ACK,
+    );
+    transport_handle.queue_message(ack_msg);
+    let _ = protocol.receive_message();
+
+    // Session should now be confirmed and pending messages flushed
+    assert!(
+        protocol.confirmed_sessions.contains("bob"),
+        "Session should be confirmed after receiving ack with SendAttempted welcome"
+    );
+    assert!(
+        !protocol.pending_encrypted_messages.contains_key("bob"),
+        "Pending messages should be flushed after session confirmation"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Accept `WelcomeDeliveryState::SendAttempted` alongside `Sent` in `can_confirm_from_source()` so probe/ack/decrypt events can confirm sessions even when the welcome lifecycle hasn't reached `Sent` (e.g. DORS fell back from BLE to Internet, or platform hasn't called `on_transport_send_confirmed` yet)
- Send an immediate confirmation probe in `on_transport_send_confirmed()` so Internet transport sessions don't wait up to 7s for the next `process()` tick

Supersedes #72 — same core fix plus the Internet transport optimization and test coverage.

## Problem

When sending encrypted messages, the welcome delivery state can stay in `SendAttempted` in several scenarios:

1. **DORS fallback**: BLE send fails, falls back to Internet — `current_transport()` returns `Internet`, welcome stays `SendAttempted`
2. **Internet transport**: `send()` only enqueues for platform polling, lifecycle stays non-terminal until explicit `on_transport_send_confirmed()`
3. **Transport timing**: Welcome sent but transport hasn't confirmed delivery yet

The `can_confirm_from_source()` gate only accepted `Sent`, blocking `decrypt_success`, `confirmation_ack_received`, and `confirmation_probe_received` events. This caused:
- Queued messages never flushing
- No `message_sent` / `message_delivered` events
- Sessions stuck in `Pending` state indefinitely

The demo app was unaffected in the happy path because auto key exchange ensures both peers send Welcomes, and `"welcome_received"` bypasses the gate entirely. The bug surfaces under real-world conditions: BLE packet loss, range issues, or one-sided session establishment.

## Fix

If the peer decrypted our Welcome and replied successfully, the session is clearly established — no need to wait for transport-level delivery confirmation.

```rust
// Before:
Some(record) => matches!(record.state, WelcomeDeliveryState::Sent),
// After:
Some(record) => matches!(record.state, WelcomeDeliveryState::Sent | WelcomeDeliveryState::SendAttempted),
```

## Test plan

- [x] `test_session_confirms_via_ack_when_welcome_is_send_attempted` — BLE scenario: welcome stuck at `SendAttempted`, peer sends ack, session confirms and pending messages flush (verified test **fails** without the fix)
- [x] `test_on_transport_send_confirmed_sends_immediate_probe` — Internet scenario: `on_transport_send_confirmed` immediately sends a probe
- [x] All 531 tests pass, clippy clean