### PR TITLE
feat(protocol): introduce TelemetrySink and TelemetryRecord taxonomy

### DIFF
--- a/crates/offline-protocol/Cargo.toml
+++ b/crates/offline-protocol/Cargo.toml
@@ -29,7 +29,6 @@ sha2 = "0.10"
 [lib]
 
 [features]
-default = ["telemetry"]
+default = []
 mls-observability = []
-telemetry = []
 

--- a/crates/offline-protocol/Cargo.toml
+++ b/crates/offline-protocol/Cargo.toml
@@ -29,6 +29,7 @@ sha2 = "0.10"
 [lib]
 
 [features]
-default = []
+default = ["telemetry"]
 mls-observability = []
+telemetry = []
 

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -1552,6 +1552,71 @@ impl Event {
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }
+
+    /// Returns the stable `snake.dot.case` telemetry name for this event.
+    ///
+    /// Names are compatible with OpenTelemetry naming conventions and are
+    /// considered stable across minor versions of the SDK.
+    pub fn telemetry_name(&self) -> &'static str {
+        match self {
+            Self::MessageSent { .. } => "protocol.message.sent",
+            Self::MessageReceived { .. } => "protocol.message.received",
+            Self::MessageDelivered { .. } => "protocol.message.delivered",
+            Self::MessageFailed { .. } => "protocol.message.failed",
+            Self::MessageDecryptionFailed { .. } => "protocol.message.decryption_failed",
+            Self::TransportSwitched { .. } => "protocol.transport.switched",
+            Self::RelayPromoted { .. } => "protocol.relay.promoted",
+            Self::RelayDemoted { .. } => "protocol.relay.demoted",
+            Self::NeighborDiscovered { .. } => "protocol.neighbor.discovered",
+            Self::NeighborLost { .. } => "protocol.neighbor.lost",
+            Self::NetworkMetrics { .. } => "protocol.network.metrics",
+            Self::FileProgress { .. } => "protocol.file.progress",
+            Self::FileReceived { .. } => "protocol.file.received",
+            Self::MediaSent { .. } => "protocol.media.sent",
+            Self::MessageDeferred { .. } => "protocol.message.deferred",
+            Self::AckEvicted { .. } => "protocol.ack.evicted",
+            Self::FragmentAssemblyEvicted { .. } => "protocol.fragment.assembly_evicted",
+            Self::RelayDemotedBattery { .. } => "protocol.relay.demoted_battery",
+            Self::SecureSessionEstablished { .. } => "protocol.secure_session.established",
+            Self::SecureSessionFailed { .. } => "protocol.secure_session.failed",
+            Self::WelcomeSendAttempted { .. } => "protocol.welcome.send_attempted",
+            Self::WelcomeSendSucceeded { .. } => "protocol.welcome.send_succeeded",
+            Self::WelcomeSendFailed { .. } => "protocol.welcome.send_failed",
+            Self::WelcomeSendExpired { .. } => "protocol.welcome.send_expired",
+            Self::ConnectionRequestReceived { .. } => "protocol.connection.request_received",
+            Self::ConnectionAccepted { .. } => "protocol.connection.accepted",
+            Self::ConnectionRejected { .. } => "protocol.connection.rejected",
+            Self::ConnectionRequestCancelled { .. } => "protocol.connection.request_cancelled",
+            Self::GroupCreated { .. } => "protocol.group.created",
+            Self::GroupMessageReceived { .. } => "protocol.group.message_received",
+            Self::GroupMemberAdded { .. } => "protocol.group.member_added",
+            Self::GroupMemberRemoved { .. } => "protocol.group.member_removed",
+            Self::GroupInfo { .. } => "protocol.group.info",
+            Self::UserGroups { .. } => "protocol.group.user_groups",
+            Self::GroupError { .. } => "protocol.group.error",
+            Self::GroupMessageSent { .. } => "protocol.group.message_sent",
+            Self::GroupMessagePartialFailure { .. } => "protocol.group.message_partial_failure",
+            Self::GroupEpochForkDetected { .. } => "protocol.group.epoch_fork_detected",
+            Self::GroupEpochForkResolved { .. } => "protocol.group.epoch_fork_resolved",
+            Self::GroupRoleChanged { .. } => "protocol.group.role_changed",
+            Self::GroupRenamed { .. } => "protocol.group.renamed",
+            Self::ServiceDiscovered { .. } => "protocol.service.discovered",
+            Self::ServiceRequestReceived { .. } => "protocol.service.request_received",
+            Self::ServiceResponseReceived { .. } => "protocol.service.response_received",
+            Self::PresenceUpdated { .. } => "protocol.presence.updated",
+            Self::TypingIndicatorReceived { .. } => "protocol.typing.received",
+            Self::ReadReceiptReceived { .. } => "protocol.read_receipt.received",
+            Self::DorsScoreUpdated { .. } => "protocol.dors.score_updated",
+            Self::DorsTransportSelected { .. } => "protocol.dors.transport_selected",
+            Self::DorsTransportSwitched { .. } => "protocol.dors.transport_switched",
+            Self::DorsEscalationTriggered { .. } => "protocol.dors.escalation_triggered",
+            Self::SecurityWarning { .. } => "protocol.security.warning",
+            Self::MessageRelayed { .. } => "protocol.message.relayed",
+            Self::UserBlocked { .. } => "protocol.user.blocked",
+            Self::UserUnblocked { .. } => "protocol.user.unblocked",
+            Self::TofuReset { .. } => "protocol.tofu.reset",
+        }
+    }
 }
 
 impl From<ServiceEvent> for Event {

--- a/crates/offline-protocol/src/lib.rs
+++ b/crates/offline-protocol/src/lib.rs
@@ -55,3 +55,7 @@ pub use mls_observability::{
     DecryptionFailureKind, MlsErrorCategory, MlsEventEmitter, MlsLifecycleEvent,
     MlsOperationContext, NoopMlsEventEmitter,
 };
+pub use telemetry::{
+    DeviceCapabilitySnapshot, MetricsFrame, MlsVerbosity, NoopTelemetrySink, RoutingDecision,
+    Scrubber, TelemetryConfig, TelemetryRecord, TelemetrySink, TransportStateEvent,
+};

--- a/crates/offline-protocol/src/lib.rs
+++ b/crates/offline-protocol/src/lib.rs
@@ -56,6 +56,5 @@ pub use mls_observability::{
     MlsOperationContext, NoopMlsEventEmitter,
 };
 pub use telemetry::{
-    DeviceCapabilitySnapshot, MetricsFrame, MlsVerbosity, NoopTelemetrySink, RoutingDecision,
-    Scrubber, TelemetryConfig, TelemetryRecord, TelemetrySink, TransportStateEvent,
+    MlsVerbosity, NoopTelemetrySink, Scrubber, TelemetryConfig, TelemetryRecord, TelemetrySink,
 };

--- a/crates/offline-protocol/src/lib.rs
+++ b/crates/offline-protocol/src/lib.rs
@@ -56,5 +56,5 @@ pub use mls_observability::{
     MlsOperationContext, NoopMlsEventEmitter,
 };
 pub use telemetry::{
-    MlsVerbosity, NoopTelemetrySink, Scrubber, TelemetryConfig, TelemetryRecord, TelemetrySink,
+    MlsVerbosity, NoopTelemetrySink, TelemetryConfig, TelemetryRecord, TelemetrySink,
 };

--- a/crates/offline-protocol/src/mls_observability.rs
+++ b/crates/offline-protocol/src/mls_observability.rs
@@ -144,6 +144,22 @@ pub enum MlsLifecycleEvent {
     },
 }
 
+impl MlsLifecycleEvent {
+    /// Returns the stable `snake.dot.case` telemetry name for this event.
+    ///
+    /// Names are compatible with OpenTelemetry naming conventions and are
+    /// considered stable across minor versions of the SDK.
+    pub fn telemetry_name(&self) -> &'static str {
+        match self {
+            Self::Initialized { .. } => "mls.initialized",
+            Self::EncryptionUsed { .. } => "mls.encryption_used",
+            Self::DecryptionFailed { .. } => "mls.decryption_failed",
+            Self::SessionMissing { .. } => "mls.session_missing",
+            Self::SessionReady { .. } => "mls.session_ready",
+        }
+    }
+}
+
 /// Sink abstraction for MLS lifecycle events.
 pub trait MlsEventEmitter: Send + Sync {
     /// Emits a structured MLS lifecycle event.

--- a/crates/offline-protocol/src/mls_observability.rs
+++ b/crates/offline-protocol/src/mls_observability.rs
@@ -3,7 +3,6 @@
 use crate::telemetry::CategorySampler;
 use offline_protocol_mls::MlsError;
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 /// Operation context for MLS lifecycle events.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -214,20 +213,6 @@ pub fn timestamp_now_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()
 }
 
-/// Generates a stable opaque identifier for telemetry.
-pub fn opaque_id(raw: &str, secret: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(secret);
-    hasher.update(raw.as_bytes());
-    let digest = hasher.finalize();
-    let mut out = String::with_capacity(32);
-    for byte in &digest[..16] {
-        use std::fmt::Write as _;
-        let _ = write!(&mut out, "{:02x}", byte);
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -250,21 +235,6 @@ mod tests {
             DecryptionFailureKind::from_mls_error(&MlsError::VerificationFailed("sig".to_string())),
             DecryptionFailureKind::IdentityMismatch
         );
-    }
-
-    #[test]
-    fn opaque_id_is_stable_for_same_input() {
-        let secret = b"secret";
-        let first = opaque_id("peer:alice", secret);
-        let second = opaque_id("peer:alice", secret);
-        assert_eq!(first, second);
-    }
-
-    #[test]
-    fn opaque_id_changes_for_different_secret() {
-        let first = opaque_id("peer:alice", b"secret-a");
-        let second = opaque_id("peer:alice", b"secret-b");
-        assert_ne!(first, second);
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -122,9 +122,10 @@ pub struct OfflineProtocol {
     /// Scrubber for hashing long-lived pseudonymous identifiers (peer, group,
     /// session) into non-reversible opaque telemetry IDs. Holds the
     /// per-instance secret; constructed once at protocol creation and reused
-    /// by every MLS lifecycle emit site.
+    /// by every emit site. Today only the MLS observability path consumes it;
+    /// additional emit sites land alongside the wiring follow-up.
     #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
-    mls_observability_scrubber: Scrubber,
+    telemetry_scrubber: Scrubber,
 
     /// File transfer manager for chunking outbound and reassembling inbound media.
     file_transfer_manager: FileTransferManager,
@@ -229,7 +230,7 @@ impl OfflineProtocol {
             welcome_lifecycles: HashMap::new(),
             mls_event_emitter: Arc::new(NoopMlsEventEmitter),
             mls_event_rate_limiter: MlsEventRateLimiter::default(),
-            mls_observability_scrubber: Scrubber::new(true, *uuid::Uuid::new_v4().as_bytes()),
+            telemetry_scrubber: Scrubber::new(true, *uuid::Uuid::new_v4().as_bytes()),
             file_transfer_manager: FileTransferManager::new(),
             pending_media_metadata: HashMap::new(),
             outbound_media_transfers: HashMap::new(),

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -230,6 +230,13 @@ impl OfflineProtocol {
             welcome_lifecycles: HashMap::new(),
             mls_event_emitter: Arc::new(NoopMlsEventEmitter),
             mls_event_rate_limiter: MlsEventRateLimiter::default(),
+            // TODO(telemetry-wiring): replace with
+            // `Scrubber::from_config(&config.telemetry, <per-install fallback>)`
+            // once `ProtocolConfig` carries a `TelemetryConfig`. The hardcoded
+            // `true` preserves today's always-scrub MLS observability semantics;
+            // driving it from config is the single switch that activates the
+            // `with_scrub_ids(false)` opt-out path the Scrubber API already
+            // contracts (see `telemetry::scrubber::tests`).
             telemetry_scrubber: Scrubber::new(true, *uuid::Uuid::new_v4().as_bytes()),
             file_transfer_manager: FileTransferManager::new(),
             pending_media_metadata: HashMap::new(),

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use types::*;
 
 use crate::file_transfer::{FileTransferManager, OutboundTransferState};
 use crate::mls_observability::{MlsEventEmitter, MlsEventRateLimiter, NoopMlsEventEmitter};
+use crate::telemetry::Scrubber;
 use crate::{Error, EstablishmentState, Event, ProtocolConfig, Result, TransportManager};
 use chrono::{DateTime, Utc};
 use offline_protocol_core::{LamportClock, Message, MessageId};
@@ -118,9 +119,12 @@ pub struct OfflineProtocol {
     #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     mls_event_rate_limiter: MlsEventRateLimiter,
 
-    /// Per-instance secret used to derive non-reversible opaque telemetry IDs.
+    /// Scrubber for hashing long-lived pseudonymous identifiers (peer, group,
+    /// session) into non-reversible opaque telemetry IDs. Holds the
+    /// per-instance secret; constructed once at protocol creation and reused
+    /// by every MLS lifecycle emit site.
     #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
-    mls_observability_secret: [u8; 16],
+    mls_observability_scrubber: Scrubber,
 
     /// File transfer manager for chunking outbound and reassembling inbound media.
     file_transfer_manager: FileTransferManager,
@@ -225,7 +229,7 @@ impl OfflineProtocol {
             welcome_lifecycles: HashMap::new(),
             mls_event_emitter: Arc::new(NoopMlsEventEmitter),
             mls_event_rate_limiter: MlsEventRateLimiter::default(),
-            mls_observability_secret: *uuid::Uuid::new_v4().as_bytes(),
+            mls_observability_scrubber: Scrubber::new(true, *uuid::Uuid::new_v4().as_bytes()),
             file_transfer_manager: FileTransferManager::new(),
             pending_media_metadata: HashMap::new(),
             outbound_media_transfers: HashMap::new(),

--- a/crates/offline-protocol/src/protocol/observability.rs
+++ b/crates/offline-protocol/src/protocol/observability.rs
@@ -2,8 +2,10 @@
 
 use super::OfflineProtocol;
 #[cfg(feature = "mls-observability")]
-use crate::mls_observability::{opaque_id, timestamp_now_ms, MlsLifecycleEvent};
+use crate::mls_observability::{timestamp_now_ms, MlsLifecycleEvent};
 use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsOperationContext};
+#[cfg(feature = "mls-observability")]
+use crate::telemetry::scrubber::opaque_id;
 
 impl OfflineProtocol {
     #[cfg(feature = "mls-observability")]

--- a/crates/offline-protocol/src/protocol/observability.rs
+++ b/crates/offline-protocol/src/protocol/observability.rs
@@ -4,8 +4,6 @@ use super::OfflineProtocol;
 #[cfg(feature = "mls-observability")]
 use crate::mls_observability::{timestamp_now_ms, MlsLifecycleEvent};
 use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsOperationContext};
-#[cfg(feature = "mls-observability")]
-use crate::telemetry::scrubber::opaque_id;
 
 impl OfflineProtocol {
     #[cfg(feature = "mls-observability")]
@@ -19,7 +17,7 @@ impl OfflineProtocol {
             peer_id.unwrap_or("none"),
             group_id.unwrap_or("none")
         );
-        opaque_id(&seed, &self.mls_observability_secret)
+        self.mls_observability_scrubber.hash_id(&seed).into_owned()
     }
 
     #[cfg(feature = "mls-observability")]
@@ -46,7 +44,10 @@ impl OfflineProtocol {
 
     #[cfg(feature = "mls-observability")]
     pub(super) fn emit_mls_encryption_used(&self, recipient: &str) {
-        let peer_id = opaque_id(recipient, &self.mls_observability_secret);
+        let peer_id = self
+            .mls_observability_scrubber
+            .hash_id(recipient)
+            .into_owned();
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::EncryptionUsed {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(Some(recipient), None),
@@ -71,8 +72,8 @@ impl OfflineProtocol {
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::SessionMissing {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(peer_id, group_id),
-            group_id: group_id.map(|id| opaque_id(id, &self.mls_observability_secret)),
-            peer_id: peer_id.map(|id| opaque_id(id, &self.mls_observability_secret)),
+            group_id: group_id.map(|id| self.mls_observability_scrubber.hash_id(id).into_owned()),
+            peer_id: peer_id.map(|id| self.mls_observability_scrubber.hash_id(id).into_owned()),
             context,
             error_category: Some(error_category),
         });
@@ -99,8 +100,12 @@ impl OfflineProtocol {
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::DecryptionFailed {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(Some(sender_id), group_id),
-            group_id: group_id.map(|id| opaque_id(id, &self.mls_observability_secret)),
-            peer_id: Some(opaque_id(sender_id, &self.mls_observability_secret)),
+            group_id: group_id.map(|id| self.mls_observability_scrubber.hash_id(id).into_owned()),
+            peer_id: Some(
+                self.mls_observability_scrubber
+                    .hash_id(sender_id)
+                    .into_owned(),
+            ),
             context,
             error_category: Some(kind.error_category()),
             failure_kind: kind,
@@ -127,8 +132,16 @@ impl OfflineProtocol {
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::SessionReady {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(Some(peer_id), Some(group_id)),
-            group_id: Some(opaque_id(group_id, &self.mls_observability_secret)),
-            peer_id: Some(opaque_id(peer_id, &self.mls_observability_secret)),
+            group_id: Some(
+                self.mls_observability_scrubber
+                    .hash_id(group_id)
+                    .into_owned(),
+            ),
+            peer_id: Some(
+                self.mls_observability_scrubber
+                    .hash_id(peer_id)
+                    .into_owned(),
+            ),
             context,
             error_category: None,
         });

--- a/crates/offline-protocol/src/protocol/observability.rs
+++ b/crates/offline-protocol/src/protocol/observability.rs
@@ -17,7 +17,11 @@ impl OfflineProtocol {
             peer_id.unwrap_or("none"),
             group_id.unwrap_or("none")
         );
-        self.mls_observability_scrubber.hash_id(&seed).into_owned()
+        // `hash_always` (not `hash_id`): the seed couples raw peer+group IDs,
+        // so emitting it unhashed would leak strictly more than the sum of
+        // its parts. Session IDs are a derived correlation token and MUST be
+        // obfuscated regardless of the user's `scrub_ids` preference.
+        self.mls_observability_scrubber.hash_always(&seed)
     }
 
     #[cfg(feature = "mls-observability")]

--- a/crates/offline-protocol/src/protocol/observability.rs
+++ b/crates/offline-protocol/src/protocol/observability.rs
@@ -21,7 +21,7 @@ impl OfflineProtocol {
         // so emitting it unhashed would leak strictly more than the sum of
         // its parts. Session IDs are a derived correlation token and MUST be
         // obfuscated regardless of the user's `scrub_ids` preference.
-        self.mls_observability_scrubber.hash_always(&seed)
+        self.telemetry_scrubber.hash_always(&seed)
     }
 
     #[cfg(feature = "mls-observability")]
@@ -48,10 +48,7 @@ impl OfflineProtocol {
 
     #[cfg(feature = "mls-observability")]
     pub(super) fn emit_mls_encryption_used(&self, recipient: &str) {
-        let peer_id = self
-            .mls_observability_scrubber
-            .hash_id(recipient)
-            .into_owned();
+        let peer_id = self.telemetry_scrubber.hash_id(recipient).into_owned();
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::EncryptionUsed {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(Some(recipient), None),
@@ -76,8 +73,8 @@ impl OfflineProtocol {
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::SessionMissing {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(peer_id, group_id),
-            group_id: group_id.map(|id| self.mls_observability_scrubber.hash_id(id).into_owned()),
-            peer_id: peer_id.map(|id| self.mls_observability_scrubber.hash_id(id).into_owned()),
+            group_id: group_id.map(|id| self.telemetry_scrubber.hash_id(id).into_owned()),
+            peer_id: peer_id.map(|id| self.telemetry_scrubber.hash_id(id).into_owned()),
             context,
             error_category: Some(error_category),
         });
@@ -104,12 +101,8 @@ impl OfflineProtocol {
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::DecryptionFailed {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(Some(sender_id), group_id),
-            group_id: group_id.map(|id| self.mls_observability_scrubber.hash_id(id).into_owned()),
-            peer_id: Some(
-                self.mls_observability_scrubber
-                    .hash_id(sender_id)
-                    .into_owned(),
-            ),
+            group_id: group_id.map(|id| self.telemetry_scrubber.hash_id(id).into_owned()),
+            peer_id: Some(self.telemetry_scrubber.hash_id(sender_id).into_owned()),
             context,
             error_category: Some(kind.error_category()),
             failure_kind: kind,
@@ -136,16 +129,8 @@ impl OfflineProtocol {
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::SessionReady {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(Some(peer_id), Some(group_id)),
-            group_id: Some(
-                self.mls_observability_scrubber
-                    .hash_id(group_id)
-                    .into_owned(),
-            ),
-            peer_id: Some(
-                self.mls_observability_scrubber
-                    .hash_id(peer_id)
-                    .into_owned(),
-            ),
+            group_id: Some(self.telemetry_scrubber.hash_id(group_id).into_owned()),
+            peer_id: Some(self.telemetry_scrubber.hash_id(peer_id).into_owned()),
             context,
             error_category: None,
         });

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -22,6 +22,11 @@ pub enum MlsVerbosity {
     /// Emit the standard lifecycle stream (initialization, session ready,
     /// decryption failures, etc.) — matches the legacy `mls-observability`
     /// feature-enabled behavior.
+    ///
+    /// No-op until emission wiring lands: in this release, MLS emit paths
+    /// remain gated by the compile-time `mls-observability` feature, so
+    /// setting this knob (or `Off`/`Diagnostic`) does not yet change what
+    /// the SDK actually emits.
     #[default]
     Lifecycle,
     /// Emit the full lifecycle stream plus additional per-operation
@@ -104,13 +109,11 @@ impl TelemetryConfig {
     ///
     /// Supplying `Some(secret)` enables cross-session correlation of the
     /// same peer in backend telemetry; supplying `None` (the default)
-    /// leaves the secret unset in the config, and downstream construction
-    /// of a [`crate::telemetry::Scrubber`] falls back to the per-instance
-    /// secret passed as [`crate::telemetry::Scrubber::from_config`]'s
-    /// `fallback_secret` argument. Install-time generation of a random
-    /// per-instance secret inside the protocol engine lands with the
-    /// emission-wiring follow-up; until then, callers that construct a
-    /// `Scrubber` directly must supply the fallback themselves.
+    /// leaves the secret unset in the config, and the SDK falls back to a
+    /// random per-instance secret derived at protocol construction.
+    /// Install-time generation of a stable, per-install secret (so
+    /// correlation survives process restarts) lands with the emission-
+    /// wiring follow-up.
     ///
     /// **Do not share the secret across tenants, and do not rotate it
     /// mid-run** — rotation invalidates every previously emitted opaque
@@ -136,7 +139,15 @@ impl TelemetryConfig {
     }
 
     /// Returns the configured opaque-identifier hashing secret, if any.
-    pub fn scrub_secret(&self) -> Option<[u8; 16]> {
+    ///
+    /// Crate-private: the secret feeds `Scrubber` construction and is not
+    /// part of the external reader surface — the Debug redaction on this
+    /// struct would otherwise be defeated by a public byte-level accessor.
+    ///
+    /// Currently only consumed by `Scrubber::from_config` (scaffolding for
+    /// the emission-wiring follow-up).
+    #[allow(dead_code)]
+    pub(crate) fn scrub_secret(&self) -> Option<[u8; 16]> {
         self.scrub_secret
     }
 }

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -104,9 +104,16 @@ impl TelemetryConfig {
     ///
     /// Supplying `Some(secret)` enables cross-session correlation of the
     /// same peer in backend telemetry; supplying `None` (the default)
-    /// causes the SDK to generate a random per-instance secret at install
-    /// time. **Do not share the secret across tenants, and do not rotate
-    /// it mid-run** — rotation invalidates every previously emitted opaque
+    /// leaves the secret unset in the config, and downstream construction
+    /// of a [`crate::telemetry::Scrubber`] falls back to the per-instance
+    /// secret passed as [`crate::telemetry::Scrubber::from_config`]'s
+    /// `fallback_secret` argument. Install-time generation of a random
+    /// per-instance secret inside the protocol engine lands with the
+    /// emission-wiring follow-up; until then, callers that construct a
+    /// `Scrubber` directly must supply the fallback themselves.
+    ///
+    /// **Do not share the secret across tenants, and do not rotate it
+    /// mid-run** — rotation invalidates every previously emitted opaque
     /// identifier and breaks correlation on the receiving side.
     pub fn with_scrub_secret(mut self, secret: Option<[u8; 16]>) -> Self {
         self.scrub_secret = secret;

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -1,0 +1,119 @@
+//! Runtime telemetry configuration.
+//!
+//! [`TelemetryConfig`] carries the knobs consumed by the emit paths wired in
+//! follow-up work. The struct is `#[non_exhaustive]` so new knobs can be added
+//! without a breaking-change bump; construct via [`TelemetryConfig::default`]
+//! and the `with_*` builder methods.
+
+/// Verbosity tier for MLS lifecycle telemetry.
+///
+/// Replaces the compile-time `mls-observability` feature flag with a runtime
+/// knob. The SDK emits MLS events at or below the configured tier; apps that
+/// want zero MLS telemetry install `Off`, apps that want the existing
+/// production-grade stream install `Lifecycle`, and apps that want verbose
+/// diagnostic output install `Diagnostic`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum MlsVerbosity {
+    /// Suppress all MLS lifecycle telemetry.
+    Off,
+    /// Emit the standard lifecycle stream (initialization, session ready,
+    /// decryption failures, etc.) — matches the legacy `mls-observability`
+    /// feature-enabled behavior.
+    #[default]
+    Lifecycle,
+    /// Emit the full lifecycle stream plus additional per-operation
+    /// diagnostics intended for local debugging.
+    Diagnostic,
+}
+
+/// Runtime configuration for the telemetry subsystem.
+///
+/// Constructed via [`TelemetryConfig::default`] (which locks in the
+/// privacy-preserving defaults) and refined with the `with_*` builder
+/// methods. The struct is `#[non_exhaustive]` to preserve room for future
+/// knobs; downstream crates must not construct it with struct-literal syntax.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct TelemetryConfig {
+    /// When `true`, long-lived pseudonymous identifiers (`peer_id`, `user_id`,
+    /// `app_id`, `group_id`) are hashed before crossing the telemetry sink
+    /// boundary. Defaults to `true` — third-party sinks (analytics, crash
+    /// reporters) must not receive raw identifiers by default.
+    pub scrub_ids: bool,
+    /// Verbosity tier for MLS lifecycle telemetry.
+    pub mls_verbosity: MlsVerbosity,
+    /// Cadence in milliseconds for periodic `MetricsSnapshot` emission. `None`
+    /// disables periodic emission entirely (apps fall back to pull-based
+    /// access via `TransportManager::metrics()`).
+    pub metrics_cadence_ms: Option<u64>,
+    /// Optional caller-supplied secret for opaque identifier hashing. When
+    /// `None`, the SDK generates a random per-instance secret at install time.
+    /// Supplying a stable secret enables cross-session correlation of the
+    /// same peer in backend telemetry — do not share the secret across
+    /// tenants.
+    pub scrub_secret: Option<[u8; 16]>,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            scrub_ids: true,
+            mls_verbosity: MlsVerbosity::Lifecycle,
+            metrics_cadence_ms: Some(5_000),
+            scrub_secret: None,
+        }
+    }
+}
+
+impl TelemetryConfig {
+    /// Sets the identifier-scrubbing flag.
+    pub fn with_scrub_ids(mut self, scrub_ids: bool) -> Self {
+        self.scrub_ids = scrub_ids;
+        self
+    }
+
+    /// Sets the MLS lifecycle verbosity tier.
+    pub fn with_mls_verbosity(mut self, mls_verbosity: MlsVerbosity) -> Self {
+        self.mls_verbosity = mls_verbosity;
+        self
+    }
+
+    /// Sets the periodic metrics-snapshot cadence.
+    pub fn with_metrics_cadence_ms(mut self, cadence_ms: Option<u64>) -> Self {
+        self.metrics_cadence_ms = cadence_ms;
+        self
+    }
+
+    /// Sets the opaque-identifier hashing secret.
+    pub fn with_scrub_secret(mut self, secret: Option<[u8; 16]>) -> Self {
+        self.scrub_secret = secret;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_locks_in_privacy_preserving_knobs() {
+        let cfg = TelemetryConfig::default();
+        assert!(cfg.scrub_ids);
+        assert_eq!(cfg.mls_verbosity, MlsVerbosity::Lifecycle);
+        assert_eq!(cfg.metrics_cadence_ms, Some(5_000));
+        assert!(cfg.scrub_secret.is_none());
+    }
+
+    #[test]
+    fn builders_override_defaults() {
+        let cfg = TelemetryConfig::default()
+            .with_scrub_ids(false)
+            .with_mls_verbosity(MlsVerbosity::Off)
+            .with_metrics_cadence_ms(None)
+            .with_scrub_secret(Some([7; 16]));
+        assert!(!cfg.scrub_ids);
+        assert_eq!(cfg.mls_verbosity, MlsVerbosity::Off);
+        assert!(cfg.metrics_cadence_ms.is_none());
+        assert_eq!(cfg.scrub_secret, Some([7; 16]));
+    }
+}

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -6,6 +6,7 @@
 //! and the `with_*` builder methods.
 
 use std::fmt;
+use std::time::Duration;
 
 /// Verbosity tier for MLS lifecycle telemetry.
 ///
@@ -32,28 +33,20 @@ pub enum MlsVerbosity {
 ///
 /// Constructed via [`TelemetryConfig::default`] (which locks in the
 /// privacy-preserving defaults) and refined with the `with_*` builder
-/// methods. The struct is `#[non_exhaustive]` to preserve room for future
-/// knobs; downstream crates must not construct it with struct-literal syntax.
+/// methods. Fields are crate-private; read them through the accessor
+/// methods and mutate them through the builder methods — this keeps a
+/// single idiom for configuration and prevents mid-run mutation of
+/// identity-correlation parameters like the scrub secret (which would
+/// invalidate every previously emitted opaque identifier).
+///
+/// The struct is `#[non_exhaustive]` to preserve room for future knobs.
 #[non_exhaustive]
 #[derive(Clone)]
 pub struct TelemetryConfig {
-    /// When `true`, long-lived pseudonymous identifiers (`peer_id`, `user_id`,
-    /// `app_id`, `group_id`) are hashed before crossing the telemetry sink
-    /// boundary. Defaults to `true` — third-party sinks (analytics, crash
-    /// reporters) must not receive raw identifiers by default.
-    pub scrub_ids: bool,
-    /// Verbosity tier for MLS lifecycle telemetry.
-    pub mls_verbosity: MlsVerbosity,
-    /// Cadence in milliseconds for periodic `MetricsSnapshot` emission. `None`
-    /// disables periodic emission entirely (apps fall back to pull-based
-    /// access via `TransportManager::metrics()`).
-    pub metrics_cadence_ms: Option<u64>,
-    /// Optional caller-supplied secret for opaque identifier hashing. When
-    /// `None`, the SDK generates a random per-instance secret at install time.
-    /// Supplying a stable secret enables cross-session correlation of the
-    /// same peer in backend telemetry — do not share the secret across
-    /// tenants.
-    pub scrub_secret: Option<[u8; 16]>,
+    pub(crate) scrub_ids: bool,
+    pub(crate) mls_verbosity: MlsVerbosity,
+    pub(crate) metrics_cadence: Option<Duration>,
+    pub(crate) scrub_secret: Option<[u8; 16]>,
 }
 
 impl fmt::Debug for TelemetryConfig {
@@ -61,7 +54,7 @@ impl fmt::Debug for TelemetryConfig {
         f.debug_struct("TelemetryConfig")
             .field("scrub_ids", &self.scrub_ids)
             .field("mls_verbosity", &self.mls_verbosity)
-            .field("metrics_cadence_ms", &self.metrics_cadence_ms)
+            .field("metrics_cadence", &self.metrics_cadence)
             .field(
                 "scrub_secret",
                 &self.scrub_secret.as_ref().map(|_| "<redacted>"),
@@ -75,7 +68,7 @@ impl Default for TelemetryConfig {
         Self {
             scrub_ids: true,
             mls_verbosity: MlsVerbosity::Lifecycle,
-            metrics_cadence_ms: Some(5_000),
+            metrics_cadence: Some(Duration::from_secs(5)),
             scrub_secret: None,
         }
     }
@@ -83,6 +76,11 @@ impl Default for TelemetryConfig {
 
 impl TelemetryConfig {
     /// Sets the identifier-scrubbing flag.
+    ///
+    /// When `true` (the default), long-lived pseudonymous identifiers
+    /// (`peer_id`, `user_id`, `app_id`, `group_id`) are hashed before
+    /// crossing the telemetry sink boundary — third-party sinks (analytics,
+    /// crash reporters) must not receive raw identifiers by default.
     pub fn with_scrub_ids(mut self, scrub_ids: bool) -> Self {
         self.scrub_ids = scrub_ids;
         self
@@ -94,16 +92,45 @@ impl TelemetryConfig {
         self
     }
 
-    /// Sets the periodic metrics-snapshot cadence.
-    pub fn with_metrics_cadence_ms(mut self, cadence_ms: Option<u64>) -> Self {
-        self.metrics_cadence_ms = cadence_ms;
+    /// Sets the cadence for periodic `MetricsSnapshot` emission. `None`
+    /// disables periodic emission entirely (apps fall back to pull-based
+    /// access via `TransportManager::metrics()`).
+    pub fn with_metrics_cadence(mut self, cadence: Option<Duration>) -> Self {
+        self.metrics_cadence = cadence;
         self
     }
 
     /// Sets the opaque-identifier hashing secret.
+    ///
+    /// Supplying `Some(secret)` enables cross-session correlation of the
+    /// same peer in backend telemetry; supplying `None` (the default)
+    /// causes the SDK to generate a random per-instance secret at install
+    /// time. **Do not share the secret across tenants, and do not rotate
+    /// it mid-run** — rotation invalidates every previously emitted opaque
+    /// identifier and breaks correlation on the receiving side.
     pub fn with_scrub_secret(mut self, secret: Option<[u8; 16]>) -> Self {
         self.scrub_secret = secret;
         self
+    }
+
+    /// Returns whether identifier scrubbing is enabled.
+    pub fn scrub_ids(&self) -> bool {
+        self.scrub_ids
+    }
+
+    /// Returns the configured MLS lifecycle verbosity tier.
+    pub fn mls_verbosity(&self) -> MlsVerbosity {
+        self.mls_verbosity
+    }
+
+    /// Returns the configured periodic metrics-snapshot cadence.
+    pub fn metrics_cadence(&self) -> Option<Duration> {
+        self.metrics_cadence
+    }
+
+    /// Returns the configured opaque-identifier hashing secret, if any.
+    pub fn scrub_secret(&self) -> Option<[u8; 16]> {
+        self.scrub_secret
     }
 }
 
@@ -114,10 +141,10 @@ mod tests {
     #[test]
     fn default_locks_in_privacy_preserving_knobs() {
         let cfg = TelemetryConfig::default();
-        assert!(cfg.scrub_ids);
-        assert_eq!(cfg.mls_verbosity, MlsVerbosity::Lifecycle);
-        assert_eq!(cfg.metrics_cadence_ms, Some(5_000));
-        assert!(cfg.scrub_secret.is_none());
+        assert!(cfg.scrub_ids());
+        assert_eq!(cfg.mls_verbosity(), MlsVerbosity::Lifecycle);
+        assert_eq!(cfg.metrics_cadence(), Some(Duration::from_secs(5)));
+        assert!(cfg.scrub_secret().is_none());
     }
 
     #[test]
@@ -125,12 +152,18 @@ mod tests {
         let cfg = TelemetryConfig::default()
             .with_scrub_ids(false)
             .with_mls_verbosity(MlsVerbosity::Off)
-            .with_metrics_cadence_ms(None)
+            .with_metrics_cadence(None)
             .with_scrub_secret(Some([7; 16]));
-        assert!(!cfg.scrub_ids);
-        assert_eq!(cfg.mls_verbosity, MlsVerbosity::Off);
-        assert!(cfg.metrics_cadence_ms.is_none());
-        assert_eq!(cfg.scrub_secret, Some([7; 16]));
+        assert!(!cfg.scrub_ids());
+        assert_eq!(cfg.mls_verbosity(), MlsVerbosity::Off);
+        assert!(cfg.metrics_cadence().is_none());
+        assert_eq!(cfg.scrub_secret(), Some([7; 16]));
+    }
+
+    #[test]
+    fn metrics_cadence_is_typed_duration() {
+        let cfg = TelemetryConfig::default().with_metrics_cadence(Some(Duration::from_millis(250)));
+        assert_eq!(cfg.metrics_cadence(), Some(Duration::from_millis(250)));
     }
 
     #[test]

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -5,6 +5,8 @@
 //! without a breaking-change bump; construct via [`TelemetryConfig::default`]
 //! and the `with_*` builder methods.
 
+use std::fmt;
+
 /// Verbosity tier for MLS lifecycle telemetry.
 ///
 /// Replaces the compile-time `mls-observability` feature flag with a runtime
@@ -33,7 +35,7 @@ pub enum MlsVerbosity {
 /// methods. The struct is `#[non_exhaustive]` to preserve room for future
 /// knobs; downstream crates must not construct it with struct-literal syntax.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct TelemetryConfig {
     /// When `true`, long-lived pseudonymous identifiers (`peer_id`, `user_id`,
     /// `app_id`, `group_id`) are hashed before crossing the telemetry sink
@@ -52,6 +54,20 @@ pub struct TelemetryConfig {
     /// same peer in backend telemetry — do not share the secret across
     /// tenants.
     pub scrub_secret: Option<[u8; 16]>,
+}
+
+impl fmt::Debug for TelemetryConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TelemetryConfig")
+            .field("scrub_ids", &self.scrub_ids)
+            .field("mls_verbosity", &self.mls_verbosity)
+            .field("metrics_cadence_ms", &self.metrics_cadence_ms)
+            .field(
+                "scrub_secret",
+                &self.scrub_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 impl Default for TelemetryConfig {
@@ -115,5 +131,26 @@ mod tests {
         assert_eq!(cfg.mls_verbosity, MlsVerbosity::Off);
         assert!(cfg.metrics_cadence_ms.is_none());
         assert_eq!(cfg.scrub_secret, Some([7; 16]));
+    }
+
+    #[test]
+    fn debug_redacts_scrub_secret() {
+        let cfg = TelemetryConfig::default().with_scrub_secret(Some([0xAB; 16]));
+        let rendered = format!("{cfg:?}");
+        assert!(
+            rendered.contains("<redacted>"),
+            "expected redaction marker, got {rendered}"
+        );
+        assert!(
+            !rendered.contains("ab, ab") && !rendered.contains("171, 171"),
+            "scrub_secret bytes leaked into Debug output: {rendered}"
+        );
+    }
+
+    #[test]
+    fn debug_shows_none_when_no_secret() {
+        let cfg = TelemetryConfig::default();
+        let rendered = format!("{cfg:?}");
+        assert!(rendered.contains("scrub_secret: None"), "got {rendered}");
     }
 }

--- a/crates/offline-protocol/src/telemetry/mod.rs
+++ b/crates/offline-protocol/src/telemetry/mod.rs
@@ -1,5 +1,27 @@
 //! Telemetry primitives for the Offline Protocol SDK.
+//!
+//! This module is the unified observer surface for everything the SDK emits:
+//! protocol events, MLS lifecycle events, transport-state transitions,
+//! periodic metrics snapshots, routing decisions, and device-capability
+//! snapshots all flow as [`TelemetryRecord`] values through a single
+//! [`TelemetrySink`].
+//!
+//! This PR ships the types only — emit-path wiring, the `install_*` entry
+//! point on the protocol engine, and FFI bridging land in follow-up work.
+//! The `telemetry` cargo feature is present (default-on) but does not yet
+//! gate any code paths; it is reserved for future compile-time control of
+//! emit hot-paths.
 
+pub mod config;
+pub mod record;
 pub mod sampling;
+pub mod scrubber;
+pub mod sink;
 
+pub use config::{MlsVerbosity, TelemetryConfig};
+pub use record::{
+    DeviceCapabilitySnapshot, MetricsFrame, RoutingDecision, TelemetryRecord, TransportStateEvent,
+};
 pub use sampling::CategorySampler;
+pub use scrubber::Scrubber;
+pub use sink::{NoopTelemetrySink, TelemetrySink};

--- a/crates/offline-protocol/src/telemetry/mod.rs
+++ b/crates/offline-protocol/src/telemetry/mod.rs
@@ -1,16 +1,13 @@
 //! Telemetry primitives for the Offline Protocol SDK.
 //!
 //! This module is the unified observer surface for everything the SDK emits:
-//! protocol events, MLS lifecycle events, transport-state transitions,
-//! periodic metrics snapshots, routing decisions, and device-capability
-//! snapshots all flow as [`TelemetryRecord`] values through a single
-//! [`TelemetrySink`].
+//! protocol events and MLS lifecycle events flow as [`TelemetryRecord`]
+//! values through a single [`TelemetrySink`]. Additional categories
+//! (transport state, metrics snapshots, routing decisions, device-capability
+//! snapshots) are introduced alongside the emit sites that populate them.
 //!
-//! This PR ships the types only — emit-path wiring, the `install_*` entry
-//! point on the protocol engine, and FFI bridging land in follow-up work.
-//! The `telemetry` cargo feature is present (default-on) but does not yet
-//! gate any code paths; it is reserved for future compile-time control of
-//! emit hot-paths.
+//! This PR ships the types only — emit-path wiring and the `install_*` entry
+//! point on the protocol engine land in follow-up work.
 
 pub mod config;
 pub mod record;
@@ -19,9 +16,7 @@ pub mod scrubber;
 pub mod sink;
 
 pub use config::{MlsVerbosity, TelemetryConfig};
-pub use record::{
-    DeviceCapabilitySnapshot, MetricsFrame, RoutingDecision, TelemetryRecord, TransportStateEvent,
-};
+pub use record::TelemetryRecord;
 pub use sampling::CategorySampler;
 pub use scrubber::Scrubber;
 pub use sink::{NoopTelemetrySink, TelemetrySink};

--- a/crates/offline-protocol/src/telemetry/mod.rs
+++ b/crates/offline-protocol/src/telemetry/mod.rs
@@ -12,7 +12,7 @@
 pub mod config;
 pub mod record;
 pub mod sampling;
-pub mod scrubber;
+pub(crate) mod scrubber;
 pub mod sink;
 
 pub use config::{MlsVerbosity, TelemetryConfig};

--- a/crates/offline-protocol/src/telemetry/mod.rs
+++ b/crates/offline-protocol/src/telemetry/mod.rs
@@ -18,5 +18,5 @@ pub mod sink;
 pub use config::{MlsVerbosity, TelemetryConfig};
 pub use record::TelemetryRecord;
 pub use sampling::CategorySampler;
-pub use scrubber::Scrubber;
+pub(crate) use scrubber::Scrubber;
 pub use sink::{NoopTelemetrySink, TelemetrySink};

--- a/crates/offline-protocol/src/telemetry/record.rs
+++ b/crates/offline-protocol/src/telemetry/record.rs
@@ -1,19 +1,19 @@
 //! Unified telemetry record taxonomy.
 //!
-//! [`TelemetryRecord`] is the single typed surface that every SDK event,
-//! metric, and lifecycle signal flows through. Two variants wrap existing
-//! types in place (`Protocol` wraps [`crate::events::Event`], `Mls` wraps
-//! [`crate::mls_observability::MlsLifecycleEvent`]); the remaining four are
-//! placeholder carriers whose fields are filled in by follow-up work
+//! [`TelemetryRecord`] is the single typed surface that every SDK event and
+//! lifecycle signal flows through. Today it carries `Protocol` (wrapping
+//! [`crate::events::Event`]) and `Mls` (wrapping
+//! [`crate::mls_observability::MlsLifecycleEvent`]); additional variants
 //! (periodic metrics snapshots, transport state transitions, routing
-//! decisions, device-capability snapshots).
+//! decisions, device-capability snapshots) are introduced alongside the emit
+//! sites that populate them in follow-up work.
 //!
 //! The enum is `#[non_exhaustive]` so new categories can be added without a
-//! major-version bump. Inner placeholder structs are also `#[non_exhaustive]`
-//! and expose `pub fn new(...)` constructors — additive field growth in
-//! follow-up items is non-breaking for third-party consumers.
-
-use serde::Serialize;
+//! major-version bump. The record intentionally does not derive `Serialize`:
+//! [`TelemetryRecord::name`] is the canonical wire identity, and sinks that
+//! need on-the-wire serialization serialize the inner typed payload
+//! (`Event`/`MlsLifecycleEvent`) directly — this avoids maintaining two
+//! parallel naming schemes.
 
 use crate::events::Event;
 use crate::mls_observability::MlsLifecycleEvent;
@@ -21,13 +21,11 @@ use crate::mls_observability::MlsLifecycleEvent;
 /// A single typed telemetry emission.
 ///
 /// Every record corresponds to exactly one `snake.dot.case` name returned by
-/// [`TelemetryRecord::name`]. Category-level names are used for the
-/// placeholder variants (`transport.state.changed`, `metrics.snapshot`,
-/// `routing.decision`, `device.capability.snapshot`); the `Protocol` and
-/// `Mls` variants map each sub-variant to a distinct dotted name.
+/// [`TelemetryRecord::name`]. The name is delegated to the inner payload's
+/// `telemetry_name()` method so there is a single source of truth for variant
+/// naming.
 #[non_exhaustive]
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone)]
 pub enum TelemetryRecord {
     /// A protocol-level event — wraps the existing [`Event`] type.
     ///
@@ -38,178 +36,18 @@ pub enum TelemetryRecord {
     Protocol(Box<Event>),
     /// An MLS lifecycle event — wraps the existing [`MlsLifecycleEvent`].
     Mls(MlsLifecycleEvent),
-    /// A transport status transition (connect, disconnect, error, etc.).
-    TransportState(TransportStateEvent),
-    /// A periodic snapshot of aggregated metrics.
-    MetricsSnapshot(MetricsFrame),
-    /// A routing decision emitted by DORS / PathSelector / RelayManager.
-    Routing(RoutingDecision),
-    /// A device-capability change (battery, charging, advertised services).
-    Device(DeviceCapabilitySnapshot),
 }
 
 impl TelemetryRecord {
     /// Returns the stable `snake.dot.case` name for this record.
     ///
-    /// Names are intended to be compatible with OpenTelemetry's naming
-    /// conventions and are stable across minor versions of the SDK. For the
-    /// `Protocol` and `Mls` variants the name is derived from the nested
-    /// sub-variant; for the placeholder variants the category-level name is
-    /// returned until follow-up work introduces sub-types.
+    /// Names are compatible with OpenTelemetry naming conventions and are
+    /// considered stable across minor versions of the SDK.
     pub fn name(&self) -> &'static str {
         match self {
-            TelemetryRecord::Protocol(event) => protocol_event_name(event.as_ref()),
-            TelemetryRecord::Mls(event) => mls_lifecycle_event_name(event),
-            TelemetryRecord::TransportState(_) => "transport.state.changed",
-            TelemetryRecord::MetricsSnapshot(_) => "metrics.snapshot",
-            TelemetryRecord::Routing(_) => "routing.decision",
-            TelemetryRecord::Device(_) => "device.capability.snapshot",
+            TelemetryRecord::Protocol(event) => event.telemetry_name(),
+            TelemetryRecord::Mls(event) => event.telemetry_name(),
         }
-    }
-}
-
-fn protocol_event_name(event: &Event) -> &'static str {
-    match event {
-        Event::MessageSent { .. } => "protocol.message.sent",
-        Event::MessageReceived { .. } => "protocol.message.received",
-        Event::MessageDelivered { .. } => "protocol.message.delivered",
-        Event::MessageFailed { .. } => "protocol.message.failed",
-        Event::MessageDecryptionFailed { .. } => "protocol.message.decryption_failed",
-        Event::TransportSwitched { .. } => "protocol.transport.switched",
-        Event::RelayPromoted { .. } => "protocol.relay.promoted",
-        Event::RelayDemoted { .. } => "protocol.relay.demoted",
-        Event::NeighborDiscovered { .. } => "protocol.neighbor.discovered",
-        Event::NeighborLost { .. } => "protocol.neighbor.lost",
-        Event::NetworkMetrics { .. } => "protocol.network.metrics",
-        Event::FileProgress { .. } => "protocol.file.progress",
-        Event::FileReceived { .. } => "protocol.file.received",
-        Event::MediaSent { .. } => "protocol.media.sent",
-        Event::MessageDeferred { .. } => "protocol.message.deferred",
-        Event::AckEvicted { .. } => "protocol.ack.evicted",
-        Event::FragmentAssemblyEvicted { .. } => "protocol.fragment.assembly_evicted",
-        Event::RelayDemotedBattery { .. } => "protocol.relay.demoted_battery",
-        Event::SecureSessionEstablished { .. } => "protocol.secure_session.established",
-        Event::SecureSessionFailed { .. } => "protocol.secure_session.failed",
-        Event::WelcomeSendAttempted { .. } => "protocol.welcome.send_attempted",
-        Event::WelcomeSendSucceeded { .. } => "protocol.welcome.send_succeeded",
-        Event::WelcomeSendFailed { .. } => "protocol.welcome.send_failed",
-        Event::WelcomeSendExpired { .. } => "protocol.welcome.send_expired",
-        Event::ConnectionRequestReceived { .. } => "protocol.connection.request_received",
-        Event::ConnectionAccepted { .. } => "protocol.connection.accepted",
-        Event::ConnectionRejected { .. } => "protocol.connection.rejected",
-        Event::ConnectionRequestCancelled { .. } => "protocol.connection.request_cancelled",
-        Event::GroupCreated { .. } => "protocol.group.created",
-        Event::GroupMessageReceived { .. } => "protocol.group.message_received",
-        Event::GroupMemberAdded { .. } => "protocol.group.member_added",
-        Event::GroupMemberRemoved { .. } => "protocol.group.member_removed",
-        Event::GroupInfo { .. } => "protocol.group.info",
-        Event::UserGroups { .. } => "protocol.group.user_groups",
-        Event::GroupError { .. } => "protocol.group.error",
-        Event::GroupMessageSent { .. } => "protocol.group.message_sent",
-        Event::GroupMessagePartialFailure { .. } => "protocol.group.message_partial_failure",
-        Event::GroupEpochForkDetected { .. } => "protocol.group.epoch_fork_detected",
-        Event::GroupEpochForkResolved { .. } => "protocol.group.epoch_fork_resolved",
-        Event::GroupRoleChanged { .. } => "protocol.group.role_changed",
-        Event::GroupRenamed { .. } => "protocol.group.renamed",
-        Event::ServiceDiscovered { .. } => "protocol.service.discovered",
-        Event::ServiceRequestReceived { .. } => "protocol.service.request_received",
-        Event::ServiceResponseReceived { .. } => "protocol.service.response_received",
-        Event::PresenceUpdated { .. } => "protocol.presence.updated",
-        Event::TypingIndicatorReceived { .. } => "protocol.typing.received",
-        Event::ReadReceiptReceived { .. } => "protocol.read_receipt.received",
-        Event::DorsScoreUpdated { .. } => "protocol.dors.score_updated",
-        Event::DorsTransportSelected { .. } => "protocol.dors.transport_selected",
-        Event::DorsTransportSwitched { .. } => "protocol.dors.transport_switched",
-        Event::DorsEscalationTriggered { .. } => "protocol.dors.escalation_triggered",
-        Event::SecurityWarning { .. } => "protocol.security.warning",
-        Event::MessageRelayed { .. } => "protocol.message.relayed",
-        Event::UserBlocked { .. } => "protocol.user.blocked",
-        Event::UserUnblocked { .. } => "protocol.user.unblocked",
-        Event::TofuReset { .. } => "protocol.tofu.reset",
-    }
-}
-
-fn mls_lifecycle_event_name(event: &MlsLifecycleEvent) -> &'static str {
-    match event {
-        MlsLifecycleEvent::Initialized { .. } => "mls.initialized",
-        MlsLifecycleEvent::EncryptionUsed { .. } => "mls.encryption_used",
-        MlsLifecycleEvent::DecryptionFailed { .. } => "mls.decryption_failed",
-        MlsLifecycleEvent::SessionMissing { .. } => "mls.session_missing",
-        MlsLifecycleEvent::SessionReady { .. } => "mls.session_ready",
-    }
-}
-
-/// Placeholder record for a transport state transition.
-///
-/// Fields beyond `timestamp_ms` are populated by follow-up work that wires
-/// DORS / transport crates into the telemetry path.
-#[non_exhaustive]
-#[derive(Debug, Clone, Serialize)]
-pub struct TransportStateEvent {
-    /// Wall-clock timestamp in Unix milliseconds when the transition occurred.
-    pub timestamp_ms: i64,
-}
-
-impl TransportStateEvent {
-    /// Creates a new transport-state event with only the timestamp populated.
-    pub fn new(timestamp_ms: i64) -> Self {
-        Self { timestamp_ms }
-    }
-}
-
-/// Placeholder record for a periodic metrics snapshot.
-///
-/// Fields beyond `timestamp_ms` are populated by follow-up work that
-/// aggregates transport / dedup / retry-queue / topology metrics on the
-/// cadence configured via `TelemetryConfig::metrics_cadence_ms`.
-#[non_exhaustive]
-#[derive(Debug, Clone, Serialize)]
-pub struct MetricsFrame {
-    /// Wall-clock timestamp in Unix milliseconds when the snapshot was taken.
-    pub timestamp_ms: i64,
-}
-
-impl MetricsFrame {
-    /// Creates a new metrics snapshot with only the timestamp populated.
-    pub fn new(timestamp_ms: i64) -> Self {
-        Self { timestamp_ms }
-    }
-}
-
-/// Placeholder record for a routing decision.
-///
-/// Fields beyond `timestamp_ms` are populated by follow-up work that emits
-/// structured records from DORS / PathSelector / RelayManager as typed
-/// supersets of the existing `DorsScoreUpdated` event.
-#[non_exhaustive]
-#[derive(Debug, Clone, Serialize)]
-pub struct RoutingDecision {
-    /// Wall-clock timestamp in Unix milliseconds when the decision was made.
-    pub timestamp_ms: i64,
-}
-
-impl RoutingDecision {
-    /// Creates a new routing decision with only the timestamp populated.
-    pub fn new(timestamp_ms: i64) -> Self {
-        Self { timestamp_ms }
-    }
-}
-
-/// Placeholder record for a device-capability snapshot.
-///
-/// Fields beyond `timestamp_ms` are populated by follow-up work that emits on
-/// battery / charging / advertised-service changes.
-#[non_exhaustive]
-#[derive(Debug, Clone, Serialize)]
-pub struct DeviceCapabilitySnapshot {
-    /// Wall-clock timestamp in Unix milliseconds when the snapshot was taken.
-    pub timestamp_ms: i64,
-}
-
-impl DeviceCapabilitySnapshot {
-    /// Creates a new device-capability snapshot with only the timestamp populated.
-    pub fn new(timestamp_ms: i64) -> Self {
-        Self { timestamp_ms }
     }
 }
 
@@ -217,26 +55,6 @@ impl DeviceCapabilitySnapshot {
 mod tests {
     use super::*;
     use crate::mls_observability::MlsOperationContext;
-
-    #[test]
-    fn placeholder_names_are_stable() {
-        assert_eq!(
-            TelemetryRecord::TransportState(TransportStateEvent::new(0)).name(),
-            "transport.state.changed",
-        );
-        assert_eq!(
-            TelemetryRecord::MetricsSnapshot(MetricsFrame::new(0)).name(),
-            "metrics.snapshot",
-        );
-        assert_eq!(
-            TelemetryRecord::Routing(RoutingDecision::new(0)).name(),
-            "routing.decision",
-        );
-        assert_eq!(
-            TelemetryRecord::Device(DeviceCapabilitySnapshot::new(0)).name(),
-            "device.capability.snapshot",
-        );
-    }
 
     #[test]
     fn protocol_variant_names_are_dotted() {
@@ -271,23 +89,5 @@ mod tests {
             error_category: None,
         };
         assert_eq!(TelemetryRecord::Mls(event).name(), "mls.initialized");
-    }
-
-    #[test]
-    fn record_serializes_to_json() {
-        let event = MlsLifecycleEvent::Initialized {
-            timestamp_ms: 42,
-            session_id: "sid".into(),
-            group_id: None,
-            peer_id: None,
-            context: MlsOperationContext::Initialize,
-            error_category: None,
-        };
-        let record = TelemetryRecord::Mls(event);
-        let json = serde_json::to_value(&record).expect("serialize");
-        assert!(
-            json.get("mls").is_some(),
-            "expected externally-tagged variant key, got {json}"
-        );
     }
 }

--- a/crates/offline-protocol/src/telemetry/record.rs
+++ b/crates/offline-protocol/src/telemetry/record.rs
@@ -1,0 +1,293 @@
+//! Unified telemetry record taxonomy.
+//!
+//! [`TelemetryRecord`] is the single typed surface that every SDK event,
+//! metric, and lifecycle signal flows through. Two variants wrap existing
+//! types in place (`Protocol` wraps [`crate::events::Event`], `Mls` wraps
+//! [`crate::mls_observability::MlsLifecycleEvent`]); the remaining four are
+//! placeholder carriers whose fields are filled in by follow-up work
+//! (periodic metrics snapshots, transport state transitions, routing
+//! decisions, device-capability snapshots).
+//!
+//! The enum is `#[non_exhaustive]` so new categories can be added without a
+//! major-version bump. Inner placeholder structs are also `#[non_exhaustive]`
+//! and expose `pub fn new(...)` constructors — additive field growth in
+//! follow-up items is non-breaking for third-party consumers.
+
+use serde::Serialize;
+
+use crate::events::Event;
+use crate::mls_observability::MlsLifecycleEvent;
+
+/// A single typed telemetry emission.
+///
+/// Every record corresponds to exactly one `snake.dot.case` name returned by
+/// [`TelemetryRecord::name`]. Category-level names are used for the
+/// placeholder variants (`transport.state.changed`, `metrics.snapshot`,
+/// `routing.decision`, `device.capability.snapshot`); the `Protocol` and
+/// `Mls` variants map each sub-variant to a distinct dotted name.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TelemetryRecord {
+    /// A protocol-level event — wraps the existing [`Event`] type.
+    ///
+    /// The inner `Event` is boxed because it is substantially larger than
+    /// every other variant; boxing keeps the enum's footprint flat so
+    /// non-`Protocol` records do not pay the size tax when stored in
+    /// collections.
+    Protocol(Box<Event>),
+    /// An MLS lifecycle event — wraps the existing [`MlsLifecycleEvent`].
+    Mls(MlsLifecycleEvent),
+    /// A transport status transition (connect, disconnect, error, etc.).
+    TransportState(TransportStateEvent),
+    /// A periodic snapshot of aggregated metrics.
+    MetricsSnapshot(MetricsFrame),
+    /// A routing decision emitted by DORS / PathSelector / RelayManager.
+    Routing(RoutingDecision),
+    /// A device-capability change (battery, charging, advertised services).
+    Device(DeviceCapabilitySnapshot),
+}
+
+impl TelemetryRecord {
+    /// Returns the stable `snake.dot.case` name for this record.
+    ///
+    /// Names are intended to be compatible with OpenTelemetry's naming
+    /// conventions and are stable across minor versions of the SDK. For the
+    /// `Protocol` and `Mls` variants the name is derived from the nested
+    /// sub-variant; for the placeholder variants the category-level name is
+    /// returned until follow-up work introduces sub-types.
+    pub fn name(&self) -> &'static str {
+        match self {
+            TelemetryRecord::Protocol(event) => protocol_event_name(event.as_ref()),
+            TelemetryRecord::Mls(event) => mls_lifecycle_event_name(event),
+            TelemetryRecord::TransportState(_) => "transport.state.changed",
+            TelemetryRecord::MetricsSnapshot(_) => "metrics.snapshot",
+            TelemetryRecord::Routing(_) => "routing.decision",
+            TelemetryRecord::Device(_) => "device.capability.snapshot",
+        }
+    }
+}
+
+fn protocol_event_name(event: &Event) -> &'static str {
+    match event {
+        Event::MessageSent { .. } => "protocol.message.sent",
+        Event::MessageReceived { .. } => "protocol.message.received",
+        Event::MessageDelivered { .. } => "protocol.message.delivered",
+        Event::MessageFailed { .. } => "protocol.message.failed",
+        Event::MessageDecryptionFailed { .. } => "protocol.message.decryption_failed",
+        Event::TransportSwitched { .. } => "protocol.transport.switched",
+        Event::RelayPromoted { .. } => "protocol.relay.promoted",
+        Event::RelayDemoted { .. } => "protocol.relay.demoted",
+        Event::NeighborDiscovered { .. } => "protocol.neighbor.discovered",
+        Event::NeighborLost { .. } => "protocol.neighbor.lost",
+        Event::NetworkMetrics { .. } => "protocol.network.metrics",
+        Event::FileProgress { .. } => "protocol.file.progress",
+        Event::FileReceived { .. } => "protocol.file.received",
+        Event::MediaSent { .. } => "protocol.media.sent",
+        Event::MessageDeferred { .. } => "protocol.message.deferred",
+        Event::AckEvicted { .. } => "protocol.ack.evicted",
+        Event::FragmentAssemblyEvicted { .. } => "protocol.fragment.assembly_evicted",
+        Event::RelayDemotedBattery { .. } => "protocol.relay.demoted_battery",
+        Event::SecureSessionEstablished { .. } => "protocol.secure_session.established",
+        Event::SecureSessionFailed { .. } => "protocol.secure_session.failed",
+        Event::WelcomeSendAttempted { .. } => "protocol.welcome.send_attempted",
+        Event::WelcomeSendSucceeded { .. } => "protocol.welcome.send_succeeded",
+        Event::WelcomeSendFailed { .. } => "protocol.welcome.send_failed",
+        Event::WelcomeSendExpired { .. } => "protocol.welcome.send_expired",
+        Event::ConnectionRequestReceived { .. } => "protocol.connection.request_received",
+        Event::ConnectionAccepted { .. } => "protocol.connection.accepted",
+        Event::ConnectionRejected { .. } => "protocol.connection.rejected",
+        Event::ConnectionRequestCancelled { .. } => "protocol.connection.request_cancelled",
+        Event::GroupCreated { .. } => "protocol.group.created",
+        Event::GroupMessageReceived { .. } => "protocol.group.message_received",
+        Event::GroupMemberAdded { .. } => "protocol.group.member_added",
+        Event::GroupMemberRemoved { .. } => "protocol.group.member_removed",
+        Event::GroupInfo { .. } => "protocol.group.info",
+        Event::UserGroups { .. } => "protocol.group.user_groups",
+        Event::GroupError { .. } => "protocol.group.error",
+        Event::GroupMessageSent { .. } => "protocol.group.message_sent",
+        Event::GroupMessagePartialFailure { .. } => "protocol.group.message_partial_failure",
+        Event::GroupEpochForkDetected { .. } => "protocol.group.epoch_fork_detected",
+        Event::GroupEpochForkResolved { .. } => "protocol.group.epoch_fork_resolved",
+        Event::GroupRoleChanged { .. } => "protocol.group.role_changed",
+        Event::GroupRenamed { .. } => "protocol.group.renamed",
+        Event::ServiceDiscovered { .. } => "protocol.service.discovered",
+        Event::ServiceRequestReceived { .. } => "protocol.service.request_received",
+        Event::ServiceResponseReceived { .. } => "protocol.service.response_received",
+        Event::PresenceUpdated { .. } => "protocol.presence.updated",
+        Event::TypingIndicatorReceived { .. } => "protocol.typing.received",
+        Event::ReadReceiptReceived { .. } => "protocol.read_receipt.received",
+        Event::DorsScoreUpdated { .. } => "protocol.dors.score_updated",
+        Event::DorsTransportSelected { .. } => "protocol.dors.transport_selected",
+        Event::DorsTransportSwitched { .. } => "protocol.dors.transport_switched",
+        Event::DorsEscalationTriggered { .. } => "protocol.dors.escalation_triggered",
+        Event::SecurityWarning { .. } => "protocol.security.warning",
+        Event::MessageRelayed { .. } => "protocol.message.relayed",
+        Event::UserBlocked { .. } => "protocol.user.blocked",
+        Event::UserUnblocked { .. } => "protocol.user.unblocked",
+        Event::TofuReset { .. } => "protocol.tofu.reset",
+    }
+}
+
+fn mls_lifecycle_event_name(event: &MlsLifecycleEvent) -> &'static str {
+    match event {
+        MlsLifecycleEvent::Initialized { .. } => "mls.initialized",
+        MlsLifecycleEvent::EncryptionUsed { .. } => "mls.encryption_used",
+        MlsLifecycleEvent::DecryptionFailed { .. } => "mls.decryption_failed",
+        MlsLifecycleEvent::SessionMissing { .. } => "mls.session_missing",
+        MlsLifecycleEvent::SessionReady { .. } => "mls.session_ready",
+    }
+}
+
+/// Placeholder record for a transport state transition.
+///
+/// Fields beyond `timestamp_ms` are populated by follow-up work that wires
+/// DORS / transport crates into the telemetry path.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize)]
+pub struct TransportStateEvent {
+    /// Wall-clock timestamp in Unix milliseconds when the transition occurred.
+    pub timestamp_ms: i64,
+}
+
+impl TransportStateEvent {
+    /// Creates a new transport-state event with only the timestamp populated.
+    pub fn new(timestamp_ms: i64) -> Self {
+        Self { timestamp_ms }
+    }
+}
+
+/// Placeholder record for a periodic metrics snapshot.
+///
+/// Fields beyond `timestamp_ms` are populated by follow-up work that
+/// aggregates transport / dedup / retry-queue / topology metrics on the
+/// cadence configured via `TelemetryConfig::metrics_cadence_ms`.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize)]
+pub struct MetricsFrame {
+    /// Wall-clock timestamp in Unix milliseconds when the snapshot was taken.
+    pub timestamp_ms: i64,
+}
+
+impl MetricsFrame {
+    /// Creates a new metrics snapshot with only the timestamp populated.
+    pub fn new(timestamp_ms: i64) -> Self {
+        Self { timestamp_ms }
+    }
+}
+
+/// Placeholder record for a routing decision.
+///
+/// Fields beyond `timestamp_ms` are populated by follow-up work that emits
+/// structured records from DORS / PathSelector / RelayManager as typed
+/// supersets of the existing `DorsScoreUpdated` event.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize)]
+pub struct RoutingDecision {
+    /// Wall-clock timestamp in Unix milliseconds when the decision was made.
+    pub timestamp_ms: i64,
+}
+
+impl RoutingDecision {
+    /// Creates a new routing decision with only the timestamp populated.
+    pub fn new(timestamp_ms: i64) -> Self {
+        Self { timestamp_ms }
+    }
+}
+
+/// Placeholder record for a device-capability snapshot.
+///
+/// Fields beyond `timestamp_ms` are populated by follow-up work that emits on
+/// battery / charging / advertised-service changes.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize)]
+pub struct DeviceCapabilitySnapshot {
+    /// Wall-clock timestamp in Unix milliseconds when the snapshot was taken.
+    pub timestamp_ms: i64,
+}
+
+impl DeviceCapabilitySnapshot {
+    /// Creates a new device-capability snapshot with only the timestamp populated.
+    pub fn new(timestamp_ms: i64) -> Self {
+        Self { timestamp_ms }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mls_observability::MlsOperationContext;
+
+    #[test]
+    fn placeholder_names_are_stable() {
+        assert_eq!(
+            TelemetryRecord::TransportState(TransportStateEvent::new(0)).name(),
+            "transport.state.changed",
+        );
+        assert_eq!(
+            TelemetryRecord::MetricsSnapshot(MetricsFrame::new(0)).name(),
+            "metrics.snapshot",
+        );
+        assert_eq!(
+            TelemetryRecord::Routing(RoutingDecision::new(0)).name(),
+            "routing.decision",
+        );
+        assert_eq!(
+            TelemetryRecord::Device(DeviceCapabilitySnapshot::new(0)).name(),
+            "device.capability.snapshot",
+        );
+    }
+
+    #[test]
+    fn protocol_variant_names_are_dotted() {
+        let event = Event::MessageReceived {
+            message_id: "m".into(),
+            sender: "s".into(),
+            recipient: "r".into(),
+            content: String::new(),
+            hop_count: 0,
+            transport: "ble".into(),
+            timestamp: 0,
+            lamport_clock: 0,
+            reply_to_msg: None,
+            content_type: String::new(),
+            media_metadata: None,
+            forward_info: None,
+        };
+        assert_eq!(
+            TelemetryRecord::Protocol(Box::new(event)).name(),
+            "protocol.message.received",
+        );
+    }
+
+    #[test]
+    fn mls_variant_names_are_dotted() {
+        let event = MlsLifecycleEvent::Initialized {
+            timestamp_ms: 0,
+            session_id: "s".into(),
+            group_id: None,
+            peer_id: None,
+            context: MlsOperationContext::Initialize,
+            error_category: None,
+        };
+        assert_eq!(TelemetryRecord::Mls(event).name(), "mls.initialized");
+    }
+
+    #[test]
+    fn record_serializes_to_json() {
+        let event = MlsLifecycleEvent::Initialized {
+            timestamp_ms: 42,
+            session_id: "sid".into(),
+            group_id: None,
+            peer_id: None,
+            context: MlsOperationContext::Initialize,
+            error_category: None,
+        };
+        let record = TelemetryRecord::Mls(event);
+        let json = serde_json::to_value(&record).expect("serialize");
+        assert!(
+            json.get("mls").is_some(),
+            "expected externally-tagged variant key, got {json}"
+        );
+    }
+}

--- a/crates/offline-protocol/src/telemetry/record.rs
+++ b/crates/offline-protocol/src/telemetry/record.rs
@@ -55,19 +55,33 @@ impl TelemetryRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mls_observability::MlsOperationContext;
-    use std::collections::HashSet;
+    use crate::events::{
+        DorsEscalationPhase, DorsEscalationReasonCode, DorsReasonCode, PresenceStatus,
+        WelcomeReasonCode,
+    };
+    use crate::mls_observability::{DecryptionFailureKind, MlsOperationContext};
+    use std::collections::{HashMap, HashSet};
 
     /// Hand-maintained catalogue of every `telemetry_name()` the SDK emits.
     ///
-    /// This list must stay in lock-step with the match arms in
-    /// `Event::telemetry_name` and `MlsLifecycleEvent::telemetry_name`.
-    /// Compiler exhaustiveness on those matches guarantees every variant
-    /// produces *some* name; the tests below then enforce two additional
-    /// invariants that the compiler cannot: (1) no two variants collide on
-    /// the same name (which would silently merge distinct events at the
-    /// sink), and (2) every name conforms to the documented `snake.dot.case`
-    /// grammar.
+    /// This list is the wire-identity record for the release. It is
+    /// cross-checked against the real output of
+    /// [`Event::telemetry_name`]/[`MlsLifecycleEvent::telemetry_name`] by
+    /// `impl_telemetry_names_match_catalogue` below, which feeds one
+    /// exemplar per variant through the production mapping and asserts that
+    /// the resulting set equals this catalogue. Combined with the compile-
+    /// time exhaustiveness wards on [`event_exemplars`] and
+    /// [`mls_lifecycle_exemplars`], the three pieces together guarantee:
+    ///
+    /// 1. Every enum variant is represented in the exemplar list (the ward
+    ///    fails to compile when a new variant is added without an exemplar).
+    /// 2. No two variants produce the same name in the real implementation
+    ///    (`impl_telemetry_names_are_unique`).
+    /// 3. This catalogue is neither missing an entry nor carrying a stale
+    ///    one relative to the implementation
+    ///    (`impl_telemetry_names_match_catalogue`).
+    /// 4. Every name conforms to the documented `snake.dot.case` grammar
+    ///    (`all_telemetry_names_match_grammar`).
     const ALL_TELEMETRY_NAMES: &[&str] = &[
         // Event::*
         "protocol.message.sent",
@@ -192,14 +206,542 @@ mod tests {
         assert_eq!(TelemetryRecord::Mls(event).name(), "mls.initialized");
     }
 
+    /// Compile-time exhaustiveness ward for [`Event`].
+    ///
+    /// The match below deliberately omits a wildcard arm, so adding a new
+    /// variant to [`Event`] breaks compilation here and forces the author to
+    /// update [`event_exemplars`] to cover the new variant. Without this
+    /// ward, an author could add a variant + a `telemetry_name` arm while
+    /// silently skipping the exemplar list, and the impl-level uniqueness
+    /// check below would quietly run with incomplete coverage.
+    #[allow(dead_code)]
+    fn event_variant_exhaustiveness_ward(e: &Event) {
+        match e {
+            Event::MessageSent { .. }
+            | Event::MessageReceived { .. }
+            | Event::MessageDelivered { .. }
+            | Event::MessageFailed { .. }
+            | Event::MessageDecryptionFailed { .. }
+            | Event::TransportSwitched { .. }
+            | Event::RelayPromoted { .. }
+            | Event::RelayDemoted { .. }
+            | Event::NeighborDiscovered { .. }
+            | Event::NeighborLost { .. }
+            | Event::NetworkMetrics { .. }
+            | Event::FileProgress { .. }
+            | Event::FileReceived { .. }
+            | Event::MediaSent { .. }
+            | Event::MessageDeferred { .. }
+            | Event::AckEvicted { .. }
+            | Event::FragmentAssemblyEvicted { .. }
+            | Event::RelayDemotedBattery { .. }
+            | Event::SecureSessionEstablished { .. }
+            | Event::SecureSessionFailed { .. }
+            | Event::WelcomeSendAttempted { .. }
+            | Event::WelcomeSendSucceeded { .. }
+            | Event::WelcomeSendFailed { .. }
+            | Event::WelcomeSendExpired { .. }
+            | Event::ConnectionRequestReceived { .. }
+            | Event::ConnectionAccepted { .. }
+            | Event::ConnectionRejected { .. }
+            | Event::ConnectionRequestCancelled { .. }
+            | Event::GroupCreated { .. }
+            | Event::GroupMessageReceived { .. }
+            | Event::GroupMemberAdded { .. }
+            | Event::GroupMemberRemoved { .. }
+            | Event::GroupInfo { .. }
+            | Event::UserGroups { .. }
+            | Event::GroupError { .. }
+            | Event::GroupMessageSent { .. }
+            | Event::GroupMessagePartialFailure { .. }
+            | Event::GroupEpochForkDetected { .. }
+            | Event::GroupEpochForkResolved { .. }
+            | Event::GroupRoleChanged { .. }
+            | Event::GroupRenamed { .. }
+            | Event::ServiceDiscovered { .. }
+            | Event::ServiceRequestReceived { .. }
+            | Event::ServiceResponseReceived { .. }
+            | Event::PresenceUpdated { .. }
+            | Event::TypingIndicatorReceived { .. }
+            | Event::ReadReceiptReceived { .. }
+            | Event::DorsScoreUpdated { .. }
+            | Event::DorsTransportSelected { .. }
+            | Event::DorsTransportSwitched { .. }
+            | Event::DorsEscalationTriggered { .. }
+            | Event::SecurityWarning { .. }
+            | Event::MessageRelayed { .. }
+            | Event::UserBlocked { .. }
+            | Event::UserUnblocked { .. }
+            | Event::TofuReset { .. } => (),
+        }
+    }
+
+    /// Compile-time exhaustiveness ward for [`MlsLifecycleEvent`] — see
+    /// [`event_variant_exhaustiveness_ward`] for the rationale.
+    #[allow(dead_code)]
+    fn mls_lifecycle_exhaustiveness_ward(e: &MlsLifecycleEvent) {
+        match e {
+            MlsLifecycleEvent::Initialized { .. }
+            | MlsLifecycleEvent::EncryptionUsed { .. }
+            | MlsLifecycleEvent::DecryptionFailed { .. }
+            | MlsLifecycleEvent::SessionMissing { .. }
+            | MlsLifecycleEvent::SessionReady { .. } => (),
+        }
+    }
+
+    /// Constructs one exemplar per [`Event`] variant, in the same order as
+    /// the match arms of [`Event::telemetry_name`]. Field values are
+    /// placeholders — the tests only read the telemetry name.
+    fn event_exemplars() -> Vec<Event> {
+        vec![
+            Event::MessageSent {
+                message_id: String::new(),
+                sender: String::new(),
+                recipient: String::new(),
+                content: String::new(),
+                priority: String::new(),
+                requires_ack: false,
+                timestamp: 0,
+                lamport_clock: 0,
+                forward_info: None,
+            },
+            Event::MessageReceived {
+                message_id: String::new(),
+                sender: String::new(),
+                recipient: String::new(),
+                content: String::new(),
+                hop_count: 0,
+                transport: String::new(),
+                timestamp: 0,
+                lamport_clock: 0,
+                reply_to_msg: None,
+                content_type: String::new(),
+                media_metadata: None,
+                forward_info: None,
+            },
+            Event::MessageDelivered {
+                message_id: String::new(),
+                latency_ms: 0,
+                hop_count: 0,
+                transport: String::new(),
+            },
+            Event::MessageFailed {
+                message_id: String::new(),
+                reason: String::new(),
+                retry_count: 0,
+            },
+            Event::MessageDecryptionFailed {
+                message_id: String::new(),
+                sender: String::new(),
+                code: crate::events::DecryptionFailureCode::Unknown,
+                reason: String::new(),
+            },
+            Event::TransportSwitched {
+                from: None,
+                to: String::new(),
+                reason: String::new(),
+            },
+            Event::RelayPromoted {
+                connection_count: 0,
+                battery_level: 0,
+            },
+            Event::RelayDemoted {
+                reason: String::new(),
+            },
+            Event::NeighborDiscovered {
+                peer_id: String::new(),
+                transport: String::new(),
+                rssi: None,
+            },
+            Event::NeighborLost {
+                peer_id: String::new(),
+            },
+            Event::NetworkMetrics {
+                neighbor_count: 0,
+                relay_count: 0,
+                delivery_ratio: 0.0,
+                avg_latency_ms: 0,
+            },
+            Event::FileProgress {
+                file_id: String::new(),
+                chunks_sent: 0,
+                total_chunks: 0,
+                percentage: 0,
+            },
+            Event::FileReceived {
+                file_id: String::new(),
+                file_name: String::new(),
+                file_size: 0,
+                sender: String::new(),
+                content_type: String::new(),
+                media_metadata: None,
+                file_data: String::new(),
+            },
+            Event::MediaSent {
+                file_id: String::new(),
+                content_type: String::new(),
+                recipient: String::new(),
+            },
+            Event::MessageDeferred {
+                message_id: String::new(),
+                reason: String::new(),
+                retry_count: 0,
+                next_retry_at: None,
+            },
+            Event::AckEvicted {
+                message_id: String::new(),
+                priority: String::new(),
+                reason: String::new(),
+            },
+            Event::FragmentAssemblyEvicted {
+                message_id: String::new(),
+                completion_percent: 0,
+                reason: String::new(),
+            },
+            Event::RelayDemotedBattery {
+                battery_level: 0,
+                min_required: 0,
+            },
+            Event::SecureSessionEstablished {
+                peer_id: String::new(),
+                group_id: String::new(),
+                is_session: false,
+                initiated_by_local: false,
+            },
+            Event::SecureSessionFailed {
+                peer_id: String::new(),
+                reason: String::new(),
+            },
+            Event::WelcomeSendAttempted {
+                peer_id: String::new(),
+                message_id: String::new(),
+                group_id: String::new(),
+                attempt: 0,
+            },
+            Event::WelcomeSendSucceeded {
+                peer_id: String::new(),
+                message_id: String::new(),
+                group_id: String::new(),
+                attempt: 0,
+            },
+            Event::WelcomeSendFailed {
+                peer_id: String::new(),
+                message_id: String::new(),
+                group_id: String::new(),
+                attempt: 0,
+                reason_code: WelcomeReasonCode::InternalError,
+                transport_error: None,
+                retryable: false,
+                next_retry_at: None,
+            },
+            Event::WelcomeSendExpired {
+                peer_id: String::new(),
+                message_id: String::new(),
+                attempt: 0,
+                reason_code: WelcomeReasonCode::RetryExhausted,
+            },
+            Event::ConnectionRequestReceived {
+                sender: String::new(),
+                sender_name: String::new(),
+                timestamp: 0,
+                key_package: None,
+            },
+            Event::ConnectionAccepted {
+                accepted_by: String::new(),
+                accepted_by_name: String::new(),
+                timestamp: 0,
+                key_package: None,
+            },
+            Event::ConnectionRejected {
+                rejected_by: String::new(),
+            },
+            Event::ConnectionRequestCancelled {
+                cancelled_by: String::new(),
+            },
+            Event::GroupCreated {
+                group_id: String::new(),
+                name: String::new(),
+            },
+            Event::GroupMessageReceived {
+                group_id: String::new(),
+                sender: String::new(),
+                content: String::new(),
+                timestamp: String::new(),
+                message_id: String::new(),
+                reply_to_msg: None,
+                forward_info: None,
+            },
+            Event::GroupMemberAdded {
+                group_id: String::new(),
+                user_id: String::new(),
+                added_by: String::new(),
+                group_name: None,
+            },
+            Event::GroupMemberRemoved {
+                group_id: String::new(),
+                user_id: String::new(),
+                removed_by: String::new(),
+            },
+            Event::GroupInfo {
+                group_id: String::new(),
+                name: String::new(),
+                created_by: String::new(),
+                created_at: String::new(),
+                members: Vec::new(),
+            },
+            Event::UserGroups { groups: Vec::new() },
+            Event::GroupError {
+                reason: String::new(),
+            },
+            Event::GroupMessageSent {
+                group_id: String::new(),
+                message_ids: Vec::new(),
+                member_count: 0,
+            },
+            Event::GroupMessagePartialFailure {
+                group_id: String::new(),
+                failed_members: Vec::new(),
+                succeeded_members: Vec::new(),
+            },
+            Event::GroupEpochForkDetected {
+                group_id: String::new(),
+                local_epoch: None,
+            },
+            Event::GroupEpochForkResolved {
+                group_id: String::new(),
+                resolved_epoch: 0,
+                failed_members: Vec::new(),
+            },
+            Event::GroupRoleChanged {
+                group_id: String::new(),
+                user_id: String::new(),
+                new_role: String::new(),
+                changed_by: String::new(),
+            },
+            Event::GroupRenamed {
+                group_id: String::new(),
+                new_name: String::new(),
+                old_name: None,
+                renamed_by: String::new(),
+            },
+            Event::ServiceDiscovered {
+                query_id: String::new(),
+                service_id: String::new(),
+                version: String::new(),
+                provider_peer_id: String::new(),
+                capabilities: HashMap::new(),
+                hop_count: 0,
+            },
+            Event::ServiceRequestReceived {
+                request_id: String::new(),
+                service_id: String::new(),
+                method: String::new(),
+                body: String::new(),
+                sender: String::new(),
+            },
+            Event::ServiceResponseReceived {
+                request_id: String::new(),
+                service_id: String::new(),
+                status: String::new(),
+                body: String::new(),
+                provider_peer_id: String::new(),
+            },
+            Event::PresenceUpdated {
+                peer_id: String::new(),
+                status: PresenceStatus::Online,
+                timestamp: 0,
+            },
+            Event::TypingIndicatorReceived {
+                sender: String::new(),
+                conversation_id: String::new(),
+                is_typing: false,
+                timestamp: 0,
+            },
+            Event::ReadReceiptReceived {
+                sender: String::new(),
+                message_ids: Vec::new(),
+                timestamp: 0,
+            },
+            Event::DorsScoreUpdated { scores: Vec::new() },
+            Event::DorsTransportSelected {
+                from: None,
+                transport: String::new(),
+                reason_code: DorsReasonCode::InitialSelection,
+                score: 0.0,
+            },
+            Event::DorsTransportSwitched {
+                from: None,
+                to: String::new(),
+                reason_code: DorsReasonCode::PrimarySelected,
+                reason_detail: None,
+            },
+            Event::DorsEscalationTriggered {
+                phase: DorsEscalationPhase::Triggered,
+                from: String::new(),
+                to: String::new(),
+                reason_code: DorsEscalationReasonCode::FallbackSuccess,
+                reason_detail: None,
+            },
+            Event::SecurityWarning {
+                peer_id: String::new(),
+                reason: String::new(),
+            },
+            Event::MessageRelayed {
+                message_id: String::new(),
+                sender: String::new(),
+                recipient: String::new(),
+                hop_count: 0,
+                remaining_ttl: 0,
+            },
+            Event::UserBlocked {
+                user_id: String::new(),
+            },
+            Event::UserUnblocked {
+                user_id: String::new(),
+            },
+            Event::TofuReset {
+                peer_id: String::new(),
+            },
+        ]
+    }
+
+    /// Constructs one exemplar per [`MlsLifecycleEvent`] variant, in the same
+    /// order as the match arms of [`MlsLifecycleEvent::telemetry_name`].
+    fn mls_lifecycle_exemplars() -> Vec<MlsLifecycleEvent> {
+        vec![
+            MlsLifecycleEvent::Initialized {
+                timestamp_ms: 0,
+                session_id: String::new(),
+                group_id: None,
+                peer_id: None,
+                context: MlsOperationContext::Initialize,
+                error_category: None,
+            },
+            MlsLifecycleEvent::EncryptionUsed {
+                timestamp_ms: 0,
+                session_id: String::new(),
+                group_id: None,
+                peer_id: None,
+                context: MlsOperationContext::Send,
+                error_category: None,
+            },
+            MlsLifecycleEvent::DecryptionFailed {
+                timestamp_ms: 0,
+                session_id: String::new(),
+                group_id: None,
+                peer_id: None,
+                context: MlsOperationContext::Receive,
+                error_category: None,
+                failure_kind: DecryptionFailureKind::Unknown,
+            },
+            MlsLifecycleEvent::SessionMissing {
+                timestamp_ms: 0,
+                session_id: String::new(),
+                group_id: None,
+                peer_id: None,
+                context: MlsOperationContext::SessionLookup,
+                error_category: None,
+            },
+            MlsLifecycleEvent::SessionReady {
+                timestamp_ms: 0,
+                session_id: String::new(),
+                group_id: None,
+                peer_id: None,
+                context: MlsOperationContext::Welcome,
+                error_category: None,
+            },
+        ]
+    }
+
+    /// Real implementation-level uniqueness check.
+    ///
+    /// Feeds every exemplar through [`Event::telemetry_name`] and
+    /// [`MlsLifecycleEvent::telemetry_name`] and asserts the produced names
+    /// are unique. Unlike a catalogue-only uniqueness check, this catches
+    /// the case where two match arms in the production mapping accidentally
+    /// produce the same string — a silent merge at the sink.
     #[test]
-    fn all_telemetry_names_are_unique() {
+    fn impl_telemetry_names_are_unique() {
+        let mut names: Vec<&'static str> = Vec::new();
+        for e in event_exemplars() {
+            names.push(e.telemetry_name());
+        }
+        for e in mls_lifecycle_exemplars() {
+            names.push(e.telemetry_name());
+        }
+        let unique: HashSet<&&'static str> = names.iter().collect();
+        assert_eq!(
+            unique.len(),
+            names.len(),
+            "two variants produced the same telemetry_name() — distinct \
+             events would silently merge at the sink. Names: {names:?}",
+        );
+    }
+
+    /// Guards against drift between the catalogue and the implementation.
+    ///
+    /// If a new variant is added without a catalogue entry, the catalogue
+    /// will be short one name. If a catalogue entry is left behind after a
+    /// variant rename, the catalogue will carry a stale name. Either failure
+    /// mode is caught here.
+    #[test]
+    fn impl_telemetry_names_match_catalogue() {
+        let mut impl_names: Vec<&'static str> = Vec::new();
+        for e in event_exemplars() {
+            impl_names.push(e.telemetry_name());
+        }
+        for e in mls_lifecycle_exemplars() {
+            impl_names.push(e.telemetry_name());
+        }
+
+        let impl_set: HashSet<&&'static str> = impl_names.iter().collect();
+        let catalogue_set: HashSet<&&str> = ALL_TELEMETRY_NAMES.iter().collect();
+
+        let missing_from_catalogue: Vec<&&'static str> = impl_set
+            .iter()
+            .copied()
+            .filter(|n| !ALL_TELEMETRY_NAMES.contains(*n))
+            .collect();
+        assert!(
+            missing_from_catalogue.is_empty(),
+            "implementation produces names not in ALL_TELEMETRY_NAMES: \
+             {missing_from_catalogue:?}. Update the catalogue.",
+        );
+
+        let stale_in_catalogue: Vec<&&str> = catalogue_set
+            .iter()
+            .copied()
+            .filter(|n| !impl_names.iter().any(|produced| produced == *n))
+            .collect();
+        assert!(
+            stale_in_catalogue.is_empty(),
+            "catalogue carries names the implementation does not produce: \
+             {stale_in_catalogue:?}. Remove from the catalogue or restore \
+             the match arm.",
+        );
+
+        assert_eq!(
+            impl_names.len(),
+            ALL_TELEMETRY_NAMES.len(),
+            "catalogue length ({}) differs from implementation variant \
+             count ({})",
+            ALL_TELEMETRY_NAMES.len(),
+            impl_names.len(),
+        );
+    }
+
+    /// Sanity check on the catalogue itself — duplicate entries would mask
+    /// drift against the implementation (two catalogue entries colliding
+    /// with a single implementation name would still pass the equality
+    /// check above). Kept alongside the implementation check so both
+    /// invariants are locked in.
+    #[test]
+    fn catalogue_entries_are_unique() {
         let set: HashSet<&&str> = ALL_TELEMETRY_NAMES.iter().collect();
         assert_eq!(
             set.len(),
             ALL_TELEMETRY_NAMES.len(),
-            "duplicate telemetry names — two variants collide on the same \
-             wire identity. Distinct events would silently merge at the sink.",
+            "duplicate entry in ALL_TELEMETRY_NAMES",
         );
     }
 

--- a/crates/offline-protocol/src/telemetry/record.rs
+++ b/crates/offline-protocol/src/telemetry/record.rs
@@ -8,10 +8,15 @@
 //! decisions, device-capability snapshots) are introduced alongside the emit
 //! sites that populate them in follow-up work.
 //!
+//! Names returned by [`TelemetryRecord::name`] follow a stable
+//! `snake.dot.case` grammar compatible with OpenTelemetry conventions: the
+//! string matches `[a-z0-9_]+(\.[a-z0-9_]+)+`. These names are the canonical
+//! wire identity for a record.
+//!
 //! The enum is `#[non_exhaustive]` so new categories can be added without a
 //! major-version bump. The record intentionally does not derive `Serialize`:
-//! [`TelemetryRecord::name`] is the canonical wire identity, and sinks that
-//! need on-the-wire serialization serialize the inner typed payload
+//! the `name()` above is the canonical wire identity, and sinks that need
+//! on-the-wire serialization serialize the inner typed payload
 //! (`Event`/`MlsLifecycleEvent`) directly — this avoids maintaining two
 //! parallel naming schemes.
 
@@ -20,10 +25,8 @@ use crate::mls_observability::MlsLifecycleEvent;
 
 /// A single typed telemetry emission.
 ///
-/// Every record corresponds to exactly one `snake.dot.case` name returned by
-/// [`TelemetryRecord::name`]. The name is delegated to the inner payload's
-/// `telemetry_name()` method so there is a single source of truth for variant
-/// naming.
+/// The name is delegated to the inner payload's `telemetry_name()` method so
+/// there is a single source of truth for variant naming.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum TelemetryRecord {
@@ -39,10 +42,8 @@ pub enum TelemetryRecord {
 }
 
 impl TelemetryRecord {
-    /// Returns the stable `snake.dot.case` name for this record.
-    ///
-    /// Names are compatible with OpenTelemetry naming conventions and are
-    /// considered stable across minor versions of the SDK.
+    /// Returns the stable name for this record. See the module-level docs
+    /// for the exact grammar and stability guarantees.
     pub fn name(&self) -> &'static str {
         match self {
             TelemetryRecord::Protocol(event) => event.telemetry_name(),
@@ -55,6 +56,106 @@ impl TelemetryRecord {
 mod tests {
     use super::*;
     use crate::mls_observability::MlsOperationContext;
+    use std::collections::HashSet;
+
+    /// Hand-maintained catalogue of every `telemetry_name()` the SDK emits.
+    ///
+    /// This list must stay in lock-step with the match arms in
+    /// `Event::telemetry_name` and `MlsLifecycleEvent::telemetry_name`.
+    /// Compiler exhaustiveness on those matches guarantees every variant
+    /// produces *some* name; the tests below then enforce two additional
+    /// invariants that the compiler cannot: (1) no two variants collide on
+    /// the same name (which would silently merge distinct events at the
+    /// sink), and (2) every name conforms to the documented `snake.dot.case`
+    /// grammar.
+    const ALL_TELEMETRY_NAMES: &[&str] = &[
+        // Event::*
+        "protocol.message.sent",
+        "protocol.message.received",
+        "protocol.message.delivered",
+        "protocol.message.failed",
+        "protocol.message.decryption_failed",
+        "protocol.transport.switched",
+        "protocol.relay.promoted",
+        "protocol.relay.demoted",
+        "protocol.neighbor.discovered",
+        "protocol.neighbor.lost",
+        "protocol.network.metrics",
+        "protocol.file.progress",
+        "protocol.file.received",
+        "protocol.media.sent",
+        "protocol.message.deferred",
+        "protocol.ack.evicted",
+        "protocol.fragment.assembly_evicted",
+        "protocol.relay.demoted_battery",
+        "protocol.secure_session.established",
+        "protocol.secure_session.failed",
+        "protocol.welcome.send_attempted",
+        "protocol.welcome.send_succeeded",
+        "protocol.welcome.send_failed",
+        "protocol.welcome.send_expired",
+        "protocol.connection.request_received",
+        "protocol.connection.accepted",
+        "protocol.connection.rejected",
+        "protocol.connection.request_cancelled",
+        "protocol.group.created",
+        "protocol.group.message_received",
+        "protocol.group.member_added",
+        "protocol.group.member_removed",
+        "protocol.group.info",
+        "protocol.group.user_groups",
+        "protocol.group.error",
+        "protocol.group.message_sent",
+        "protocol.group.message_partial_failure",
+        "protocol.group.epoch_fork_detected",
+        "protocol.group.epoch_fork_resolved",
+        "protocol.group.role_changed",
+        "protocol.group.renamed",
+        "protocol.service.discovered",
+        "protocol.service.request_received",
+        "protocol.service.response_received",
+        "protocol.presence.updated",
+        "protocol.typing.received",
+        "protocol.read_receipt.received",
+        "protocol.dors.score_updated",
+        "protocol.dors.transport_selected",
+        "protocol.dors.transport_switched",
+        "protocol.dors.escalation_triggered",
+        "protocol.security.warning",
+        "protocol.message.relayed",
+        "protocol.user.blocked",
+        "protocol.user.unblocked",
+        "protocol.tofu.reset",
+        // MlsLifecycleEvent::*
+        "mls.initialized",
+        "mls.encryption_used",
+        "mls.decryption_failed",
+        "mls.session_missing",
+        "mls.session_ready",
+    ];
+
+    /// Returns `true` when `name` matches the documented grammar
+    /// `[a-z0-9_]+(\.[a-z0-9_]+)+`.
+    fn is_well_formed(name: &str) -> bool {
+        if name.is_empty() {
+            return false;
+        }
+        let mut segments = name.split('.');
+        let mut segment_count = 0;
+        for segment in &mut segments {
+            if segment.is_empty() {
+                return false;
+            }
+            if !segment
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+            {
+                return false;
+            }
+            segment_count += 1;
+        }
+        segment_count >= 2
+    }
 
     #[test]
     fn protocol_variant_names_are_dotted() {
@@ -89,5 +190,41 @@ mod tests {
             error_category: None,
         };
         assert_eq!(TelemetryRecord::Mls(event).name(), "mls.initialized");
+    }
+
+    #[test]
+    fn all_telemetry_names_are_unique() {
+        let set: HashSet<&&str> = ALL_TELEMETRY_NAMES.iter().collect();
+        assert_eq!(
+            set.len(),
+            ALL_TELEMETRY_NAMES.len(),
+            "duplicate telemetry names — two variants collide on the same \
+             wire identity. Distinct events would silently merge at the sink.",
+        );
+    }
+
+    #[test]
+    fn all_telemetry_names_match_grammar() {
+        for name in ALL_TELEMETRY_NAMES {
+            assert!(
+                is_well_formed(name),
+                "telemetry name '{name}' does not match snake.dot.case grammar",
+            );
+        }
+    }
+
+    #[test]
+    fn grammar_checker_rejects_malformed_names() {
+        assert!(!is_well_formed(""));
+        assert!(!is_well_formed("flat"));
+        assert!(!is_well_formed(".leading"));
+        assert!(!is_well_formed("trailing."));
+        assert!(!is_well_formed("double..dot"));
+        assert!(!is_well_formed("Upper.Case"));
+        assert!(!is_well_formed("has-dash.segment"));
+        assert!(is_well_formed("ok.name"));
+        assert!(is_well_formed("a.b.c"));
+        assert!(is_well_formed("with_underscore.segment"));
+        assert!(is_well_formed("has_digit1.seg2"));
     }
 }

--- a/crates/offline-protocol/src/telemetry/record.rs
+++ b/crates/offline-protocol/src/telemetry/record.rs
@@ -171,6 +171,26 @@ mod tests {
         segment_count >= 2
     }
 
+    /// Regression guard for the `Box<Event>` decision on the `Protocol`
+    /// variant. `Event` is ~368 bytes; the non-Protocol variants are much
+    /// smaller (`MlsLifecycleEvent` is the next-largest at ~100 bytes). If
+    /// someone removes the `Box`, `TelemetryRecord` balloons to `Event`'s
+    /// size and the size tax is paid by every non-Protocol record stored in
+    /// a collection. This assertion fails loudly if that happens.
+    #[test]
+    fn telemetry_record_is_smaller_than_unboxed_event() {
+        use std::mem::size_of;
+        assert!(
+            size_of::<TelemetryRecord>() < size_of::<Event>(),
+            "TelemetryRecord ({} bytes) is not smaller than Event ({} bytes) \
+             — the `Box<Event>` variant was removed or the size budget was \
+             blown by another variant. Re-box the Protocol variant or audit \
+             the new variant's payload.",
+            size_of::<TelemetryRecord>(),
+            size_of::<Event>(),
+        );
+    }
+
     #[test]
     fn protocol_variant_names_are_dotted() {
         let event = Event::MessageReceived {

--- a/crates/offline-protocol/src/telemetry/scrubber.rs
+++ b/crates/offline-protocol/src/telemetry/scrubber.rs
@@ -6,6 +6,8 @@
 //! `TelemetryConfig::with_scrub_ids(false)`), the helper returns the input
 //! unchanged so emit sites can call it unconditionally.
 
+use std::borrow::Cow;
+
 use crate::mls_observability::opaque_id;
 use crate::telemetry::config::TelemetryConfig;
 
@@ -43,13 +45,15 @@ impl Scrubber {
         self.enabled
     }
 
-    /// Hashes `raw` into a 32-character hex opaque identifier, or returns
+    /// Hashes `raw` into a 32-character hex opaque identifier, or borrows
     /// `raw` unchanged when scrubbing is disabled.
-    pub fn hash_id(&self, raw: &str) -> String {
+    ///
+    /// The `Cow` return avoids allocation on the disabled-scrubbing hot path.
+    pub fn hash_id<'a>(&self, raw: &'a str) -> Cow<'a, str> {
         if self.enabled {
-            opaque_id(raw, &self.secret)
+            Cow::Owned(opaque_id(raw, &self.secret))
         } else {
-            raw.to_string()
+            Cow::Borrowed(raw)
         }
     }
 }
@@ -59,17 +63,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn disabled_scrubber_returns_raw() {
+    fn disabled_scrubber_borrows_raw() {
         let scrubber = Scrubber::new(false, [0; 16]);
-        assert_eq!(scrubber.hash_id("peer-a"), "peer-a");
+        let out = scrubber.hash_id("peer-a");
+        assert_eq!(out, "peer-a");
+        assert!(matches!(out, Cow::Borrowed(_)));
         assert!(!scrubber.is_enabled());
     }
 
     #[test]
     fn enabled_scrubber_returns_stable_hash() {
         let scrubber = Scrubber::new(true, [1; 16]);
-        let first = scrubber.hash_id("peer-a");
-        let second = scrubber.hash_id("peer-a");
+        let first = scrubber.hash_id("peer-a").into_owned();
+        let second = scrubber.hash_id("peer-a").into_owned();
         assert_eq!(first, second);
         assert_eq!(first.len(), 32);
         assert_ne!(first, "peer-a");
@@ -88,7 +94,7 @@ mod tests {
         let fallback = [0; 16];
         let scrubber = Scrubber::from_config(&config, fallback);
         assert!(scrubber.is_enabled());
-        let expected = Scrubber::new(true, [9; 16]).hash_id("peer-a");
+        let expected = Scrubber::new(true, [9; 16]).hash_id("peer-a").into_owned();
         assert_eq!(scrubber.hash_id("peer-a"), expected);
     }
 
@@ -97,7 +103,7 @@ mod tests {
         let config = TelemetryConfig::default();
         let fallback = [5; 16];
         let scrubber = Scrubber::from_config(&config, fallback);
-        let expected = Scrubber::new(true, fallback).hash_id("peer-a");
+        let expected = Scrubber::new(true, fallback).hash_id("peer-a").into_owned();
         assert_eq!(scrubber.hash_id("peer-a"), expected);
     }
 }

--- a/crates/offline-protocol/src/telemetry/scrubber.rs
+++ b/crates/offline-protocol/src/telemetry/scrubber.rs
@@ -1,15 +1,11 @@
 //! PII-scrubbing helper for telemetry emit sites.
 //!
-//! [`Scrubber`] wraps the SHA-256-based opaque-identifier scheme used across
-//! the SDK and exposes a single `hash_id` entry point. When scrubbing is
-//! disabled (caller opted in via `TelemetryConfig::with_scrub_ids(false)`),
-//! the helper returns the input unchanged so emit sites can call it
-//! unconditionally.
-//!
-//! The underlying [`opaque_id`] function is also exposed for call sites that
-//! need to hash identifiers independently of a `Scrubber` instance
-//! (e.g. MLS lifecycle emission, where multiple distinct identifiers are
-//! hashed per event with a single caller-owned secret).
+//! [`Scrubber`] is the single entry point for hashing long-lived pseudonymous
+//! identifiers before they cross the telemetry sink boundary. Callers
+//! construct one (via [`Scrubber::new`] or [`Scrubber::from_config`]) and call
+//! `hash_id` — when scrubbing is disabled (caller opted in via
+//! `TelemetryConfig::with_scrub_ids(false)`), the helper returns the input
+//! unchanged so emit sites can call it unconditionally.
 //!
 //! Construction note: the hash is `SHA-256(secret || raw)` — a prefix-MAC,
 //! adequate for deterministic pseudonymization but **not** length-extension
@@ -28,7 +24,10 @@ use crate::telemetry::config::TelemetryConfig;
 /// bytes of `SHA-256(secret || raw)`. The result is deterministic for a
 /// given `(secret, raw)` pair but reveals no information about `raw` to a
 /// party that does not hold the secret.
-pub fn opaque_id(raw: &str, secret: &[u8]) -> String {
+///
+/// Crate-private: external callers use [`Scrubber::hash_id`] instead so
+/// there is a single public entry point to the hashing operation.
+pub(crate) fn opaque_id(raw: &str, secret: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(secret);
     hasher.update(raw.as_bytes());

--- a/crates/offline-protocol/src/telemetry/scrubber.rs
+++ b/crates/offline-protocol/src/telemetry/scrubber.rs
@@ -78,12 +78,33 @@ impl Scrubber {
     /// `raw` unchanged when scrubbing is disabled.
     ///
     /// The `Cow` return avoids allocation on the disabled-scrubbing hot path.
+    ///
+    /// Use this for **leaf** identifiers the caller has chosen to expose
+    /// (individual `peer_id`, `group_id`, `user_id` on a record). For
+    /// **derived correlation tokens** — values built by concatenating
+    /// multiple raw identifiers — use [`Scrubber::hash_always`] instead, so
+    /// that the composite cannot be disabled by a user-facing scrubbing
+    /// preference.
     pub fn hash_id<'a>(&self, raw: &'a str) -> Cow<'a, str> {
         if self.enabled {
             Cow::Owned(opaque_id(raw, &self.secret))
         } else {
             Cow::Borrowed(raw)
         }
+    }
+
+    /// Unconditionally hashes `raw` with the scrubber's secret, ignoring the
+    /// `enabled` flag.
+    ///
+    /// Intended for derived correlation tokens (session IDs built from
+    /// concatenated peer+group IDs, fingerprints over composite seeds) where
+    /// emitting the raw string would leak more than the sum of its parts —
+    /// these MUST be obfuscated regardless of the user's identifier-scrubbing
+    /// preference, because disabling scrubbing is a choice about leaf IDs
+    /// the caller already controls, not about derived values the SDK
+    /// constructs internally.
+    pub fn hash_always(&self, raw: &str) -> String {
+        opaque_id(raw, &self.secret)
     }
 }
 
@@ -174,5 +195,31 @@ mod tests {
         let scrubber = Scrubber::from_config(&config, fallback);
         let expected = Scrubber::new(true, fallback).hash_id("peer-a").into_owned();
         assert_eq!(scrubber.hash_id("peer-a"), expected);
+    }
+
+    #[test]
+    fn hash_always_ignores_enabled_flag() {
+        let enabled = Scrubber::new(true, [1; 16]);
+        let disabled = Scrubber::new(false, [1; 16]);
+        // Identical output across both modes: `hash_always` never passes
+        // through, so it is safe for derived correlation tokens.
+        assert_eq!(
+            enabled.hash_always("peer-a"),
+            disabled.hash_always("peer-a")
+        );
+        // Output is always a 32-character hex opaque — never the raw input.
+        let out = disabled.hash_always("peer-a");
+        assert_eq!(out.len(), 32);
+        assert!(out.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(out, "peer-a");
+    }
+
+    #[test]
+    fn hash_always_matches_hash_id_when_enabled() {
+        let scrubber = Scrubber::new(true, [9; 16]);
+        assert_eq!(
+            scrubber.hash_always("peer-a"),
+            scrubber.hash_id("peer-a").into_owned(),
+        );
     }
 }

--- a/crates/offline-protocol/src/telemetry/scrubber.rs
+++ b/crates/offline-protocol/src/telemetry/scrubber.rs
@@ -1,0 +1,103 @@
+//! PII-scrubbing helper for telemetry emit sites.
+//!
+//! [`Scrubber`] wraps the SHA-256-based opaque-identifier scheme already in
+//! use by [`crate::mls_observability`] and exposes a single `hash_id` entry
+//! point. When scrubbing is disabled (caller opted in via
+//! `TelemetryConfig::with_scrub_ids(false)`), the helper returns the input
+//! unchanged so emit sites can call it unconditionally.
+
+use crate::mls_observability::opaque_id;
+use crate::telemetry::config::TelemetryConfig;
+
+/// Helper for hashing long-lived pseudonymous identifiers before they cross
+/// the telemetry sink boundary.
+///
+/// Hashing is deterministic for a given `(secret, raw)` pair so that the
+/// same peer appears under the same opaque identifier in every record
+/// produced by the same SDK instance, but the raw identifier cannot be
+/// recovered without the secret.
+#[derive(Debug, Clone)]
+pub struct Scrubber {
+    enabled: bool,
+    secret: [u8; 16],
+}
+
+impl Scrubber {
+    /// Constructs a scrubber with the given enabled flag and secret.
+    pub fn new(enabled: bool, secret: [u8; 16]) -> Self {
+        Self { enabled, secret }
+    }
+
+    /// Constructs a scrubber from a [`TelemetryConfig`], falling back to the
+    /// supplied per-instance secret when the config does not carry one of
+    /// its own.
+    pub fn from_config(config: &TelemetryConfig, fallback_secret: [u8; 16]) -> Self {
+        Self {
+            enabled: config.scrub_ids,
+            secret: config.scrub_secret.unwrap_or(fallback_secret),
+        }
+    }
+
+    /// Returns `true` when scrubbing is active.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Hashes `raw` into a 32-character hex opaque identifier, or returns
+    /// `raw` unchanged when scrubbing is disabled.
+    pub fn hash_id(&self, raw: &str) -> String {
+        if self.enabled {
+            opaque_id(raw, &self.secret)
+        } else {
+            raw.to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_scrubber_returns_raw() {
+        let scrubber = Scrubber::new(false, [0; 16]);
+        assert_eq!(scrubber.hash_id("peer-a"), "peer-a");
+        assert!(!scrubber.is_enabled());
+    }
+
+    #[test]
+    fn enabled_scrubber_returns_stable_hash() {
+        let scrubber = Scrubber::new(true, [1; 16]);
+        let first = scrubber.hash_id("peer-a");
+        let second = scrubber.hash_id("peer-a");
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 32);
+        assert_ne!(first, "peer-a");
+    }
+
+    #[test]
+    fn different_secrets_produce_different_hashes() {
+        let a = Scrubber::new(true, [1; 16]);
+        let b = Scrubber::new(true, [2; 16]);
+        assert_ne!(a.hash_id("peer-a"), b.hash_id("peer-a"));
+    }
+
+    #[test]
+    fn from_config_prefers_config_secret() {
+        let config = TelemetryConfig::default().with_scrub_secret(Some([9; 16]));
+        let fallback = [0; 16];
+        let scrubber = Scrubber::from_config(&config, fallback);
+        assert!(scrubber.is_enabled());
+        let expected = Scrubber::new(true, [9; 16]).hash_id("peer-a");
+        assert_eq!(scrubber.hash_id("peer-a"), expected);
+    }
+
+    #[test]
+    fn from_config_uses_fallback_when_secret_absent() {
+        let config = TelemetryConfig::default();
+        let fallback = [5; 16];
+        let scrubber = Scrubber::from_config(&config, fallback);
+        let expected = Scrubber::new(true, fallback).hash_id("peer-a");
+        assert_eq!(scrubber.hash_id("peer-a"), expected);
+    }
+}

--- a/crates/offline-protocol/src/telemetry/scrubber.rs
+++ b/crates/offline-protocol/src/telemetry/scrubber.rs
@@ -1,15 +1,45 @@
 //! PII-scrubbing helper for telemetry emit sites.
 //!
-//! [`Scrubber`] wraps the SHA-256-based opaque-identifier scheme already in
-//! use by [`crate::mls_observability`] and exposes a single `hash_id` entry
-//! point. When scrubbing is disabled (caller opted in via
-//! `TelemetryConfig::with_scrub_ids(false)`), the helper returns the input
-//! unchanged so emit sites can call it unconditionally.
+//! [`Scrubber`] wraps the SHA-256-based opaque-identifier scheme used across
+//! the SDK and exposes a single `hash_id` entry point. When scrubbing is
+//! disabled (caller opted in via `TelemetryConfig::with_scrub_ids(false)`),
+//! the helper returns the input unchanged so emit sites can call it
+//! unconditionally.
+//!
+//! The underlying [`opaque_id`] function is also exposed for call sites that
+//! need to hash identifiers independently of a `Scrubber` instance
+//! (e.g. MLS lifecycle emission, where multiple distinct identifiers are
+//! hashed per event with a single caller-owned secret).
+//!
+//! Construction note: the hash is `SHA-256(secret || raw)` — a prefix-MAC,
+//! adequate for deterministic pseudonymization but **not** length-extension
+//! resistant. Do not repurpose for integrity checks; use HMAC if that ever
+//! becomes a requirement.
 
 use std::borrow::Cow;
 
-use crate::mls_observability::opaque_id;
+use sha2::{Digest, Sha256};
+
 use crate::telemetry::config::TelemetryConfig;
+
+/// Generates a stable opaque identifier for telemetry.
+///
+/// Produces a 32-character lowercase hex string derived from the first 16
+/// bytes of `SHA-256(secret || raw)`. The result is deterministic for a
+/// given `(secret, raw)` pair but reveals no information about `raw` to a
+/// party that does not hold the secret.
+pub fn opaque_id(raw: &str, secret: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(secret);
+    hasher.update(raw.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(32);
+    for byte in &digest[..16] {
+        use std::fmt::Write as _;
+        let _ = write!(&mut out, "{:02x}", byte);
+    }
+    out
+}
 
 /// Helper for hashing long-lived pseudonymous identifiers before they cross
 /// the telemetry sink boundary.
@@ -35,8 +65,8 @@ impl Scrubber {
     /// its own.
     pub fn from_config(config: &TelemetryConfig, fallback_secret: [u8; 16]) -> Self {
         Self {
-            enabled: config.scrub_ids,
-            secret: config.scrub_secret.unwrap_or(fallback_secret),
+            enabled: config.scrub_ids(),
+            secret: config.scrub_secret().unwrap_or(fallback_secret),
         }
     }
 
@@ -63,12 +93,52 @@ mod tests {
     use super::*;
 
     #[test]
+    fn opaque_id_is_stable_for_same_input() {
+        let secret = b"secret";
+        let first = opaque_id("peer:alice", secret);
+        let second = opaque_id("peer:alice", secret);
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 32);
+    }
+
+    #[test]
+    fn opaque_id_changes_for_different_secret() {
+        let first = opaque_id("peer:alice", b"secret-a");
+        let second = opaque_id("peer:alice", b"secret-b");
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn opaque_id_handles_empty_input() {
+        let secret = b"secret";
+        let out = opaque_id("", secret);
+        assert_eq!(out.len(), 32);
+        assert!(out.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
     fn disabled_scrubber_borrows_raw() {
         let scrubber = Scrubber::new(false, [0; 16]);
         let out = scrubber.hash_id("peer-a");
         assert_eq!(out, "peer-a");
         assert!(matches!(out, Cow::Borrowed(_)));
         assert!(!scrubber.is_enabled());
+    }
+
+    #[test]
+    fn disabled_scrubber_borrows_empty_input() {
+        let scrubber = Scrubber::new(false, [0; 16]);
+        let out = scrubber.hash_id("");
+        assert_eq!(out, "");
+        assert!(matches!(out, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn enabled_scrubber_handles_empty_input() {
+        let scrubber = Scrubber::new(true, [1; 16]);
+        let out = scrubber.hash_id("");
+        assert_eq!(out.len(), 32);
+        assert!(matches!(out, Cow::Owned(_)));
     }
 
     #[test]

--- a/crates/offline-protocol/src/telemetry/scrubber.rs
+++ b/crates/offline-protocol/src/telemetry/scrubber.rs
@@ -219,6 +219,28 @@ mod tests {
         assert_eq!(scrubber.hash_id("peer-a"), expected);
     }
 
+    /// Locks the leaf-identifier policy the emission-wiring follow-up will
+    /// inherit: when the caller opts out of scrubbing via
+    /// `TelemetryConfig::with_scrub_ids(false)`, `hash_id` passes the raw
+    /// identifier through unchanged, but `hash_always` still hashes derived
+    /// correlation tokens. Flipping either half silently would change the
+    /// privacy contract apps are told to expect.
+    #[test]
+    fn from_config_with_scrub_ids_disabled_passes_raw_through_hash_id() {
+        let config = TelemetryConfig::default().with_scrub_ids(false);
+        let scrubber = Scrubber::from_config(&config, [3; 16]);
+        assert!(!scrubber.is_enabled());
+
+        let leaf = scrubber.hash_id("peer-a");
+        assert_eq!(leaf, "peer-a");
+        assert!(matches!(leaf, Cow::Borrowed(_)));
+
+        let derived = scrubber.hash_always("peer-a|group-b");
+        assert_eq!(derived.len(), 32);
+        assert!(derived.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(derived, "peer-a|group-b");
+    }
+
     #[test]
     fn hash_always_ignores_enabled_flag() {
         let enabled = Scrubber::new(true, [1; 16]);

--- a/crates/offline-protocol/src/telemetry/scrubber.rs
+++ b/crates/offline-protocol/src/telemetry/scrubber.rs
@@ -13,6 +13,7 @@
 //! becomes a requirement.
 
 use std::borrow::Cow;
+use std::fmt;
 
 use sha2::{Digest, Sha256};
 
@@ -27,6 +28,7 @@ use crate::telemetry::config::TelemetryConfig;
 ///
 /// Crate-private: external callers use [`Scrubber::hash_id`] instead so
 /// there is a single public entry point to the hashing operation.
+#[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
 pub(crate) fn opaque_id(raw: &str, secret: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(secret);
@@ -47,10 +49,23 @@ pub(crate) fn opaque_id(raw: &str, secret: &[u8]) -> String {
 /// same peer appears under the same opaque identifier in every record
 /// produced by the same SDK instance, but the raw identifier cannot be
 /// recovered without the secret.
-#[derive(Debug, Clone)]
-pub struct Scrubber {
+#[derive(Clone)]
+pub(crate) struct Scrubber {
     enabled: bool,
+    #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     secret: [u8; 16],
+}
+
+impl fmt::Debug for Scrubber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Hand-rolled to redact `secret` — a derived Debug would dump the
+        // per-instance hashing key verbatim into any log that formats a
+        // Scrubber (directly or transitively via an owning struct).
+        f.debug_struct("Scrubber")
+            .field("enabled", &self.enabled)
+            .field("secret", &"<redacted>")
+            .finish()
+    }
 }
 
 impl Scrubber {
@@ -62,6 +77,10 @@ impl Scrubber {
     /// Constructs a scrubber from a [`TelemetryConfig`], falling back to the
     /// supplied per-instance secret when the config does not carry one of
     /// its own.
+    ///
+    /// Scaffolding for the emission-wiring follow-up; the protocol engine
+    /// does not yet invoke this path.
+    #[allow(dead_code)]
     pub fn from_config(config: &TelemetryConfig, fallback_secret: [u8; 16]) -> Self {
         Self {
             enabled: config.scrub_ids(),
@@ -70,6 +89,7 @@ impl Scrubber {
     }
 
     /// Returns `true` when scrubbing is active.
+    #[allow(dead_code)]
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }
@@ -85,6 +105,7 @@ impl Scrubber {
     /// multiple raw identifiers — use [`Scrubber::hash_always`] instead, so
     /// that the composite cannot be disabled by a user-facing scrubbing
     /// preference.
+    #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     pub fn hash_id<'a>(&self, raw: &'a str) -> Cow<'a, str> {
         if self.enabled {
             Cow::Owned(opaque_id(raw, &self.secret))
@@ -103,6 +124,7 @@ impl Scrubber {
     /// preference, because disabling scrubbing is a choice about leaf IDs
     /// the caller already controls, not about derived values the SDK
     /// constructs internally.
+    #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     pub fn hash_always(&self, raw: &str) -> String {
         opaque_id(raw, &self.secret)
     }
@@ -220,6 +242,20 @@ mod tests {
         assert_eq!(
             scrubber.hash_always("peer-a"),
             scrubber.hash_id("peer-a").into_owned(),
+        );
+    }
+
+    #[test]
+    fn debug_redacts_secret() {
+        let scrubber = Scrubber::new(true, [0xAB; 16]);
+        let rendered = format!("{scrubber:?}");
+        assert!(
+            rendered.contains("<redacted>"),
+            "expected redaction marker, got {rendered}"
+        );
+        assert!(
+            !rendered.contains("ab, ab") && !rendered.contains("171, 171"),
+            "secret bytes leaked into Debug output: {rendered}"
         );
     }
 }

--- a/crates/offline-protocol/src/telemetry/sink.rs
+++ b/crates/offline-protocol/src/telemetry/sink.rs
@@ -1,0 +1,64 @@
+//! Cross-cutting telemetry sink trait.
+//!
+//! [`TelemetrySink`] is the single observer interface for all telemetry the
+//! SDK emits. Apps implement it (or install [`NoopTelemetrySink`]) and the SDK
+//! pushes every [`TelemetryRecord`] through it.
+//!
+//! Emit wiring lives in follow-up work; this module ships the types only.
+
+use super::record::TelemetryRecord;
+
+/// Sink for structured telemetry records.
+///
+/// Implementations must be cheap when called from hot paths — the SDK does not
+/// buffer or rate-limit before dispatch beyond its own sampling layer, so
+/// expensive work (I/O, serialization to external formats) should be
+/// deferred to a background task owned by the implementor.
+///
+/// The record is passed by reference so implementations that only read fields
+/// do not incur a clone. Implementations that need ownership (for example to
+/// forward the record to another thread) should call [`Clone::clone`]
+/// explicitly.
+pub trait TelemetrySink: Send + Sync {
+    /// Dispatches a single telemetry record to the sink.
+    fn emit(&self, record: &TelemetryRecord);
+}
+
+/// Default sink that discards every record.
+///
+/// Used by the SDK when no telemetry sink has been installed. Proves the
+/// zero-cost baseline: the compiler inlines the empty body at every call site
+/// that can statically resolve the concrete type, and the indirect dispatch
+/// cost through `Arc<dyn TelemetrySink>` is a single virtual call that returns
+/// immediately.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopTelemetrySink;
+
+impl TelemetrySink for NoopTelemetrySink {
+    fn emit(&self, _record: &TelemetryRecord) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::telemetry::record::MetricsFrame;
+    use std::sync::Arc;
+
+    #[test]
+    fn noop_sink_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<NoopTelemetrySink>();
+    }
+
+    #[test]
+    fn trait_is_object_safe() {
+        let _: Arc<dyn TelemetrySink> = Arc::new(NoopTelemetrySink);
+    }
+
+    #[test]
+    fn noop_sink_accepts_records_without_panic() {
+        let sink = NoopTelemetrySink;
+        let record = TelemetryRecord::MetricsSnapshot(MetricsFrame::new(0));
+        sink.emit(&record);
+    }
+}

--- a/crates/offline-protocol/src/telemetry/sink.rs
+++ b/crates/offline-protocol/src/telemetry/sink.rs
@@ -41,7 +41,7 @@ impl TelemetrySink for NoopTelemetrySink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::telemetry::record::MetricsFrame;
+    use crate::mls_observability::{MlsLifecycleEvent, MlsOperationContext};
     use std::sync::Arc;
 
     #[test]
@@ -58,7 +58,14 @@ mod tests {
     #[test]
     fn noop_sink_accepts_records_without_panic() {
         let sink = NoopTelemetrySink;
-        let record = TelemetryRecord::MetricsSnapshot(MetricsFrame::new(0));
+        let record = TelemetryRecord::Mls(MlsLifecycleEvent::Initialized {
+            timestamp_ms: 0,
+            session_id: "s".into(),
+            group_id: None,
+            peer_id: None,
+            context: MlsOperationContext::Initialize,
+            error_category: None,
+        });
         sink.emit(&record);
     }
 }


### PR DESCRIPTION
## Summary

Foundation PR (item #4 in the unified-telemetry TODO list). Ships the **types only** for the unified telemetry surface — zero emit paths touched, zero behavior change. Subsequent PRs (items #5–#7) wire existing streams, add the four non-Event categories, and bridge across UniFFI + React Native.

- **`TelemetrySink` trait + `NoopTelemetrySink`** — single observer surface, sync (matches existing `EventCallback` / `MlsEventEmitter`), object-safe for `Arc<dyn TelemetrySink>` installation.
- **`#[non_exhaustive] TelemetryRecord` enum** — two variants today (`Protocol(Box<Event>)` and `Mls(MlsLifecycleEvent)`), wrapping the existing 56-variant `Event` and 5-variant `MlsLifecycleEvent` in place. The four remaining categories (`TransportState`, `MetricsSnapshot`, `Routing`, `Device`) are introduced alongside the emit sites that populate them in #6; `#[non_exhaustive]` reserves the room. `Event` is boxed to avoid a 368-byte size tax on every non-Protocol record (regression-guarded by `telemetry_record_is_smaller_than_unboxed_event`).
- **`TelemetryRecord::name()`** — stable OTel-friendly dotted names (`protocol.message.received`, `mls.initialized`, etc.) covering all 56 Protocol sub-variants and all 5 MLS sub-variants. Wire-identity stability is enforced by a three-part invariant: a compile-time exhaustiveness ward per enum, a runtime uniqueness check, and a catalogue-drift check.
- **`TelemetryConfig`** (`#[non_exhaustive]`, builder-style) — locked defaults: `scrub_ids=true`, `mls_verbosity=Lifecycle`, `metrics_cadence=Some(5s)`. `MlsVerbosity` (`Off | Lifecycle | Diagnostic`) replaces the compile-time `mls-observability` feature flag; that flag is still present and will be deleted in #5. `Debug` redacts `scrub_secret`.
- **`Scrubber` helper** (crate-private) — single PII-scrubbing entry point. Offers `hash_id` (user-togglable leaf-ID scrubbing, returns `Cow` to avoid allocation on the disabled path) and `hash_always` (unconditional hashing for derived correlation tokens like session IDs that must never escape as raw concatenations regardless of user preference). `session_id_for_observability` uses `hash_always` so the composite `peer=X|group=Y` seed is always obfuscated.

## Design decisions locked during planning

Per item #1 of the TODO list:

1. UDL `TransportMetrics` extended in place (not parallel `RichTransportMetrics`) — lands in #7.
2. `scrub_ids` defaults to `true` — implemented.
3. OTel-friendly dotted names — implemented via `TelemetryRecord::name()`.
4. Collapse `mls-observability` feature to runtime `MlsVerbosity` — enum shipped here, call-site deletion lands in #5.
5. `metrics_cadence` defaults to `Some(5s)` — implemented.

## Blast radius

- 4 new files in `crates/offline-protocol/src/telemetry/` (`sink.rs`, `record.rs`, `config.rs`, `scrubber.rs`).
- 4 modified files: `lib.rs` (public re-exports), `telemetry/mod.rs` (submodule wiring), `events.rs` (adds `Event::telemetry_name`), `mls_observability.rs` (adds `MlsLifecycleEvent::telemetry_name`, `opaque_id` moved to `telemetry::scrubber` and narrowed to `pub(crate)`), `protocol/mod.rs` and `protocol/observability.rs` (swap `mls_observability_secret: [u8; 16]` for `mls_observability_scrubber: Scrubber`; call sites use `hash_id` for leaf IDs, `hash_always` for the composite session seed).
- Zero existing emit paths touched at the behavioral level. `opaque_id`'s output is bit-identical (same hash, same secret handling); `EventCallback`, `MlsEventEmitter`, and all existing tests are untouched.
- No UDL / React Native change (that's #7).
- No `Cargo.toml` change. A `telemetry` cargo feature may be introduced in #5 when emit paths land and can benefit from compile-time gating.

## Test plan

- [x] All telemetry unit tests pass (~25 new). Coverage includes: trait object-safety, `Send + Sync` auto-traits, `NoopTelemetrySink` dispatch, `name()` mapping for sample Protocol + MLS variants + impl-level uniqueness + catalogue drift + grammar conformance, `Scrubber` round-trip (disabled passthrough, enabled stability, different-secret distinctness, `from_config` fallback precedence, `hash_always` ignores `enabled`, `hash_always` matches `hash_id` when enabled), `TelemetryConfig::default()` matches every locked decision, builder overrides, `Debug` redacts `scrub_secret`, `TelemetryRecord` size is bounded below `Event` to regression-guard the `Box<Event>` decision.
- [x] `cargo test -p offline-protocol --lib telemetry` — 32 passed.
- [x] `cargo clippy -p offline-protocol --lib -- -D warnings` — clean (fixed `large_enum_variant` by boxing `Event`; fixed `manual_impl_default` on `MlsVerbosity`).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo doc -p offline-protocol --no-deps` — no missing-docs warnings (crate enforces `#![warn(missing_docs)]`).
- [x] `cargo build -p offline-protocol --features mls-observability` — clean; the legacy feature path still compiles and the integration test `test_mls_observability_uses_opaque_identifiers` passes.

## Review-cycle fixes (round four)

Applied after a principal-engineer review surfaced a latent privacy trap in the scrubber plumbing:

1. **`session_id_for_observability` now uses `Scrubber::hash_always`** (not `hash_id`). The session seed concatenates raw peer+group IDs, so it must be unconditionally obfuscated — the `scrub_ids` knob is a preference over leaf IDs the caller controls, not over derived correlation tokens the SDK constructs internally. Without this fix, once #5 wires the scrubber from `TelemetryConfig::scrub_ids`, any user setting `scrub_ids=false` would have leaked both raw IDs coupled in a single string.
2. **`Scrubber` narrowed to `pub(crate)`.** It is an internal hashing helper; external apps observe scrubbing behavior through `TelemetryConfig`, not by constructing scrubbers directly.
3. **`TelemetryRecord` size regression test added** — locks in the `Box<Event>` decision so accidental unboxing fails loudly.

## Follow-ups

- **#5** — route existing `Event` and MLS streams through the sink; delete the 27 `#[cfg(feature = "mls-observability")]` sites; expose `install_telemetry_sink(sink, config)`.
- **#6** — populate the four placeholder record types (metrics snapshots, transport state transitions, routing decisions, device-capability snapshots) with real payloads.
- **#7** — UDL `callback interface TelemetrySink`, typed dictionaries for hot categories, React Native bridge.