### PR TITLE
fix(bindings): align Reticulum transport lifecycle with Nostr

### DIFF
--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -683,20 +683,8 @@ class OfflineProtocolModule: RCTEventEmitter {
                 emitDiagnostic(level: "warning", message: "Internet manager exists but no server URL configured")
             }
 
-            // Start Reticulum manager if configured
-            if let manager = reticulumManager {
-                do {
-                    try manager.start()
-                    print("[OfflineProtocolModule] Reticulum Manager started")
-                    emitDiagnostic(level: "info", message: "Reticulum manager started")
-                } catch {
-                    print("[OfflineProtocolModule] Warning: Failed to start Reticulum Manager: \(error.localizedDescription)")
-                    emitDiagnostic(level: "error", message: "Failed to start Reticulum manager", context: [
-                        "error": error.localizedDescription
-                    ])
-                    // Don't fail the entire start if Reticulum fails
-                }
-            }
+            // Reticulum manager is started on-demand via enableTransport("reticulum")
+            // from the JS layer, not here — avoids double-start conflicts.
 
             // Nostr manager is started on-demand via enableTransport("nostr")
             // from the JS layer, not here — avoids double-start conflicts.

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -30,6 +30,7 @@ import type {
   MessageReceivedEvent,
   BleTransportConfig,
   NostrTransportConfig,
+  ReticulumTransportConfig,
   AckConfig,
   RetryConfig,
   DedupConfig,
@@ -682,6 +683,20 @@ export class OfflineProtocol {
         );
       }
     }
+
+    // Auto-enable reticulum transport if configured
+    const reticulumConfig = this.config.transports?.reticulum;
+    if (reticulumConfig?.enabled) {
+      try {
+        await this.enableTransport("reticulum", reticulumConfig);
+        console.log("[OfflineProtocol] Reticulum transport auto-enabled");
+      } catch (error) {
+        console.warn(
+          "[OfflineProtocol] Failed to auto-enable reticulum transport:",
+          error
+        );
+      }
+    }
   }
 
   /**
@@ -839,7 +854,7 @@ export class OfflineProtocol {
    */
   async enableTransport(
     type: TransportType,
-    config?: InternetTransportConfig | WifiDirectTransportConfig | NostrTransportConfig
+    config?: InternetTransportConfig | WifiDirectTransportConfig | NostrTransportConfig | ReticulumTransportConfig
   ): Promise<void> {
     return await OfflineProtocolNativeModule.enableTransport(type, config);
   }


### PR DESCRIPTION
## Summary

- **Remove iOS native auto-start** for Reticulum in `start()` — it was the only transport that auto-started from native while all others defer to the JS layer via `enableTransport()`
- **Add TypeScript auto-enable** for Reticulum in `start()`, matching the existing Nostr/Internet pattern — triggers when `reticulum.enabled` is `true` in config
- **Add `ReticulumTransportConfig`** to the `enableTransport()` type signature union and import, restoring type safety

Both transports now follow the same lifecycle: native `initialize()` creates + configures the manager → JS `start()` auto-enables → native `enableTransport` → `configureAndStart*()`.

## Test plan

- [ ] Verify Reticulum transport starts correctly when `reticulum.enabled = true` is set in config
- [ ] Verify Reticulum transport does NOT start when `reticulum.enabled` is omitted or `false`
- [ ] Verify Nostr transport still auto-enables correctly (no regression)
- [ ] Verify `enableTransport("reticulum", config)` works from JS with proper TypeScript types
- [ ] Verify iOS does not double-start Reticulum on protocol start