### PR TITLE
refactor(protocol): extract CategorySampler from MlsEventRateLimiter

### DIFF
--- a/crates/offline-protocol/src/lib.rs
+++ b/crates/offline-protocol/src/lib.rs
@@ -17,6 +17,7 @@ mod group_mesh;
 pub mod mls;
 pub mod mls_observability;
 pub mod protocol;
+pub mod telemetry;
 pub mod transport_manager;
 pub mod visualization;
 

--- a/crates/offline-protocol/src/mls_observability.rs
+++ b/crates/offline-protocol/src/mls_observability.rs
@@ -1,14 +1,9 @@
 //! MLS lifecycle observability primitives.
 
+use crate::telemetry::CategorySampler;
 use offline_protocol_mls::MlsError;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
-use std::sync::Mutex;
-
-const DEFAULT_RATE_LIMIT_WINDOW_MS: i64 = 1_000;
-const DEFAULT_RATE_LIMIT_MAX_EVENTS: u32 = 10;
-const MAX_RATE_LIMIT_KEYS: usize = 4096;
 
 /// Operation context for MLS lifecycle events.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -163,64 +158,16 @@ impl MlsEventEmitter for NoopMlsEventEmitter {
     fn emit(&self, _event: MlsLifecycleEvent) {}
 }
 
-#[derive(Debug, Clone)]
-struct EventWindow {
-    window_start_ms: i64,
-    count: u32,
-}
-
 /// Best-effort fixed-window limiter to reduce high-volume failure event floods.
-#[derive(Debug)]
+///
+/// Thin wrapper around [`CategorySampler`] that maps MLS lifecycle events to
+/// rate-limit keys.
+#[derive(Debug, Default)]
 pub struct MlsEventRateLimiter {
-    max_events_per_window: u32,
-    window_ms: i64,
-    windows: Mutex<HashMap<String, EventWindow>>,
-}
-
-impl Default for MlsEventRateLimiter {
-    fn default() -> Self {
-        Self {
-            max_events_per_window: DEFAULT_RATE_LIMIT_MAX_EVENTS,
-            window_ms: DEFAULT_RATE_LIMIT_WINDOW_MS,
-            windows: Mutex::new(HashMap::new()),
-        }
-    }
+    sampler: CategorySampler,
 }
 
 impl MlsEventRateLimiter {
-    /// Returns true when an event should be emitted for the current window.
-    pub fn allow(&self, key: &str, now_ms: i64) -> bool {
-        let Ok(mut windows) = self.windows.lock() else {
-            return true;
-        };
-
-        if windows.len() >= MAX_RATE_LIMIT_KEYS && !windows.contains_key(key) {
-            windows.retain(|_, window| {
-                now_ms.saturating_sub(window.window_start_ms) <= DEFAULT_RATE_LIMIT_WINDOW_MS
-            });
-            if windows.len() >= MAX_RATE_LIMIT_KEYS {
-                windows.clear();
-            }
-        }
-
-        let window = windows.entry(key.to_string()).or_insert(EventWindow {
-            window_start_ms: now_ms,
-            count: 0,
-        });
-
-        if now_ms.saturating_sub(window.window_start_ms) >= self.window_ms {
-            window.window_start_ms = now_ms;
-            window.count = 0;
-        }
-
-        if window.count >= self.max_events_per_window {
-            return false;
-        }
-
-        window.count = window.count.saturating_add(1);
-        true
-    }
-
     /// Returns true if the event passes rate limiting.
     pub fn should_emit(&self, event: &MlsLifecycleEvent) -> bool {
         let now_ms = timestamp_now_ms();
@@ -235,11 +182,11 @@ impl MlsEventRateLimiter {
                     peer_id.as_deref().unwrap_or("none"),
                     failure_kind
                 );
-                self.allow(&key, now_ms)
+                self.sampler.allow(&key, now_ms)
             }
             MlsLifecycleEvent::SessionMissing { peer_id, .. } => {
                 let key = format!("session_missing:{}", peer_id.as_deref().unwrap_or("none"));
-                self.allow(&key, now_ms)
+                self.sampler.allow(&key, now_ms)
             }
             _ => true,
         }
@@ -305,14 +252,32 @@ mod tests {
     }
 
     #[test]
-    fn limiter_blocks_after_budget() {
+    fn limiter_suppresses_flood() {
         let limiter = MlsEventRateLimiter::default();
-        let now = 1000_i64;
-        let key = "k";
-        for _ in 0..DEFAULT_RATE_LIMIT_MAX_EVENTS {
-            assert!(limiter.allow(key, now));
+        let base_ts = 1000_i64;
+        // First 10 DecryptionFailed events for the same peer+kind pass.
+        for i in 0..10 {
+            let event = MlsLifecycleEvent::DecryptionFailed {
+                timestamp_ms: base_ts + i,
+                session_id: "s".to_string(),
+                group_id: None,
+                peer_id: Some("peer-a".to_string()),
+                context: MlsOperationContext::Receive,
+                error_category: None,
+                failure_kind: DecryptionFailureKind::InvalidCiphertext,
+            };
+            assert!(limiter.should_emit(&event));
         }
-        assert!(!limiter.allow(key, now));
-        assert!(limiter.allow(key, now + DEFAULT_RATE_LIMIT_WINDOW_MS));
+        // 11th is suppressed.
+        let event = MlsLifecycleEvent::DecryptionFailed {
+            timestamp_ms: base_ts + 10,
+            session_id: "s".to_string(),
+            group_id: None,
+            peer_id: Some("peer-a".to_string()),
+            context: MlsOperationContext::Receive,
+            error_category: None,
+            failure_kind: DecryptionFailureKind::InvalidCiphertext,
+        };
+        assert!(!limiter.should_emit(&event));
     }
 }

--- a/crates/offline-protocol/src/telemetry/mod.rs
+++ b/crates/offline-protocol/src/telemetry/mod.rs
@@ -1,0 +1,5 @@
+//! Telemetry primitives for the Offline Protocol SDK.
+
+pub mod sampling;
+
+pub use sampling::CategorySampler;

--- a/crates/offline-protocol/src/telemetry/sampling.rs
+++ b/crates/offline-protocol/src/telemetry/sampling.rs
@@ -1,0 +1,135 @@
+//! Generic fixed-window rate limiter for event sampling.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+const DEFAULT_WINDOW_MS: i64 = 1_000;
+const DEFAULT_MAX_EVENTS: u32 = 10;
+const DEFAULT_MAX_KEYS: usize = 4096;
+
+#[derive(Debug, Clone)]
+struct EventWindow {
+    window_start_ms: i64,
+    count: u32,
+}
+
+/// Best-effort fixed-window sampler that limits events per category key.
+///
+/// Each unique key gets its own window. When a key's budget is exhausted for
+/// the current window, further events with that key are suppressed until the
+/// window resets. An eviction policy prevents unbounded memory growth when
+/// the number of distinct keys exceeds `max_keys`.
+#[derive(Debug)]
+pub struct CategorySampler {
+    max_events_per_window: u32,
+    window_ms: i64,
+    max_keys: usize,
+    windows: Mutex<HashMap<String, EventWindow>>,
+}
+
+impl Default for CategorySampler {
+    fn default() -> Self {
+        Self {
+            max_events_per_window: DEFAULT_MAX_EVENTS,
+            window_ms: DEFAULT_WINDOW_MS,
+            max_keys: DEFAULT_MAX_KEYS,
+            windows: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl CategorySampler {
+    /// Creates a sampler with custom parameters.
+    pub fn new(max_events_per_window: u32, window_ms: i64, max_keys: usize) -> Self {
+        Self {
+            max_events_per_window,
+            window_ms,
+            max_keys,
+            windows: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns `true` when an event with the given key should be emitted.
+    ///
+    /// If the mutex is poisoned the call conservatively returns `true` so
+    /// events are never silently dropped due to an unrelated panic.
+    pub fn allow(&self, key: &str, now_ms: i64) -> bool {
+        let Ok(mut windows) = self.windows.lock() else {
+            return true;
+        };
+
+        if windows.len() >= self.max_keys && !windows.contains_key(key) {
+            windows.retain(|_, window| {
+                now_ms.saturating_sub(window.window_start_ms) <= self.window_ms
+            });
+            if windows.len() >= self.max_keys {
+                windows.clear();
+            }
+        }
+
+        let window = windows.entry(key.to_string()).or_insert(EventWindow {
+            window_start_ms: now_ms,
+            count: 0,
+        });
+
+        if now_ms.saturating_sub(window.window_start_ms) >= self.window_ms {
+            window.window_start_ms = now_ms;
+            window.count = 0;
+        }
+
+        if window.count >= self.max_events_per_window {
+            return false;
+        }
+
+        window.count = window.count.saturating_add(1);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_after_budget_exhausted() {
+        let sampler = CategorySampler::default();
+        let now = 1000_i64;
+        let key = "k";
+        for _ in 0..DEFAULT_MAX_EVENTS {
+            assert!(sampler.allow(key, now));
+        }
+        assert!(!sampler.allow(key, now));
+    }
+
+    #[test]
+    fn window_resets_after_elapsed() {
+        let sampler = CategorySampler::default();
+        let now = 1000_i64;
+        for _ in 0..DEFAULT_MAX_EVENTS {
+            sampler.allow("k", now);
+        }
+        assert!(!sampler.allow("k", now));
+        assert!(sampler.allow("k", now + DEFAULT_WINDOW_MS));
+    }
+
+    #[test]
+    fn independent_keys_have_separate_budgets() {
+        let sampler = CategorySampler::default();
+        let now = 1000_i64;
+        for _ in 0..DEFAULT_MAX_EVENTS {
+            sampler.allow("a", now);
+        }
+        assert!(!sampler.allow("a", now));
+        assert!(sampler.allow("b", now));
+    }
+
+    #[test]
+    fn eviction_under_key_pressure() {
+        let sampler = CategorySampler::new(10, 1_000, 2);
+        let now = 1000_i64;
+        assert!(sampler.allow("a", now));
+        assert!(sampler.allow("b", now));
+        // Third key triggers eviction — should still be accepted.
+        assert!(sampler.allow("c", now));
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts the generic fixed-window rate limiting logic from `MlsEventRateLimiter` into a reusable `CategorySampler` type at `crates/offline-protocol/src/telemetry/sampling.rs`
- `MlsEventRateLimiter` becomes a thin wrapper that maps MLS lifecycle events to string keys and delegates to `CategorySampler.allow()`
- Zero behavior change — all 974 workspace tests pass, clippy clean

## Context

Prep step for the unified telemetry system (TODO items 4–7). The upcoming `TelemetrySink` / `TelemetryRecord` work needs the same sampling logic for non-MLS event categories. Extracting now avoids copy-paste or coupling telemetry to MLS types.

## Changes

| File | Action |
|------|--------|
| `crates/offline-protocol/src/telemetry/mod.rs` | New — module root, re-exports `CategorySampler` |
| `crates/offline-protocol/src/telemetry/sampling.rs` | New — generic `CategorySampler` with 4 unit tests |
| `crates/offline-protocol/src/mls_observability.rs` | Modified — `MlsEventRateLimiter` wraps `CategorySampler` |
| `crates/offline-protocol/src/lib.rs` | Modified — added `pub mod telemetry` |

## Test plan

- [x] All 974 workspace tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `MlsEventRateLimiter` test rewritten to exercise `should_emit()` at the public API level
- [x] 4 new `CategorySampler` unit tests: budget exhaustion, window reset, independent keys, eviction under pressure