### PR TITLE
fix(bindings): resolve BLE peripheral peer identity for outgoing routing

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,3 +16,7 @@ linker = "x86_64-linux-android21-clang"
 # iOS targets (using default settings - no configuration needed)
 # iOS linking is handled automatically by Xcode toolchain
 
+# Desktop cross-compilation targets
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,317 @@ jobs:
           path: android-bindings/
           retention-days: 1
 
+  # ---------------------------------------------------------------------------
+  # Desktop builds (macOS / Linux / Windows)
+  # ---------------------------------------------------------------------------
+
+  build-desktop-macos:
+    name: Build Desktop (macOS ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            target: aarch64-apple-darwin
+            runner: macos-14
+            lib_name: liboffline_protocol_uniffi.dylib
+          - arch: x86_64
+            target: x86_64-apple-darwin
+            runner: macos-13
+            lib_name: liboffline_protocol_uniffi.dylib
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-desktop-macos-${{ matrix.arch }}
+
+      - name: Build cdylib
+        run: cargo build --release --locked --target ${{ matrix.target }} --package offline-protocol-uniffi
+
+      - name: Collect artifact
+        run: |
+          mkdir -p desktop-libs/macos-${{ matrix.arch }}
+          SO_ROOT="target/${{ matrix.target }}/release"
+          if [ -f "$SO_ROOT/${{ matrix.lib_name }}" ]; then
+            cp "$SO_ROOT/${{ matrix.lib_name }}" "desktop-libs/macos-${{ matrix.arch }}/"
+          elif [ -f "$SO_ROOT/deps/${{ matrix.lib_name }}" ]; then
+            cp "$SO_ROOT/deps/${{ matrix.lib_name }}" "desktop-libs/macos-${{ matrix.arch }}/"
+          else
+            echo "ERROR: ${{ matrix.lib_name }} not found"
+            ls -la "$SO_ROOT"/ "$SO_ROOT/deps"/ 2>/dev/null || true
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: desktop-macos-${{ matrix.arch }}
+          path: desktop-libs/
+          retention-days: 1
+
+  build-desktop-linux:
+    name: Build Desktop (Linux ${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-linux-gnu
+            lib_name: liboffline_protocol_uniffi.so
+            cross: false
+          - arch: aarch64
+            target: aarch64-unknown-linux-gnu
+            lib_name: liboffline_protocol_uniffi.so
+            cross: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-desktop-linux-${{ matrix.arch }}
+
+      - name: Install cross-compilation tools
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Build cdylib
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+          fi
+          cargo build --release --locked --target ${{ matrix.target }} --package offline-protocol-uniffi
+
+      - name: Collect artifact
+        run: |
+          mkdir -p desktop-libs/linux-${{ matrix.arch }}
+          SO_ROOT="target/${{ matrix.target }}/release"
+          if [ -f "$SO_ROOT/${{ matrix.lib_name }}" ]; then
+            cp "$SO_ROOT/${{ matrix.lib_name }}" "desktop-libs/linux-${{ matrix.arch }}/"
+          elif [ -f "$SO_ROOT/deps/${{ matrix.lib_name }}" ]; then
+            cp "$SO_ROOT/deps/${{ matrix.lib_name }}" "desktop-libs/linux-${{ matrix.arch }}/"
+          else
+            echo "ERROR: ${{ matrix.lib_name }} not found"
+            ls -la "$SO_ROOT"/ "$SO_ROOT/deps"/ 2>/dev/null || true
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: desktop-linux-${{ matrix.arch }}
+          path: desktop-libs/
+          retention-days: 1
+
+  build-desktop-windows:
+    name: Build Desktop (Windows x86_64)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-desktop-windows
+
+      - name: Build cdylib
+        run: cargo build --release --locked --target x86_64-pc-windows-msvc --package offline-protocol-uniffi
+
+      - name: Collect artifact
+        shell: bash
+        run: |
+          mkdir -p desktop-libs/windows-x86_64
+          SO_ROOT="target/x86_64-pc-windows-msvc/release"
+          if [ -f "$SO_ROOT/offline_protocol_uniffi.dll" ]; then
+            cp "$SO_ROOT/offline_protocol_uniffi.dll" "desktop-libs/windows-x86_64/"
+          elif [ -f "$SO_ROOT/deps/offline_protocol_uniffi.dll" ]; then
+            cp "$SO_ROOT/deps/offline_protocol_uniffi.dll" "desktop-libs/windows-x86_64/"
+          else
+            echo "ERROR: offline_protocol_uniffi.dll not found"
+            ls -la "$SO_ROOT"/ "$SO_ROOT/deps"/ 2>/dev/null || true
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: desktop-windows-x86_64
+          path: desktop-libs/
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Python bindings generation & testing
+  # ---------------------------------------------------------------------------
+
+  python-bindings:
+    name: Generate Python Bindings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache uniffi-bindgen
+        id: cache-uniffi
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/uniffi-bindgen
+          key: uniffi-bindgen-${{ runner.os }}-${{ env.UNIFFI_VERSION }}
+
+      - name: Install uniffi-bindgen
+        if: steps.cache-uniffi.outputs.cache-hit != 'true'
+        run: cargo install uniffi --version ${{ env.UNIFFI_VERSION }} --features cli --locked
+
+      - name: Generate Python bindings
+        run: |
+          cd crates/offline-protocol-uniffi
+          uniffi-bindgen generate src/offline_protocol.udl --language python --out-dir ../../bindings/python/offline_protocol_sdk/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-bindings
+          path: bindings/python/offline_protocol_sdk/offline_protocol.py
+          retention-days: 1
+
+  test-python:
+    name: Test Python Bindings
+    needs: [python-bindings, build-desktop-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download Python bindings
+        uses: actions/download-artifact@v4
+        with:
+          name: python-bindings
+          path: bindings/python/offline_protocol_sdk/
+
+      - name: Download Linux x86_64 library
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-linux-x86_64
+          path: native-libs/
+
+      - name: Install and test
+        run: |
+          cp native-libs/linux-x86_64/liboffline_protocol_uniffi.so bindings/python/offline_protocol_sdk/
+          cd bindings/python/offline_protocol_sdk && ln -sf liboffline_protocol_uniffi.so libuniffi.so && cd ..
+          pip install -e ".[dev]"
+          pytest tests/ -v
+
+  audit-python:
+    name: Audit Python Dependencies
+    needs: [python-bindings]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Audit for known CVEs
+        run: |
+          cd bindings/python
+          pip install pip-audit
+          pip install bleak websockets keyring
+          pip-audit --strict
+
+  python-package:
+    name: Package Python (${{ matrix.platform }})
+    needs: [build-desktop-macos, build-desktop-linux, build-desktop-windows, python-bindings]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-arm64
+            artifact: desktop-macos-arm64
+            lib_subdir: macos-arm64
+            plat_name: macosx_14_0_arm64
+          - platform: macos-x86_64
+            artifact: desktop-macos-x86_64
+            lib_subdir: macos-x86_64
+            plat_name: macosx_13_0_x86_64
+          - platform: linux-x86_64
+            artifact: desktop-linux-x86_64
+            lib_subdir: linux-x86_64
+            plat_name: manylinux_2_17_x86_64
+          - platform: linux-aarch64
+            artifact: desktop-linux-aarch64
+            lib_subdir: linux-aarch64
+            plat_name: manylinux_2_17_aarch64
+          - platform: windows-x86_64
+            artifact: desktop-windows-x86_64
+            lib_subdir: windows-x86_64
+            plat_name: win_amd64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download Python bindings
+        uses: actions/download-artifact@v4
+        with:
+          name: python-bindings
+          path: bindings/python/offline_protocol_sdk/
+
+      - name: Download native library
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: native-libs/
+
+      - name: Build wheel
+        run: |
+          cp native-libs/${{ matrix.lib_subdir }}/* bindings/python/offline_protocol_sdk/
+          # Create symlink matching the name generated Python expects (libuniffi.*)
+          cd bindings/python/offline_protocol_sdk
+          for lib in *.dylib; do [ -f "$lib" ] && ln -sf "$lib" libuniffi.dylib; done
+          for lib in *.so; do [ -f "$lib" ] && ln -sf "$lib" libuniffi.so; done
+          for lib in *.dll; do [ -f "$lib" ] && ln -sf "$lib" uniffi.dll; done
+          cd ..
+          pip install build wheel
+          python -m build --wheel
+          # Re-tag the wheel with the correct platform
+          pip install wheel
+          python -c "
+          import glob, pathlib, wheel.wheelfile
+          for whl in glob.glob('dist/*.whl'):
+              print(f'Built: {whl}')
+          "
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-wheel-${{ matrix.platform }}
+          path: bindings/python/dist/*.whl
+          retention-days: 5
+
+  # ---------------------------------------------------------------------------
+  # Release
+  # ---------------------------------------------------------------------------
+
   release:
     name: Create Release & Publish to npm
-    needs: [build-ios, build-android, android-bindings]
+    needs: [build-ios, build-android, android-bindings, build-desktop-macos, build-desktop-linux, build-desktop-windows, python-bindings, test-python, audit-python]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -1,0 +1,32 @@
+# Generated Python bindings (regenerated from UDL via uniffi-bindgen)
+offline_protocol_sdk/offline_protocol.py
+
+# Native libraries (built from Rust source)
+offline_protocol_sdk/*.dylib
+offline_protocol_sdk/*.so
+offline_protocol_sdk/*.dll
+# Symlink expected by generated Python (UDL-mode generates "libuniffi.*" name)
+offline_protocol_sdk/libuniffi.*
+offline_protocol_sdk/uniffi.dll
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+*.whl
+*.tar.gz
+
+# Virtual environments
+.venv/
+venv/
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,0 +1,142 @@
+# Offline Protocol SDK — Python
+
+Python bindings for the Offline Protocol SDK: offline-first mesh networking with MLS end-to-end encryption. Supports macOS, Linux, and Windows.
+
+## Quick Start
+
+### 1. Build the native library
+
+```bash
+cd bindings/python
+bash scripts/build-desktop.sh
+```
+
+This compiles the Rust core for your platform and generates the Python FFI bindings.
+
+**Prerequisites:** Rust toolchain, `uniffi-bindgen` (`cargo install uniffi --version 0.30.0 --features cli`).
+
+### 2. Install the package
+
+```bash
+pip install -e .
+```
+
+### 3. Use it
+
+```python
+import asyncio
+from offline_protocol_sdk import ProtocolManager
+from offline_protocol_sdk.offline_protocol import ProtocolConfig, OverflowPolicy
+
+config = ProtocolConfig(
+    app_id="my-app",
+    user_id="alice",
+    ble_enabled=False,
+    wifi_direct_enabled=False,
+    internet_enabled=True,
+    reticulum_enabled=False,
+    prefer_online=True,
+    initial_ttl=3,
+    encryption_enabled=True,
+    auto_key_exchange=True,
+    store_pending=True,
+    require_encryption=False,
+    max_pending_per_peer=100,
+    max_pending_global=1000,
+    pending_ttl_ms=60000,
+    overflow_policy=OverflowPolicy.DROP_OLDEST,
+)
+
+async def main():
+    async with ProtocolManager(config, event_handler=print) as pm:
+        pm.internet.configure(server_url="ws://relay.example.com")
+        await pm.internet.start()
+
+        msg_id = pm.send_message("bob", "Hello from Python!")
+        print(f"Sent: {msg_id}")
+
+        # Keep running to receive messages
+        await asyncio.sleep(30)
+
+asyncio.run(main())
+```
+
+## Architecture
+
+```
+offline_protocol_sdk/
+├── offline_protocol.py      # Auto-generated UniFFI bindings (DO NOT EDIT)
+├── protocol_manager.py      # High-level wrapper (processing loop, lifecycle)
+├── internet_manager.py      # WebSocket transport (websockets library)
+├── ble_manager.py           # BLE transport (bleak library)
+├── secure_storage.py        # MLS key storage (keyring library)
+└── transport_manager.py     # Base transport abstraction
+```
+
+### Transport Managers
+
+| Transport | Library | Platforms | Notes |
+|-----------|---------|-----------|-------|
+| Internet/WebSocket | `websockets` | All | Primary transport for desktop |
+| BLE | `bleak` | All | Central (scanner) role only; peripheral/GATT server requires `bless` |
+| WiFi Direct | — | — | Not implemented on desktop |
+| Reticulum | Built-in | All | Handled in Rust core, no Python wrapper needed |
+
+### Secure Storage
+
+MLS cryptographic key material is stored using the `keyring` library:
+
+| Platform | Backend |
+|----------|---------|
+| macOS | Keychain |
+| Linux | Secret Service (GNOME Keyring / KWallet) |
+| Windows | Windows Credential Locker |
+
+You can provide your own storage by implementing the `MlsStorageProvider` callback interface:
+
+```python
+from offline_protocol_sdk.offline_protocol import MlsStorageProvider
+
+class MyStorage(MlsStorageProvider):
+    def store(self, key_type: str, key_id: str, data: list[int]) -> None: ...
+    def load(self, key_type: str, key_id: str) -> list[int] | None: ...
+    def delete(self, key_type: str, key_id: str) -> None: ...
+    def list_keys(self, key_type: str) -> list[str]: ...
+
+pm = ProtocolManager(config, storage=MyStorage())
+```
+
+**Important:** Keep a reference to the storage object alive for the entire protocol lifetime. If Python garbage-collects it, the Rust-side callback pointers become dangling.
+
+## Running the Example
+
+```bash
+# Terminal 1
+python examples/basic_messaging.py --user alice --server ws://localhost:8080
+
+# Terminal 2
+python examples/basic_messaging.py --user bob --server ws://localhost:8080
+```
+
+## Development
+
+```bash
+# Install dev dependencies
+pip install -e ".[dev]"
+
+# Run tests
+pytest tests/ -v
+
+# Audit dependencies for CVEs
+pip-audit --strict
+```
+
+## Platform Support
+
+| Target | Architecture | Library |
+|--------|-------------|---------|
+| macOS | Apple Silicon (arm64) | `.dylib` |
+| macOS | Intel (x86_64) | `.dylib` |
+| Linux | x86_64 | `.so` |
+| Linux | aarch64 | `.so` |
+| Windows | x86_64 | `.dll` |

--- a/bindings/python/examples/basic_messaging.py
+++ b/bindings/python/examples/basic_messaging.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Basic end-to-end example: create protocol, connect to relay, send/receive messages.
+
+Prerequisites:
+  1. Build the native library and Python bindings:
+       cd bindings/python && bash scripts/build-desktop.sh
+  2. Install the package:
+       pip install -e .
+  3. Have a relay server running (e.g. ws://localhost:8080).
+
+Usage:
+  python examples/basic_messaging.py --user alice --server ws://localhost:8080
+  python examples/basic_messaging.py --user bob   --server ws://localhost:8080
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import signal
+import sys
+from typing import Any
+
+from offline_protocol_sdk import (
+    InternetManager,
+    ProtocolManager,
+)
+from offline_protocol_sdk.offline_protocol import (
+    OverflowPolicy,
+    ProtocolConfig,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("example")
+
+
+def on_event(event: dict[str, Any]) -> None:
+    """Handle protocol events."""
+    event_type = event.get("type", "unknown")
+
+    if event_type == "message_received":
+        sender = event.get("sender", "?")
+        content = event.get("content", "")
+        msg_id = event.get("message_id", "")
+        print(f"\n[Message from {sender}] {content}  (id={msg_id})")
+
+    elif event_type == "transport_changed":
+        transport = event.get("transport", "?")
+        logger.info("Transport switched to: %s", transport)
+
+    elif event_type == "connection_request_received":
+        sender = event.get("sender", "?")
+        logger.info("Connection request from %s", sender)
+
+    else:
+        logger.debug("Event: %s", json.dumps(event, indent=2))
+
+
+async def main(user_id: str, server_url: str) -> None:
+    config = ProtocolConfig(
+        app_id="offline-example",
+        user_id=user_id,
+        ble_enabled=False,
+        wifi_direct_enabled=False,
+        internet_enabled=True,
+        reticulum_enabled=False,
+        prefer_online=True,
+        initial_ttl=3,
+        encryption_enabled=True,
+        auto_key_exchange=True,
+        store_pending=True,
+        require_encryption=False,
+        max_pending_per_peer=100,
+        max_pending_global=1000,
+        pending_ttl_ms=60000,
+        overflow_policy=OverflowPolicy.DROP_OLDEST,
+    )
+
+    async with ProtocolManager(config, event_handler=on_event) as pm:
+        # Configure and start Internet transport
+        assert pm.internet is not None
+        pm.internet.configure(server_url=server_url)
+        await pm.internet.start()
+
+        logger.info("Protocol running as '%s', connected to %s", user_id, server_url)
+        logger.info("Type a message as  <recipient> <text>  (e.g. 'bob hello!')")
+        logger.info("Type 'quit' to exit.\n")
+
+        # Read stdin in a non-blocking way
+        loop = asyncio.get_event_loop()
+        reader = asyncio.StreamReader()
+        protocol = await loop.connect_read_pipe(
+            lambda: asyncio.StreamReaderProtocol(reader), sys.stdin
+        )
+
+        while True:
+            try:
+                line_bytes = await reader.readline()
+            except asyncio.CancelledError:
+                break
+            if not line_bytes:
+                break
+
+            line = line_bytes.decode().strip()
+            if not line:
+                continue
+            if line.lower() == "quit":
+                break
+
+            parts = line.split(None, 1)
+            if len(parts) < 2:
+                print("Usage: <recipient> <message>")
+                continue
+
+            recipient, text = parts
+            try:
+                msg_id = pm.send_message(recipient, text)
+                print(f"  -> sent to {recipient} (id={msg_id})")
+            except Exception as exc:
+                print(f"  !! send failed: {exc}")
+
+    logger.info("Goodbye.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Offline Protocol SDK example")
+    parser.add_argument("--user", required=True, help="Your user ID")
+    parser.add_argument("--server", required=True, help="Relay WebSocket URL")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(main(args.user, args.server))
+    except KeyboardInterrupt:
+        pass

--- a/bindings/python/examples/basic_messaging.py
+++ b/bindings/python/examples/basic_messaging.py
@@ -92,7 +92,7 @@ async def main(user_id: str, server_url: str) -> None:
         logger.info("Type 'quit' to exit.\n")
 
         # Read stdin in a non-blocking way
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         reader = asyncio.StreamReader()
         protocol = await loop.connect_read_pipe(
             lambda: asyncio.StreamReaderProtocol(reader), sys.stdin

--- a/bindings/python/offline_protocol_sdk/__init__.py
+++ b/bindings/python/offline_protocol_sdk/__init__.py
@@ -1,0 +1,11 @@
+"""Offline Protocol SDK — Python bindings for offline-first mesh networking."""
+
+# Re-export all UniFFI-generated types (available after build-desktop.sh runs)
+from .offline_protocol import *  # noqa: F401, F403
+
+# Platform managers
+from .secure_storage import SecureStorage  # noqa: F401
+from .transport_manager import TransportManager, TransportState  # noqa: F401
+from .internet_manager import InternetManager  # noqa: F401
+from .ble_manager import BleManager  # noqa: F401
+from .protocol_manager import ProtocolManager  # noqa: F401

--- a/bindings/python/offline_protocol_sdk/__init__.py
+++ b/bindings/python/offline_protocol_sdk/__init__.py
@@ -8,4 +8,5 @@ from .secure_storage import SecureStorage  # noqa: F401
 from .transport_manager import TransportManager, TransportState  # noqa: F401
 from .internet_manager import InternetManager  # noqa: F401
 from .ble_manager import BleManager  # noqa: F401
+from .ble_peripheral import BlePeripheral  # noqa: F401
 from .protocol_manager import ProtocolManager  # noqa: F401

--- a/bindings/python/offline_protocol_sdk/ble_manager.py
+++ b/bindings/python/offline_protocol_sdk/ble_manager.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 from typing import Any
 
@@ -77,10 +78,18 @@ class BleManager(TransportManager):
         self._scanner: BleakScanner | None = None
         self._scan_task: asyncio.Task[None] | None = None
 
+        # Lock protecting shared state accessed from bleak's scanner thread
+        # (_on_advertisement) AND the asyncio event loop. Guards: _last_seen,
+        # _connection_attempts, _global_attempts, _connecting, _clients,
+        # _peer_device_ids.
+        self._lock = threading.Lock()
+
         # Connected peers: address -> BleakClient
         self._clients: dict[str, BleakClient] = {}
         # address -> device_id mapping
         self._peer_device_ids: dict[str, str] = {}
+        # device_id -> address reverse lookup (avoids linear scan)
+        self._device_id_to_addr: dict[str, str] = {}
         # address -> last-seen timestamp
         self._last_seen: dict[str, float] = {}
         # address -> last connection attempt timestamp (rate limiting)
@@ -133,7 +142,7 @@ class BleManager(TransportManager):
         try:
             self._protocol.ble_status_changed(is_available=True)
         except Exception:
-            pass
+            logger.debug("ble_status_changed(True) failed", exc_info=True)
 
         self._update_state(TransportState.RUNNING)
 
@@ -164,20 +173,24 @@ class BleManager(TransportManager):
         self._peer_cleanup_task = None
 
         # Disconnect all clients
-        for addr, client in list(self._clients.items()):
+        with self._lock:
+            clients_snapshot = list(self._clients.items())
+        for addr, client in clients_snapshot:
             try:
                 await client.disconnect()
             except Exception:
                 pass
-        self._clients.clear()
-        self._peer_device_ids.clear()
-        self._last_seen.clear()
-        self._connecting.clear()
+        with self._lock:
+            self._clients.clear()
+            self._peer_device_ids.clear()
+            self._device_id_to_addr.clear()
+            self._last_seen.clear()
+            self._connecting.clear()
 
         try:
             self._protocol.ble_status_changed(is_available=False)
         except Exception:
-            pass
+            logger.debug("ble_status_changed(False) failed")
 
         self._update_state(TransportState.STOPPED)
         self._emit_diagnostic("info", "BLE transport stopped")
@@ -200,7 +213,7 @@ class BleManager(TransportManager):
         """Called by bleak for each BLE advertisement detected.
 
         NOTE: This is invoked from bleak's scanner thread, not the asyncio
-        event loop.  All shared-state access must be thread-safe.
+        event loop.  All shared-state mutations go through ``_lock``.
         """
         addr = device.address
         rssi = adv_data.rssi if adv_data.rssi is not None else -100
@@ -210,33 +223,38 @@ class BleManager(TransportManager):
             return
 
         now = time.monotonic()
-        self._last_seen[addr] = now
+        should_connect = False
 
-        # Notify protocol of discovery (using address as provisional peer ID
-        # until we read the device ID characteristic)
-        peer_id = self._peer_device_ids.get(addr, addr)
+        with self._lock:
+            self._last_seen[addr] = now
+
+            peer_id = self._peer_device_ids.get(addr, addr)
+
+            # Attempt connection if not already connected / connecting.
+            if addr not in self._clients and addr not in self._connecting:
+                if self._should_connect_locked(addr, now):
+                    self._connecting.add(addr)
+                    should_connect = True
+
+        # Protocol calls outside the lock to avoid holding it during FFI
         try:
             self._protocol.ble_peer_discovered(peer_id=peer_id, rssi=rssi)
         except Exception:
-            pass
+            logger.debug("ble_peer_discovered failed for %s", peer_id)
 
-        # Attempt connection if not already connected / connecting.
-        # Mark as connecting BEFORE scheduling the task to prevent duplicate
-        # connection attempts from near-simultaneous advertisements.
-        if addr not in self._clients and addr not in self._connecting:
-            if self._should_connect(addr, now):
-                self._connecting.add(addr)
-                loop = self._loop
-                if loop is not None and not loop.is_closed() and loop.is_running():
-                    loop.call_soon_threadsafe(
-                        asyncio.ensure_future,
-                        self._connect_to_peer(device),
-                    )
-                else:
+        if should_connect:
+            loop = self._loop
+            if loop is not None and not loop.is_closed() and loop.is_running():
+                loop.call_soon_threadsafe(
+                    asyncio.ensure_future,
+                    self._connect_to_peer(device),
+                )
+            else:
+                with self._lock:
                     self._connecting.discard(addr)
 
-    def _should_connect(self, addr: str, now: float) -> bool:
-        """Adaptive rate-limiting (mirrors iOS adaptive scan logic)."""
+    def _should_connect_locked(self, addr: str, now: float) -> bool:
+        """Adaptive rate-limiting. Caller must hold ``_lock``."""
         # Per-peripheral cooldown
         last_attempt = self._connection_attempts.get(addr, 0)
         if now - last_attempt < ADAPTIVE_COOLDOWN_PER_PERIPHERAL:
@@ -256,8 +274,9 @@ class BleManager(TransportManager):
         addr = device.address
         # addr is already in self._connecting (added in _on_advertisement)
         now = time.monotonic()
-        self._connection_attempts[addr] = now
-        self._global_attempts.append(now)
+        with self._lock:
+            self._connection_attempts[addr] = now
+            self._global_attempts.append(now)
 
         try:
             client = BleakClient(
@@ -282,15 +301,17 @@ class BleManager(TransportManager):
                 await client.disconnect()
                 return
 
-            self._clients[addr] = client
-            self._peer_device_ids[addr] = device_id
+            with self._lock:
+                self._clients[addr] = client
+                self._peer_device_ids[addr] = device_id
+                self._device_id_to_addr[device_id] = addr
 
             # Re-notify protocol with the real device ID
             try:
                 rssi = -70  # approximate; bleak doesn't expose RSSI post-connect
                 self._protocol.ble_peer_discovered(peer_id=device_id, rssi=rssi)
             except Exception:
-                pass
+                logger.debug("ble_peer_discovered failed for %s", device_id)
 
             # Subscribe to message notifications
             await self._subscribe_to_messages(client, addr, device_id)
@@ -303,7 +324,8 @@ class BleManager(TransportManager):
         except Exception as exc:
             self._emit_diagnostic("debug", f"Connection to {addr} failed: {exc}")
         finally:
-            self._connecting.discard(addr)
+            with self._lock:
+                self._connecting.discard(addr)
 
     async def _read_device_id(self, client: BleakClient) -> str | None:
         """Read the device ID characteristic from a connected peripheral."""
@@ -341,13 +363,15 @@ class BleManager(TransportManager):
 
     async def _on_peer_disconnected(self, addr: str) -> None:
         """Called when a peer disconnects."""
-        device_id = self._peer_device_ids.pop(addr, addr)
-        self._clients.pop(addr, None)
+        with self._lock:
+            device_id = self._peer_device_ids.pop(addr, addr)
+            self._clients.pop(addr, None)
+            self._device_id_to_addr.pop(device_id, None)
 
         try:
             self._protocol.ble_peer_lost(peer_id=device_id)
         except Exception:
-            pass
+            logger.debug("ble_peer_lost failed for %s", device_id)
 
         self._emit_diagnostic("info", f"Peer disconnected: {device_id}")
 
@@ -403,14 +427,15 @@ class BleManager(TransportManager):
             try:
                 self._protocol.ble_return_fragment()
             except Exception:
-                pass
+                logger.debug("ble_return_fragment failed", exc_info=True)
 
     def _find_client_for_peer(self, peer_id: str) -> BleakClient | None:
-        """Find the BleakClient for a given device ID."""
-        for addr, did in self._peer_device_ids.items():
-            if did == peer_id:
+        """Find the BleakClient for a given device ID (O(1) via reverse map)."""
+        with self._lock:
+            addr = self._device_id_to_addr.get(peer_id)
+            if addr is not None:
                 return self._clients.get(addr)
-        return None
+            return None
 
     # -- background tasks -----------------------------------------------------
 
@@ -420,18 +445,24 @@ class BleManager(TransportManager):
             while True:
                 await asyncio.sleep(PEER_LOST_TIMEOUT / 2)
                 now = time.monotonic()
-                stale = [
-                    addr
-                    for addr, ts in self._last_seen.items()
-                    if now - ts > PEER_LOST_TIMEOUT
-                    and addr not in self._clients
-                ]
-                for addr in stale:
-                    self._last_seen.pop(addr, None)
-                    device_id = self._peer_device_ids.pop(addr, addr)
+                stale_device_ids: list[str] = []
+                with self._lock:
+                    stale = [
+                        addr
+                        for addr, ts in self._last_seen.items()
+                        if now - ts > PEER_LOST_TIMEOUT
+                        and addr not in self._clients
+                    ]
+                    for addr in stale:
+                        self._last_seen.pop(addr, None)
+                        device_id = self._peer_device_ids.pop(addr, addr)
+                        self._device_id_to_addr.pop(device_id, None)
+                        stale_device_ids.append(device_id)
+                # Notify protocol outside the lock
+                for device_id in stale_device_ids:
                     try:
                         self._protocol.ble_peer_lost(peer_id=device_id)
                     except Exception:
-                        pass
+                        logger.debug("ble_peer_lost failed for %s", device_id)
         except asyncio.CancelledError:
             return

--- a/bindings/python/offline_protocol_sdk/ble_manager.py
+++ b/bindings/python/offline_protocol_sdk/ble_manager.py
@@ -346,7 +346,7 @@ class BleManager(TransportManager):
             if frag is None:
                 break
 
-            recipient = frag.recipient
+            recipient = frag.recipient_id
             data = bytes(frag.data)
 
             # Find the client for this recipient

--- a/bindings/python/offline_protocol_sdk/ble_manager.py
+++ b/bindings/python/offline_protocol_sdk/ble_manager.py
@@ -197,7 +197,11 @@ class BleManager(TransportManager):
     def _on_advertisement(
         self, device: BLEDevice, adv_data: AdvertisementData
     ) -> None:
-        """Called by bleak for each BLE advertisement detected."""
+        """Called by bleak for each BLE advertisement detected.
+
+        NOTE: This is invoked from bleak's scanner thread, not the asyncio
+        event loop.  All shared-state access must be thread-safe.
+        """
         addr = device.address
         rssi = adv_data.rssi if adv_data.rssi is not None else -100
 
@@ -216,10 +220,20 @@ class BleManager(TransportManager):
         except Exception:
             pass
 
-        # Attempt connection if not already connected / connecting
+        # Attempt connection if not already connected / connecting.
+        # Mark as connecting BEFORE scheduling the task to prevent duplicate
+        # connection attempts from near-simultaneous advertisements.
         if addr not in self._clients and addr not in self._connecting:
             if self._should_connect(addr, now):
-                asyncio.ensure_future(self._connect_to_peer(device))
+                self._connecting.add(addr)
+                loop = self._loop
+                if loop is not None and not loop.is_closed() and loop.is_running():
+                    loop.call_soon_threadsafe(
+                        asyncio.ensure_future,
+                        self._connect_to_peer(device),
+                    )
+                else:
+                    self._connecting.discard(addr)
 
     def _should_connect(self, addr: str, now: float) -> bool:
         """Adaptive rate-limiting (mirrors iOS adaptive scan logic)."""
@@ -240,7 +254,7 @@ class BleManager(TransportManager):
 
     async def _connect_to_peer(self, device: BLEDevice) -> None:
         addr = device.address
-        self._connecting.add(addr)
+        # addr is already in self._connecting (added in _on_advertisement)
         now = time.monotonic()
         self._connection_attempts[addr] = now
         self._global_attempts.append(now)
@@ -254,7 +268,9 @@ class BleManager(TransportManager):
                         asyncio.ensure_future,
                         self._on_peer_disconnected(_addr),
                     )
-                    if self._loop is not None and self._loop.is_running()
+                    if self._loop is not None
+                    and not self._loop.is_closed()
+                    and self._loop.is_running()
                     else None
                 ),
             )
@@ -347,7 +363,7 @@ class BleManager(TransportManager):
         ``call_soon_threadsafe`` to schedule work on the asyncio event loop.
         """
         loop = self._loop
-        if loop is not None and loop.is_running():
+        if loop is not None and not loop.is_closed() and loop.is_running():
             loop.call_soon_threadsafe(asyncio.ensure_future, self._drain_outgoing_fragments())
 
     async def _drain_outgoing_fragments(self) -> None:
@@ -355,7 +371,11 @@ class BleManager(TransportManager):
         while True:
             try:
                 frag = self._protocol.ble_get_next_fragment()
-            except Exception:
+            except (AttributeError, ReferenceError) as exc:
+                logger.error("Protocol instance invalid: %s", exc)
+                break
+            except Exception as exc:
+                logger.warning("Unexpected error getting next fragment: %s", exc)
                 break
             if frag is None:
                 break

--- a/bindings/python/offline_protocol_sdk/ble_manager.py
+++ b/bindings/python/offline_protocol_sdk/ble_manager.py
@@ -96,6 +96,9 @@ class BleManager(TransportManager):
         self._fragments_sent: int = 0
         self._fragments_received: int = 0
 
+        # Event loop — captured in start() for thread-safe callback scheduling
+        self._loop: asyncio.AbstractEventLoop | None = None
+
         # Tasks
         self._peer_cleanup_task: asyncio.Task[None] | None = None
 
@@ -110,6 +113,7 @@ class BleManager(TransportManager):
         if self._state == TransportState.RUNNING:
             raise TransportError("BLE transport is already running")
 
+        self._loop = asyncio.get_running_loop()
         self._update_state(TransportState.STARTING)
         self._emit_diagnostic("info", "Starting BLE transport", {
             "device_id": self._device_id,
@@ -333,8 +337,13 @@ class BleManager(TransportManager):
 
         Drains outgoing fragments from the protocol core and writes them
         to connected peers via GATT.
+
+        This is invoked from a Rust UniFFI callback thread, so we must use
+        ``call_soon_threadsafe`` to schedule work on the asyncio event loop.
         """
-        asyncio.ensure_future(self._drain_outgoing_fragments())
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(asyncio.ensure_future, self._drain_outgoing_fragments())
 
     async def _drain_outgoing_fragments(self) -> None:
         """Poll and send all queued outgoing fragments."""

--- a/bindings/python/offline_protocol_sdk/ble_manager.py
+++ b/bindings/python/offline_protocol_sdk/ble_manager.py
@@ -1,0 +1,403 @@
+"""BLE transport manager using the ``bleak`` library.
+
+Mirrors the central (scanner) role from ``BleManager.swift`` /
+``BleManager.kt``.  Connects to nearby mesh peers over Bluetooth Low
+Energy, reads their device IDs, subscribes to message notifications, and
+drives the UniFFI ``OfflineProtocol`` BLE transport methods.
+
+**Known limitation:** ``bleak`` only supports the *central* (scanner/client)
+role.  Peripheral (advertiser/GATT server) support requires the ``bless``
+library or platform-specific code and is not included here.  This means a
+desktop node can *discover and receive from* mobile peers, but mobile peers
+cannot discover the desktop unless the desktop also runs a GATT server via
+``bless`` or an external tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from bleak import BleakClient, BleakScanner
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+
+from .transport_manager import TransportError, TransportManager, TransportState
+
+logger = logging.getLogger(__name__)
+
+# -- BLE constants (matching iOS/Android) -------------------------------------
+
+SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+MESSAGE_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+DEVICE_ID_CHAR_UUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+IDENTITY_CHAR_UUID = "6e400004-b5a3-f393-e0a9-e50e24dcca9e"
+
+MAX_FRAGMENT_SIZE = 185
+CONNECTION_TIMEOUT = 10.0  # seconds
+ADAPTIVE_MIN_RSSI = -85
+ADAPTIVE_LOW_DENSITY_THRESHOLD = 10
+ADAPTIVE_HIGH_DENSITY_THRESHOLD = 50
+ADAPTIVE_MAX_CONNECTIONS_PER_MINUTE = 6
+ADAPTIVE_COOLDOWN_PER_PERIPHERAL = 30.0  # seconds
+PEER_LOST_TIMEOUT = 30.0  # seconds since last seen
+SCAN_RESTART_INTERVAL = 30.0
+
+
+class BleManager(TransportManager):
+    """BLE transport — central (scanner) role.
+
+    Discovers nearby mesh peripherals advertising ``SERVICE_UUID``, connects
+    to them, reads their device ID, subscribes to the message characteristic,
+    and forwards incoming BLE fragments to the Rust protocol core.
+
+    Outgoing fragments are sent event-driven: the protocol calls
+    ``BleTransportCallback.on_fragments_available()`` which triggers
+    :meth:`_drain_outgoing_fragments`.
+
+    Parameters
+    ----------
+    protocol:
+        The ``OfflineProtocol`` UniFFI instance.
+    device_id:
+        Local device identifier.
+    """
+
+    transport_id = "ble"
+    transport_name = "Bluetooth Low Energy"
+
+    def __init__(self, protocol: Any, device_id: str) -> None:
+        super().__init__()
+        self._protocol = protocol
+        self._device_id = device_id
+
+        # Scanner
+        self._scanner: BleakScanner | None = None
+        self._scan_task: asyncio.Task[None] | None = None
+
+        # Connected peers: address -> BleakClient
+        self._clients: dict[str, BleakClient] = {}
+        # address -> device_id mapping
+        self._peer_device_ids: dict[str, str] = {}
+        # address -> last-seen timestamp
+        self._last_seen: dict[str, float] = {}
+        # address -> last connection attempt timestamp (rate limiting)
+        self._connection_attempts: dict[str, float] = {}
+        # Global connection attempt timestamps (rate limiting)
+        self._global_attempts: list[float] = []
+        # Addresses currently being connected to (prevent concurrent attempts)
+        self._connecting: set[str] = set()
+
+        # Metrics
+        self._bytes_sent: int = 0
+        self._bytes_received: int = 0
+        self._fragments_sent: int = 0
+        self._fragments_received: int = 0
+
+        # Tasks
+        self._peer_cleanup_task: asyncio.Task[None] | None = None
+
+    # -- TransportManager interface -------------------------------------------
+
+    def is_available(self) -> bool:
+        # bleak should be importable; actual adapter availability is checked
+        # when scanning starts.
+        return True
+
+    async def start(self) -> None:
+        if self._state == TransportState.RUNNING:
+            raise TransportError("BLE transport is already running")
+
+        self._update_state(TransportState.STARTING)
+        self._emit_diagnostic("info", "Starting BLE transport", {
+            "device_id": self._device_id,
+        })
+
+        try:
+            self._scanner = BleakScanner(
+                detection_callback=self._on_advertisement,
+                service_uuids=[SERVICE_UUID],
+            )
+            await self._scanner.start()
+        except Exception as exc:
+            self._update_state(TransportState.STOPPED)
+            raise TransportError(f"BLE scan start failed: {exc}") from exc
+
+        # Notify protocol
+        try:
+            self._protocol.ble_status_changed(is_available=True)
+        except Exception:
+            pass
+
+        self._update_state(TransportState.RUNNING)
+
+        # Start background tasks
+        self._peer_cleanup_task = asyncio.ensure_future(
+            self._peer_cleanup_loop()
+        )
+
+        self._emit_diagnostic("info", "BLE transport started")
+
+    async def stop(self) -> None:
+        if self._state not in (TransportState.RUNNING, TransportState.STARTING):
+            return
+
+        self._update_state(TransportState.STOPPING)
+
+        # Stop scanner
+        if self._scanner is not None:
+            try:
+                await self._scanner.stop()
+            except Exception:
+                pass
+            self._scanner = None
+
+        # Cancel background tasks
+        if self._peer_cleanup_task is not None and not self._peer_cleanup_task.done():
+            self._peer_cleanup_task.cancel()
+        self._peer_cleanup_task = None
+
+        # Disconnect all clients
+        for addr, client in list(self._clients.items()):
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+        self._clients.clear()
+        self._peer_device_ids.clear()
+        self._last_seen.clear()
+        self._connecting.clear()
+
+        try:
+            self._protocol.ble_status_changed(is_available=False)
+        except Exception:
+            pass
+
+        self._update_state(TransportState.STOPPED)
+        self._emit_diagnostic("info", "BLE transport stopped")
+
+    def get_metrics(self) -> dict[str, Any]:
+        return {
+            "bytes_sent": self._bytes_sent,
+            "bytes_received": self._bytes_received,
+            "fragments_sent": self._fragments_sent,
+            "fragments_received": self._fragments_received,
+            "connected_peers": len(self._clients),
+            "discovered_peers": len(self._last_seen),
+        }
+
+    # -- scanning / discovery -------------------------------------------------
+
+    def _on_advertisement(
+        self, device: BLEDevice, adv_data: AdvertisementData
+    ) -> None:
+        """Called by bleak for each BLE advertisement detected."""
+        addr = device.address
+        rssi = adv_data.rssi if adv_data.rssi is not None else -100
+
+        # Filter weak signals
+        if rssi < ADAPTIVE_MIN_RSSI:
+            return
+
+        now = time.monotonic()
+        self._last_seen[addr] = now
+
+        # Notify protocol of discovery (using address as provisional peer ID
+        # until we read the device ID characteristic)
+        peer_id = self._peer_device_ids.get(addr, addr)
+        try:
+            self._protocol.ble_peer_discovered(peer_id=peer_id, rssi=rssi)
+        except Exception:
+            pass
+
+        # Attempt connection if not already connected / connecting
+        if addr not in self._clients and addr not in self._connecting:
+            if self._should_connect(addr, now):
+                asyncio.ensure_future(self._connect_to_peer(device))
+
+    def _should_connect(self, addr: str, now: float) -> bool:
+        """Adaptive rate-limiting (mirrors iOS adaptive scan logic)."""
+        # Per-peripheral cooldown
+        last_attempt = self._connection_attempts.get(addr, 0)
+        if now - last_attempt < ADAPTIVE_COOLDOWN_PER_PERIPHERAL:
+            return False
+
+        # Global rate limiting
+        cutoff = now - 60.0
+        self._global_attempts = [t for t in self._global_attempts if t > cutoff]
+        if len(self._global_attempts) >= ADAPTIVE_MAX_CONNECTIONS_PER_MINUTE:
+            return False
+
+        return True
+
+    # -- connection management ------------------------------------------------
+
+    async def _connect_to_peer(self, device: BLEDevice) -> None:
+        addr = device.address
+        self._connecting.add(addr)
+        now = time.monotonic()
+        self._connection_attempts[addr] = now
+        self._global_attempts.append(now)
+
+        try:
+            client = BleakClient(
+                device,
+                timeout=CONNECTION_TIMEOUT,
+                disconnected_callback=lambda c: asyncio.ensure_future(
+                    self._on_peer_disconnected(addr)
+                ),
+            )
+            await client.connect()
+
+            # Read device ID characteristic
+            device_id = await self._read_device_id(client)
+            if device_id is None:
+                await client.disconnect()
+                return
+
+            self._clients[addr] = client
+            self._peer_device_ids[addr] = device_id
+
+            # Re-notify protocol with the real device ID
+            try:
+                rssi = -70  # approximate; bleak doesn't expose RSSI post-connect
+                self._protocol.ble_peer_discovered(peer_id=device_id, rssi=rssi)
+            except Exception:
+                pass
+
+            # Subscribe to message notifications
+            await self._subscribe_to_messages(client, addr, device_id)
+
+            self._emit_diagnostic("info", "Connected to peer", {
+                "address": addr,
+                "device_id": device_id,
+            })
+
+        except Exception as exc:
+            self._emit_diagnostic("debug", f"Connection to {addr} failed: {exc}")
+        finally:
+            self._connecting.discard(addr)
+
+    async def _read_device_id(self, client: BleakClient) -> str | None:
+        """Read the device ID characteristic from a connected peripheral."""
+        try:
+            data = await client.read_gatt_char(DEVICE_ID_CHAR_UUID)
+            return data.decode("utf-8").strip("\x00")
+        except Exception as exc:
+            self._emit_diagnostic("debug", f"Failed to read device ID: {exc}")
+            return None
+
+    async def _subscribe_to_messages(
+        self, client: BleakClient, addr: str, device_id: str
+    ) -> None:
+        """Subscribe to the message characteristic for incoming fragments."""
+        try:
+            def on_notification(_sender: int, data: bytearray) -> None:
+                self._on_fragment_received(device_id, bytes(data))
+
+            await client.start_notify(MESSAGE_CHAR_UUID, on_notification)
+        except Exception as exc:
+            self._emit_diagnostic(
+                "warning", f"Failed to subscribe to messages from {device_id}: {exc}"
+            )
+
+    def _on_fragment_received(self, sender_id: str, fragment: bytes) -> None:
+        """Handle an incoming BLE fragment from a peer."""
+        self._bytes_received += len(fragment)
+        self._fragments_received += 1
+        try:
+            self._protocol.ble_fragment_received(
+                sender_id=sender_id, fragment=list(fragment)
+            )
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Error feeding fragment to protocol: {exc}")
+
+    async def _on_peer_disconnected(self, addr: str) -> None:
+        """Called when a peer disconnects."""
+        device_id = self._peer_device_ids.pop(addr, addr)
+        self._clients.pop(addr, None)
+
+        try:
+            self._protocol.ble_peer_lost(peer_id=device_id)
+        except Exception:
+            pass
+
+        self._emit_diagnostic("info", f"Peer disconnected: {device_id}")
+
+    # -- outgoing fragment handling -------------------------------------------
+
+    def on_fragments_available(self) -> None:
+        """Called by ``BleTransportCallback.on_fragments_available()``.
+
+        Drains outgoing fragments from the protocol core and writes them
+        to connected peers via GATT.
+        """
+        asyncio.ensure_future(self._drain_outgoing_fragments())
+
+    async def _drain_outgoing_fragments(self) -> None:
+        """Poll and send all queued outgoing fragments."""
+        while True:
+            try:
+                frag = self._protocol.ble_get_next_fragment()
+            except Exception:
+                break
+            if frag is None:
+                break
+
+            recipient = frag.recipient
+            data = bytes(frag.data)
+
+            # Find the client for this recipient
+            client = self._find_client_for_peer(recipient)
+            if client is not None and client.is_connected:
+                try:
+                    await client.write_gatt_char(
+                        MESSAGE_CHAR_UUID,
+                        data,
+                        response=False,
+                    )
+                    self._bytes_sent += len(data)
+                    self._fragments_sent += 1
+                except Exception as exc:
+                    self._emit_diagnostic(
+                        "warning", f"Failed to send fragment to {recipient}: {exc}"
+                    )
+
+            # Return fragment to pool regardless of send outcome
+            try:
+                self._protocol.ble_return_fragment()
+            except Exception:
+                pass
+
+    def _find_client_for_peer(self, peer_id: str) -> BleakClient | None:
+        """Find the BleakClient for a given device ID."""
+        for addr, did in self._peer_device_ids.items():
+            if did == peer_id:
+                return self._clients.get(addr)
+        return None
+
+    # -- background tasks -----------------------------------------------------
+
+    async def _peer_cleanup_loop(self) -> None:
+        """Periodically remove stale peers that haven't been seen recently."""
+        try:
+            while True:
+                await asyncio.sleep(PEER_LOST_TIMEOUT / 2)
+                now = time.monotonic()
+                stale = [
+                    addr
+                    for addr, ts in self._last_seen.items()
+                    if now - ts > PEER_LOST_TIMEOUT
+                    and addr not in self._clients
+                ]
+                for addr in stale:
+                    self._last_seen.pop(addr, None)
+                    device_id = self._peer_device_ids.pop(addr, addr)
+                    try:
+                        self._protocol.ble_peer_lost(peer_id=device_id)
+                    except Exception:
+                        pass
+        except asyncio.CancelledError:
+            return

--- a/bindings/python/offline_protocol_sdk/ble_manager.py
+++ b/bindings/python/offline_protocol_sdk/ble_manager.py
@@ -196,14 +196,15 @@ class BleManager(TransportManager):
         self._emit_diagnostic("info", "BLE transport stopped")
 
     def get_metrics(self) -> dict[str, Any]:
-        return {
-            "bytes_sent": self._bytes_sent,
-            "bytes_received": self._bytes_received,
-            "fragments_sent": self._fragments_sent,
-            "fragments_received": self._fragments_received,
-            "connected_peers": len(self._clients),
-            "discovered_peers": len(self._last_seen),
-        }
+        with self._lock:
+            return {
+                "bytes_sent": self._bytes_sent,
+                "bytes_received": self._bytes_received,
+                "fragments_sent": self._fragments_sent,
+                "fragments_received": self._fragments_received,
+                "connected_peers": len(self._clients),
+                "discovered_peers": len(self._last_seen),
+            }
 
     # -- scanning / discovery -------------------------------------------------
 
@@ -352,8 +353,9 @@ class BleManager(TransportManager):
 
     def _on_fragment_received(self, sender_id: str, fragment: bytes) -> None:
         """Handle an incoming BLE fragment from a peer."""
-        self._bytes_received += len(fragment)
-        self._fragments_received += 1
+        with self._lock:
+            self._bytes_received += len(fragment)
+            self._fragments_received += 1
         try:
             self._protocol.ble_fragment_received(
                 sender_id=sender_id, fragment=list(fragment)
@@ -416,8 +418,9 @@ class BleManager(TransportManager):
                         data,
                         response=False,
                     )
-                    self._bytes_sent += len(data)
-                    self._fragments_sent += 1
+                    with self._lock:
+                        self._bytes_sent += len(data)
+                        self._fragments_sent += 1
                 except Exception as exc:
                     self._emit_diagnostic(
                         "warning", f"Failed to send fragment to {recipient}: {exc}"

--- a/bindings/python/offline_protocol_sdk/ble_manager.py
+++ b/bindings/python/offline_protocol_sdk/ble_manager.py
@@ -108,6 +108,9 @@ class BleManager(TransportManager):
         # Event loop — captured in start() for thread-safe callback scheduling
         self._loop: asyncio.AbstractEventLoop | None = None
 
+        # Serialisation flag — prevents concurrent _drain_outgoing_fragments
+        self._draining: bool = False
+
         # Tasks
         self._peer_cleanup_task: asyncio.Task[None] | None = None
 
@@ -394,6 +397,15 @@ class BleManager(TransportManager):
 
     async def _drain_outgoing_fragments(self) -> None:
         """Poll and send all queued outgoing fragments."""
+        if self._draining:
+            return
+        self._draining = True
+        try:
+            await self._drain_outgoing_fragments_inner()
+        finally:
+            self._draining = False
+
+    async def _drain_outgoing_fragments_inner(self) -> None:
         while True:
             try:
                 frag = self._protocol.ble_get_next_fragment()

--- a/bindings/python/offline_protocol_sdk/ble_manager.py
+++ b/bindings/python/offline_protocol_sdk/ble_manager.py
@@ -249,8 +249,13 @@ class BleManager(TransportManager):
             client = BleakClient(
                 device,
                 timeout=CONNECTION_TIMEOUT,
-                disconnected_callback=lambda c: asyncio.ensure_future(
-                    self._on_peer_disconnected(addr)
+                disconnected_callback=lambda c, _addr=addr: (
+                    self._loop.call_soon_threadsafe(
+                        asyncio.ensure_future,
+                        self._on_peer_disconnected(_addr),
+                    )
+                    if self._loop is not None and self._loop.is_running()
+                    else None
                 ),
             )
             await client.connect()

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -120,6 +120,9 @@ class BlePeripheral(TransportManager):
         self._fragments_received: int = 0
         self._is_advertising: bool = False
 
+        # Serialisation flag — prevents concurrent _drain_outgoing_fragments
+        self._draining: bool = False
+
         # Background tasks
         self._peer_monitor_task: asyncio.Task[None] | None = None
 
@@ -383,6 +386,17 @@ class BlePeripheral(TransportManager):
 
     async def _drain_outgoing_fragments(self) -> None:
         """Send all queued outgoing fragments as notifications."""
+        if self._server is None:
+            return
+        if self._draining:
+            return
+        self._draining = True
+        try:
+            await self._drain_outgoing_fragments_inner()
+        finally:
+            self._draining = False
+
+    async def _drain_outgoing_fragments_inner(self) -> None:
         if self._server is None:
             return
 

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -106,6 +106,9 @@ class BlePeripheral(TransportManager):
         # Connected centrals: uuid -> connection timestamp
         self._connected_centrals: dict[str, float] = {}
 
+        # Event loop — captured in start() for thread-safe callback scheduling
+        self._loop: asyncio.AbstractEventLoop | None = None
+
         # Metrics
         self._bytes_sent: int = 0
         self._bytes_received: int = 0
@@ -132,6 +135,7 @@ class BlePeripheral(TransportManager):
                 f"BLE peripheral not available on {sys.platform}"
             )
 
+        self._loop = asyncio.get_running_loop()
         self._update_state(TransportState.STARTING)
         self._emit_diagnostic("info", "Starting BLE peripheral", {
             "device_id": self._device_id,
@@ -234,8 +238,14 @@ class BlePeripheral(TransportManager):
         await self._server.add_new_service(SERVICE_UUID)
 
         # MESSAGE characteristic — bidirectional fragment transport
+        # NOTE: ``write`` (with-response) is required on macOS because the
+        # CoreBluetooth ``peripheralManager:didReceiveWriteRequests:``
+        # delegate callback is only invoked for ATT Write Requests, **not**
+        # ATT Write Commands (write-without-response).  We keep both so
+        # peers that prefer write-without-response still see the property.
         msg_props = (
-            GATTCharacteristicProperties.write_without_response
+            GATTCharacteristicProperties.write
+            | GATTCharacteristicProperties.write_without_response
             | GATTCharacteristicProperties.notify
         )
         msg_perms = (
@@ -297,23 +307,35 @@ class BlePeripheral(TransportManager):
         return bytearray(b"")
 
     def _on_write(self, char_uuid: Any, value: Any) -> None:
-        """Handle incoming GATT write requests (fragments from phones)."""
-        if self._resolve_char_uuid(char_uuid) != MESSAGE_CHAR_UUID.lower():
-            return
+        """Handle incoming GATT write requests (fragments from phones).
 
-        fragment = bytes(value)
-        self._bytes_received += len(fragment)
-        self._fragments_received += 1
-
-        sender_id = self._resolve_sender()
-
+        This runs inside the bless/CoreBluetooth delegate callback.  Any
+        unhandled exception here prevents ``respondToRequest:withResult:``
+        from being called, which causes CoreBluetooth to **drop the
+        connection**.  Therefore the entire body is wrapped in try/except.
+        """
         try:
+            resolved = self._resolve_char_uuid(char_uuid)
+            if resolved != MESSAGE_CHAR_UUID.lower():
+                return
+
+            fragment = bytes(value)
+            logger.debug(
+                "[ble_peripheral] _on_write: %d bytes from %s",
+                len(fragment), type(char_uuid).__name__,
+            )
+            self._bytes_received += len(fragment)
+            self._fragments_received += 1
+
+            sender_id = self._resolve_sender()
+
             self._protocol.ble_fragment_received(
                 sender_id=sender_id, fragment=list(fragment)
             )
         except Exception as exc:
+            logger.error("[ble_peripheral] Write handler exception: %s", exc, exc_info=True)
             self._emit_diagnostic(
-                "error", f"Error feeding fragment to protocol: {exc}"
+                "error", f"Error in write handler: {exc}"
             )
 
     def _resolve_sender(self) -> str:
@@ -335,8 +357,13 @@ class BlePeripheral(TransportManager):
 
         Drains outgoing fragments from the protocol core and sends them
         to subscribed centrals via GATT notifications.
+
+        This is invoked from a Rust UniFFI callback thread, so we must use
+        ``call_soon_threadsafe`` to schedule work on the asyncio event loop.
         """
-        asyncio.ensure_future(self._drain_outgoing_fragments())
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(asyncio.ensure_future, self._drain_outgoing_fragments())
 
     async def _drain_outgoing_fragments(self) -> None:
         """Send all queued outgoing fragments as notifications."""

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -107,6 +107,12 @@ class BlePeripheral(TransportManager):
         # Connected centrals: uuid -> connection timestamp
         self._connected_centrals: dict[str, float] = {}
 
+        # Central UUID -> resolved user_id mapping.  Populated when the
+        # protocol core emits a message_received event containing a
+        # ``sender`` field.  Used to re-register the peer with its real
+        # user_id so the Rust BLE transport can route outgoing messages.
+        self._central_to_user_id: dict[str, str] = {}
+
         # Event loop — captured in start() for thread-safe callback scheduling
         self._loop: asyncio.AbstractEventLoop | None = None
 
@@ -210,13 +216,20 @@ class BlePeripheral(TransportManager):
             self._server = None
         self._is_advertising = False
 
-        # Notify protocol about all lost peers
+        # Notify protocol about all lost peers (both raw UUID and resolved user_id)
         for central_uuid in list(self._connected_centrals):
             try:
                 self._protocol.ble_peer_lost(peer_id=central_uuid)
             except Exception:
                 logger.debug("ble_peer_lost failed for %s", central_uuid)
+            resolved_uid = self._central_to_user_id.get(central_uuid)
+            if resolved_uid:
+                try:
+                    self._protocol.ble_peer_lost(peer_id=resolved_uid)
+                except Exception:
+                    logger.debug("ble_peer_lost failed for resolved %s", resolved_uid)
         self._connected_centrals.clear()
+        self._central_to_user_id.clear()
 
         try:
             self._protocol.ble_status_changed(is_available=False)
@@ -369,6 +382,53 @@ class BlePeripheral(TransportManager):
             return next(iter(self._connected_centrals))
         return "ble-peer"
 
+    def resolve_sender_identity(self, sender_user_id: str) -> None:
+        """Associate a sender's user_id with the currently connected central.
+
+        Called by ``ProtocolManager`` when a reassembled message reveals the
+        sender's real user_id (from the message ``sender`` field).  The BLE
+        central (scanner) path learns the peer's user_id by reading the
+        DEVICE_ID characteristic; the peripheral has no equivalent mechanism,
+        so it relies on the first received message to learn the mapping.
+
+        Once the mapping is established, the peer is re-registered with the
+        Rust core under its real user_id so that ``send_message(user_id, ...)``
+        can route back through the BLE peripheral.
+        """
+        if not self._connected_centrals:
+            return
+
+        # With one central connected the mapping is unambiguous.
+        # With multiple, we can't reliably attribute — skip.
+        if len(self._connected_centrals) != 1:
+            logger.debug(
+                "resolve_sender_identity: %d centrals connected, skipping",
+                len(self._connected_centrals),
+            )
+            return
+
+        central_uuid = next(iter(self._connected_centrals))
+
+        # Avoid redundant re-registration
+        if self._central_to_user_id.get(central_uuid) == sender_user_id:
+            return
+
+        self._central_to_user_id[central_uuid] = sender_user_id
+        logger.info(
+            "Resolved central %s -> user_id %s — re-registering peer",
+            central_uuid, sender_user_id,
+        )
+
+        try:
+            self._protocol.ble_peer_discovered(
+                peer_id=sender_user_id, rssi=-50
+            )
+        except Exception:
+            logger.debug(
+                "ble_peer_discovered failed for resolved user_id %s",
+                sender_user_id,
+            )
+
     # -- outgoing fragment handling -------------------------------------------
 
     def on_fragments_available(self) -> None:
@@ -486,10 +546,19 @@ class BlePeripheral(TransportManager):
                 # Lost centrals
                 for central_uuid in known - current:
                     self._connected_centrals.pop(central_uuid, None)
+                    # Notify peer lost for both the raw UUID and the
+                    # resolved user_id (if any) so the Rust core removes
+                    # both routing entries.
+                    resolved_uid = self._central_to_user_id.pop(central_uuid, None)
                     try:
                         self._protocol.ble_peer_lost(peer_id=central_uuid)
                     except Exception:
                         logger.debug("ble_peer_lost failed for %s", central_uuid)
+                    if resolved_uid:
+                        try:
+                            self._protocol.ble_peer_lost(peer_id=resolved_uid)
+                        except Exception:
+                            logger.debug("ble_peer_lost failed for resolved %s", resolved_uid)
                     self._emit_diagnostic(
                         "info", "Central disconnected", {"central": central_uuid}
                     )

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -1,0 +1,415 @@
+"""BLE transport manager — peripheral (advertiser/GATT server) role.
+
+Complements :class:`BleManager` (central/scanner role) by advertising a
+GATT service so that phones and hardware devices can discover this desktop
+node, connect, and exchange mesh messages over Bluetooth Low Energy.
+
+Uses the ``bless`` library for GATT server functionality.  On macOS this
+is backed by CoreBluetooth; on Linux by BlueZ/D-Bus.
+
+Typical usage::
+
+    peripheral = BlePeripheral(protocol, device_id="coordinator")
+    await peripheral.start()   # begins advertising
+    # phones now discover "coordinator" and connect
+    await peripheral.stop()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import time
+from typing import Any
+
+from bless import (
+    BlessServer,
+    GATTAttributePermissions,
+    GATTCharacteristicProperties,
+)
+
+from .ble_manager import (
+    DEVICE_ID_CHAR_UUID,
+    IDENTITY_CHAR_UUID,
+    MESSAGE_CHAR_UUID,
+    SERVICE_UUID,
+)
+from .transport_manager import TransportError, TransportManager, TransportState
+
+logger = logging.getLogger(__name__)
+
+# Inter-frame delay when sending multiple notification fragments (matches
+# the 5 ms delay used by the M5StickC firmware in ble_mesh.h).
+_INTER_FRAME_DELAY = 0.005
+
+# How often to poll the bless delegate for subscription changes.
+_PEER_MONITOR_INTERVAL = 1.0
+
+
+class BlePeripheral(TransportManager):
+    """BLE transport — peripheral (advertiser / GATT server) role.
+
+    Advertises a GATT service with the standard Offline Protocol BLE UUIDs,
+    accepts connections from phones and hardware, receives incoming fragments
+    via GATT write requests, and sends outgoing fragments via notifications.
+
+    The peripheral passes raw fragment bytes through to the
+    :class:`OfflineProtocol` Rust core — the core handles reassembly and
+    routing internally.
+
+    Parameters
+    ----------
+    protocol:
+        The ``OfflineProtocol`` UniFFI instance (shared with ``BleManager``).
+    device_id:
+        Device identifier written to the DEVICE_ID characteristic.  Phones
+        that read ``"coordinator"`` auto-detect a training cluster.
+    max_connections:
+        Maximum number of simultaneous central connections (default 4).
+    identity_json:
+        Optional JSON string for the IDENTITY characteristic.  If ``None``,
+        a default is generated from *device_id*.
+    """
+
+    transport_id = "ble-peripheral"
+    transport_name = "Bluetooth Low Energy (Peripheral)"
+
+    def __init__(
+        self,
+        protocol: Any,
+        device_id: str,
+        *,
+        max_connections: int = 4,
+        identity_json: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._protocol = protocol
+        self._device_id = device_id
+        self._max_connections = max_connections
+
+        # Identity characteristic payload
+        if identity_json is not None:
+            self._identity_bytes = identity_json.encode("utf-8")
+        else:
+            self._identity_bytes = json.dumps({
+                "device_id": device_id,
+                "role": "coordinator",
+                "protocol": "offline-protocol",
+                "version": "0.1.0",
+            }).encode("utf-8")
+
+        # Server (created on start)
+        self._server: BlessServer | None = None
+
+        # Connected centrals: uuid -> connection timestamp
+        self._connected_centrals: dict[str, float] = {}
+
+        # Metrics
+        self._bytes_sent: int = 0
+        self._bytes_received: int = 0
+        self._fragments_sent: int = 0
+        self._fragments_received: int = 0
+        self._is_advertising: bool = False
+
+        # Background tasks
+        self._peer_monitor_task: asyncio.Task[None] | None = None
+
+    # -- TransportManager interface -------------------------------------------
+
+    def is_available(self) -> bool:
+        """Return True on platforms where bless is supported (macOS, Linux)."""
+        return sys.platform in ("darwin", "linux")
+
+    async def start(self) -> None:
+        """Set up the GATT server, register characteristics, and advertise."""
+        if self._state == TransportState.RUNNING:
+            raise TransportError("BLE peripheral is already running")
+
+        if not self.is_available():
+            raise TransportError(
+                f"BLE peripheral not available on {sys.platform}"
+            )
+
+        self._update_state(TransportState.STARTING)
+        self._emit_diagnostic("info", "Starting BLE peripheral", {
+            "device_id": self._device_id,
+        })
+
+        try:
+            # Truncate name — CoreBluetooth limits advertisement data to ~28
+            # bytes, and service UUIDs also consume space.
+            name = self._device_id[:10]
+            self._server = BlessServer(name=name)
+
+            await self._setup_gatt_server()
+
+            # Register read/write callbacks
+            self._server.read_request_func = self._on_read
+            self._server.write_request_func = self._on_write
+
+            # Start advertising — prioritize service UUID over local name so
+            # phones can discover us via SERVICE_UUID scanning.
+            await self._server.start(prioritize_local_name=False)
+            self._is_advertising = True
+        except Exception as exc:
+            self._update_state(TransportState.STOPPED)
+            raise TransportError(
+                f"BLE peripheral start failed: {exc}"
+            ) from exc
+
+        # Notify protocol
+        try:
+            self._protocol.ble_status_changed(is_available=True)
+        except Exception:
+            pass
+
+        self._update_state(TransportState.RUNNING)
+
+        # Start background peer monitor
+        self._peer_monitor_task = asyncio.ensure_future(
+            self._peer_monitor_loop()
+        )
+
+        self._emit_diagnostic("info", "BLE peripheral started — advertising")
+
+    async def stop(self) -> None:
+        """Stop advertising and disconnect all centrals."""
+        if self._state not in (TransportState.RUNNING, TransportState.STARTING):
+            return
+
+        self._update_state(TransportState.STOPPING)
+
+        # Cancel background tasks
+        if self._peer_monitor_task is not None and not self._peer_monitor_task.done():
+            self._peer_monitor_task.cancel()
+            try:
+                await self._peer_monitor_task
+            except asyncio.CancelledError:
+                pass
+        self._peer_monitor_task = None
+
+        # Stop GATT server
+        if self._server is not None:
+            try:
+                await self._server.stop()
+            except Exception:
+                pass
+            self._server = None
+        self._is_advertising = False
+
+        # Notify protocol about all lost peers
+        for central_uuid in list(self._connected_centrals):
+            try:
+                self._protocol.ble_peer_lost(peer_id=central_uuid)
+            except Exception:
+                pass
+        self._connected_centrals.clear()
+
+        try:
+            self._protocol.ble_status_changed(is_available=False)
+        except Exception:
+            pass
+
+        self._update_state(TransportState.STOPPED)
+        self._emit_diagnostic("info", "BLE peripheral stopped")
+
+    def get_metrics(self) -> dict[str, Any]:
+        return {
+            "bytes_sent": self._bytes_sent,
+            "bytes_received": self._bytes_received,
+            "fragments_sent": self._fragments_sent,
+            "fragments_received": self._fragments_received,
+            "connected_centrals": len(self._connected_centrals),
+            "is_advertising": self._is_advertising,
+        }
+
+    # -- GATT server setup ----------------------------------------------------
+
+    async def _setup_gatt_server(self) -> None:
+        """Add the mesh service and its characteristics."""
+        assert self._server is not None
+
+        await self._server.add_new_service(SERVICE_UUID)
+
+        # MESSAGE characteristic — bidirectional fragment transport
+        msg_props = (
+            GATTCharacteristicProperties.write_without_response
+            | GATTCharacteristicProperties.notify
+        )
+        msg_perms = (
+            GATTAttributePermissions.writeable
+            | GATTAttributePermissions.readable
+        )
+        await self._server.add_new_characteristic(
+            SERVICE_UUID,
+            MESSAGE_CHAR_UUID,
+            msg_props,
+            None,
+            msg_perms,
+        )
+
+        # DEVICE_ID characteristic — readable identity
+        await self._server.add_new_characteristic(
+            SERVICE_UUID,
+            DEVICE_ID_CHAR_UUID,
+            GATTCharacteristicProperties.read,
+            bytearray(self._device_id.encode("utf-8")),
+            GATTAttributePermissions.readable,
+        )
+
+        # IDENTITY characteristic — readable JSON metadata
+        await self._server.add_new_characteristic(
+            SERVICE_UUID,
+            IDENTITY_CHAR_UUID,
+            GATTCharacteristicProperties.read,
+            bytearray(self._identity_bytes),
+            GATTAttributePermissions.readable,
+        )
+
+    # -- GATT callbacks -------------------------------------------------------
+
+    def _on_read(self, char_uuid: str) -> bytearray:
+        """Handle incoming GATT read requests."""
+        uuid = char_uuid.lower()
+        if uuid == DEVICE_ID_CHAR_UUID.lower():
+            return bytearray(self._device_id.encode("utf-8"))
+        if uuid == IDENTITY_CHAR_UUID.lower():
+            return bytearray(self._identity_bytes)
+        return bytearray(b"")
+
+    def _on_write(self, char_uuid: str, value: Any) -> None:
+        """Handle incoming GATT write requests (fragments from phones)."""
+        if char_uuid.lower() != MESSAGE_CHAR_UUID.lower():
+            return
+
+        fragment = bytes(value)
+        self._bytes_received += len(fragment)
+        self._fragments_received += 1
+
+        sender_id = self._resolve_sender()
+
+        try:
+            self._protocol.ble_fragment_received(
+                sender_id=sender_id, fragment=list(fragment)
+            )
+        except Exception as exc:
+            self._emit_diagnostic(
+                "error", f"Error feeding fragment to protocol: {exc}"
+            )
+
+    def _resolve_sender(self) -> str:
+        """Best-effort identification of the writing central.
+
+        The bless write callback does not pass the central's UUID, so we
+        use the subscription dict as a proxy.  When exactly one central is
+        connected the mapping is unambiguous.  With multiple centrals the
+        Rust core identifies the sender from the reassembled message content.
+        """
+        if len(self._connected_centrals) == 1:
+            return next(iter(self._connected_centrals))
+        return "ble-peer"
+
+    # -- outgoing fragment handling -------------------------------------------
+
+    def on_fragments_available(self) -> None:
+        """Called by ``BleTransportCallback.on_fragments_available()``.
+
+        Drains outgoing fragments from the protocol core and sends them
+        to subscribed centrals via GATT notifications.
+        """
+        asyncio.ensure_future(self._drain_outgoing_fragments())
+
+    async def _drain_outgoing_fragments(self) -> None:
+        """Send all queued outgoing fragments as notifications."""
+        if self._server is None:
+            return
+
+        while True:
+            try:
+                frag = self._protocol.ble_get_next_fragment()
+            except Exception:
+                break
+            if frag is None:
+                break
+
+            data = bytes(frag.data)
+
+            char = self._server.get_characteristic(MESSAGE_CHAR_UUID)
+            if char is not None:
+                char.value = data
+                self._server.update_value(SERVICE_UUID, MESSAGE_CHAR_UUID)
+                self._bytes_sent += len(data)
+                self._fragments_sent += 1
+
+                # Inter-frame delay to avoid overwhelming the BLE stack
+                await asyncio.sleep(_INTER_FRAME_DELAY)
+
+            # Return fragment to pool regardless of send outcome
+            try:
+                self._protocol.ble_return_fragment()
+            except Exception:
+                pass
+
+    # -- background tasks -----------------------------------------------------
+
+    async def _peer_monitor_loop(self) -> None:
+        """Poll the bless delegate's subscription dict for changes.
+
+        When a central subscribes to the MESSAGE characteristic we treat it
+        as a peer connection; when it unsubscribes, a disconnection.
+        """
+        known: set[str] = set()
+        try:
+            while True:
+                await asyncio.sleep(_PEER_MONITOR_INTERVAL)
+
+                if self._server is None:
+                    continue
+
+                delegate = self._server.peripheral_manager_delegate
+                current = set(delegate._central_subscriptions.keys())
+
+                # New centrals
+                for central_uuid in current - known:
+                    if len(self._connected_centrals) >= self._max_connections:
+                        self._emit_diagnostic(
+                            "warning",
+                            f"Max connections ({self._max_connections}) reached, "
+                            f"ignoring {central_uuid}",
+                        )
+                        continue
+
+                    self._connected_centrals[central_uuid] = time.monotonic()
+                    try:
+                        self._protocol.ble_peer_discovered(
+                            peer_id=central_uuid, rssi=-50
+                        )
+                    except Exception:
+                        pass
+                    self._emit_diagnostic(
+                        "info", "Central connected", {"central": central_uuid}
+                    )
+
+                # Lost centrals
+                for central_uuid in known - current:
+                    self._connected_centrals.pop(central_uuid, None)
+                    try:
+                        self._protocol.ble_peer_lost(peer_id=central_uuid)
+                    except Exception:
+                        pass
+                    self._emit_diagnostic(
+                        "info", "Central disconnected", {"central": central_uuid}
+                    )
+
+                known = current.copy()
+
+                # Update cached advertising state
+                try:
+                    self._is_advertising = self._server.peripheral_manager_delegate.is_advertising()
+                except Exception:
+                    pass
+
+        except asyncio.CancelledError:
+            return

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -21,6 +21,7 @@ import asyncio
 import json
 import logging
 import sys
+import threading
 import time
 from typing import Any
 
@@ -108,6 +109,9 @@ class BlePeripheral(TransportManager):
 
         # Event loop — captured in start() for thread-safe callback scheduling
         self._loop: asyncio.AbstractEventLoop | None = None
+
+        # Lock protecting metrics — _on_write runs on bless's delegate thread
+        self._lock = threading.Lock()
 
         # Metrics
         self._bytes_sent: int = 0
@@ -220,14 +224,15 @@ class BlePeripheral(TransportManager):
         self._emit_diagnostic("info", "BLE peripheral stopped")
 
     def get_metrics(self) -> dict[str, Any]:
-        return {
-            "bytes_sent": self._bytes_sent,
-            "bytes_received": self._bytes_received,
-            "fragments_sent": self._fragments_sent,
-            "fragments_received": self._fragments_received,
-            "connected_centrals": len(self._connected_centrals),
-            "is_advertising": self._is_advertising,
-        }
+        with self._lock:
+            return {
+                "bytes_sent": self._bytes_sent,
+                "bytes_received": self._bytes_received,
+                "fragments_sent": self._fragments_sent,
+                "fragments_received": self._fragments_received,
+                "connected_centrals": len(self._connected_centrals),
+                "is_advertising": self._is_advertising,
+            }
 
     # -- GATT server setup ----------------------------------------------------
 
@@ -329,8 +334,9 @@ class BlePeripheral(TransportManager):
                 "_on_write: %d bytes, sender=%s",
                 len(fragment), self._resolve_sender(),
             )
-            self._bytes_received += len(fragment)
-            self._fragments_received += 1
+            with self._lock:
+                self._bytes_received += len(fragment)
+                self._fragments_received += 1
 
             sender_id = self._resolve_sender()
 
@@ -398,8 +404,9 @@ class BlePeripheral(TransportManager):
             if char is not None:
                 char.value = data
                 self._server.update_value(SERVICE_UUID, MESSAGE_CHAR_UUID)
-                self._bytes_sent += len(data)
-                self._fragments_sent += 1
+                with self._lock:
+                    self._bytes_sent += len(data)
+                    self._fragments_sent += 1
 
                 # Inter-frame delay to avoid overwhelming the BLE stack
                 await asyncio.sleep(_INTER_FRAME_DELAY)

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -316,14 +316,13 @@ class BlePeripheral(TransportManager):
         """
         try:
             resolved = self._resolve_char_uuid(char_uuid)
+            print(f"[ble_peripheral] _on_write called: uuid={resolved}, value_type={type(value).__name__}, value_len={len(value) if value else 0}")
             if resolved != MESSAGE_CHAR_UUID.lower():
+                print(f"[ble_peripheral] _on_write: ignoring write to {resolved}")
                 return
 
             fragment = bytes(value)
-            logger.debug(
-                "[ble_peripheral] _on_write: %d bytes from %s",
-                len(fragment), type(char_uuid).__name__,
-            )
+            print(f"[ble_peripheral] _on_write: {len(fragment)} bytes, sender={self._resolve_sender()}")
             self._bytes_received += len(fragment)
             self._fragments_received += 1
 
@@ -332,11 +331,11 @@ class BlePeripheral(TransportManager):
             self._protocol.ble_fragment_received(
                 sender_id=sender_id, fragment=list(fragment)
             )
-        except Exception as exc:
-            logger.error("[ble_peripheral] Write handler exception: %s", exc, exc_info=True)
-            self._emit_diagnostic(
-                "error", f"Error in write handler: {exc}"
-            )
+            print("[ble_peripheral] _on_write: fragment fed to protocol OK")
+        except BaseException as exc:
+            print(f"[ble_peripheral] _on_write EXCEPTION: {type(exc).__name__}: {exc}")
+            import traceback
+            traceback.print_exc()
 
     def _resolve_sender(self) -> str:
         """Best-effort identification of the writing central.

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -316,13 +316,19 @@ class BlePeripheral(TransportManager):
         """
         try:
             resolved = self._resolve_char_uuid(char_uuid)
-            print(f"[ble_peripheral] _on_write called: uuid={resolved}, value_type={type(value).__name__}, value_len={len(value) if value else 0}")
+            logger.debug(
+                "_on_write called: uuid=%s, value_type=%s, value_len=%d",
+                resolved, type(value).__name__, len(value) if value else 0,
+            )
             if resolved != MESSAGE_CHAR_UUID.lower():
-                print(f"[ble_peripheral] _on_write: ignoring write to {resolved}")
+                logger.debug("_on_write: ignoring write to %s", resolved)
                 return
 
             fragment = bytes(value)
-            print(f"[ble_peripheral] _on_write: {len(fragment)} bytes, sender={self._resolve_sender()}")
+            logger.debug(
+                "_on_write: %d bytes, sender=%s",
+                len(fragment), self._resolve_sender(),
+            )
             self._bytes_received += len(fragment)
             self._fragments_received += 1
 
@@ -331,11 +337,9 @@ class BlePeripheral(TransportManager):
             self._protocol.ble_fragment_received(
                 sender_id=sender_id, fragment=list(fragment)
             )
-            print("[ble_peripheral] _on_write: fragment fed to protocol OK")
+            logger.debug("_on_write: fragment fed to protocol OK")
         except BaseException as exc:
-            print(f"[ble_peripheral] _on_write EXCEPTION: {type(exc).__name__}: {exc}")
-            import traceback
-            traceback.print_exc()
+            logger.exception("_on_write failed: %s", exc)
 
     def _resolve_sender(self) -> str:
         """Best-effort identification of the writing central.
@@ -411,8 +415,12 @@ class BlePeripheral(TransportManager):
                 if self._server is None:
                     continue
 
-                delegate = self._server.peripheral_manager_delegate
-                current = set(delegate._central_subscriptions.keys())
+                try:
+                    delegate = self._server.peripheral_manager_delegate
+                    current = set(delegate._central_subscriptions.keys())
+                except (AttributeError, TypeError):
+                    # bless internal API may change across versions
+                    continue
 
                 # New centrals
                 for central_uuid in current - known:

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -270,18 +270,35 @@ class BlePeripheral(TransportManager):
 
     # -- GATT callbacks -------------------------------------------------------
 
-    def _on_read(self, char_uuid: str) -> bytearray:
+    @staticmethod
+    def _resolve_char_uuid(char_uuid: Any) -> str:
+        """Extract a lowercase UUID string from a characteristic or string.
+
+        ``bless`` may pass either a plain UUID string or a
+        ``BlessGATTCharacteristic*`` object depending on version/platform.
+        """
+        if isinstance(char_uuid, str):
+            return char_uuid.lower()
+        # BlessGATTCharacteristic objects expose a .uuid property (str)
+        if hasattr(char_uuid, "uuid"):
+            return str(char_uuid.uuid).lower()
+        # CoreBluetooth-backed objects — try ObjC CBCharacteristic.UUID()
+        if hasattr(char_uuid, "UUID"):
+            return str(char_uuid.UUID().UUIDString()).lower()
+        return str(char_uuid).lower()
+
+    def _on_read(self, char_uuid: Any) -> bytearray:
         """Handle incoming GATT read requests."""
-        uuid = char_uuid.lower()
+        uuid = self._resolve_char_uuid(char_uuid)
         if uuid == DEVICE_ID_CHAR_UUID.lower():
             return bytearray(self._device_id.encode("utf-8"))
         if uuid == IDENTITY_CHAR_UUID.lower():
             return bytearray(self._identity_bytes)
         return bytearray(b"")
 
-    def _on_write(self, char_uuid: str, value: Any) -> None:
+    def _on_write(self, char_uuid: Any, value: Any) -> None:
         """Handle incoming GATT write requests (fragments from phones)."""
-        if char_uuid.lower() != MESSAGE_CHAR_UUID.lower():
+        if self._resolve_char_uuid(char_uuid) != MESSAGE_CHAR_UUID.lower():
             return
 
         fragment = bytes(value)

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -167,7 +167,7 @@ class BlePeripheral(TransportManager):
         try:
             self._protocol.ble_status_changed(is_available=True)
         except Exception:
-            pass
+            logger.debug("ble_status_changed(True) failed", exc_info=True)
 
         self._update_state(TransportState.RUNNING)
 
@@ -208,13 +208,13 @@ class BlePeripheral(TransportManager):
             try:
                 self._protocol.ble_peer_lost(peer_id=central_uuid)
             except Exception:
-                pass
+                logger.debug("ble_peer_lost failed for %s", central_uuid)
         self._connected_centrals.clear()
 
         try:
             self._protocol.ble_status_changed(is_available=False)
         except Exception:
-            pass
+            logger.debug("ble_status_changed(False) failed", exc_info=True)
 
         self._update_state(TransportState.STOPPED)
         self._emit_diagnostic("info", "BLE peripheral stopped")
@@ -408,7 +408,7 @@ class BlePeripheral(TransportManager):
             try:
                 self._protocol.ble_return_fragment()
             except Exception:
-                pass
+                logger.debug("ble_return_fragment failed", exc_info=True)
 
     # -- background tasks -----------------------------------------------------
 
@@ -428,9 +428,17 @@ class BlePeripheral(TransportManager):
 
                 try:
                     delegate = self._server.peripheral_manager_delegate
+                    # NOTE: _central_subscriptions is a bless-internal dict.
+                    # Validated against bless 0.3.x. If this attribute is
+                    # missing after a bless upgrade, the except below logs a
+                    # warning and the monitor degrades gracefully (no peer
+                    # tracking, but data transfer still works).
                     current = set(delegate._central_subscriptions.keys())
                 except (AttributeError, TypeError):
-                    # bless internal API may change across versions
+                    logger.debug(
+                        "Cannot read bless _central_subscriptions — "
+                        "peer monitoring disabled (bless API may have changed)"
+                    )
                     continue
 
                 # New centrals
@@ -449,7 +457,7 @@ class BlePeripheral(TransportManager):
                             peer_id=central_uuid, rssi=-50
                         )
                     except Exception:
-                        pass
+                        logger.debug("ble_peer_discovered failed for %s", central_uuid)
                     self._emit_diagnostic(
                         "info", "Central connected", {"central": central_uuid}
                     )
@@ -460,7 +468,7 @@ class BlePeripheral(TransportManager):
                     try:
                         self._protocol.ble_peer_lost(peer_id=central_uuid)
                     except Exception:
-                        pass
+                        logger.debug("ble_peer_lost failed for %s", central_uuid)
                     self._emit_diagnostic(
                         "info", "Central disconnected", {"central": central_uuid}
                     )

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -338,7 +338,7 @@ class BlePeripheral(TransportManager):
                 sender_id=sender_id, fragment=list(fragment)
             )
             logger.debug("_on_write: fragment fed to protocol OK")
-        except BaseException as exc:
+        except Exception as exc:
             logger.exception("_on_write failed: %s", exc)
 
     def _resolve_sender(self) -> str:

--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -344,10 +344,17 @@ class BlePeripheral(TransportManager):
     def _resolve_sender(self) -> str:
         """Best-effort identification of the writing central.
 
-        The bless write callback does not pass the central's UUID, so we
-        use the subscription dict as a proxy.  When exactly one central is
-        connected the mapping is unambiguous.  With multiple centrals the
-        Rust core identifies the sender from the reassembled message content.
+        **Known limitation:** The ``bless`` write callback does not provide
+        the central's identity (UUID).  We use the subscription dict as a
+        proxy: when exactly one central is connected the mapping is
+        unambiguous.  With multiple centrals we return ``"ble-peer"`` and
+        rely on the Rust core to identify the sender from the reassembled
+        message payload.
+
+        This means that **sender attribution is unreliable when multiple
+        centrals are connected simultaneously**.  Do not use sender identity
+        from BLE peripheral writes for authorisation decisions in
+        multi-central deployments.
         """
         if len(self._connected_centrals) == 1:
             return next(iter(self._connected_centrals))
@@ -365,7 +372,7 @@ class BlePeripheral(TransportManager):
         ``call_soon_threadsafe`` to schedule work on the asyncio event loop.
         """
         loop = self._loop
-        if loop is not None and loop.is_running():
+        if loop is not None and not loop.is_closed() and loop.is_running():
             loop.call_soon_threadsafe(asyncio.ensure_future, self._drain_outgoing_fragments())
 
     async def _drain_outgoing_fragments(self) -> None:
@@ -376,7 +383,11 @@ class BlePeripheral(TransportManager):
         while True:
             try:
                 frag = self._protocol.ble_get_next_fragment()
-            except Exception:
+            except (AttributeError, ReferenceError) as exc:
+                logger.error("Protocol instance invalid: %s", exc)
+                break
+            except Exception as exc:
+                logger.warning("Unexpected error getting next fragment: %s", exc)
                 break
             if frag is None:
                 break

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -371,7 +371,8 @@ class InternetManager(TransportManager):
     async def _receive_loop(self) -> None:
         """Continuously receive messages from the WebSocket."""
         try:
-            assert self._ws is not None
+            if self._ws is None:
+                return
             async for raw in self._ws:
                 if isinstance(raw, bytes):
                     data = raw
@@ -631,7 +632,10 @@ class InternetManager(TransportManager):
                     message_id=message_id, reason="Not connected"
                 )
             except Exception:
-                self._protocol.internet_send_failed(message_id=message_id)
+                try:
+                    self._protocol.internet_send_failed(message_id=message_id)
+                except Exception:
+                    logger.debug("internet_send_failed also failed", exc_info=True)
             return
 
         async with self._send_semaphore:
@@ -663,7 +667,10 @@ class InternetManager(TransportManager):
                         message_id=message_id, reason=str(exc)
                     )
                 except Exception:
-                    self._protocol.internet_send_failed(message_id=message_id)
+                    try:
+                        self._protocol.internet_send_failed(message_id=message_id)
+                    except Exception:
+                        logger.debug("internet_send_failed also failed", exc_info=True)
 
                 if self._consecutive_send_failures >= _MAX_CONSECUTIVE_FAILURES:
                     self._emit_diagnostic(

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -125,7 +125,11 @@ class InternetManager(TransportManager):
             "has_token": token is not None,
         })
         if self._connected and self._ws is not None:
-            asyncio.ensure_future(self._send_authentication())
+            loop = self._loop
+            if loop is not None and not loop.is_closed() and loop.is_running():
+                loop.call_soon_threadsafe(
+                    asyncio.ensure_future, self._send_authentication()
+                )
 
     # -- TransportManager interface -------------------------------------------
 
@@ -178,7 +182,7 @@ class InternetManager(TransportManager):
         try:
             self._protocol.internet_status_changed(is_connected=False)
         except Exception:
-            pass
+            logger.debug("internet_status_changed(False) failed", exc_info=True)
 
         self._update_state(TransportState.STOPPED)
         self._emit_diagnostic("info", "Internet transport stopped")
@@ -287,7 +291,7 @@ class InternetManager(TransportManager):
             try:
                 self._protocol.internet_status_changed(is_connected=False)
             except Exception:
-                pass
+                logger.debug("internet_status_changed(False) failed", exc_info=True)
 
         self._emit_diagnostic("warning", "WebSocket disconnected", {
             "error": str(error) if error else "none",
@@ -421,18 +425,21 @@ class InternetManager(TransportManager):
         self._messages_received += 1
 
         # Try to parse content as full Message JSON, otherwise wrap it
+        is_full_message = False
+        message_dict: dict[str, Any] = {}
         try:
             content_json = json.loads(content)
-            if "sender" in content_json and "recipient" in content_json:
+            if isinstance(content_json, dict) and "sender" in content_json and "recipient" in content_json:
                 message_dict = content_json
                 if message_id and "id" not in message_dict:
                     message_dict["id"] = message_id
                 if reply_to_msg and "reply_to_msg" not in message_dict:
                     message_dict["reply_to_msg"] = reply_to_msg
-            else:
-                raise ValueError("not a full message")
-        except (json.JSONDecodeError, ValueError):
-            message_dict: dict[str, Any] = {
+                is_full_message = True
+        except json.JSONDecodeError:
+            pass
+        if not is_full_message:
+            message_dict = {
                 "sender": sender_id,
                 "recipient": self._device_id,
                 "content": content,
@@ -561,10 +568,15 @@ class InternetManager(TransportManager):
     def _poll_and_send_messages(self) -> None:
         """Drain outgoing messages from the protocol and send them.
 
-        Concurrency is bounded by ``_send_semaphore`` to prevent unbounded
-        task spawning when the protocol core has a large outbox.
+        Only dequeues up to the number of available semaphore slots to
+        prevent unbounded task creation when the protocol core has a large
+        outbox.  Remaining messages will be picked up on the next poll tick.
         """
-        while True:
+        # Limit to available concurrency slots to avoid creating thousands
+        # of tasks that all block on the semaphore.
+        available_slots = self._send_semaphore._value
+        drained = 0
+        while drained < available_slots:
             try:
                 msg = self._protocol.internet_get_next_message()
             except (AttributeError, ReferenceError) as exc:
@@ -585,6 +597,7 @@ class InternetManager(TransportManager):
             )
             self._send_tasks.add(task)
             task.add_done_callback(self._send_tasks.discard)
+            drained += 1
 
     async def _send_message(
         self, message_id: str, recipient: str, data: bytes

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -92,10 +92,14 @@ class InternetManager(TransportManager):
         self._messages_sent: int = 0
         self._messages_received: int = 0
 
+        # Event loop — captured in start() for thread-safe scheduling
+        self._loop: asyncio.AbstractEventLoop | None = None
+
         # Async tasks
         self._recv_task: asyncio.Task[None] | None = None
         self._poll_task: asyncio.Task[None] | None = None
         self._ping_task: asyncio.Task[None] | None = None
+        self._send_tasks: set[asyncio.Task[None]] = set()
         self._reconnect_handle: asyncio.TimerHandle | None = None
 
     # -- configuration --------------------------------------------------------
@@ -134,6 +138,7 @@ class InternetManager(TransportManager):
             raise TransportError(
                 "Server URL not configured. Call configure(server_url=...) first."
             )
+        self._loop = asyncio.get_running_loop()
         self._emit_diagnostic("info", "Starting Internet transport", {
             "device_id": self._device_id,
             "server_url": self._server_url,
@@ -156,6 +161,12 @@ class InternetManager(TransportManager):
             if task is not None and not task.done():
                 task.cancel()
         self._recv_task = self._poll_task = self._ping_task = None
+
+        # Cancel in-flight send tasks
+        for task in list(self._send_tasks):
+            if not task.done():
+                task.cancel()
+        self._send_tasks.clear()
 
         # Close WebSocket
         await self._disconnect()
@@ -309,7 +320,12 @@ class InternetManager(TransportManager):
             "delay_seconds": delay,
         })
 
-        loop = asyncio.get_event_loop()
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            self._emit_diagnostic("warning", "No running event loop for reconnect")
+            self._update_state(TransportState.STOPPED)
+            return
+
         self._reconnect_handle = loop.call_later(
             delay,
             lambda: asyncio.ensure_future(self._connect()),
@@ -548,9 +564,11 @@ class InternetManager(TransportManager):
             recipient = msg.recipient
             data = bytes(msg.data)
 
-            asyncio.ensure_future(
+            task = asyncio.ensure_future(
                 self._send_message(message_id, recipient, data)
             )
+            self._send_tasks.add(task)
+            task.add_done_callback(self._send_tasks.discard)
 
     async def _send_message(
         self, message_id: str, recipient: str, data: bytes

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -66,10 +66,12 @@ class InternetManager(TransportManager):
         auth_token: str | None = None,
         auto_reconnect: bool = True,
         max_reconnect_attempts: int = 0,
+        app_id: str = "offline-messenger",
     ) -> None:
         super().__init__()
         self._protocol = protocol
         self._device_id = device_id
+        self._app_id = app_id
         self._server_url = server_url
         self._auth_token = auth_token
         self._auto_reconnect = auto_reconnect
@@ -300,6 +302,8 @@ class InternetManager(TransportManager):
         })
 
     async def _handle_connection_closed(self, error: Exception | None) -> None:
+        if not self._connected and not self._authenticated:
+            return  # already handled — guard against concurrent callers
         was_connected = self._connected
         self._connected = False
         self._authenticated = False
@@ -377,7 +381,7 @@ class InternetManager(TransportManager):
                 if isinstance(raw, bytes):
                     data = raw
                 else:
-                    data = raw.encode("utf-8") if isinstance(raw, str) else raw
+                    data = raw.encode("utf-8")
                 self._bytes_received += len(data)
                 self._process_received(data)
         except websockets.ConnectionClosed:
@@ -467,7 +471,7 @@ class InternetManager(TransportManager):
                 "sender": sender_id,
                 "recipient": self._device_id,
                 "content": content,
-                "app_id": "offline-messenger",
+                "app_id": self._app_id,
                 "priority": "Medium",
                 "ttl": 8,
                 "hop_count": 0,
@@ -571,7 +575,7 @@ class InternetManager(TransportManager):
             "sender": sender_id,
             "recipient": self._device_id,
             "content": content,
-            "app_id": "offline-messenger",
+            "app_id": self._app_id,
             "priority": "Medium",
             "ttl": 8,
             "hop_count": 0,
@@ -623,22 +627,34 @@ class InternetManager(TransportManager):
             task.add_done_callback(self._send_tasks.discard)
             drained += 1
 
+    def _notify_send_failed(self, message_id: str, reason: str) -> None:
+        """Best-effort notification to the protocol that a send failed."""
+        try:
+            self._protocol.internet_send_failed_with_reason(
+                message_id=message_id, reason=reason
+            )
+        except Exception:
+            try:
+                self._protocol.internet_send_failed(message_id=message_id)
+            except Exception:
+                logger.debug("internet_send_failed also failed", exc_info=True)
+
     async def _send_message(
         self, message_id: str, recipient: str, data: bytes
     ) -> None:
-        if self._ws is None or not self._connected:
-            try:
-                self._protocol.internet_send_failed_with_reason(
-                    message_id=message_id, reason="Not connected"
-                )
-            except Exception:
-                try:
-                    self._protocol.internet_send_failed(message_id=message_id)
-                except Exception:
-                    logger.debug("internet_send_failed also failed", exc_info=True)
+        ws = self._ws
+        if ws is None or not self._connected:
+            self._notify_send_failed(message_id, "Not connected")
             return
 
         async with self._send_semaphore:
+            # Re-check after yielding to the semaphore — connection may have
+            # been torn down while we were waiting for a slot.
+            ws = self._ws
+            if ws is None or not self._connected:
+                self._notify_send_failed(message_id, "Disconnected while waiting")
+                return
+
             try:
                 try:
                     content = data.decode("utf-8")
@@ -649,7 +665,7 @@ class InternetManager(TransportManager):
                     "recipient": recipient,
                     "content": content,
                 })
-                await self._ws.send(payload)
+                await ws.send(payload)
                 self._bytes_sent += len(payload)
                 self._messages_sent += 1
                 self._consecutive_send_failures = 0
@@ -662,15 +678,7 @@ class InternetManager(TransportManager):
                     "message_id": message_id,
                     "consecutive_failures": self._consecutive_send_failures,
                 })
-                try:
-                    self._protocol.internet_send_failed_with_reason(
-                        message_id=message_id, reason=str(exc)
-                    )
-                except Exception:
-                    try:
-                        self._protocol.internet_send_failed(message_id=message_id)
-                    except Exception:
-                        logger.debug("internet_send_failed also failed", exc_info=True)
+                self._notify_send_failed(message_id, str(exc))
 
                 if self._consecutive_send_failures >= _MAX_CONSECUTIVE_FAILURES:
                     self._emit_diagnostic(

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -100,6 +100,7 @@ class InternetManager(TransportManager):
         self._poll_task: asyncio.Task[None] | None = None
         self._ping_task: asyncio.Task[None] | None = None
         self._send_tasks: set[asyncio.Task[None]] = set()
+        self._send_semaphore: asyncio.Semaphore = asyncio.Semaphore(50)
         self._reconnect_handle: asyncio.TimerHandle | None = None
 
     # -- configuration --------------------------------------------------------
@@ -162,11 +163,13 @@ class InternetManager(TransportManager):
                 task.cancel()
         self._recv_task = self._poll_task = self._ping_task = None
 
-        # Cancel in-flight send tasks
-        for task in list(self._send_tasks):
+        # Cancel in-flight send tasks — snapshot to avoid "Set changed size
+        # during iteration" if done-callbacks fire concurrently.
+        pending_sends = list(self._send_tasks)
+        self._send_tasks.clear()
+        for task in pending_sends:
             if not task.done():
                 task.cancel()
-        self._send_tasks.clear()
 
         # Close WebSocket
         await self._disconnect()
@@ -211,11 +214,12 @@ class InternetManager(TransportManager):
             self._consecutive_send_failures = 0
             self._consecutive_ping_failures = 0
 
+            # Start receive loop BEFORE auth so it's always cleaned up on
+            # failure — prevents _recv_task staying None if auth throws.
+            self._recv_task = asyncio.ensure_future(self._receive_loop())
+
             self._emit_diagnostic("info", "WebSocket connected, authenticating...")
             await self._send_authentication()
-
-            # Start receive loop
-            self._recv_task = asyncio.ensure_future(self._receive_loop())
 
         except Exception as exc:
             self._emit_diagnostic("error", "WebSocket connection failed", {
@@ -315,13 +319,17 @@ class InternetManager(TransportManager):
             _RECONNECT_MAX_DELAY,
         )
 
+        # Transition to STARTING so callers see a consistent state while
+        # waiting for the reconnect timer (avoids RUNNING + _connected=False).
+        self._update_state(TransportState.STARTING)
+
         self._emit_diagnostic("info", "Scheduling reconnect", {
             "attempt": self._reconnect_attempts,
             "delay_seconds": delay,
         })
 
         loop = self._loop
-        if loop is None or not loop.is_running():
+        if loop is None or loop.is_closed() or not loop.is_running():
             self._emit_diagnostic("warning", "No running event loop for reconnect")
             self._update_state(TransportState.STOPPED)
             return
@@ -551,11 +559,19 @@ class InternetManager(TransportManager):
             return
 
     def _poll_and_send_messages(self) -> None:
-        """Drain outgoing messages from the protocol and send them."""
+        """Drain outgoing messages from the protocol and send them.
+
+        Concurrency is bounded by ``_send_semaphore`` to prevent unbounded
+        task spawning when the protocol core has a large outbox.
+        """
         while True:
             try:
                 msg = self._protocol.internet_get_next_message()
-            except Exception:
+            except (AttributeError, ReferenceError) as exc:
+                logger.error("Protocol instance invalid: %s", exc)
+                break
+            except Exception as exc:
+                logger.warning("Unexpected error polling outgoing messages: %s", exc)
                 break
             if msg is None:
                 break
@@ -582,37 +598,38 @@ class InternetManager(TransportManager):
                 self._protocol.internet_send_failed(message_id=message_id)
             return
 
-        try:
-            payload = json.dumps({
-                "type": "SendMessage",
-                "recipient": recipient,
-                "content": data.decode("utf-8", errors="replace"),
-            })
-            await self._ws.send(payload)
-            self._bytes_sent += len(payload)
-            self._messages_sent += 1
-            self._consecutive_send_failures = 0
-
-            self._protocol.internet_confirm_sent(message_id=message_id)
-
-        except Exception as exc:
-            self._consecutive_send_failures += 1
-            self._emit_diagnostic("error", f"Send failed: {exc}", {
-                "message_id": message_id,
-                "consecutive_failures": self._consecutive_send_failures,
-            })
+        async with self._send_semaphore:
             try:
-                self._protocol.internet_send_failed_with_reason(
-                    message_id=message_id, reason=str(exc)
-                )
-            except Exception:
-                self._protocol.internet_send_failed(message_id=message_id)
+                payload = json.dumps({
+                    "type": "SendMessage",
+                    "recipient": recipient,
+                    "content": data.decode("utf-8", errors="replace"),
+                })
+                await self._ws.send(payload)
+                self._bytes_sent += len(payload)
+                self._messages_sent += 1
+                self._consecutive_send_failures = 0
 
-            if self._consecutive_send_failures >= _MAX_CONSECUTIVE_FAILURES:
-                self._emit_diagnostic(
-                    "error", "Too many consecutive send failures, disconnecting"
-                )
-                await self._handle_connection_closed(exc)
+                self._protocol.internet_confirm_sent(message_id=message_id)
+
+            except Exception as exc:
+                self._consecutive_send_failures += 1
+                self._emit_diagnostic("error", f"Send failed: {exc}", {
+                    "message_id": message_id,
+                    "consecutive_failures": self._consecutive_send_failures,
+                })
+                try:
+                    self._protocol.internet_send_failed_with_reason(
+                        message_id=message_id, reason=str(exc)
+                    )
+                except Exception:
+                    self._protocol.internet_send_failed(message_id=message_id)
+
+                if self._consecutive_send_failures >= _MAX_CONSECUTIVE_FAILURES:
+                    self._emit_diagnostic(
+                        "error", "Too many consecutive send failures, disconnecting"
+                    )
+                    await self._handle_connection_closed(exc)
 
     # -- ping loop ------------------------------------------------------------
 

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -302,7 +302,11 @@ class InternetManager(TransportManager):
         })
 
     async def _handle_connection_closed(self, error: Exception | None) -> None:
-        if not self._connected and not self._authenticated:
+        if (
+            not self._connected
+            and not self._authenticated
+            and self._state in (TransportState.STOPPING, TransportState.STOPPED)
+        ):
             return  # already handled — guard against concurrent callers
         was_connected = self._connected
         self._connected = False

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -8,6 +8,7 @@ relay server for internet-based message routing and drives the UniFFI
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 from typing import Any
@@ -28,6 +29,7 @@ _RECONNECT_BACKOFF_MULTIPLIER = 2.0
 _PING_INTERVAL = 10.0  # seconds
 _CONNECTION_TIMEOUT = 10.0
 _MAX_CONSECUTIVE_FAILURES = 2
+_MAX_CONCURRENT_SENDS = 50
 
 
 class InternetManager(TransportManager):
@@ -100,7 +102,7 @@ class InternetManager(TransportManager):
         self._poll_task: asyncio.Task[None] | None = None
         self._ping_task: asyncio.Task[None] | None = None
         self._send_tasks: set[asyncio.Task[None]] = set()
-        self._send_semaphore: asyncio.Semaphore = asyncio.Semaphore(50)
+        self._send_semaphore: asyncio.Semaphore = asyncio.Semaphore(_MAX_CONCURRENT_SENDS)
         self._reconnect_handle: asyncio.TimerHandle | None = None
 
     # -- configuration --------------------------------------------------------
@@ -262,6 +264,13 @@ class InternetManager(TransportManager):
             self._emit_diagnostic("error", f"Authentication handler failed: {exc}")
             await self._handle_connection_closed(exc)
 
+    async def _safe_handle_connection_closed(self, error: Exception | None) -> None:
+        """Wrapper that catches exceptions from connection-closed handling."""
+        try:
+            await self._handle_connection_closed(error)
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Connection-closed handler failed: {exc}")
+
     async def _handle_authenticated(self, user_id: str, username: str) -> None:
         self._authenticated = True
         self._update_state(TransportState.RUNNING)
@@ -271,6 +280,12 @@ class InternetManager(TransportManager):
             self._protocol.internet_status_changed(is_connected=True)
         except Exception as exc:
             self._emit_diagnostic("error", f"Protocol notify failed: {exc}")
+
+        # Cancel any existing poll/ping tasks before creating new ones
+        # (guards against duplicate Authenticated messages from the server)
+        for task in (self._poll_task, self._ping_task):
+            if task is not None and not task.done():
+                task.cancel()
 
         # Start polling and ping tasks
         self._poll_task = asyncio.ensure_future(self._poll_outgoing_loop())
@@ -391,7 +406,7 @@ class InternetManager(TransportManager):
         elif msg_type == "AuthError":
             reason = msg.get("reason", "Unknown")
             self._emit_diagnostic("error", f"Auth failed: {reason}")
-            asyncio.ensure_future(self._handle_connection_closed(None))
+            asyncio.ensure_future(self._safe_handle_connection_closed(None))
 
         elif msg_type == "MessageReceived":
             self._handle_incoming_message(msg)
@@ -582,7 +597,7 @@ class InternetManager(TransportManager):
         """
         # Limit to available concurrency slots to avoid creating thousands
         # of tasks that all block on the semaphore.
-        available_slots = max(0, 50 - len(self._send_tasks))
+        available_slots = max(0, _MAX_CONCURRENT_SENDS - len(self._send_tasks))
         drained = 0
         while drained < available_slots:
             try:
@@ -621,10 +636,14 @@ class InternetManager(TransportManager):
 
         async with self._send_semaphore:
             try:
+                try:
+                    content = data.decode("utf-8")
+                except UnicodeDecodeError:
+                    content = base64.b64encode(data).decode("ascii")
                 payload = json.dumps({
                     "type": "SendMessage",
                     "recipient": recipient,
-                    "content": data.decode("utf-8", errors="replace"),
+                    "content": content,
                 })
                 await self._ws.send(payload)
                 self._bytes_sent += len(payload)

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -254,6 +254,14 @@ class InternetManager(TransportManager):
         except Exception as exc:
             self._emit_diagnostic("error", f"Failed to send auth: {exc}")
 
+    async def _safe_handle_authenticated(self, user_id: str, username: str) -> None:
+        """Wrapper that catches exceptions to prevent stuck STARTING state."""
+        try:
+            await self._handle_authenticated(user_id, username)
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Authentication handler failed: {exc}")
+            await self._handle_connection_closed(exc)
+
     async def _handle_authenticated(self, user_id: str, username: str) -> None:
         self._authenticated = True
         self._update_state(TransportState.RUNNING)
@@ -378,7 +386,7 @@ class InternetManager(TransportManager):
         if msg_type == "Authenticated":
             user_id = msg.get("user_id", self._device_id)
             username = msg.get("username", self._device_id)
-            asyncio.ensure_future(self._handle_authenticated(user_id, username))
+            asyncio.ensure_future(self._safe_handle_authenticated(user_id, username))
 
         elif msg_type == "AuthError":
             reason = msg.get("reason", "Unknown")
@@ -574,7 +582,7 @@ class InternetManager(TransportManager):
         """
         # Limit to available concurrency slots to avoid creating thousands
         # of tasks that all block on the semaphore.
-        available_slots = self._send_semaphore._value
+        available_slots = max(0, 50 - len(self._send_tasks))
         drained = 0
         while drained < available_slots:
             try:

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -1,0 +1,620 @@
+"""Internet transport manager using WebSocket.
+
+Mirrors ``InternetManager.swift`` / ``InternetManager.kt`` — connects to a
+relay server for internet-based message routing and drives the UniFFI
+``OfflineProtocol`` internet transport methods.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+import websockets
+from websockets.asyncio.client import ClientConnection
+
+from .transport_manager import TransportError, TransportManager, TransportState
+
+logger = logging.getLogger(__name__)
+
+# -- Constants (matching iOS InternetManager.swift) ---------------------------
+
+_MESSAGE_POLL_INTERVAL = 0.1  # 100 ms
+_RECONNECT_INITIAL_DELAY = 1.0  # seconds
+_RECONNECT_MAX_DELAY = 30.0
+_RECONNECT_BACKOFF_MULTIPLIER = 2.0
+_PING_INTERVAL = 10.0  # seconds
+_CONNECTION_TIMEOUT = 10.0
+_MAX_CONSECUTIVE_FAILURES = 2
+
+
+class InternetManager(TransportManager):
+    """WebSocket-based internet transport.
+
+    Connects to a relay server, authenticates, and then continuously:
+    * receives incoming messages and feeds them to the Rust protocol core
+    * polls the protocol core for outgoing messages and sends them over WS
+
+    Parameters
+    ----------
+    protocol:
+        The ``OfflineProtocol`` UniFFI instance.
+    device_id:
+        The local device identifier (used for auth fallback and message routing).
+    server_url:
+        WebSocket URL of the relay server (e.g. ``ws://relay.example.com``).
+    auth_token:
+        Optional auth token (falls back to *device_id* if ``None``).
+    auto_reconnect:
+        Whether to reconnect on disconnection.
+    max_reconnect_attempts:
+        0 means infinite.
+    """
+
+    transport_id = "internet"
+    transport_name = "Internet (WebSocket)"
+
+    def __init__(
+        self,
+        protocol: Any,
+        device_id: str,
+        server_url: str | None = None,
+        auth_token: str | None = None,
+        auto_reconnect: bool = True,
+        max_reconnect_attempts: int = 0,
+    ) -> None:
+        super().__init__()
+        self._protocol = protocol
+        self._device_id = device_id
+        self._server_url = server_url
+        self._auth_token = auth_token
+        self._auto_reconnect = auto_reconnect
+        self._max_reconnect_attempts = max_reconnect_attempts
+
+        # Connection state
+        self._ws: ClientConnection | None = None
+        self._connected = False
+        self._authenticated = False
+
+        # Reconnection state
+        self._reconnect_attempts = 0
+        self._current_reconnect_delay = _RECONNECT_INITIAL_DELAY
+
+        # Failure tracking for DORS
+        self._consecutive_send_failures = 0
+        self._consecutive_ping_failures = 0
+
+        # Metrics
+        self._bytes_sent: int = 0
+        self._bytes_received: int = 0
+        self._messages_sent: int = 0
+        self._messages_received: int = 0
+
+        # Async tasks
+        self._recv_task: asyncio.Task[None] | None = None
+        self._poll_task: asyncio.Task[None] | None = None
+        self._ping_task: asyncio.Task[None] | None = None
+        self._reconnect_handle: asyncio.TimerHandle | None = None
+
+    # -- configuration --------------------------------------------------------
+
+    def configure(
+        self,
+        server_url: str,
+        auto_reconnect: bool = True,
+        max_reconnect_attempts: int = 0,
+    ) -> None:
+        self._server_url = server_url
+        self._auto_reconnect = auto_reconnect
+        self._max_reconnect_attempts = max_reconnect_attempts
+        self._emit_diagnostic("info", "Internet transport configured", {
+            "server_url": server_url,
+            "auto_reconnect": auto_reconnect,
+        })
+
+    def set_auth_token(self, token: str | None) -> None:
+        self._auth_token = token
+        self._emit_diagnostic("info", "Auth token updated", {
+            "has_token": token is not None,
+        })
+        if self._connected and self._ws is not None:
+            asyncio.ensure_future(self._send_authentication())
+
+    # -- TransportManager interface -------------------------------------------
+
+    def is_available(self) -> bool:
+        return self._server_url is not None
+
+    async def start(self) -> None:
+        if self._state == TransportState.RUNNING:
+            raise TransportError("Internet transport is already running")
+        if self._server_url is None:
+            raise TransportError(
+                "Server URL not configured. Call configure(server_url=...) first."
+            )
+        self._emit_diagnostic("info", "Starting Internet transport", {
+            "device_id": self._device_id,
+            "server_url": self._server_url,
+        })
+        self._update_state(TransportState.STARTING)
+        await self._connect()
+
+    async def stop(self) -> None:
+        if self._state not in (TransportState.RUNNING, TransportState.STARTING):
+            return
+        self._update_state(TransportState.STOPPING)
+
+        # Cancel reconnect
+        if self._reconnect_handle is not None:
+            self._reconnect_handle.cancel()
+            self._reconnect_handle = None
+
+        # Cancel async tasks
+        for task in (self._recv_task, self._poll_task, self._ping_task):
+            if task is not None and not task.done():
+                task.cancel()
+        self._recv_task = self._poll_task = self._ping_task = None
+
+        # Close WebSocket
+        await self._disconnect()
+
+        # Notify protocol
+        try:
+            self._protocol.internet_status_changed(is_connected=False)
+        except Exception:
+            pass
+
+        self._update_state(TransportState.STOPPED)
+        self._emit_diagnostic("info", "Internet transport stopped")
+
+    def get_metrics(self) -> dict[str, Any]:
+        return {
+            "bytes_sent": self._bytes_sent,
+            "bytes_received": self._bytes_received,
+            "messages_sent": self._messages_sent,
+            "messages_received": self._messages_received,
+            "is_connected": self._connected,
+            "reconnect_attempts": self._reconnect_attempts,
+        }
+
+    # -- connection management ------------------------------------------------
+
+    async def _connect(self) -> None:
+        if self._connected or self._server_url is None:
+            return
+        try:
+            extra_headers = {"X-Device-ID": self._device_id}
+            self._ws = await asyncio.wait_for(
+                websockets.connect(
+                    self._server_url,
+                    additional_headers=extra_headers,
+                ),
+                timeout=_CONNECTION_TIMEOUT,
+            )
+            self._connected = True
+            self._authenticated = False
+            self._reconnect_attempts = 0
+            self._current_reconnect_delay = _RECONNECT_INITIAL_DELAY
+            self._consecutive_send_failures = 0
+            self._consecutive_ping_failures = 0
+
+            self._emit_diagnostic("info", "WebSocket connected, authenticating...")
+            await self._send_authentication()
+
+            # Start receive loop
+            self._recv_task = asyncio.ensure_future(self._receive_loop())
+
+        except Exception as exc:
+            self._emit_diagnostic("error", "WebSocket connection failed", {
+                "error": str(exc),
+            })
+            await self._handle_connection_closed(exc)
+
+    async def _disconnect(self) -> None:
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+        self._connected = False
+        self._authenticated = False
+
+    async def _send_authentication(self) -> None:
+        if self._ws is None:
+            return
+        token = self._auth_token or self._device_id
+        auth_msg = json.dumps({"type": "Authenticate", "token": token})
+        try:
+            await self._ws.send(auth_msg)
+            self._emit_diagnostic("debug", "Auth message sent", {
+                "user_id": self._device_id,
+            })
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Failed to send auth: {exc}")
+
+    async def _handle_authenticated(self, user_id: str, username: str) -> None:
+        self._authenticated = True
+        self._update_state(TransportState.RUNNING)
+
+        # Notify protocol — triggers outbox flush
+        try:
+            self._protocol.internet_status_changed(is_connected=True)
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Protocol notify failed: {exc}")
+
+        # Start polling and ping tasks
+        self._poll_task = asyncio.ensure_future(self._poll_outgoing_loop())
+        self._ping_task = asyncio.ensure_future(self._ping_loop())
+
+        # Immediate flush
+        self._poll_and_send_messages()
+
+        self._emit_diagnostic("info", "Authenticated with relay server", {
+            "user_id": user_id,
+            "username": username,
+        })
+
+    async def _handle_connection_closed(self, error: Exception | None) -> None:
+        was_connected = self._connected
+        self._connected = False
+        self._authenticated = False
+
+        # Cancel poll/ping tasks
+        for task in (self._poll_task, self._ping_task):
+            if task is not None and not task.done():
+                task.cancel()
+        self._poll_task = self._ping_task = None
+
+        if was_connected:
+            try:
+                self._protocol.internet_status_changed(is_connected=False)
+            except Exception:
+                pass
+
+        self._emit_diagnostic("warning", "WebSocket disconnected", {
+            "error": str(error) if error else "none",
+        })
+
+        if (
+            self._auto_reconnect
+            and self._state not in (TransportState.STOPPING, TransportState.STOPPED)
+        ):
+            self._schedule_reconnect()
+        else:
+            self._update_state(TransportState.STOPPED)
+
+    def _schedule_reconnect(self) -> None:
+        if not self._auto_reconnect:
+            return
+        if (
+            self._max_reconnect_attempts > 0
+            and self._reconnect_attempts >= self._max_reconnect_attempts
+        ):
+            self._emit_diagnostic("error", "Max reconnect attempts reached")
+            self._update_state(TransportState.STOPPED)
+            return
+
+        self._reconnect_attempts += 1
+        delay = self._current_reconnect_delay
+        self._current_reconnect_delay = min(
+            self._current_reconnect_delay * _RECONNECT_BACKOFF_MULTIPLIER,
+            _RECONNECT_MAX_DELAY,
+        )
+
+        self._emit_diagnostic("info", "Scheduling reconnect", {
+            "attempt": self._reconnect_attempts,
+            "delay_seconds": delay,
+        })
+
+        loop = asyncio.get_event_loop()
+        self._reconnect_handle = loop.call_later(
+            delay,
+            lambda: asyncio.ensure_future(self._connect()),
+        )
+
+    # -- receive loop ---------------------------------------------------------
+
+    async def _receive_loop(self) -> None:
+        """Continuously receive messages from the WebSocket."""
+        try:
+            assert self._ws is not None
+            async for raw in self._ws:
+                if isinstance(raw, bytes):
+                    data = raw
+                else:
+                    data = raw.encode("utf-8") if isinstance(raw, str) else raw
+                self._bytes_received += len(data)
+                self._process_received(data)
+        except websockets.ConnectionClosed:
+            await self._handle_connection_closed(None)
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            await self._handle_connection_closed(exc)
+
+    def _process_received(self, data: bytes) -> None:
+        """Dispatch an incoming WebSocket frame to the protocol core."""
+        try:
+            msg = json.loads(data)
+        except json.JSONDecodeError:
+            self._emit_diagnostic("warning", "Non-JSON message received")
+            return
+
+        msg_type = msg.get("type")
+        if msg_type is None:
+            return
+
+        if msg_type == "Authenticated":
+            user_id = msg.get("user_id", self._device_id)
+            username = msg.get("username", self._device_id)
+            asyncio.ensure_future(self._handle_authenticated(user_id, username))
+
+        elif msg_type == "AuthError":
+            reason = msg.get("reason", "Unknown")
+            self._emit_diagnostic("error", f"Auth failed: {reason}")
+            asyncio.ensure_future(self._handle_connection_closed(None))
+
+        elif msg_type == "MessageReceived":
+            self._handle_incoming_message(msg)
+
+        elif msg_type == "ConnectionRequestReceived":
+            self._handle_connection_request(msg)
+
+        elif msg_type == "ConnectionAccepted":
+            self._handle_connection_accepted(msg)
+
+        elif msg_type == "ConnectionRejected":
+            self._handle_connection_rejected(msg)
+
+        elif msg_type == "DeliveryError":
+            recipient = msg.get("recipient", "unknown")
+            reason = msg.get("reason", "unknown")
+            self._emit_diagnostic("warning", "Delivery failed", {
+                "recipient": recipient,
+                "reason": reason,
+            })
+
+        elif msg_type in ("GroupCreated", "GroupInvitation", "GroupMessageReceived"):
+            self._handle_group_message(msg_type, msg)
+
+        else:
+            self._emit_diagnostic("debug", f"Unhandled relay message type: {msg_type}")
+
+    # -- incoming message handlers --------------------------------------------
+
+    def _handle_incoming_message(self, msg: dict[str, Any]) -> None:
+        sender_id = msg.get("sender", "")
+        content = msg.get("content", "")
+        message_id = msg.get("message_id")
+        reply_to_msg = msg.get("reply_to_msg")
+
+        if not sender_id:
+            return
+
+        self._messages_received += 1
+
+        # Try to parse content as full Message JSON, otherwise wrap it
+        try:
+            content_json = json.loads(content)
+            if "sender" in content_json and "recipient" in content_json:
+                message_dict = content_json
+                if message_id and "id" not in message_dict:
+                    message_dict["id"] = message_id
+                if reply_to_msg and "reply_to_msg" not in message_dict:
+                    message_dict["reply_to_msg"] = reply_to_msg
+            else:
+                raise ValueError("not a full message")
+        except (json.JSONDecodeError, ValueError):
+            message_dict: dict[str, Any] = {
+                "sender": sender_id,
+                "recipient": self._device_id,
+                "content": content,
+                "app_id": "offline-messenger",
+                "priority": "Medium",
+                "ttl": 8,
+                "hop_count": 0,
+                "requires_ack": True,
+            }
+            if message_id:
+                message_dict["id"] = message_id
+            if reply_to_msg:
+                message_dict["reply_to_msg"] = reply_to_msg
+
+        data_bytes = json.dumps(message_dict).encode("utf-8")
+        try:
+            self._protocol.internet_message_received(
+                sender_id=sender_id, data=list(data_bytes)
+            )
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Error feeding message to protocol: {exc}")
+
+    def _handle_connection_request(self, msg: dict[str, Any]) -> None:
+        sender_id = msg.get("sender", "")
+        if not sender_id:
+            return
+        sender_name = msg.get("sender_name", sender_id)
+        payload = {"sender_name": sender_name}
+        kp = msg.get("key_package")
+        if kp is not None:
+            payload["key_package"] = [b & 0xFF for b in kp]
+        content = "__CONN_REQ__" + json.dumps(payload)
+        data_bytes = json.dumps(
+            self._build_internal_message(sender_id, content)
+        ).encode("utf-8")
+        try:
+            self._protocol.internet_message_received(
+                sender_id=sender_id, data=list(data_bytes)
+            )
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Error processing ConnectionRequest: {exc}")
+
+    def _handle_connection_accepted(self, msg: dict[str, Any]) -> None:
+        accepted_by = msg.get("accepted_by") or msg.get("sender", "")
+        if not accepted_by:
+            return
+        accepted_by_name = (
+            msg.get("accepted_by_name") or msg.get("sender_name", accepted_by)
+        )
+        payload: dict[str, Any] = {"accepted_by_name": accepted_by_name}
+        kp = msg.get("key_package")
+        if kp is not None:
+            payload["key_package"] = [b & 0xFF for b in kp]
+        content = "__CONN_ACC__" + json.dumps(payload)
+        data_bytes = json.dumps(
+            self._build_internal_message(accepted_by, content)
+        ).encode("utf-8")
+        try:
+            self._protocol.internet_message_received(
+                sender_id=accepted_by, data=list(data_bytes)
+            )
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Error processing ConnectionAccepted: {exc}")
+
+    def _handle_connection_rejected(self, msg: dict[str, Any]) -> None:
+        rejected_by = msg.get("rejected_by") or msg.get("sender", "")
+        if not rejected_by:
+            return
+        content = "__CONN_REJ__"
+        data_bytes = json.dumps(
+            self._build_internal_message(rejected_by, content)
+        ).encode("utf-8")
+        try:
+            self._protocol.internet_message_received(
+                sender_id=rejected_by, data=list(data_bytes)
+            )
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Error processing ConnectionRejected: {exc}")
+
+    def _handle_group_message(self, msg_type: str, msg: dict[str, Any]) -> None:
+        group_id = msg.get("group_id", "")
+        if not group_id:
+            return
+        sender_id = msg.get("sender", "system")
+        content_prefix = {
+            "GroupCreated": "__GRP_CREATED__",
+            "GroupInvitation": "__GRP_INVITE__",
+            "GroupMessageReceived": "__GRP_MSG__",
+        }.get(msg_type, "")
+        content = content_prefix + json.dumps(msg)
+        data_bytes = json.dumps(
+            self._build_internal_message(sender_id, content)
+        ).encode("utf-8")
+        try:
+            self._protocol.internet_message_received(
+                sender_id=sender_id, data=list(data_bytes)
+            )
+        except Exception as exc:
+            self._emit_diagnostic("error", f"Error processing {msg_type}: {exc}")
+
+    def _build_internal_message(
+        self, sender_id: str, content: str
+    ) -> dict[str, Any]:
+        return {
+            "sender": sender_id,
+            "recipient": self._device_id,
+            "content": content,
+            "app_id": "offline-messenger",
+            "priority": "Medium",
+            "ttl": 8,
+            "hop_count": 0,
+            "requires_ack": False,
+        }
+
+    # -- outgoing message poll loop -------------------------------------------
+
+    async def _poll_outgoing_loop(self) -> None:
+        """Poll the protocol core for outgoing messages every 100 ms."""
+        try:
+            while self._connected and self._authenticated:
+                self._poll_and_send_messages()
+                await asyncio.sleep(_MESSAGE_POLL_INTERVAL)
+        except asyncio.CancelledError:
+            return
+
+    def _poll_and_send_messages(self) -> None:
+        """Drain outgoing messages from the protocol and send them."""
+        while True:
+            try:
+                msg = self._protocol.internet_get_next_message()
+            except Exception:
+                break
+            if msg is None:
+                break
+
+            message_id = msg.message_id
+            recipient = msg.recipient
+            data = bytes(msg.data)
+
+            asyncio.ensure_future(
+                self._send_message(message_id, recipient, data)
+            )
+
+    async def _send_message(
+        self, message_id: str, recipient: str, data: bytes
+    ) -> None:
+        if self._ws is None or not self._connected:
+            try:
+                self._protocol.internet_send_failed_with_reason(
+                    message_id=message_id, reason="Not connected"
+                )
+            except Exception:
+                self._protocol.internet_send_failed(message_id=message_id)
+            return
+
+        try:
+            payload = json.dumps({
+                "type": "SendMessage",
+                "recipient": recipient,
+                "content": data.decode("utf-8", errors="replace"),
+            })
+            await self._ws.send(payload)
+            self._bytes_sent += len(payload)
+            self._messages_sent += 1
+            self._consecutive_send_failures = 0
+
+            self._protocol.internet_confirm_sent(message_id=message_id)
+
+        except Exception as exc:
+            self._consecutive_send_failures += 1
+            self._emit_diagnostic("error", f"Send failed: {exc}", {
+                "message_id": message_id,
+                "consecutive_failures": self._consecutive_send_failures,
+            })
+            try:
+                self._protocol.internet_send_failed_with_reason(
+                    message_id=message_id, reason=str(exc)
+                )
+            except Exception:
+                self._protocol.internet_send_failed(message_id=message_id)
+
+            if self._consecutive_send_failures >= _MAX_CONSECUTIVE_FAILURES:
+                self._emit_diagnostic(
+                    "error", "Too many consecutive send failures, disconnecting"
+                )
+                await self._handle_connection_closed(exc)
+
+    # -- ping loop ------------------------------------------------------------
+
+    async def _ping_loop(self) -> None:
+        """Send WebSocket pings at regular intervals."""
+        try:
+            while self._connected and self._authenticated:
+                await asyncio.sleep(_PING_INTERVAL)
+                if self._ws is not None:
+                    try:
+                        await self._ws.ping()
+                        self._consecutive_ping_failures = 0
+                    except Exception:
+                        self._consecutive_ping_failures += 1
+                        if self._consecutive_ping_failures >= _MAX_CONSECUTIVE_FAILURES:
+                            self._emit_diagnostic(
+                                "error",
+                                "Too many ping failures, disconnecting",
+                            )
+                            await self._handle_connection_closed(None)
+                            return
+        except asyncio.CancelledError:
+            return

--- a/bindings/python/offline_protocol_sdk/protocol_manager.py
+++ b/bindings/python/offline_protocol_sdk/protocol_manager.py
@@ -1,0 +1,259 @@
+"""High-level protocol manager for desktop platforms.
+
+Mirrors ``OfflineProtocolModule.swift`` / ``OfflineProtocolModule.kt`` —
+wraps the UniFFI ``OfflineProtocol`` instance with transport managers, a
+100 ms processing loop, event dispatch, and lifecycle management.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Callable
+
+from .offline_protocol import (
+    BleTransportCallback,
+    EventCallback,
+    MessagePriority,
+    OfflineProtocol,
+    ProtocolConfig,
+    WifiDirectTransportCallback,
+)
+from .ble_manager import BleManager
+from .internet_manager import InternetManager
+from .secure_storage import SecureStorage
+
+logger = logging.getLogger(__name__)
+
+# Processing loop interval (matches iOS/Android: 100 ms)
+_PROCESS_INTERVAL = 0.1
+# Maximum messages to drain per process tick (matches iOS maxMessagesPerProcessTick)
+_MAX_MESSAGES_PER_TICK = 100
+
+
+class _EventCallbackImpl(EventCallback):
+    """Routes protocol events to Python callbacks."""
+
+    def __init__(self, handler: Callable[[dict[str, Any]], None] | None) -> None:
+        self._handler = handler
+
+    def on_event(self, event_json: str) -> None:
+        if self._handler is None:
+            return
+        try:
+            event = json.loads(event_json)
+        except json.JSONDecodeError:
+            event = {"raw": event_json}
+        self._handler(event)
+
+
+class _BleTransportCallbackImpl(BleTransportCallback):
+    """Bridges Rust BLE fragment-ready notifications to the BLE manager."""
+
+    def __init__(self, ble_manager: BleManager | None) -> None:
+        self._ble = ble_manager
+
+    def on_fragments_available(self) -> None:
+        if self._ble is not None:
+            self._ble.on_fragments_available()
+
+
+class _WifiDirectTransportCallbackImpl(WifiDirectTransportCallback):
+    """Stub — WiFi Direct is not implemented on desktop."""
+
+    def on_messages_available(self) -> None:
+        pass
+
+
+class ProtocolManager:
+    """Manages the full protocol lifecycle for desktop platforms.
+
+    Typical usage::
+
+        async with ProtocolManager(config) as pm:
+            pm.on_event(lambda e: print(e))
+            pm.internet.configure(server_url="ws://relay.example.com")
+            await pm.internet.start()
+            pm.send_message("peer-id", "hello")
+
+    Or without ``async with``::
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        ...
+        await pm.stop()
+
+    Parameters
+    ----------
+    config:
+        ``ProtocolConfig`` dict/object (UniFFI-generated).
+    event_handler:
+        Optional callback invoked for every protocol event (parsed JSON dict).
+    storage:
+        Optional ``MlsStorageProvider`` for MLS key material.  Defaults to
+        :class:`SecureStorage` backed by the platform keyring.
+    """
+
+    def __init__(
+        self,
+        config: ProtocolConfig,
+        event_handler: Callable[[dict[str, Any]], None] | None = None,
+        storage: Any | None = None,
+    ) -> None:
+        self._config = config
+        self._event_handler = event_handler
+        self._storage = storage or SecureStorage()
+
+        # Create the core protocol instance
+        self._protocol = OfflineProtocol(config)
+
+        # Transport managers
+        device_id = config.user_id  # type: ignore[union-attr]
+
+        self.ble: BleManager | None = None
+        if getattr(config, "ble_enabled", False):
+            self.ble = BleManager(self._protocol, device_id)
+
+        self.internet: InternetManager | None = None
+        if getattr(config, "internet_enabled", False):
+            self.internet = InternetManager(self._protocol, device_id)
+
+        # Processing loop task
+        self._process_task: asyncio.Task[None] | None = None
+        self._running = False
+
+    @property
+    def protocol(self) -> OfflineProtocol:
+        """Direct access to the underlying UniFFI ``OfflineProtocol``."""
+        return self._protocol
+
+    # -- lifecycle ------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Wire callbacks, initialise MLS, and start the processing loop."""
+        if self._running:
+            return
+
+        # Set event callback
+        self._event_cb = _EventCallbackImpl(self._event_handler)
+        self._protocol.set_event_callback(self._event_cb)
+
+        # Set transport callbacks
+        self._ble_cb = _BleTransportCallbackImpl(self.ble)
+        self._protocol.set_ble_transport_callback(self._ble_cb)
+
+        self._wifi_cb = _WifiDirectTransportCallbackImpl()
+        self._protocol.set_wifi_direct_transport_callback(self._wifi_cb)
+
+        # Initialise MLS encryption
+        try:
+            self._protocol.initialize_mls(self._storage)
+        except Exception as exc:
+            logger.warning("MLS initialisation failed (non-fatal): %s", exc)
+
+        # Start the protocol engine
+        self._protocol.start()
+        self._running = True
+
+        # Start the 100 ms processing loop
+        self._process_task = asyncio.ensure_future(self._process_loop())
+
+        logger.info("ProtocolManager started (user_id=%s)", self._config.user_id)  # type: ignore[union-attr]
+
+    async def stop(self) -> None:
+        """Stop all transports and the processing loop."""
+        if not self._running:
+            return
+
+        self._running = False
+
+        # Cancel processing loop
+        if self._process_task is not None and not self._process_task.done():
+            self._process_task.cancel()
+            try:
+                await self._process_task
+            except asyncio.CancelledError:
+                pass
+        self._process_task = None
+
+        # Stop transports
+        if self.ble is not None:
+            await self.ble.stop()
+        if self.internet is not None:
+            await self.internet.stop()
+
+        # Stop protocol engine
+        try:
+            self._protocol.stop()
+        except Exception:
+            pass
+
+        logger.info("ProtocolManager stopped")
+
+    async def __aenter__(self) -> ProtocolManager:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.stop()
+
+    # -- event handling -------------------------------------------------------
+
+    def on_event(self, handler: Callable[[dict[str, Any]], None]) -> None:
+        """Register an event handler (replaces the current one)."""
+        self._event_handler = handler
+        # Update the live callback
+        if hasattr(self, "_event_cb"):
+            self._event_cb._handler = handler
+
+    # -- convenience wrappers -------------------------------------------------
+
+    def send_message(
+        self,
+        recipient: str,
+        content: str,
+        *,
+        priority: MessagePriority = MessagePriority.MEDIUM,
+        reply_to: str | None = None,
+    ) -> str:
+        """Send a text message and return its message ID."""
+        return self._protocol.send_message(
+            recipient=recipient,
+            content=content,
+            priority=priority,
+            reply_to_msg=reply_to,
+        )
+
+    def get_state(self) -> Any:
+        """Return the current protocol state."""
+        return self._protocol.get_state()
+
+    # -- processing loop ------------------------------------------------------
+
+    async def _process_loop(self) -> None:
+        """Call ``protocol.process()`` every 100 ms (matches iOS/Android)."""
+        try:
+            while self._running:
+                try:
+                    self._protocol.process()
+                    self._drain_incoming_messages()
+                except Exception as exc:
+                    logger.error("Process error: %s", exc)
+                await asyncio.sleep(_PROCESS_INTERVAL)
+        except asyncio.CancelledError:
+            return
+
+    def _drain_incoming_messages(self) -> None:
+        """Drain up to 100 messages per tick (matches iOS cap)."""
+        drained = 0
+        while drained < _MAX_MESSAGES_PER_TICK:
+            msg = self._protocol.receive_message()
+            if msg is None:
+                break
+            drained += 1
+        if drained == _MAX_MESSAGES_PER_TICK:
+            logger.warning(
+                "Capped receiveMessage drain at %d for this tick",
+                _MAX_MESSAGES_PER_TICK,
+            )

--- a/bindings/python/offline_protocol_sdk/protocol_manager.py
+++ b/bindings/python/offline_protocol_sdk/protocol_manager.py
@@ -135,6 +135,10 @@ class ProtocolManager:
         self._process_task: asyncio.Task[None] | None = None
         self._running = False
 
+        # Registry of objects whose pointers are held by the Rust/UniFFI side.
+        # Prevents garbage collection while the protocol is alive.
+        self._prevent_gc: list[Any] = []
+
     @property
     def protocol(self) -> OfflineProtocol:
         """Direct access to the underlying UniFFI ``OfflineProtocol``."""
@@ -157,6 +161,16 @@ class ProtocolManager:
 
         self._wifi_cb = _WifiDirectTransportCallbackImpl()
         self._protocol.set_wifi_direct_transport_callback(self._wifi_cb)
+
+        # Keep strong references to all objects passed to the Rust/UniFFI
+        # side so that Python's GC cannot collect them while Rust holds
+        # raw callback pointers.
+        self._prevent_gc = [
+            self._event_cb,
+            self._ble_cb,
+            self._wifi_cb,
+            self._storage,
+        ]
 
         # Initialise MLS encryption
         try:
@@ -203,7 +217,18 @@ class ProtocolManager:
         except Exception:
             pass
 
+        # Release GC-prevention references now that Rust no longer calls back.
+        self._prevent_gc.clear()
+
         logger.info("ProtocolManager stopped")
+
+    def __del__(self) -> None:
+        if self._running:
+            logger.error(
+                "ProtocolManager garbage-collected while still running! "
+                "Call await stop() before discarding the manager to avoid "
+                "dangling callback pointers on the Rust side."
+            )
 
     async def __aenter__(self) -> ProtocolManager:
         await self.start()

--- a/bindings/python/offline_protocol_sdk/protocol_manager.py
+++ b/bindings/python/offline_protocol_sdk/protocol_manager.py
@@ -302,15 +302,30 @@ class ProtocolManager:
             if raw is None:
                 break
             drained += 1
-            if handler is not None:
-                try:
-                    event = json.loads(raw)
-                    if isinstance(event, dict):
-                        event.setdefault("type", "message_received")
-                    else:
-                        event = {"type": "message_received", "raw": raw}
-                except json.JSONDecodeError:
+
+            try:
+                event = json.loads(raw)
+                if isinstance(event, dict):
+                    event.setdefault("type", "message_received")
+                else:
                     event = {"type": "message_received", "raw": raw}
+            except json.JSONDecodeError:
+                event = {"type": "message_received", "raw": raw}
+
+            # Resolve BLE peripheral peer identity from the sender field.
+            # The BLE central path reads the DEVICE_ID characteristic to
+            # learn the peer's user_id; the peripheral has no equivalent
+            # mechanism, so we extract it from the first received message.
+            if (
+                self.ble_peripheral is not None
+                and isinstance(event, dict)
+                and event.get("type") == "message_received"
+            ):
+                sender = event.get("sender") or event.get("sender_id")
+                if sender:
+                    self.ble_peripheral.resolve_sender_identity(sender)
+
+            if handler is not None:
                 try:
                     handler(event)
                 except Exception:

--- a/bindings/python/offline_protocol_sdk/protocol_manager.py
+++ b/bindings/python/offline_protocol_sdk/protocol_manager.py
@@ -21,6 +21,7 @@ from .offline_protocol import (
     WifiDirectTransportCallback,
 )
 from .ble_manager import BleManager
+from .ble_peripheral import BlePeripheral
 from .internet_manager import InternetManager
 from .secure_storage import SecureStorage
 
@@ -49,14 +50,21 @@ class _EventCallbackImpl(EventCallback):
 
 
 class _BleTransportCallbackImpl(BleTransportCallback):
-    """Bridges Rust BLE fragment-ready notifications to the BLE manager."""
+    """Bridges Rust BLE fragment-ready notifications to BLE managers."""
 
-    def __init__(self, ble_manager: BleManager | None) -> None:
+    def __init__(
+        self,
+        ble_manager: BleManager | None,
+        ble_peripheral: BlePeripheral | None,
+    ) -> None:
         self._ble = ble_manager
+        self._peripheral = ble_peripheral
 
     def on_fragments_available(self) -> None:
         if self._ble is not None:
             self._ble.on_fragments_available()
+        if self._peripheral is not None:
+            self._peripheral.on_fragments_available()
 
 
 class _WifiDirectTransportCallbackImpl(WifiDirectTransportCallback):
@@ -119,6 +127,10 @@ class ProtocolManager:
         if getattr(config, "internet_enabled", False):
             self.internet = InternetManager(self._protocol, device_id)
 
+        self.ble_peripheral: BlePeripheral | None = None
+        if getattr(config, "ble_enabled", False):
+            self.ble_peripheral = BlePeripheral(self._protocol, device_id)
+
         # Processing loop task
         self._process_task: asyncio.Task[None] | None = None
         self._running = False
@@ -140,7 +152,7 @@ class ProtocolManager:
         self._protocol.set_event_callback(self._event_cb)
 
         # Set transport callbacks
-        self._ble_cb = _BleTransportCallbackImpl(self.ble)
+        self._ble_cb = _BleTransportCallbackImpl(self.ble, self.ble_peripheral)
         self._protocol.set_ble_transport_callback(self._ble_cb)
 
         self._wifi_cb = _WifiDirectTransportCallbackImpl()
@@ -180,6 +192,8 @@ class ProtocolManager:
         # Stop transports
         if self.ble is not None:
             await self.ble.stop()
+        if self.ble_peripheral is not None:
+            await self.ble_peripheral.stop()
         if self.internet is not None:
             await self.internet.stop()
 

--- a/bindings/python/offline_protocol_sdk/protocol_manager.py
+++ b/bindings/python/offline_protocol_sdk/protocol_manager.py
@@ -118,6 +118,7 @@ class ProtocolManager:
 
         # Transport managers
         device_id = config.user_id  # type: ignore[union-attr]
+        app_id = getattr(config, "app_id", "offline-messenger")
 
         self.ble: BleManager | None = None
         if getattr(config, "ble_enabled", False):
@@ -125,7 +126,7 @@ class ProtocolManager:
 
         self.internet: InternetManager | None = None
         if getattr(config, "internet_enabled", False):
-            self.internet = InternetManager(self._protocol, device_id)
+            self.internet = InternetManager(self._protocol, device_id, app_id=app_id)
 
         self.ble_peripheral: BlePeripheral | None = None
         if getattr(config, "ble_enabled", False):
@@ -284,13 +285,36 @@ class ProtocolManager:
             return
 
     def _drain_incoming_messages(self) -> None:
-        """Drain up to 100 messages per tick (matches iOS cap)."""
+        """Drain up to 100 messages per tick and dispatch to the event handler.
+
+        ``receive_message()`` returns JSON strings.  Each message is parsed
+        and forwarded as a ``message_received`` event so that users only need
+        to subscribe to the event handler (matching the iOS/Android pattern).
+
+        Note: because the processing loop consumes this queue, calling
+        ``protocol.receive_message()`` directly while ProtocolManager is
+        running will always return ``None``.
+        """
+        handler = self._event_handler
         drained = 0
         while drained < _MAX_MESSAGES_PER_TICK:
-            msg = self._protocol.receive_message()
-            if msg is None:
+            raw = self._protocol.receive_message()
+            if raw is None:
                 break
             drained += 1
+            if handler is not None:
+                try:
+                    event = json.loads(raw)
+                    if isinstance(event, dict):
+                        event.setdefault("type", "message_received")
+                    else:
+                        event = {"type": "message_received", "raw": raw}
+                except json.JSONDecodeError:
+                    event = {"type": "message_received", "raw": raw}
+                try:
+                    handler(event)
+                except Exception:
+                    logger.debug("Event handler error for message", exc_info=True)
         if drained == _MAX_MESSAGES_PER_TICK:
             logger.warning(
                 "Capped receiveMessage drain at %d for this tick",

--- a/bindings/python/offline_protocol_sdk/secure_storage.py
+++ b/bindings/python/offline_protocol_sdk/secure_storage.py
@@ -42,6 +42,21 @@ class SecureStorage(MlsStorageProvider):
         self._service = service
         self._lock = threading.Lock()
 
+        # Warn if keyring resolved to a plaintext or null backend — MLS key
+        # material would be stored unprotected.
+        try:
+            backend = keyring.get_keyring()
+            backend_name = type(backend).__name__
+            if "Fail" in backend_name or "Null" in backend_name or "PlaintextKeyring" in backend_name:
+                logger.warning(
+                    "keyring backend is '%s' — MLS keys will NOT be stored "
+                    "securely. Install a platform secret service (e.g. "
+                    "gnome-keyring, kwallet) for production use.",
+                    backend_name,
+                )
+        except Exception:
+            logger.debug("Could not inspect keyring backend", exc_info=True)
+
     # -- MlsStorageProvider interface ----------------------------------------
 
     def store(self, key_type: str, key_id: str, data: list[int]) -> None:

--- a/bindings/python/offline_protocol_sdk/secure_storage.py
+++ b/bindings/python/offline_protocol_sdk/secure_storage.py
@@ -1,0 +1,141 @@
+"""Cross-platform secure storage for MLS key material.
+
+Uses the `keyring` library which delegates to platform-native credential stores:
+  - macOS: Keychain
+  - Linux: Secret Service (GNOME Keyring / KWallet)
+  - Windows: Windows Credential Locker
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import threading
+
+import keyring
+
+from .offline_protocol import MlsStorageError, MlsStorageProvider
+
+logger = logging.getLogger(__name__)
+
+# Service name used for all keyring entries
+_DEFAULT_SERVICE = "offline-protocol-mls"
+
+# Prefix for index entries that track key IDs per key_type
+_INDEX_PREFIX = "index:"
+
+
+class SecureStorage(MlsStorageProvider):
+    """MlsStorageProvider backed by platform-native credential storage.
+
+    Thread-safe: all mutating operations are serialised with a lock to keep
+    the per-key_type index consistent (same approach as Android's
+    ``MlsSecureStorage.kt``).
+
+    Important: keep a reference to this object alive for the entire lifetime
+    of the ``OfflineProtocol`` instance — if it is garbage-collected the
+    callback pointers on the Rust side become dangling.
+    """
+
+    def __init__(self, service: str = _DEFAULT_SERVICE) -> None:
+        self._service = service
+        self._lock = threading.Lock()
+
+    # -- MlsStorageProvider interface ----------------------------------------
+
+    def store(self, key_type: str, key_id: str, data: list[int]) -> None:
+        key = _make_key(key_type, key_id)
+        encoded = base64.b64encode(bytes(data)).decode("ascii")
+
+        with self._lock:
+            try:
+                keyring.set_password(self._service, key, encoded)
+                self._index_add(key_type, key_id)
+            except Exception as exc:
+                raise MlsStorageError.StoreFailed(
+                    f"keyring store failed: {exc}"
+                ) from exc
+
+    def load(self, key_type: str, key_id: str) -> list[int] | None:
+        key = _make_key(key_type, key_id)
+        try:
+            encoded = keyring.get_password(self._service, key)
+            if encoded is None:
+                return None
+            return list(base64.b64decode(encoded))
+        except Exception as exc:
+            raise MlsStorageError.LoadFailed(
+                f"keyring load failed: {exc}"
+            ) from exc
+
+    def delete(self, key_type: str, key_id: str) -> None:
+        key = _make_key(key_type, key_id)
+
+        with self._lock:
+            try:
+                keyring.delete_password(self._service, key)
+            except keyring.errors.PasswordDeleteError:
+                pass  # already gone — not an error (matches iOS Keychain behaviour)
+            except Exception as exc:
+                raise MlsStorageError.DeleteFailed(
+                    f"keyring delete failed: {exc}"
+                ) from exc
+
+            self._index_remove(key_type, key_id)
+
+    def list_keys(self, key_type: str) -> list[str]:
+        """Return all key IDs stored under *key_type*.
+
+        ``keyring`` does not natively support listing, so we maintain a
+        JSON-encoded index entry per key_type — the same strategy used by
+        the Android ``MlsSecureStorage`` (index prefix approach).
+        """
+        with self._lock:
+            try:
+                return self._index_get(key_type)
+            except Exception as exc:
+                raise MlsStorageError.LoadFailed(
+                    f"keyring list_keys failed: {exc}"
+                ) from exc
+
+    # -- index helpers -------------------------------------------------------
+
+    def _index_key(self, key_type: str) -> str:
+        return f"{_INDEX_PREFIX}{key_type}"
+
+    def _index_get(self, key_type: str) -> list[str]:
+        raw = keyring.get_password(self._service, self._index_key(key_type))
+        if raw is None:
+            return []
+        return json.loads(raw)
+
+    def _index_add(self, key_type: str, key_id: str) -> None:
+        ids = set(self._index_get(key_type))
+        ids.add(key_id)
+        keyring.set_password(
+            self._service,
+            self._index_key(key_type),
+            json.dumps(sorted(ids)),
+        )
+
+    def _index_remove(self, key_type: str, key_id: str) -> None:
+        ids = set(self._index_get(key_type))
+        ids.discard(key_id)
+        if ids:
+            keyring.set_password(
+                self._service,
+                self._index_key(key_type),
+                json.dumps(sorted(ids)),
+            )
+        else:
+            try:
+                keyring.delete_password(
+                    self._service, self._index_key(key_type)
+                )
+            except keyring.errors.PasswordDeleteError:
+                pass
+
+
+def _make_key(key_type: str, key_id: str) -> str:
+    return f"{key_type}:{key_id}"

--- a/bindings/python/offline_protocol_sdk/transport_manager.py
+++ b/bindings/python/offline_protocol_sdk/transport_manager.py
@@ -131,6 +131,7 @@ class TransportManager(ABC):
 
 _LOG_LEVELS: dict[str, int] = {
     "error": logging.ERROR,
+    "warning": logging.WARNING,
     "warn": logging.WARNING,
     "info": logging.INFO,
     "debug": logging.DEBUG,

--- a/bindings/python/offline_protocol_sdk/transport_manager.py
+++ b/bindings/python/offline_protocol_sdk/transport_manager.py
@@ -1,0 +1,137 @@
+"""Base transport manager abstraction.
+
+Mirrors the iOS ``TransportManager`` protocol and Android
+``TransportManager`` interface so that each transport (BLE, Internet, etc.)
+follows the same lifecycle contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class TransportState(Enum):
+    """Transport lifecycle states."""
+
+    UNAVAILABLE = "unavailable"
+    AVAILABLE = "available"
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+
+
+class TransportError(Exception):
+    """Base error for transport operations."""
+
+
+class TransportManager(ABC):
+    """Abstract base for all transport implementations.
+
+    Subclasses must implement :meth:`is_available`, :meth:`start`, and
+    :meth:`stop`.  Optional hooks :meth:`pause`, :meth:`resume`, and
+    :meth:`get_metrics` have sensible defaults.
+    """
+
+    transport_id: str
+    transport_name: str
+
+    def __init__(self) -> None:
+        self._state = TransportState.STOPPED
+        self._on_state_change: Callable[[TransportState], None] | None = None
+        self._on_error: Callable[[Exception], None] | None = None
+        self._on_diagnostic: (
+            Callable[[str, str, dict[str, Any]], None] | None
+        ) = None
+
+    @property
+    def state(self) -> TransportState:
+        return self._state
+
+    def set_delegate(
+        self,
+        *,
+        on_state_change: Callable[[TransportState], None] | None = None,
+        on_error: Callable[[Exception], None] | None = None,
+        on_diagnostic: (
+            Callable[[str, str, dict[str, Any]], None] | None
+        ) = None,
+    ) -> None:
+        """Set delegate callbacks (equivalent to iOS TransportManagerDelegate)."""
+        self._on_state_change = on_state_change
+        self._on_error = on_error
+        self._on_diagnostic = on_diagnostic
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Return True if transport hardware/capabilities are available."""
+        ...
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Start the transport. Raises :class:`TransportError` on failure."""
+        ...
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop the transport gracefully."""
+        ...
+
+    async def pause(self) -> None:
+        """Pause the transport (default: stop)."""
+        await self.stop()
+
+    async def resume(self) -> None:
+        """Resume the transport from paused state (default: start)."""
+        await self.start()
+
+    def get_metrics(self) -> dict[str, Any]:
+        """Return current transport metrics."""
+        return {}
+
+    # -- helpers for subclasses ------------------------------------------------
+
+    def _update_state(self, new_state: TransportState) -> None:
+        old = self._state
+        self._state = new_state
+        if old != new_state:
+            logger.debug(
+                "%s state: %s -> %s",
+                self.transport_id,
+                old.value,
+                new_state.value,
+            )
+            if self._on_state_change is not None:
+                self._on_state_change(new_state)
+
+    def _emit_error(self, exc: Exception) -> None:
+        logger.error("%s error: %s", self.transport_id, exc)
+        if self._on_error is not None:
+            self._on_error(exc)
+
+    def _emit_diagnostic(
+        self, level: str, message: str, context: dict[str, Any] | None = None
+    ) -> None:
+        ctx = context or {}
+        logger.log(
+            _LOG_LEVELS.get(level, logging.DEBUG),
+            "%s: %s %s",
+            self.transport_id,
+            message,
+            ctx if ctx else "",
+        )
+        if self._on_diagnostic is not None:
+            self._on_diagnostic(level, message, ctx)
+
+
+_LOG_LEVELS: dict[str, int] = {
+    "error": logging.ERROR,
+    "warn": logging.WARNING,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+}

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 # Upper bounds prevent surprise major-version upgrades.
 dependencies = [
     "bleak>=0.21,<4.0",
+    "bless>=0.3,<1.0",
     "websockets>=12.0,<17.0",
     "keyring>=25.0,<26.0",
 ]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "offline-protocol-sdk"
+version = "0.1.0"
+description = "Python bindings for the Offline Protocol SDK — offline-first mesh networking with MLS encryption"
+readme = "README.md"
+license = { text = "MIT OR Apache-2.0" }
+requires-python = ">=3.10"
+authors = [{ name = "Offline Protocol Contributors" }]
+keywords = ["offline", "messaging", "p2p", "mesh", "ble", "mls", "encryption"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Rust",
+    "Topic :: Communications",
+    "Topic :: Security :: Cryptography",
+]
+
+# Audited dependencies — see plan for supply chain security audit results.
+# Upper bounds prevent surprise major-version upgrades.
+dependencies = [
+    "bleak>=0.21,<4.0",
+    "websockets>=12.0,<17.0",
+    "keyring>=25.0,<26.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "pip-audit>=2.7",
+]
+
+[project.urls]
+Homepage = "https://github.com/nicholasgasior/offline-protocol-sdk"
+Repository = "https://github.com/nicholasgasior/offline-protocol-sdk"
+Issues = "https://github.com/nicholasgasior/offline-protocol-sdk/issues"
+
+[tool.setuptools.packages.find]
+include = ["offline_protocol_sdk*"]
+
+[tool.setuptools.package-data]
+offline_protocol_sdk = ["*.dylib", "*.so", "*.dll", "libuniffi.*", "uniffi.dll"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # Audited dependencies — see plan for supply chain security audit results.
 # Upper bounds prevent surprise major-version upgrades.
 dependencies = [
-    "bleak>=0.21,<4.0",
+    "bleak>=0.21,<1.0",
     "bless>=0.3,<1.0",
     "websockets>=12.0,<17.0",
     "keyring>=25.0,<26.0",

--- a/bindings/python/requirements.lock
+++ b/bindings/python/requirements.lock
@@ -15,5 +15,6 @@
 # Audit tool: pip-audit --strict
 
 bleak==3.0.1
+bless==0.3.0
 websockets==16.0
 keyring==25.7.0

--- a/bindings/python/requirements.lock
+++ b/bindings/python/requirements.lock
@@ -1,0 +1,18 @@
+# Hash-pinned dependencies for reproducible installs.
+# Regenerate with: pip-compile --generate-hashes pyproject.toml -o requirements.lock
+#
+# This lockfile prevents dependency confusion and supply chain attacks by
+# pinning exact versions with cryptographic hashes. Use it in CI and
+# production deployments:
+#
+#   pip install --require-hashes -r requirements.lock
+#
+# NOTE: This file should be regenerated periodically to pick up security
+# patches. Run pip-audit after regeneration to verify no CVEs are present.
+#
+# Last audited: 2026-04-04
+# Audit tool: pip-audit --strict
+
+bleak==3.0.1
+websockets==16.0
+keyring==25.7.0

--- a/bindings/python/requirements.lock
+++ b/bindings/python/requirements.lock
@@ -1,14 +1,15 @@
-# Hash-pinned dependencies for reproducible installs.
-# Regenerate with: pip-compile --generate-hashes pyproject.toml -o requirements.lock
+# Pinned dependencies for reproducible installs.
+# Regenerate with: pip-compile pyproject.toml -o requirements.lock
 #
-# This lockfile prevents dependency confusion and supply chain attacks by
-# pinning exact versions with cryptographic hashes. Use it in CI and
-# production deployments:
+# NOTE: This lockfile pins exact versions but does NOT include hashes.
+# For production/CI deployments requiring supply-chain protection, regenerate
+# with hashes:
 #
+#   pip-compile --generate-hashes pyproject.toml -o requirements.lock
 #   pip install --require-hashes -r requirements.lock
 #
-# NOTE: This file should be regenerated periodically to pick up security
-# patches. Run pip-audit after regeneration to verify no CVEs are present.
+# This file should be regenerated periodically to pick up security patches.
+# Run pip-audit after regeneration to verify no CVEs are present.
 #
 # Last audited: 2026-04-04
 # Audit tool: pip-audit --strict

--- a/bindings/python/scripts/build-desktop.sh
+++ b/bindings/python/scripts/build-desktop.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+
+# Build UniFFI desktop library and generate Python bindings.
+# This script builds the Rust UniFFI cdylib for the current (or specified)
+# platform and generates Python bindings via uniffi-bindgen.
+#
+# Usage:
+#   ./build-desktop.sh                      # auto-detect current platform
+#   ./build-desktop.sh --target aarch64-apple-darwin   # explicit target (CI)
+#   ./build-desktop.sh --release             # release build (default)
+#   ./build-desktop.sh --debug               # debug build
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+UNIFFI_DIR="$PROJECT_ROOT/crates/offline-protocol-uniffi"
+PKG_DIR="$SCRIPT_DIR/../offline_protocol_sdk"
+
+# Defaults
+TARGET=""
+PROFILE="release"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target)
+            TARGET="$2"
+            shift 2
+            ;;
+        --debug)
+            PROFILE="debug"
+            shift
+            ;;
+        --release)
+            PROFILE="release"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--target <triple>] [--debug|--release]"
+            exit 1
+            ;;
+    esac
+done
+
+# Auto-detect platform if --target not given
+if [[ -z "$TARGET" ]]; then
+    OS="$(uname -s)"
+    ARCH="$(uname -m)"
+
+    case "$OS" in
+        Darwin)
+            case "$ARCH" in
+                arm64)  TARGET="aarch64-apple-darwin" ;;
+                x86_64) TARGET="x86_64-apple-darwin" ;;
+                *)      echo "Unsupported macOS arch: $ARCH"; exit 1 ;;
+            esac
+            ;;
+        Linux)
+            case "$ARCH" in
+                x86_64)  TARGET="x86_64-unknown-linux-gnu" ;;
+                aarch64) TARGET="aarch64-unknown-linux-gnu" ;;
+                *)       echo "Unsupported Linux arch: $ARCH"; exit 1 ;;
+            esac
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            TARGET="x86_64-pc-windows-msvc"
+            ;;
+        *)
+            echo "Unsupported OS: $OS"
+            exit 1
+            ;;
+    esac
+
+    echo "Auto-detected platform: $TARGET"
+fi
+
+# Determine library filename by platform
+case "$TARGET" in
+    *-apple-darwin)
+        LIB_NAME="liboffline_protocol_uniffi.dylib"
+        ;;
+    *-linux-*)
+        LIB_NAME="liboffline_protocol_uniffi.so"
+        ;;
+    *-windows-*)
+        LIB_NAME="offline_protocol_uniffi.dll"
+        ;;
+    *)
+        echo "Cannot determine library name for target: $TARGET"
+        exit 1
+        ;;
+esac
+
+echo "Building UniFFI desktop library for $TARGET ($PROFILE)..."
+
+cd "$PROJECT_ROOT"
+
+# Ensure target is installed
+rustup target add "$TARGET"
+
+# Build
+CARGO_ARGS=(build --target "$TARGET" --package offline-protocol-uniffi)
+if [[ "$PROFILE" == "release" ]]; then
+    CARGO_ARGS+=(--release)
+fi
+cargo "${CARGO_ARGS[@]}"
+
+# Locate the compiled library (check release/ then deps/ — same pattern as iOS script)
+LIB_DIR="$PROJECT_ROOT/target/$TARGET/$PROFILE"
+
+cdylib_path() {
+    if [[ -f "$LIB_DIR/$LIB_NAME" ]]; then
+        echo "$LIB_DIR/$LIB_NAME"
+    elif [[ -f "$LIB_DIR/deps/$LIB_NAME" ]]; then
+        echo "$LIB_DIR/deps/$LIB_NAME"
+    else
+        echo ""
+    fi
+}
+
+CDYLIB="$(cdylib_path)"
+if [[ -z "$CDYLIB" ]]; then
+    echo "ERROR: $LIB_NAME not found in $LIB_DIR or $LIB_DIR/deps"
+    ls -la "$LIB_DIR"/ "$LIB_DIR/deps"/ 2>/dev/null || true
+    exit 1
+fi
+
+echo "Found library: $CDYLIB"
+
+# Copy native library into package
+mkdir -p "$PKG_DIR"
+cp "$CDYLIB" "$PKG_DIR/$LIB_NAME"
+echo "Copied $LIB_NAME -> $PKG_DIR/"
+
+# Create a symlink with the name the generated Python bindings expect.
+# UniFFI's UDL-mode Python codegen loads "libuniffi.{dylib,so,dll}" — create
+# the appropriately named symlink pointing at the real library.
+case "$TARGET" in
+    *-apple-darwin)  SYMLINK_NAME="libuniffi.dylib" ;;
+    *-linux-*)       SYMLINK_NAME="libuniffi.so" ;;
+    *-windows-*)     SYMLINK_NAME="uniffi.dll" ;;
+esac
+(cd "$PKG_DIR" && ln -sf "$LIB_NAME" "$SYMLINK_NAME")
+echo "Symlinked $SYMLINK_NAME -> $LIB_NAME"
+
+# Generate Python bindings
+echo ""
+echo "Generating Python bindings..."
+
+if command -v uniffi-bindgen &>/dev/null; then
+    cd "$UNIFFI_DIR"
+    uniffi-bindgen generate \
+        src/offline_protocol.udl \
+        --language python \
+        --out-dir "$PKG_DIR"
+
+    echo "Python bindings generated in $PKG_DIR/"
+else
+    echo "uniffi-bindgen not found!"
+    echo "Install it with: cargo install uniffi --version 0.30.0 --features cli"
+    echo ""
+    echo "Native library is built. Generate bindings manually when uniffi-bindgen is available:"
+    echo "  cd $UNIFFI_DIR"
+    echo "  uniffi-bindgen generate src/offline_protocol.udl --language python --out-dir $PKG_DIR"
+    exit 1
+fi
+
+echo ""
+echo "Build complete!"
+echo "  Native library: $PKG_DIR/$LIB_NAME"
+echo "  Python bindings: $PKG_DIR/offline_protocol.py"
+echo ""
+echo "To install the package:"
+echo "  cd $SCRIPT_DIR/.."
+echo "  pip install -e ."

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -1,0 +1,62 @@
+"""Shared fixtures for offline-protocol-sdk tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from offline_protocol_sdk.offline_protocol import (
+    MlsStorageError,
+    MlsStorageProvider,
+    OverflowPolicy,
+    ProtocolConfig,
+)
+
+
+class InMemoryStorage(MlsStorageProvider):
+    """Dict-backed MlsStorageProvider for testing (no keyring dependency)."""
+
+    def __init__(self) -> None:
+        self._data: dict[tuple[str, str], bytes] = {}
+
+    def store(self, key_type: str, key_id: str, data: list[int]) -> None:
+        self._data[(key_type, key_id)] = bytes(data)
+
+    def load(self, key_type: str, key_id: str) -> list[int] | None:
+        raw = self._data.get((key_type, key_id))
+        if raw is None:
+            return None
+        return list(raw)
+
+    def delete(self, key_type: str, key_id: str) -> None:
+        self._data.pop((key_type, key_id), None)
+
+    def list_keys(self, key_type: str) -> list[str]:
+        return [kid for (kt, kid) in self._data if kt == key_type]
+
+
+@pytest.fixture
+def in_memory_storage() -> InMemoryStorage:
+    return InMemoryStorage()
+
+
+@pytest.fixture
+def default_config() -> ProtocolConfig:
+    """A minimal ProtocolConfig with only Internet enabled."""
+    return ProtocolConfig(
+        app_id="test-app",
+        user_id="test-user-1",
+        ble_enabled=False,
+        wifi_direct_enabled=False,
+        internet_enabled=True,
+        reticulum_enabled=False,
+        prefer_online=True,
+        initial_ttl=3,
+        encryption_enabled=True,
+        auto_key_exchange=True,
+        store_pending=True,
+        require_encryption=False,
+        max_pending_per_peer=100,
+        max_pending_global=1000,
+        pending_ttl_ms=60000,
+        overflow_policy=OverflowPolicy.DROP_OLDEST,
+    )

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from offline_protocol_sdk.offline_protocol import (
@@ -13,25 +15,34 @@ from offline_protocol_sdk.offline_protocol import (
 
 
 class InMemoryStorage(MlsStorageProvider):
-    """Dict-backed MlsStorageProvider for testing (no keyring dependency)."""
+    """Thread-safe dict-backed MlsStorageProvider for testing.
+
+    Mirrors the locking behaviour of :class:`SecureStorage` so that tests
+    exercise the same concurrency contract the real storage provides.
+    """
 
     def __init__(self) -> None:
         self._data: dict[tuple[str, str], bytes] = {}
+        self._lock = threading.Lock()
 
     def store(self, key_type: str, key_id: str, data: list[int]) -> None:
-        self._data[(key_type, key_id)] = bytes(data)
+        with self._lock:
+            self._data[(key_type, key_id)] = bytes(data)
 
     def load(self, key_type: str, key_id: str) -> list[int] | None:
-        raw = self._data.get((key_type, key_id))
-        if raw is None:
-            return None
-        return list(raw)
+        with self._lock:
+            raw = self._data.get((key_type, key_id))
+            if raw is None:
+                return None
+            return list(raw)
 
     def delete(self, key_type: str, key_id: str) -> None:
-        self._data.pop((key_type, key_id), None)
+        with self._lock:
+            self._data.pop((key_type, key_id), None)
 
     def list_keys(self, key_type: str) -> list[str]:
-        return [kid for (kt, kid) in self._data if kt == key_type]
+        with self._lock:
+            return [kid for (kt, kid) in self._data if kt == key_type]
 
 
 @pytest.fixture

--- a/bindings/python/tests/test_basic.py
+++ b/bindings/python/tests/test_basic.py
@@ -1,0 +1,70 @@
+"""Core protocol smoke tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from offline_protocol_sdk.offline_protocol import (
+    OfflineProtocol,
+    OverflowPolicy,
+    ProtocolConfig,
+    ProtocolState,
+)
+
+from conftest import InMemoryStorage
+
+
+def test_create_protocol(default_config: ProtocolConfig) -> None:
+    """Protocol can be instantiated and starts in STOPPED state."""
+    proto = OfflineProtocol(default_config)
+    assert proto.get_state() == ProtocolState.STOPPED
+
+
+def test_start_stop_lifecycle(default_config: ProtocolConfig) -> None:
+    """Protocol transitions STOPPED -> RUNNING -> STOPPED."""
+    proto = OfflineProtocol(default_config)
+    assert proto.get_state() == ProtocolState.STOPPED
+
+    proto.start()
+    assert proto.get_state() == ProtocolState.RUNNING
+
+    proto.stop()
+    assert proto.get_state() == ProtocolState.STOPPED
+
+
+def test_initialize_mls(default_config: ProtocolConfig) -> None:
+    """MLS can be initialised with an in-memory storage provider."""
+    proto = OfflineProtocol(default_config)
+    storage = InMemoryStorage()
+    proto.initialize_mls(storage)
+    # Should not raise; MLS is now ready
+
+
+def test_process_does_not_crash(default_config: ProtocolConfig) -> None:
+    """Calling process() on a running protocol should not raise."""
+    proto = OfflineProtocol(default_config)
+    proto.start()
+    try:
+        proto.process()
+    finally:
+        proto.stop()
+
+
+def test_receive_message_returns_none_when_empty(
+    default_config: ProtocolConfig,
+) -> None:
+    """receive_message() returns None when the inbox is empty."""
+    proto = OfflineProtocol(default_config)
+    proto.start()
+    try:
+        assert proto.receive_message() is None
+    finally:
+        proto.stop()
+
+
+def test_poll_event_returns_none_initially(
+    default_config: ProtocolConfig,
+) -> None:
+    """poll_event() returns None when no events have been emitted."""
+    proto = OfflineProtocol(default_config)
+    assert proto.poll_event() is None

--- a/bindings/python/tests/test_ble_manager.py
+++ b/bindings/python/tests/test_ble_manager.py
@@ -1,0 +1,348 @@
+"""Tests for BleManager — BLE central (scanner) role.
+
+All tests mock bleak and OfflineProtocol so they run without actual
+Bluetooth hardware.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from offline_protocol_sdk.ble_manager import (
+    ADAPTIVE_COOLDOWN_PER_PERIPHERAL,
+    ADAPTIVE_MAX_CONNECTIONS_PER_MINUTE,
+    ADAPTIVE_MIN_RSSI,
+    DEVICE_ID_CHAR_UUID,
+    MESSAGE_CHAR_UUID,
+    SERVICE_UUID,
+    BleManager,
+)
+from offline_protocol_sdk.transport_manager import TransportError, TransportState
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_protocol():
+    """A mock OfflineProtocol with BLE methods stubbed."""
+    p = MagicMock()
+    p.ble_fragment_received = MagicMock()
+    p.ble_get_next_fragment = MagicMock(return_value=None)
+    p.ble_return_fragment = MagicMock()
+    p.ble_peer_discovered = MagicMock()
+    p.ble_peer_lost = MagicMock()
+    p.ble_status_changed = MagicMock()
+    return p
+
+
+@pytest.fixture
+def manager(mock_protocol):
+    """A BleManager instance (not started)."""
+    return BleManager(mock_protocol, device_id="desktop-1")
+
+
+# ---------------------------------------------------------------------------
+# Initial state
+# ---------------------------------------------------------------------------
+
+
+class TestInitialState:
+    def test_initial_state_is_stopped(self, manager):
+        assert manager.state == TransportState.STOPPED
+
+    def test_is_available(self, manager):
+        assert manager.is_available() is True
+
+    def test_get_metrics_defaults(self, manager):
+        m = manager.get_metrics()
+        assert m["bytes_sent"] == 0
+        assert m["bytes_received"] == 0
+        assert m["fragments_sent"] == 0
+        assert m["fragments_received"] == 0
+        assert m["connected_peers"] == 0
+        assert m["discovered_peers"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiting:
+    def test_should_connect_allows_first_attempt(self, manager):
+        now = time.monotonic()
+        assert manager._should_connect_locked("AA:BB", now) is True
+
+    def test_should_connect_blocks_during_cooldown(self, manager):
+        now = time.monotonic()
+        manager._connection_attempts["AA:BB"] = now
+        assert manager._should_connect_locked("AA:BB", now + 1.0) is False
+
+    def test_should_connect_allows_after_cooldown(self, manager):
+        now = time.monotonic()
+        manager._connection_attempts["AA:BB"] = now
+        assert manager._should_connect_locked(
+            "AA:BB", now + ADAPTIVE_COOLDOWN_PER_PERIPHERAL + 1.0
+        ) is True
+
+    def test_global_rate_limit(self, manager):
+        now = time.monotonic()
+        # Fill up global attempts
+        manager._global_attempts = [
+            now - i for i in range(ADAPTIVE_MAX_CONNECTIONS_PER_MINUTE)
+        ]
+        assert manager._should_connect_locked("NEW:ADDR", now) is False
+
+    def test_global_rate_limit_expires(self, manager):
+        now = time.monotonic()
+        # All attempts older than 60 seconds
+        manager._global_attempts = [
+            now - 61.0 for _ in range(ADAPTIVE_MAX_CONNECTIONS_PER_MINUTE)
+        ]
+        assert manager._should_connect_locked("NEW:ADDR", now) is True
+
+
+# ---------------------------------------------------------------------------
+# Advertisement handling
+# ---------------------------------------------------------------------------
+
+
+class TestAdvertisementHandling:
+    def test_weak_signal_ignored(self, manager, mock_protocol):
+        """Advertisements below RSSI threshold are dropped."""
+        manager._loop = asyncio.new_event_loop()
+        device = MagicMock()
+        device.address = "AA:BB:CC:DD:EE:FF"
+        adv = MagicMock()
+        adv.rssi = ADAPTIVE_MIN_RSSI - 1  # too weak
+
+        manager._on_advertisement(device, adv)
+
+        mock_protocol.ble_peer_discovered.assert_not_called()
+
+    def test_advertisement_updates_last_seen(self, manager, mock_protocol):
+        """Valid advertisements update the last-seen timestamp."""
+        manager._loop = MagicMock()
+        manager._loop.is_closed.return_value = False
+        manager._loop.is_running.return_value = True
+        manager._loop.call_soon_threadsafe = MagicMock()
+
+        device = MagicMock()
+        device.address = "AA:BB:CC:DD:EE:FF"
+        adv = MagicMock()
+        adv.rssi = -60
+
+        manager._on_advertisement(device, adv)
+
+        assert "AA:BB:CC:DD:EE:FF" in manager._last_seen
+        mock_protocol.ble_peer_discovered.assert_called_once()
+
+    def test_advertisement_triggers_connection(self, manager, mock_protocol):
+        """First advertisement for an unknown peer triggers connection."""
+        mock_loop = MagicMock()
+        mock_loop.is_closed.return_value = False
+        mock_loop.is_running.return_value = True
+        manager._loop = mock_loop
+
+        device = MagicMock()
+        device.address = "AA:BB:CC:DD:EE:FF"
+        adv = MagicMock()
+        adv.rssi = -60
+
+        manager._on_advertisement(device, adv)
+
+        mock_loop.call_soon_threadsafe.assert_called_once()
+        assert "AA:BB:CC:DD:EE:FF" in manager._connecting
+
+    def test_already_connected_peer_not_reconnected(self, manager, mock_protocol):
+        """Peers already in _clients don't trigger new connections."""
+        mock_loop = MagicMock()
+        mock_loop.is_closed.return_value = False
+        mock_loop.is_running.return_value = True
+        manager._loop = mock_loop
+
+        addr = "AA:BB:CC:DD:EE:FF"
+        manager._clients[addr] = MagicMock()  # already connected
+
+        device = MagicMock()
+        device.address = addr
+        adv = MagicMock()
+        adv.rssi = -60
+
+        manager._on_advertisement(device, adv)
+
+        mock_loop.call_soon_threadsafe.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Fragment handling
+# ---------------------------------------------------------------------------
+
+
+class TestFragmentHandling:
+    def test_on_fragment_received_feeds_protocol(self, manager, mock_protocol):
+        manager._on_fragment_received("peer-1", b"\x03\x00hello")
+
+        mock_protocol.ble_fragment_received.assert_called_once_with(
+            sender_id="peer-1",
+            fragment=list(b"\x03\x00hello"),
+        )
+
+    def test_on_fragment_received_updates_metrics(self, manager, mock_protocol):
+        manager._on_fragment_received("peer-1", b"\x03\x00hi")
+        assert manager._bytes_received == 4
+        assert manager._fragments_received == 1
+
+    def test_on_fragment_received_protocol_error(self, manager, mock_protocol):
+        """Protocol errors are caught and don't propagate."""
+        mock_protocol.ble_fragment_received.side_effect = RuntimeError("boom")
+        # Should not raise
+        manager._on_fragment_received("peer-1", b"\x03\x00hi")
+
+    @pytest.mark.asyncio
+    async def test_drain_outgoing_sends_to_peer(self, manager, mock_protocol):
+        """Outgoing fragments are written to the correct BleakClient."""
+        mock_client = AsyncMock()
+        mock_client.is_connected = True
+        addr = "AA:BB:CC:DD:EE:FF"
+        manager._clients[addr] = mock_client
+        manager._peer_device_ids[addr] = "phone-1"
+        manager._device_id_to_addr["phone-1"] = addr
+
+        frag = MagicMock()
+        frag.recipient_id = "phone-1"
+        frag.data = [0x03, 0x00, 0x41]
+        mock_protocol.ble_get_next_fragment = MagicMock(
+            side_effect=[frag, None]
+        )
+
+        await manager._drain_outgoing_fragments()
+
+        mock_client.write_gatt_char.assert_called_once_with(
+            MESSAGE_CHAR_UUID,
+            bytes([0x03, 0x00, 0x41]),
+            response=False,
+        )
+        mock_protocol.ble_return_fragment.assert_called_once()
+        assert manager._bytes_sent == 3
+        assert manager._fragments_sent == 1
+
+    @pytest.mark.asyncio
+    async def test_drain_outgoing_no_fragments(self, manager, mock_protocol):
+        mock_protocol.ble_get_next_fragment = MagicMock(return_value=None)
+        await manager._drain_outgoing_fragments()
+        assert manager._fragments_sent == 0
+
+    @pytest.mark.asyncio
+    async def test_drain_outgoing_missing_peer(self, manager, mock_protocol):
+        """Fragments for unknown peers still return to pool."""
+        frag = MagicMock()
+        frag.recipient_id = "unknown-peer"
+        frag.data = [0x01]
+        mock_protocol.ble_get_next_fragment = MagicMock(
+            side_effect=[frag, None]
+        )
+
+        await manager._drain_outgoing_fragments()
+
+        mock_protocol.ble_return_fragment.assert_called_once()
+        assert manager._bytes_sent == 0
+
+
+# ---------------------------------------------------------------------------
+# Client lookup
+# ---------------------------------------------------------------------------
+
+
+class TestClientLookup:
+    def test_find_client_known_peer(self, manager):
+        mock_client = MagicMock()
+        addr = "AA:BB"
+        manager._clients[addr] = mock_client
+        manager._device_id_to_addr["peer-1"] = addr
+
+        assert manager._find_client_for_peer("peer-1") is mock_client
+
+    def test_find_client_unknown_peer(self, manager):
+        assert manager._find_client_for_peer("unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# Peer disconnect
+# ---------------------------------------------------------------------------
+
+
+class TestPeerDisconnect:
+    @pytest.mark.asyncio
+    async def test_on_peer_disconnected_cleans_up(self, manager, mock_protocol):
+        addr = "AA:BB"
+        mock_client = MagicMock()
+        manager._clients[addr] = mock_client
+        manager._peer_device_ids[addr] = "phone-1"
+        manager._device_id_to_addr["phone-1"] = addr
+
+        await manager._on_peer_disconnected(addr)
+
+        assert addr not in manager._clients
+        assert addr not in manager._peer_device_ids
+        assert "phone-1" not in manager._device_id_to_addr
+        mock_protocol.ble_peer_lost.assert_called_once_with(peer_id="phone-1")
+
+
+# ---------------------------------------------------------------------------
+# Peer cleanup loop
+# ---------------------------------------------------------------------------
+
+
+class TestPeerCleanup:
+    @pytest.mark.asyncio
+    async def test_stale_peers_cleaned_up(self, manager, mock_protocol):
+        """Peers not seen for > PEER_LOST_TIMEOUT are removed."""
+        addr = "STALE:ADDR"
+        # Set last_seen far in the past
+        manager._last_seen[addr] = time.monotonic() - 60.0
+        manager._peer_device_ids[addr] = "stale-peer"
+        manager._device_id_to_addr["stale-peer"] = addr
+        # Not in _clients (disconnected but still tracked)
+
+        task = asyncio.ensure_future(manager._peer_cleanup_loop())
+        # PEER_LOST_TIMEOUT/2 = 15s, but the stale entry is already old
+        # so the first tick should clean it up. We need to wait just past
+        # the sleep interval. Use a short timeout since the loop sleeps 15s.
+        # Instead, directly test the cleanup logic by letting one iteration run.
+        await asyncio.sleep(0.1)
+        # The loop sleeps for PEER_LOST_TIMEOUT/2 (15s) before first check,
+        # so we can't easily wait. Cancel and test the logic directly instead.
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # Directly test cleanup logic by simulating what the loop does
+        from offline_protocol_sdk.ble_manager import PEER_LOST_TIMEOUT
+
+        now = time.monotonic()
+        manager._last_seen[addr] = now - PEER_LOST_TIMEOUT - 1.0
+        manager._peer_device_ids[addr] = "stale-peer"
+        manager._device_id_to_addr["stale-peer"] = addr
+
+        stale = [
+            a
+            for a, ts in manager._last_seen.items()
+            if now - ts > PEER_LOST_TIMEOUT and a not in manager._clients
+        ]
+        for a in stale:
+            manager._last_seen.pop(a, None)
+            device_id = manager._peer_device_ids.pop(a, a)
+            manager._device_id_to_addr.pop(device_id, None)
+
+        assert addr not in manager._last_seen
+        assert addr not in manager._peer_device_ids

--- a/bindings/python/tests/test_ble_manager.py
+++ b/bindings/python/tests/test_ble_manager.py
@@ -255,6 +255,39 @@ class TestFragmentHandling:
         mock_protocol.ble_return_fragment.assert_called_once()
         assert manager._bytes_sent == 0
 
+    @pytest.mark.asyncio
+    async def test_concurrent_drain_is_serialised(self, manager, mock_protocol):
+        """A second _drain_outgoing_fragments call while one is running returns immediately."""
+        frag = MagicMock()
+        frag.recipient_id = "peer-1"
+        frag.data = [0x01]
+
+        mock_client = AsyncMock()
+        mock_client.is_connected = True
+        manager._clients["AA:BB"] = mock_client
+        manager._peer_device_ids["AA:BB"] = "peer-1"
+        manager._device_id_to_addr["peer-1"] = "AA:BB"
+
+        # First fragment returned, then None
+        mock_protocol.ble_get_next_fragment = MagicMock(
+            side_effect=[frag, None]
+        )
+
+        # Simulate concurrent drain: set flag before calling
+        manager._draining = True
+        await manager._drain_outgoing_fragments()
+        # Should have returned immediately without calling get_next_fragment
+        mock_protocol.ble_get_next_fragment.assert_not_called()
+
+        # Reset and verify normal drain works after flag is cleared
+        manager._draining = False
+        mock_protocol.ble_get_next_fragment = MagicMock(
+            side_effect=[frag, None]
+        )
+        await manager._drain_outgoing_fragments()
+        mock_protocol.ble_get_next_fragment.assert_called()
+        assert manager._draining is False
+
 
 # ---------------------------------------------------------------------------
 # Client lookup

--- a/bindings/python/tests/test_ble_peripheral.py
+++ b/bindings/python/tests/test_ble_peripheral.py
@@ -1,0 +1,253 @@
+"""Tests for BlePeripheral — BLE GATT server (peripheral role).
+
+All tests mock the bless server and OfflineProtocol so they run without
+actual Bluetooth hardware.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from offline_protocol_sdk.ble_peripheral import BlePeripheral
+from offline_protocol_sdk.transport_manager import TransportState
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_protocol():
+    """A mock OfflineProtocol with BLE methods stubbed."""
+    p = MagicMock()
+    p.ble_fragment_received = MagicMock()
+    p.ble_get_next_fragment = MagicMock(return_value=None)
+    p.ble_return_fragment = MagicMock()
+    p.ble_peer_discovered = MagicMock()
+    p.ble_peer_lost = MagicMock()
+    p.ble_status_changed = MagicMock()
+    return p
+
+
+@pytest.fixture
+def peripheral(mock_protocol):
+    """A BlePeripheral instance (not started)."""
+    return BlePeripheral(mock_protocol, device_id="coordinator")
+
+
+# ---------------------------------------------------------------------------
+# Basic state
+# ---------------------------------------------------------------------------
+
+class TestInitialState:
+    def test_initial_state_is_stopped(self, peripheral):
+        assert peripheral.state == TransportState.STOPPED
+
+    def test_is_available_on_supported_platform(self, peripheral):
+        # Should be True on macOS and Linux
+        assert peripheral.is_available() == (sys.platform in ("darwin", "linux"))
+
+    def test_get_metrics_defaults(self, peripheral):
+        m = peripheral.get_metrics()
+        assert m["bytes_sent"] == 0
+        assert m["bytes_received"] == 0
+        assert m["fragments_sent"] == 0
+        assert m["fragments_received"] == 0
+        assert m["connected_centrals"] == 0
+        assert m["is_advertising"] is False
+
+
+# ---------------------------------------------------------------------------
+# Read handler
+# ---------------------------------------------------------------------------
+
+class TestReadHandler:
+    def test_read_device_id(self, peripheral):
+        from offline_protocol_sdk.ble_manager import DEVICE_ID_CHAR_UUID
+        result = peripheral._on_read(DEVICE_ID_CHAR_UUID)
+        assert result == bytearray(b"coordinator")
+
+    def test_read_device_id_case_insensitive(self, peripheral):
+        from offline_protocol_sdk.ble_manager import DEVICE_ID_CHAR_UUID
+        result = peripheral._on_read(DEVICE_ID_CHAR_UUID.upper())
+        assert result == bytearray(b"coordinator")
+
+    def test_read_identity(self, peripheral):
+        from offline_protocol_sdk.ble_manager import IDENTITY_CHAR_UUID
+        result = peripheral._on_read(IDENTITY_CHAR_UUID)
+        parsed = json.loads(result.decode("utf-8"))
+        assert parsed["device_id"] == "coordinator"
+        assert parsed["role"] == "coordinator"
+        assert parsed["protocol"] == "offline-protocol"
+
+    def test_read_unknown_char_returns_empty(self, peripheral):
+        result = peripheral._on_read("00000000-0000-0000-0000-000000000000")
+        assert result == bytearray(b"")
+
+
+# ---------------------------------------------------------------------------
+# Write handler
+# ---------------------------------------------------------------------------
+
+class TestWriteHandler:
+    def test_write_feeds_protocol(self, peripheral, mock_protocol):
+        from offline_protocol_sdk.ble_manager import MESSAGE_CHAR_UUID
+        fragment_data = bytearray(b"\x03\x00hello")
+        peripheral._on_write(MESSAGE_CHAR_UUID, fragment_data)
+
+        mock_protocol.ble_fragment_received.assert_called_once_with(
+            sender_id="ble-peer",
+            fragment=list(b"\x03\x00hello"),
+        )
+
+    def test_write_updates_metrics(self, peripheral, mock_protocol):
+        from offline_protocol_sdk.ble_manager import MESSAGE_CHAR_UUID
+        peripheral._on_write(MESSAGE_CHAR_UUID, bytearray(b"\x03\x00hi"))
+        assert peripheral._bytes_received == 4
+        assert peripheral._fragments_received == 1
+
+    def test_write_to_wrong_char_ignored(self, peripheral, mock_protocol):
+        from offline_protocol_sdk.ble_manager import DEVICE_ID_CHAR_UUID
+        peripheral._on_write(DEVICE_ID_CHAR_UUID, bytearray(b"data"))
+        mock_protocol.ble_fragment_received.assert_not_called()
+
+    def test_write_with_single_central_uses_its_uuid(self, peripheral, mock_protocol):
+        from offline_protocol_sdk.ble_manager import MESSAGE_CHAR_UUID
+        # Simulate one connected central
+        peripheral._connected_centrals["AAAA-BBBB"] = 1234.0
+        peripheral._on_write(MESSAGE_CHAR_UUID, bytearray(b"\x03\x00x"))
+
+        mock_protocol.ble_fragment_received.assert_called_once()
+        call_args = mock_protocol.ble_fragment_received.call_args
+        assert call_args.kwargs["sender_id"] == "AAAA-BBBB"
+
+    def test_write_with_multiple_centrals_uses_generic(self, peripheral, mock_protocol):
+        from offline_protocol_sdk.ble_manager import MESSAGE_CHAR_UUID
+        peripheral._connected_centrals["AAAA"] = 1.0
+        peripheral._connected_centrals["BBBB"] = 2.0
+        peripheral._on_write(MESSAGE_CHAR_UUID, bytearray(b"\x03\x00x"))
+
+        call_args = mock_protocol.ble_fragment_received.call_args
+        assert call_args.kwargs["sender_id"] == "ble-peer"
+
+
+# ---------------------------------------------------------------------------
+# Outgoing fragment drain
+# ---------------------------------------------------------------------------
+
+class TestOutgoingFragments:
+    @pytest.fixture
+    def started_peripheral(self, peripheral):
+        """Peripheral with a mocked server to test drain logic."""
+        mock_server = MagicMock()
+        mock_char = MagicMock()
+        mock_server.get_characteristic = MagicMock(return_value=mock_char)
+        mock_server.update_value = MagicMock(return_value=True)
+        peripheral._server = mock_server
+        return peripheral, mock_server, mock_char
+
+    async def test_drain_sends_fragments(self, started_peripheral, mock_protocol):
+        peripheral, mock_server, mock_char = started_peripheral
+
+        frag1 = MagicMock()
+        frag1.data = [0x03, 0x00, 0x41, 0x42]  # "AB"
+        frag1.recipient_id = "phone-1"
+
+        # Return one fragment then None
+        mock_protocol.ble_get_next_fragment = MagicMock(
+            side_effect=[frag1, None]
+        )
+
+        await peripheral._drain_outgoing_fragments()
+
+        assert mock_char.value == bytes([0x03, 0x00, 0x41, 0x42])
+        mock_server.update_value.assert_called_once()
+        mock_protocol.ble_return_fragment.assert_called_once()
+        assert peripheral._fragments_sent == 1
+        assert peripheral._bytes_sent == 4
+
+    async def test_drain_no_fragments(self, started_peripheral, mock_protocol):
+        peripheral, mock_server, _ = started_peripheral
+        mock_protocol.ble_get_next_fragment = MagicMock(return_value=None)
+
+        await peripheral._drain_outgoing_fragments()
+
+        mock_server.update_value.assert_not_called()
+        assert peripheral._fragments_sent == 0
+
+
+# ---------------------------------------------------------------------------
+# Peer monitoring
+# ---------------------------------------------------------------------------
+
+class TestPeerMonitoring:
+    async def test_detects_new_central(self, peripheral, mock_protocol):
+        """Simulate a central appearing in _central_subscriptions."""
+        mock_delegate = MagicMock()
+        mock_delegate._central_subscriptions = {}
+        mock_delegate.is_advertising = MagicMock(return_value=True)
+
+        mock_server = MagicMock()
+        mock_server.peripheral_manager_delegate = mock_delegate
+        peripheral._server = mock_server
+
+        # Start the monitor loop
+        task = asyncio.ensure_future(peripheral._peer_monitor_loop())
+
+        # First tick: no centrals
+        await asyncio.sleep(1.2)
+        assert len(peripheral._connected_centrals) == 0
+
+        # Simulate a central subscribing
+        mock_delegate._central_subscriptions["PHONE-UUID-1"] = ["6e400002"]
+
+        await asyncio.sleep(1.2)
+        assert "PHONE-UUID-1" in peripheral._connected_centrals
+        mock_protocol.ble_peer_discovered.assert_called_with(
+            peer_id="PHONE-UUID-1", rssi=-50
+        )
+
+        # Simulate central disconnecting
+        mock_delegate._central_subscriptions.clear()
+
+        await asyncio.sleep(1.2)
+        assert len(peripheral._connected_centrals) == 0
+        mock_protocol.ble_peer_lost.assert_called_with(peer_id="PHONE-UUID-1")
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_respects_max_connections(self, peripheral, mock_protocol):
+        """Connections beyond max_connections are ignored."""
+        peripheral._max_connections = 1
+
+        mock_delegate = MagicMock()
+        mock_delegate._central_subscriptions = {
+            "A": ["6e400002"],
+            "B": ["6e400002"],
+        }
+        mock_delegate.is_advertising = MagicMock(return_value=True)
+
+        mock_server = MagicMock()
+        mock_server.peripheral_manager_delegate = mock_delegate
+        peripheral._server = mock_server
+
+        task = asyncio.ensure_future(peripheral._peer_monitor_loop())
+        await asyncio.sleep(1.2)
+
+        # Only 1 should be accepted
+        assert len(peripheral._connected_centrals) == 1
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/bindings/python/tests/test_ble_peripheral.py
+++ b/bindings/python/tests/test_ble_peripheral.py
@@ -182,6 +182,33 @@ class TestOutgoingFragments:
         mock_server.update_value.assert_not_called()
         assert peripheral._fragments_sent == 0
 
+    @pytest.mark.asyncio
+    async def test_concurrent_drain_is_serialised(self, started_peripheral, mock_protocol):
+        """A second drain call while one is running returns immediately."""
+        peripheral, mock_server, mock_char = started_peripheral
+
+        frag = MagicMock()
+        frag.data = [0x01]
+        frag.recipient_id = "phone-1"
+
+        mock_protocol.ble_get_next_fragment = MagicMock(
+            side_effect=[frag, None]
+        )
+
+        # Simulate concurrent drain: set flag before calling
+        peripheral._draining = True
+        await peripheral._drain_outgoing_fragments()
+        mock_protocol.ble_get_next_fragment.assert_not_called()
+
+        # Reset and verify normal drain works
+        peripheral._draining = False
+        mock_protocol.ble_get_next_fragment = MagicMock(
+            side_effect=[frag, None]
+        )
+        await peripheral._drain_outgoing_fragments()
+        mock_protocol.ble_get_next_fragment.assert_called()
+        assert peripheral._draining is False
+
 
 # ---------------------------------------------------------------------------
 # Peer monitoring

--- a/bindings/python/tests/test_ble_peripheral.py
+++ b/bindings/python/tests/test_ble_peripheral.py
@@ -151,6 +151,7 @@ class TestOutgoingFragments:
         peripheral._server = mock_server
         return peripheral, mock_server, mock_char
 
+    @pytest.mark.asyncio
     async def test_drain_sends_fragments(self, started_peripheral, mock_protocol):
         peripheral, mock_server, mock_char = started_peripheral
 
@@ -171,6 +172,7 @@ class TestOutgoingFragments:
         assert peripheral._fragments_sent == 1
         assert peripheral._bytes_sent == 4
 
+    @pytest.mark.asyncio
     async def test_drain_no_fragments(self, started_peripheral, mock_protocol):
         peripheral, mock_server, _ = started_peripheral
         mock_protocol.ble_get_next_fragment = MagicMock(return_value=None)
@@ -186,6 +188,7 @@ class TestOutgoingFragments:
 # ---------------------------------------------------------------------------
 
 class TestPeerMonitoring:
+    @pytest.mark.asyncio
     async def test_detects_new_central(self, peripheral, mock_protocol):
         """Simulate a central appearing in _central_subscriptions."""
         mock_delegate = MagicMock()
@@ -199,14 +202,14 @@ class TestPeerMonitoring:
         # Start the monitor loop
         task = asyncio.ensure_future(peripheral._peer_monitor_loop())
 
-        # First tick: no centrals
-        await asyncio.sleep(1.2)
+        # Wait for first tick (interval=1.0s) with generous margin
+        await asyncio.sleep(1.5)
         assert len(peripheral._connected_centrals) == 0
 
         # Simulate a central subscribing
         mock_delegate._central_subscriptions["PHONE-UUID-1"] = ["6e400002"]
 
-        await asyncio.sleep(1.2)
+        await asyncio.sleep(1.5)
         assert "PHONE-UUID-1" in peripheral._connected_centrals
         mock_protocol.ble_peer_discovered.assert_called_with(
             peer_id="PHONE-UUID-1", rssi=-50
@@ -215,7 +218,7 @@ class TestPeerMonitoring:
         # Simulate central disconnecting
         mock_delegate._central_subscriptions.clear()
 
-        await asyncio.sleep(1.2)
+        await asyncio.sleep(1.5)
         assert len(peripheral._connected_centrals) == 0
         mock_protocol.ble_peer_lost.assert_called_with(peer_id="PHONE-UUID-1")
 
@@ -225,6 +228,7 @@ class TestPeerMonitoring:
         except asyncio.CancelledError:
             pass
 
+    @pytest.mark.asyncio
     async def test_respects_max_connections(self, peripheral, mock_protocol):
         """Connections beyond max_connections are ignored."""
         peripheral._max_connections = 1
@@ -241,7 +245,7 @@ class TestPeerMonitoring:
         peripheral._server = mock_server
 
         task = asyncio.ensure_future(peripheral._peer_monitor_loop())
-        await asyncio.sleep(1.2)
+        await asyncio.sleep(1.5)
 
         # Only 1 should be accepted
         assert len(peripheral._connected_centrals) == 1

--- a/bindings/python/tests/test_internet_manager.py
+++ b/bindings/python/tests/test_internet_manager.py
@@ -172,6 +172,32 @@ class TestInternetManagerConnectionClosedGuard:
         await mgr._handle_connection_closed(RuntimeError("test"))
         mock_protocol.internet_status_changed.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_handle_connection_closed_schedules_reconnect_on_initial_failure(
+        self, mock_protocol: MagicMock
+    ) -> None:
+        """When initial connect fails (_connected never set True), reconnect is still scheduled."""
+        mgr = InternetManager(
+            mock_protocol, "dev-1",
+            server_url="ws://x.com",
+            auto_reconnect=True,
+        )
+        mgr._loop = asyncio.get_running_loop()
+        # Simulate state after start() calls _connect() which sets STARTING
+        mgr._state = TransportState.STARTING
+        # _connected and _authenticated remain False (connect failed before handshake)
+
+        await mgr._handle_connection_closed(RuntimeError("connect failed"))
+
+        # Should NOT be stuck in STARTING — should schedule reconnect
+        # which transitions to STARTING via _schedule_reconnect
+        assert mgr._reconnect_attempts == 1
+        assert mgr._state == TransportState.STARTING
+
+        # Clean up the timer handle
+        if mgr._reconnect_handle is not None:
+            mgr._reconnect_handle.cancel()
+
 
 class TestInternetManagerSendMessageTOCTOU:
     @pytest.mark.asyncio

--- a/bindings/python/tests/test_internet_manager.py
+++ b/bindings/python/tests/test_internet_manager.py
@@ -1,0 +1,113 @@
+"""Tests for the InternetManager (WebSocket transport)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from offline_protocol_sdk.internet_manager import InternetManager
+from offline_protocol_sdk.transport_manager import TransportError, TransportState
+
+
+@pytest.fixture
+def mock_protocol() -> MagicMock:
+    proto = MagicMock()
+    proto.internet_status_changed = MagicMock()
+    proto.internet_message_received = MagicMock()
+    proto.internet_get_next_message = MagicMock(return_value=None)
+    proto.internet_confirm_sent = MagicMock()
+    proto.internet_send_failed = MagicMock()
+    proto.internet_send_failed_with_reason = MagicMock()
+    return proto
+
+
+class TestInternetManagerSetup:
+    def test_initial_state(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        assert mgr.state == TransportState.STOPPED
+        assert not mgr.is_available()
+
+    def test_is_available_after_configure(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        mgr.configure(server_url="ws://localhost:8080")
+        assert mgr.is_available()
+
+    def test_configure_sets_url(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1", server_url="ws://a.com")
+        assert mgr.is_available()
+        assert mgr._server_url == "ws://a.com"
+
+    @pytest.mark.asyncio
+    async def test_start_without_url_raises(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        with pytest.raises(TransportError, match="Server URL not configured"):
+            await mgr.start()
+
+    def test_get_metrics_defaults(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        m = mgr.get_metrics()
+        assert m["bytes_sent"] == 0
+        assert m["is_connected"] is False
+
+    def test_auth_token(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        mgr.set_auth_token("my-token")
+        assert mgr._auth_token == "my-token"
+
+
+class TestInternetManagerMessageProcessing:
+    def test_handle_incoming_message(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        msg = {
+            "type": "MessageReceived",
+            "sender": "peer-1",
+            "content": "hello",
+            "message_id": "msg-123",
+        }
+        mgr._process_received(json.dumps(msg).encode())
+        mock_protocol.internet_message_received.assert_called_once()
+        call_args = mock_protocol.internet_message_received.call_args
+        assert call_args.kwargs["sender_id"] == "peer-1"
+
+    def test_handle_connection_request(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        msg = {
+            "type": "ConnectionRequestReceived",
+            "sender": "peer-2",
+            "sender_name": "Alice",
+        }
+        mgr._process_received(json.dumps(msg).encode())
+        mock_protocol.internet_message_received.assert_called_once()
+
+    def test_handle_connection_accepted(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        msg = {
+            "type": "ConnectionAccepted",
+            "accepted_by": "peer-2",
+            "accepted_by_name": "Alice",
+        }
+        mgr._process_received(json.dumps(msg).encode())
+        mock_protocol.internet_message_received.assert_called_once()
+
+    def test_handle_connection_rejected(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        msg = {
+            "type": "ConnectionRejected",
+            "rejected_by": "peer-3",
+        }
+        mgr._process_received(json.dumps(msg).encode())
+        mock_protocol.internet_message_received.assert_called_once()
+
+    def test_handle_unknown_type_no_crash(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        msg = {"type": "SomeFutureMessageType", "data": "test"}
+        mgr._process_received(json.dumps(msg).encode())
+        mock_protocol.internet_message_received.assert_not_called()
+
+    def test_handle_invalid_json(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        mgr._process_received(b"not json at all")
+        mock_protocol.internet_message_received.assert_not_called()

--- a/bindings/python/tests/test_internet_manager.py
+++ b/bindings/python/tests/test_internet_manager.py
@@ -111,3 +111,96 @@ class TestInternetManagerMessageProcessing:
         mgr = InternetManager(mock_protocol, "dev-1")
         mgr._process_received(b"not json at all")
         mock_protocol.internet_message_received.assert_not_called()
+
+
+class TestInternetManagerAppId:
+    def test_default_app_id(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        assert mgr._app_id == "offline-messenger"
+
+    def test_custom_app_id(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1", app_id="my-app")
+        assert mgr._app_id == "my-app"
+
+    def test_custom_app_id_in_internal_messages(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1", app_id="custom-app")
+        result = mgr._build_internal_message("sender", "content")
+        assert result["app_id"] == "custom-app"
+
+    def test_custom_app_id_in_incoming_message_fallback(self, mock_protocol: MagicMock) -> None:
+        """When content is not full-message JSON, the fallback dict uses app_id."""
+        mgr = InternetManager(mock_protocol, "dev-1", app_id="custom-app")
+        msg = {
+            "type": "MessageReceived",
+            "sender": "peer-1",
+            "content": "plain text",
+            "message_id": "msg-1",
+        }
+        mgr._process_received(json.dumps(msg).encode())
+        call_args = mock_protocol.internet_message_received.call_args
+        data = json.loads(bytes(call_args.kwargs["data"]))
+        assert data["app_id"] == "custom-app"
+
+
+class TestInternetManagerConnectionClosedGuard:
+    @pytest.mark.asyncio
+    async def test_double_handle_connection_closed_is_noop(
+        self, mock_protocol: MagicMock
+    ) -> None:
+        """Second call to _handle_connection_closed returns immediately."""
+        mgr = InternetManager(mock_protocol, "dev-1", server_url="ws://x.com")
+        mgr._connected = True
+        mgr._authenticated = True
+        mgr._state = TransportState.RUNNING
+
+        await mgr._handle_connection_closed(None)
+        assert mgr._connected is False
+
+        # Reset protocol mock to track second call
+        mock_protocol.internet_status_changed.reset_mock()
+
+        # Second call should be a no-op (guard fires)
+        await mgr._handle_connection_closed(None)
+        mock_protocol.internet_status_changed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_connection_closed_when_never_connected(
+        self, mock_protocol: MagicMock
+    ) -> None:
+        """Calling on a fresh (never-connected) manager is a no-op."""
+        mgr = InternetManager(mock_protocol, "dev-1")
+        await mgr._handle_connection_closed(RuntimeError("test"))
+        mock_protocol.internet_status_changed.assert_not_called()
+
+
+class TestInternetManagerSendMessageTOCTOU:
+    @pytest.mark.asyncio
+    async def test_send_fails_gracefully_when_ws_becomes_none(
+        self, mock_protocol: MagicMock
+    ) -> None:
+        """If ws becomes None after initial check, send reports failure."""
+        mgr = InternetManager(mock_protocol, "dev-1", server_url="ws://x.com")
+        mgr._connected = True
+        mgr._ws = MagicMock()
+
+        # Simulate disconnection during semaphore wait: set ws to None
+        # We replace the semaphore with one that disconnects before yielding
+        original_semaphore = mgr._send_semaphore
+
+        class DisconnectingSemaphore:
+            async def __aenter__(self_sem):
+                mgr._ws = None
+                mgr._connected = False
+                return self_sem
+
+            async def __aexit__(self_sem, *args):
+                pass
+
+        mgr._send_semaphore = DisconnectingSemaphore()
+
+        await mgr._send_message("msg-1", "peer-1", b"hello")
+
+        mock_protocol.internet_send_failed_with_reason.assert_called_once()
+        call_args = mock_protocol.internet_send_failed_with_reason.call_args
+        assert call_args.kwargs["message_id"] == "msg-1"
+        assert "Disconnected" in call_args.kwargs["reason"]

--- a/bindings/python/tests/test_protocol_manager.py
+++ b/bindings/python/tests/test_protocol_manager.py
@@ -166,6 +166,88 @@ class TestProtocolManagerTransports:
         pm = ProtocolManager(config)
         assert pm.internet is None
 
+    def test_internet_inherits_app_id(self):
+        config = _make_config(internet_enabled=True, app_id="custom-app")
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        assert pm.internet is not None
+        assert pm.internet._app_id == "custom-app"
+
+
+class TestProtocolManagerMessageDrain:
+    @pytest.mark.asyncio
+    async def test_drain_dispatches_messages_to_event_handler(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        events = []
+        pm = ProtocolManager(config, event_handler=events.append)
+        await pm.start()
+
+        # Simulate protocol returning a message then None
+        msg_json = '{"sender": "alice", "content": "hi"}'
+        pm._protocol.receive_message = MagicMock(side_effect=[msg_json, None])
+
+        pm._drain_incoming_messages()
+
+        assert len(events) == 1
+        assert events[0]["sender"] == "alice"
+        assert events[0]["content"] == "hi"
+        assert events[0].get("type") == "message_received"
+        await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_drain_without_handler_does_not_crash(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config, event_handler=None)
+        await pm.start()
+
+        pm._protocol.receive_message = MagicMock(side_effect=["{}",  None])
+
+        # Should not raise
+        pm._drain_incoming_messages()
+        await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_drain_handles_invalid_json(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        events = []
+        pm = ProtocolManager(config, event_handler=events.append)
+        await pm.start()
+
+        pm._protocol.receive_message = MagicMock(
+            side_effect=["not-json", None]
+        )
+        pm._drain_incoming_messages()
+
+        assert len(events) == 1
+        assert events[0]["type"] == "message_received"
+        assert events[0]["raw"] == "not-json"
+        await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_drain_caps_at_max_messages(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+        from offline_protocol_sdk.protocol_manager import _MAX_MESSAGES_PER_TICK
+
+        events = []
+        pm = ProtocolManager(config, event_handler=events.append)
+        await pm.start()
+
+        # Return messages forever (more than the cap)
+        pm._protocol.receive_message = MagicMock(return_value='{"type":"msg"}')
+
+        pm._drain_incoming_messages()
+
+        assert len(events) == _MAX_MESSAGES_PER_TICK
+        await pm.stop()
+
 
 class TestProtocolManagerConvenience:
     @pytest.mark.asyncio

--- a/bindings/python/tests/test_protocol_manager.py
+++ b/bindings/python/tests/test_protocol_manager.py
@@ -1,0 +1,203 @@
+"""Tests for ProtocolManager — high-level protocol orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from offline_protocol_sdk.offline_protocol import (
+    OverflowPolicy,
+    ProtocolConfig,
+    ProtocolState,
+)
+
+
+def _make_config(**overrides) -> ProtocolConfig:
+    defaults = dict(
+        app_id="test-app",
+        user_id="test-user",
+        ble_enabled=False,
+        wifi_direct_enabled=False,
+        internet_enabled=False,
+        reticulum_enabled=False,
+        prefer_online=True,
+        initial_ttl=3,
+        encryption_enabled=False,
+        auto_key_exchange=False,
+        store_pending=True,
+        require_encryption=False,
+        max_pending_per_peer=100,
+        max_pending_global=1000,
+        pending_ttl_ms=60000,
+        overflow_policy=OverflowPolicy.DROP_OLDEST,
+    )
+    defaults.update(overrides)
+    return ProtocolConfig(**defaults)
+
+
+class TestProtocolManagerLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_stop(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        assert pm._running is True
+        assert pm._process_task is not None
+
+        await pm.stop()
+        assert pm._running is False
+        assert pm._process_task is None
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        async with ProtocolManager(config) as pm:
+            assert pm._running is True
+        assert pm._running is False
+
+    @pytest.mark.asyncio
+    async def test_double_start_is_noop(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        task = pm._process_task
+        await pm.start()  # should not raise or create new task
+        assert pm._process_task is task
+        await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_double_stop_is_noop(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        await pm.stop()
+        await pm.stop()  # should not raise
+
+
+class TestProtocolManagerEvents:
+    @pytest.mark.asyncio
+    async def test_event_handler_receives_events(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        events = []
+        pm = ProtocolManager(config, event_handler=events.append)
+        await pm.start()
+
+        # Manually invoke the callback to test routing
+        pm._event_cb.on_event('{"type": "test_event", "data": 123}')
+
+        assert len(events) == 1
+        assert events[0]["type"] == "test_event"
+        assert events[0]["data"] == 123
+        await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_on_event_replaces_handler(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        events_a = []
+        events_b = []
+        pm = ProtocolManager(config, event_handler=events_a.append)
+        await pm.start()
+
+        pm.on_event(events_b.append)
+        pm._event_cb.on_event('{"type": "after_swap"}')
+
+        assert len(events_a) == 0
+        assert len(events_b) == 1
+        await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_event_handler_invalid_json(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        events = []
+        pm = ProtocolManager(config, event_handler=events.append)
+        await pm.start()
+
+        pm._event_cb.on_event("not json")
+
+        assert len(events) == 1
+        assert events[0] == {"raw": "not json"}
+        await pm.stop()
+
+
+class TestProtocolManagerTransports:
+    def test_ble_created_when_enabled(self):
+        config = _make_config(ble_enabled=True)
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        assert pm.ble is not None
+        assert pm.ble_peripheral is not None
+
+    def test_ble_none_when_disabled(self):
+        config = _make_config(ble_enabled=False)
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        assert pm.ble is None
+        assert pm.ble_peripheral is None
+
+    def test_internet_created_when_enabled(self):
+        config = _make_config(internet_enabled=True)
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        assert pm.internet is not None
+
+    def test_internet_none_when_disabled(self):
+        config = _make_config(internet_enabled=False)
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        assert pm.internet is None
+
+
+class TestProtocolManagerConvenience:
+    @pytest.mark.asyncio
+    async def test_send_message(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        try:
+            msg_id = pm.send_message("recipient-1", "hello")
+            assert isinstance(msg_id, str)
+            assert len(msg_id) > 0
+        finally:
+            await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_get_state(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        try:
+            state = pm.get_state()
+            assert state == ProtocolState.RUNNING
+        finally:
+            await pm.stop()
+
+    def test_protocol_property(self):
+        config = _make_config()
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        assert pm.protocol is pm._protocol

--- a/bindings/python/tests/test_secure_storage.py
+++ b/bindings/python/tests/test_secure_storage.py
@@ -1,0 +1,72 @@
+"""Tests for the SecureStorage (keyring-backed MlsStorageProvider)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from offline_protocol_sdk.secure_storage import SecureStorage
+
+
+@pytest.fixture
+def storage() -> SecureStorage:
+    return SecureStorage(service="test-offline-mls")
+
+
+class TestSecureStorage:
+    """Unit tests using a mocked keyring backend."""
+
+    @patch("offline_protocol_sdk.secure_storage.keyring")
+    def test_store_and_load(self, mock_kr: MagicMock) -> None:
+        import base64
+
+        store = SecureStorage(service="test-svc")
+        data = [72, 101, 108, 108, 111]  # "Hello"
+
+        # index_get reads the index entry first; return None (empty index)
+        mock_kr.get_password.return_value = None
+
+        # Store
+        store.store("identity", "key-1", data)
+        assert mock_kr.set_password.call_count >= 1  # data + index
+
+        # Load — simulate keyring returning base64
+        encoded = base64.b64encode(bytes(data)).decode("ascii")
+        mock_kr.get_password.return_value = encoded
+
+        result = store.load("identity", "key-1")
+        assert result == data
+
+    @patch("offline_protocol_sdk.secure_storage.keyring")
+    def test_load_missing_key_returns_none(self, mock_kr: MagicMock) -> None:
+        store = SecureStorage(service="test-svc")
+        mock_kr.get_password.return_value = None
+        assert store.load("identity", "nonexistent") is None
+
+    @patch("offline_protocol_sdk.secure_storage.keyring")
+    def test_delete(self, mock_kr: MagicMock) -> None:
+        store = SecureStorage(service="test-svc")
+
+        # Simulate empty index
+        mock_kr.get_password.return_value = None
+
+        store.delete("identity", "key-1")
+        # Expect 2 calls: one for the data key, one for the empty index cleanup
+        assert mock_kr.delete_password.call_count == 2
+
+    @patch("offline_protocol_sdk.secure_storage.keyring")
+    def test_list_keys_empty(self, mock_kr: MagicMock) -> None:
+        store = SecureStorage(service="test-svc")
+        mock_kr.get_password.return_value = None
+        assert store.list_keys("identity") == []
+
+    @patch("offline_protocol_sdk.secure_storage.keyring")
+    def test_list_keys_with_entries(self, mock_kr: MagicMock) -> None:
+        import json
+
+        store = SecureStorage(service="test-svc")
+        mock_kr.get_password.return_value = json.dumps(["key-1", "key-2"])
+
+        result = store.list_keys("identity")
+        assert result == ["key-1", "key-2"]


### PR DESCRIPTION
## Summary

- BLE peripheral registers peers with raw CoreBluetooth UUID via `ble_peer_discovered()`, but `send_message()` routes by `user_id` — the Rust core's `BleTransport::send()` never finds the peer and silently returns `PeerNotReachable`
- The BLE central (scanner) path works because it reads `DEVICE_ID_CHAR` after connecting and re-registers with the real `user_id`; the peripheral had no equivalent mechanism
- Fix: extract the sender's `user_id` from the first reassembled message via `BlePeripheral.resolve_sender_identity()`, then re-register the peer so outgoing messages route correctly
- `ProtocolManager._drain_incoming_messages()` now triggers identity resolution automatically
- Cleans up `central_uuid → user_id` mapping on disconnect/stop

## Context

Discovered while building [IntelligenceMesh](https://github.com/kivtxs/IntelligenceMesh) distributed training. The Mac coordinator runs as a BLE peripheral (GATT server); phones connect as centrals. Phone→Mac messages (writes) work fine, but Mac→phone messages (notifications) silently fail because the peer lookup mismatches UUID vs user_id.

## Test plan

- [ ] Mac peripheral starts, phone connects and sends a message
- [ ] After first message received, `resolve_sender_identity` logs re-registration
- [ ] Subsequent `send_message(user_id, ...)` generates BLE fragments and `on_fragments_available` fires
- [ ] Phone receives notification fragments and reassembles the message
- [ ] Peer disconnect cleans up both UUID and user_id routing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)