### PR TITLE
feat(protocol): route Event and MLS streams through TelemetrySink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ offline-protocol-bench         ← Criterion benchmarks
 - **DORS** (`crates/offline-protocol-router/src/dors.rs`): multi-factor scoring (RSSI, congestion, bandwidth, battery, reliability, capacity) with hysteresis, cooldown, and stability window to prevent transport flapping.
 - **Protocol control messages**: internal prefix convention (`__MLS_KEY_PKG__`, `__MLS_WELCOME__`, `__MLS_ENC__`, etc.) in `crates/offline-protocol/src/protocol.rs`. Service messages use `__SVC_DISC_Q__`, `__SVC_DISC_R__`, `__SVC_REQ__`, `__SVC_RESP__` prefixes in `crates/offline-protocol-services/src/payloads.rs`.
 - **Event-driven**: `OfflineProtocol` emits events (MessageReceived, PeerDiscovered, TransportChanged, etc.) via `EventCallback`.
-- **Feature flag**: `mls-observability` in `offline-protocol` crate enables detailed MLS lifecycle events.
+- **Runtime telemetry**: apps install a `TelemetrySink` via `OfflineProtocol::install_telemetry_sink(sink, config)`; `TelemetryConfig::mls_verbosity` (`Off` | `Lifecycle` (default) | `Diagnostic`) gates MLS lifecycle emission at runtime. Replaces the retired `mls-observability` Cargo feature. Identifier scrubbing is on by default via `TelemetryConfig::scrub_ids`.
 
 ### Safety Rules
 

--- a/crates/offline-protocol/Cargo.toml
+++ b/crates/offline-protocol/Cargo.toml
@@ -28,7 +28,3 @@ sha2 = "0.10"
 
 [lib]
 
-[features]
-default = []
-mls-observability = []
-

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -139,6 +139,15 @@ pub struct OfflineProtocol {
     /// `install_telemetry_sink` is called; thereafter shared with
     /// `SharedState` via `Arc` clone so both emit paths dispatch through the
     /// same configuration.
+    ///
+    /// The duplication with [`SharedState::telemetry`] is deliberate: MLS
+    /// lifecycle emission is driven from `&self` on `OfflineProtocol` and
+    /// does not hold the shared-state lock, while protocol-event emission
+    /// happens inside `SharedState::emit_event` under the lock. Each path
+    /// reads the context from whichever side it already has in hand, and
+    /// `install_telemetry_sink` is the single writer that keeps both copies
+    /// in sync (guaranteed atomic from the caller's perspective because
+    /// `&mut self` excludes concurrent calls).
     pub(crate) telemetry: Option<Arc<TelemetryContext>>,
 
     /// File transfer manager for chunking outbound and reassembling inbound media.
@@ -397,21 +406,39 @@ impl OfflineProtocol {
     /// [`crate::mls_observability::MlsLifecycleEvent::Initialized`] fired
     /// during `initialize_mls`) are not replayed to a sink installed later.
     ///
+    /// # Re-install semantics
+    ///
+    /// Calling this method a second time *replaces* the previously installed
+    /// sink and config — the old sink stops receiving records as soon as
+    /// this call returns. The per-instance fallback secret is preserved so
+    /// opaque identifiers stay stable across the swap when the new config
+    /// does not carry its own `scrub_secret`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the shared-state mutex is poisoned (indicating an
+    /// earlier panic in another thread while holding the lock). On error no
+    /// sink is installed, and the legacy emission paths are unaffected.
+    ///
     /// [`TelemetryRecord::Protocol`]: crate::telemetry::TelemetryRecord::Protocol
     /// [`TelemetryRecord::Mls`]: crate::telemetry::TelemetryRecord::Mls
     pub fn install_telemetry_sink(
         &mut self,
         sink: Arc<dyn TelemetrySink>,
         config: TelemetryConfig,
-    ) {
+    ) -> Result<()> {
         let ctx = TelemetryContext::new(sink, config, self.telemetry_fallback_secret);
-        let Ok(mut state) = lock_shared_state(&self.shared_state) else {
-            error!("Failed to lock shared state in install_telemetry_sink");
-            return;
-        };
+        let mut state = lock_shared_state(&self.shared_state).map_err(|err| {
+            error!(
+                error = %err,
+                "install_telemetry_sink: shared-state mutex poisoned; sink NOT installed",
+            );
+            err
+        })?;
         state.telemetry = Some(ctx.clone());
         drop(state);
         self.telemetry = Some(ctx);
+        Ok(())
     }
 
     /// Starts the protocol.

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use types::*;
 
 use crate::file_transfer::{FileTransferManager, OutboundTransferState};
 use crate::mls_observability::{MlsEventEmitter, MlsEventRateLimiter, NoopMlsEventEmitter};
-use crate::telemetry::Scrubber;
+use crate::telemetry::{Scrubber, TelemetryConfig, TelemetryContext, TelemetrySink};
 use crate::{Error, EstablishmentState, Event, ProtocolConfig, Result, TransportManager};
 use chrono::{DateTime, Utc};
 use offline_protocol_core::{LamportClock, Message, MessageId};
@@ -127,6 +127,22 @@ pub struct OfflineProtocol {
     #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     telemetry_scrubber: Scrubber,
 
+    /// Per-instance fallback secret for identifier scrubbing. Random at
+    /// construction. Reused by both the pre-install `telemetry_scrubber`
+    /// and by any scrubber built inside `install_telemetry_sink` (unless the
+    /// installed `TelemetryConfig` carries its own `scrub_secret`). Keeping
+    /// the fallback stable across installs means the legacy
+    /// `MlsEventEmitter` path observes consistent opaque IDs before and
+    /// after a sink is installed on the same protocol instance.
+    telemetry_fallback_secret: [u8; 16],
+
+    /// Installed telemetry context (sink + config + scrubber). `None` until
+    /// `install_telemetry_sink` is called; thereafter shared with
+    /// `SharedState` via `Arc` clone so both emit paths dispatch through the
+    /// same configuration.
+    #[allow(dead_code)]
+    telemetry: Option<Arc<TelemetryContext>>,
+
     /// File transfer manager for chunking outbound and reassembling inbound media.
     file_transfer_manager: FileTransferManager,
 
@@ -204,6 +220,12 @@ impl OfflineProtocol {
         // Create transport manager
         let transport_manager = TransportManager::new(transport_selector);
 
+        // Per-instance fallback secret for identifier scrubbing. Stable for
+        // the life of this protocol instance so opaque IDs stay consistent
+        // across any later `install_telemetry_sink` call that does not
+        // supply its own `scrub_secret`.
+        let telemetry_fallback_secret = *uuid::Uuid::new_v4().as_bytes();
+
         Ok(Self {
             transport_manager,
             path_selector: PathSelector::with_config(
@@ -230,14 +252,20 @@ impl OfflineProtocol {
             welcome_lifecycles: HashMap::new(),
             mls_event_emitter: Arc::new(NoopMlsEventEmitter),
             mls_event_rate_limiter: MlsEventRateLimiter::default(),
-            // TODO(telemetry-wiring): replace with
-            // `Scrubber::from_config(&config.telemetry, <per-install fallback>)`
-            // once `ProtocolConfig` carries a `TelemetryConfig`. The hardcoded
-            // `true` preserves today's always-scrub MLS observability semantics;
-            // driving it from config is the single switch that activates the
-            // `with_scrub_ids(false)` opt-out path the Scrubber API already
-            // contracts (see `telemetry::scrubber::tests`).
-            telemetry_scrubber: Scrubber::new(true, *uuid::Uuid::new_v4().as_bytes()),
+            // The pre-install scrubber uses `TelemetryConfig::default()` —
+            // `scrub_ids=true`, no explicit `scrub_secret`. Identifier hashing
+            // is therefore on from the moment the protocol is constructed,
+            // matching today's always-scrub MLS observability semantics. When
+            // `install_telemetry_sink` later supplies a config with
+            // `scrub_ids(false)`, a new scrubber is derived from that config
+            // but reuses `telemetry_fallback_secret` so opaque IDs remain
+            // stable across the install boundary.
+            telemetry_scrubber: Scrubber::from_config(
+                &TelemetryConfig::default(),
+                telemetry_fallback_secret,
+            ),
+            telemetry_fallback_secret,
+            telemetry: None,
             file_transfer_manager: FileTransferManager::new(),
             pending_media_metadata: HashMap::new(),
             outbound_media_transfers: HashMap::new(),
@@ -352,6 +380,40 @@ impl OfflineProtocol {
     /// Configures the MLS lifecycle event emitter.
     pub fn set_mls_event_emitter(&mut self, emitter: Arc<dyn MlsEventEmitter>) {
         self.mls_event_emitter = emitter;
+    }
+
+    /// Installs the unified telemetry sink for this protocol instance.
+    ///
+    /// Every subsequent protocol [`Event`] and MLS lifecycle event is
+    /// additionally forwarded to `sink` as a
+    /// [`crate::telemetry::TelemetryRecord`], gated by the verbosity tier
+    /// and identifier-scrubbing preferences in `config`. Protocol events
+    /// flow through as [`TelemetryRecord::Protocol`], MLS lifecycle events
+    /// as [`TelemetryRecord::Mls`].
+    ///
+    /// This does not replace the legacy [`EventCallback`] and
+    /// [`MlsEventEmitter`] paths — they continue to fire independently for
+    /// backward compatibility.
+    ///
+    /// Events emitted before this call (for example
+    /// [`crate::mls_observability::MlsLifecycleEvent::Initialized`] fired
+    /// during `initialize_mls`) are not replayed to a sink installed later.
+    ///
+    /// [`TelemetryRecord::Protocol`]: crate::telemetry::TelemetryRecord::Protocol
+    /// [`TelemetryRecord::Mls`]: crate::telemetry::TelemetryRecord::Mls
+    pub fn install_telemetry_sink(
+        &mut self,
+        sink: Arc<dyn TelemetrySink>,
+        config: TelemetryConfig,
+    ) {
+        let ctx = TelemetryContext::new(sink, config, self.telemetry_fallback_secret);
+        let Ok(mut state) = lock_shared_state(&self.shared_state) else {
+            error!("Failed to lock shared state in install_telemetry_sink");
+            return;
+        };
+        state.telemetry = Some(ctx.clone());
+        drop(state);
+        self.telemetry = Some(ctx);
     }
 
     /// Starts the protocol.

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -116,7 +116,6 @@ pub struct OfflineProtocol {
     mls_event_emitter: Arc<dyn MlsEventEmitter>,
 
     /// Rate limiting policy for MLS failure event floods.
-    #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     mls_event_rate_limiter: MlsEventRateLimiter,
 
     /// Pre-install scrubber used by MLS emit sites before

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -119,12 +119,12 @@ pub struct OfflineProtocol {
     #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     mls_event_rate_limiter: MlsEventRateLimiter,
 
-    /// Scrubber for hashing long-lived pseudonymous identifiers (peer, group,
-    /// session) into non-reversible opaque telemetry IDs. Holds the
-    /// per-instance secret; constructed once at protocol creation and reused
-    /// by every emit site. Today only the MLS observability path consumes it;
-    /// additional emit sites land alongside the wiring follow-up.
-    #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
+    /// Pre-install scrubber used by MLS emit sites before
+    /// `install_telemetry_sink` is called. Once a sink is installed, emit
+    /// sites read `self.telemetry.scrubber` instead via `current_scrubber()`.
+    /// Both scrubbers share `telemetry_fallback_secret` so opaque identifiers
+    /// observed by the legacy `MlsEventEmitter` stay consistent across the
+    /// install boundary.
     telemetry_scrubber: Scrubber,
 
     /// Per-instance fallback secret for identifier scrubbing. Random at
@@ -140,8 +140,7 @@ pub struct OfflineProtocol {
     /// `install_telemetry_sink` is called; thereafter shared with
     /// `SharedState` via `Arc` clone so both emit paths dispatch through the
     /// same configuration.
-    #[allow(dead_code)]
-    telemetry: Option<Arc<TelemetryContext>>,
+    pub(crate) telemetry: Option<Arc<TelemetryContext>>,
 
     /// File transfer manager for chunking outbound and reassembling inbound media.
     file_transfer_manager: FileTransferManager,

--- a/crates/offline-protocol/src/protocol/observability.rs
+++ b/crates/offline-protocol/src/protocol/observability.rs
@@ -43,6 +43,18 @@ impl OfflineProtocol {
             .unwrap_or(&self.telemetry_scrubber)
     }
 
+    /// Returns the effective MLS lifecycle verbosity tier.
+    ///
+    /// Defaults to [`MlsVerbosity::Lifecycle`] when no telemetry sink has
+    /// been installed, matching the always-on legacy-emitter behavior that
+    /// the retired `mls-observability` Cargo feature used to gate.
+    pub(super) fn mls_verbosity(&self) -> MlsVerbosity {
+        self.telemetry
+            .as_ref()
+            .map(|ctx| ctx.config.mls_verbosity())
+            .unwrap_or(MlsVerbosity::Lifecycle)
+    }
+
     /// Derives the opaque session identifier used to correlate MLS lifecycle
     /// events. The raw seed (`peer=<peer_id>|group=<group_id>`) couples two
     /// identifiers, so it is hashed unconditionally via
@@ -69,12 +81,7 @@ impl OfflineProtocol {
         // feature. Verbosity defaults to `Lifecycle` when no sink is
         // installed, matching today's always-on-when-feature-was-on
         // behavior for the legacy emitter path.
-        let verbosity = self
-            .telemetry
-            .as_ref()
-            .map(|ctx| ctx.config.mls_verbosity())
-            .unwrap_or(MlsVerbosity::Lifecycle);
-        if matches!(verbosity, MlsVerbosity::Off) {
+        if matches!(self.mls_verbosity(), MlsVerbosity::Off) {
             return;
         }
         if !self.mls_event_rate_limiter.should_emit(&event) {

--- a/crates/offline-protocol/src/protocol/observability.rs
+++ b/crates/offline-protocol/src/protocol/observability.rs
@@ -1,12 +1,53 @@
 //! MLS lifecycle event emission for observability.
+//!
+//! Two fan-outs share this module:
+//!
+//! 1. The legacy [`MlsEventEmitter`] registered via
+//!    [`OfflineProtocol::set_mls_event_emitter`] — preserved for backward
+//!    compatibility with apps that wired observability before the unified
+//!    telemetry sink existed.
+//! 2. The unified [`crate::telemetry::TelemetrySink`] registered via
+//!    [`OfflineProtocol::install_telemetry_sink`] — receives every lifecycle
+//!    event as a [`TelemetryRecord::Mls`].
+//!
+//! Both fan-outs share one gate: [`crate::telemetry::MlsVerbosity`] from the
+//! installed [`crate::telemetry::TelemetryConfig`]. Setting verbosity to
+//! `Off` suppresses both. When no telemetry sink has been installed,
+//! verbosity defaults to `Lifecycle` — the same always-on behavior the old
+//! `mls-observability` Cargo feature used to gate.
+//!
+//! [`MlsEventEmitter`]: crate::mls_observability::MlsEventEmitter
+//! [`OfflineProtocol::set_mls_event_emitter`]: super::OfflineProtocol::set_mls_event_emitter
+//! [`OfflineProtocol::install_telemetry_sink`]: super::OfflineProtocol::install_telemetry_sink
 
 use super::OfflineProtocol;
-#[cfg(feature = "mls-observability")]
-use crate::mls_observability::{timestamp_now_ms, MlsLifecycleEvent};
-use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsOperationContext};
+use crate::mls_observability::{
+    timestamp_now_ms, DecryptionFailureKind, MlsErrorCategory, MlsLifecycleEvent,
+    MlsOperationContext,
+};
+use crate::telemetry::{MlsVerbosity, TelemetryRecord};
 
 impl OfflineProtocol {
-    #[cfg(feature = "mls-observability")]
+    /// Returns the current scrubber used by MLS emit sites.
+    ///
+    /// When a telemetry sink has been installed, this is the scrubber derived
+    /// from the installed [`crate::telemetry::TelemetryConfig`]. Otherwise it
+    /// is the pre-install scrubber constructed at
+    /// [`OfflineProtocol::new`], which shares its fallback secret with any
+    /// later-installed scrubber — so opaque identifiers stay consistent for
+    /// legacy-emitter consumers across the install boundary.
+    fn current_scrubber(&self) -> &crate::telemetry::Scrubber {
+        self.telemetry
+            .as_ref()
+            .map(|ctx| &ctx.scrubber)
+            .unwrap_or(&self.telemetry_scrubber)
+    }
+
+    /// Derives the opaque session identifier used to correlate MLS lifecycle
+    /// events. The raw seed (`peer=<peer_id>|group=<group_id>`) couples two
+    /// identifiers, so it is hashed unconditionally via
+    /// [`crate::telemetry::Scrubber::hash_always`] — disabling `scrub_ids`
+    /// does not disable obfuscation of derived correlation tokens.
     pub(super) fn session_id_for_observability(
         &self,
         peer_id: Option<&str>,
@@ -17,21 +58,39 @@ impl OfflineProtocol {
             peer_id.unwrap_or("none"),
             group_id.unwrap_or("none")
         );
-        // `hash_always` (not `hash_id`): the seed couples raw peer+group IDs,
-        // so emitting it unhashed would leak strictly more than the sum of
-        // its parts. Session IDs are a derived correlation token and MUST be
-        // obfuscated regardless of the user's `scrub_ids` preference.
-        self.telemetry_scrubber.hash_always(&seed)
+        self.current_scrubber().hash_always(&seed)
     }
 
-    #[cfg(feature = "mls-observability")]
+    /// Single choke point for MLS lifecycle emission. Both the legacy
+    /// [`crate::mls_observability::MlsEventEmitter`] and the installed
+    /// [`crate::telemetry::TelemetrySink`] are reached from here.
     pub(super) fn emit_mls_lifecycle_event(&self, event: MlsLifecycleEvent) {
-        if self.mls_event_rate_limiter.should_emit(&event) {
+        // Runtime replacement for the retired `mls-observability` Cargo
+        // feature. Verbosity defaults to `Lifecycle` when no sink is
+        // installed, matching today's always-on-when-feature-was-on
+        // behavior for the legacy emitter path.
+        let verbosity = self
+            .telemetry
+            .as_ref()
+            .map(|ctx| ctx.config.mls_verbosity())
+            .unwrap_or(MlsVerbosity::Lifecycle);
+        if matches!(verbosity, MlsVerbosity::Off) {
+            return;
+        }
+        if !self.mls_event_rate_limiter.should_emit(&event) {
+            return;
+        }
+        // Legacy emitter consumes a value-typed event (its existing
+        // signature), so we clone when a sink is also installed. The clone
+        // is cheap — `MlsLifecycleEvent` is small and lives on the stack.
+        if let Some(ctx) = &self.telemetry {
+            self.mls_event_emitter.emit(event.clone());
+            ctx.sink.emit(&TelemetryRecord::Mls(event));
+        } else {
             self.mls_event_emitter.emit(event);
         }
     }
 
-    #[cfg(feature = "mls-observability")]
     pub(super) fn emit_mls_initialized(&self) {
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::Initialized {
             timestamp_ms: timestamp_now_ms(),
@@ -43,12 +102,9 @@ impl OfflineProtocol {
         });
     }
 
-    #[cfg(not(feature = "mls-observability"))]
-    pub(super) fn emit_mls_initialized(&self) {}
-
-    #[cfg(feature = "mls-observability")]
     pub(super) fn emit_mls_encryption_used(&self, recipient: &str) {
-        let peer_id = self.telemetry_scrubber.hash_id(recipient).into_owned();
+        let scrubber = self.current_scrubber();
+        let peer_id = scrubber.hash_id(recipient).into_owned();
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::EncryptionUsed {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(Some(recipient), None),
@@ -59,10 +115,6 @@ impl OfflineProtocol {
         });
     }
 
-    #[cfg(not(feature = "mls-observability"))]
-    pub(super) fn emit_mls_encryption_used(&self, _recipient: &str) {}
-
-    #[cfg(feature = "mls-observability")]
     pub(super) fn emit_mls_session_missing(
         &self,
         peer_id: Option<&str>,
@@ -70,27 +122,17 @@ impl OfflineProtocol {
         context: MlsOperationContext,
         error_category: MlsErrorCategory,
     ) {
+        let scrubber = self.current_scrubber();
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::SessionMissing {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(peer_id, group_id),
-            group_id: group_id.map(|id| self.telemetry_scrubber.hash_id(id).into_owned()),
-            peer_id: peer_id.map(|id| self.telemetry_scrubber.hash_id(id).into_owned()),
+            group_id: group_id.map(|id| scrubber.hash_id(id).into_owned()),
+            peer_id: peer_id.map(|id| scrubber.hash_id(id).into_owned()),
             context,
             error_category: Some(error_category),
         });
     }
 
-    #[cfg(not(feature = "mls-observability"))]
-    pub(super) fn emit_mls_session_missing(
-        &self,
-        _peer_id: Option<&str>,
-        _group_id: Option<&str>,
-        _context: MlsOperationContext,
-        _error_category: MlsErrorCategory,
-    ) {
-    }
-
-    #[cfg(feature = "mls-observability")]
     pub(super) fn emit_mls_decryption_failed(
         &self,
         sender_id: &str,
@@ -98,50 +140,32 @@ impl OfflineProtocol {
         kind: DecryptionFailureKind,
         context: MlsOperationContext,
     ) {
+        let scrubber = self.current_scrubber();
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::DecryptionFailed {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(Some(sender_id), group_id),
-            group_id: group_id.map(|id| self.telemetry_scrubber.hash_id(id).into_owned()),
-            peer_id: Some(self.telemetry_scrubber.hash_id(sender_id).into_owned()),
+            group_id: group_id.map(|id| scrubber.hash_id(id).into_owned()),
+            peer_id: Some(scrubber.hash_id(sender_id).into_owned()),
             context,
             error_category: Some(kind.error_category()),
             failure_kind: kind,
         });
     }
 
-    #[cfg(not(feature = "mls-observability"))]
-    pub(super) fn emit_mls_decryption_failed(
-        &self,
-        _sender_id: &str,
-        _group_id: Option<&str>,
-        _kind: DecryptionFailureKind,
-        _context: MlsOperationContext,
-    ) {
-    }
-
-    #[cfg(feature = "mls-observability")]
     pub(super) fn emit_mls_session_ready(
         &self,
         peer_id: &str,
         group_id: &str,
         context: MlsOperationContext,
     ) {
+        let scrubber = self.current_scrubber();
         self.emit_mls_lifecycle_event(MlsLifecycleEvent::SessionReady {
             timestamp_ms: timestamp_now_ms(),
             session_id: self.session_id_for_observability(Some(peer_id), Some(group_id)),
-            group_id: Some(self.telemetry_scrubber.hash_id(group_id).into_owned()),
-            peer_id: Some(self.telemetry_scrubber.hash_id(peer_id).into_owned()),
+            group_id: Some(scrubber.hash_id(group_id).into_owned()),
+            peer_id: Some(scrubber.hash_id(peer_id).into_owned()),
             context,
             error_category: None,
         });
-    }
-
-    #[cfg(not(feature = "mls-observability"))]
-    pub(super) fn emit_mls_session_ready(
-        &self,
-        _peer_id: &str,
-        _group_id: &str,
-        _context: MlsOperationContext,
-    ) {
     }
 }

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::constants::ACK_FOR_KEY;
 use crate::events::{DecryptionFailureCode, PresenceStatus};
 #[cfg(feature = "mls-observability")]
-use crate::mls_observability::MlsLifecycleEvent;
+use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsLifecycleEvent};
 use chrono::Duration as ChronoDuration;
 use offline_protocol_core::{AppId, ContentType, MessagePriority, ServiceDescriptor, UserId};
 use offline_protocol_transport::{

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::constants::ACK_FOR_KEY;
 use crate::events::{DecryptionFailureCode, PresenceStatus};
-use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsLifecycleEvent};
+use crate::mls_observability::{
+    DecryptionFailureKind, MlsErrorCategory, MlsLifecycleEvent, MlsOperationContext,
+};
 use crate::telemetry::{
     MlsVerbosity, NoopTelemetrySink, TelemetryConfig, TelemetryRecord, TelemetrySink,
 };
@@ -688,7 +690,9 @@ fn test_mls_observability_uses_opaque_identifiers() {
 fn test_telemetry_sink_receives_protocol_events() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
     let sink = RecordingTelemetrySink::default();
-    protocol.install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default());
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
 
     protocol.emit_event(crate::events::Event::neighbor_lost("alice".into()));
 
@@ -715,7 +719,9 @@ fn test_telemetry_sink_receives_protocol_events() {
 fn test_telemetry_sink_receives_mls_events() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
     let sink = RecordingTelemetrySink::default();
-    protocol.install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default());
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
 
     let storage = Arc::new(crate::mls::InMemoryStorage::new());
     protocol.initialize_mls(storage).unwrap();
@@ -736,10 +742,12 @@ fn test_mls_verbosity_off_suppresses_both_sink_and_legacy_emitter() {
     let emitter = RecordingMlsEmitter::default();
     protocol.set_mls_event_emitter(Arc::new(emitter.clone()));
     let sink = RecordingTelemetrySink::default();
-    protocol.install_telemetry_sink(
-        Arc::new(sink.clone()),
-        TelemetryConfig::default().with_mls_verbosity(MlsVerbosity::Off),
-    );
+    protocol
+        .install_telemetry_sink(
+            Arc::new(sink.clone()),
+            TelemetryConfig::default().with_mls_verbosity(MlsVerbosity::Off),
+        )
+        .unwrap();
 
     let storage = Arc::new(crate::mls::InMemoryStorage::new());
     protocol.initialize_mls(storage).unwrap();
@@ -762,10 +770,12 @@ fn test_mls_verbosity_off_suppresses_both_sink_and_legacy_emitter() {
 fn test_scrub_ids_false_passes_raw_peer_id_to_sink() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
     let sink = RecordingTelemetrySink::default();
-    protocol.install_telemetry_sink(
-        Arc::new(sink.clone()),
-        TelemetryConfig::default().with_scrub_ids(false),
-    );
+    protocol
+        .install_telemetry_sink(
+            Arc::new(sink.clone()),
+            TelemetryConfig::default().with_scrub_ids(false),
+        )
+        .unwrap();
 
     protocol.emit_event(crate::events::Event::neighbor_lost("alice-raw".into()));
 
@@ -796,7 +806,9 @@ fn test_legacy_event_callback_still_fires_with_sink_installed() {
     });
 
     let sink = RecordingTelemetrySink::default();
-    protocol.install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default());
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
 
     protocol.emit_event(crate::events::Event::neighbor_lost("alice".into()));
 
@@ -830,9 +842,180 @@ fn test_noop_telemetry_sink_installs_cleanly() {
     // default apps fall back to when they want install-path wiring without
     // paying for emission.
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
-    protocol.install_telemetry_sink(Arc::new(NoopTelemetrySink), TelemetryConfig::default());
+    protocol
+        .install_telemetry_sink(Arc::new(NoopTelemetrySink), TelemetryConfig::default())
+        .unwrap();
     protocol.emit_event(crate::events::Event::neighbor_lost("alice".into()));
     // If we got here, the install + emit path did not panic.
+}
+
+#[test]
+fn test_install_telemetry_sink_replaces_previous_sink() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+    let first = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(first.clone()), TelemetryConfig::default())
+        .unwrap();
+
+    // First sink should observe the pre-swap event.
+    protocol.emit_event(crate::events::Event::neighbor_lost("alice".into()));
+
+    let second = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(second.clone()), TelemetryConfig::default())
+        .unwrap();
+
+    // After re-install, only the second sink observes the post-swap event.
+    protocol.emit_event(crate::events::Event::neighbor_lost("bob".into()));
+
+    let first_records = first.take();
+    let second_records = second.take();
+    assert_eq!(
+        first_records.len(),
+        1,
+        "first sink should see exactly the pre-swap event, got {first_records:?}",
+    );
+    assert_eq!(
+        second_records.len(),
+        1,
+        "second sink should see exactly the post-swap event, got {second_records:?}",
+    );
+}
+
+#[test]
+fn test_mls_verbosity_diagnostic_matches_lifecycle_today() {
+    // Locks the documented contract that `Diagnostic` currently emits the
+    // same stream as `Lifecycle`. If the two ever diverge, update the
+    // `MlsVerbosity::Diagnostic` rustdoc at the same time.
+    fn records_for(verbosity: MlsVerbosity) -> Vec<TelemetryRecord> {
+        let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+        let sink = RecordingTelemetrySink::default();
+        protocol
+            .install_telemetry_sink(
+                Arc::new(sink.clone()),
+                TelemetryConfig::default().with_mls_verbosity(verbosity),
+            )
+            .unwrap();
+        let storage = Arc::new(crate::mls::InMemoryStorage::new());
+        protocol.initialize_mls(storage).unwrap();
+        sink.take()
+    }
+
+    let lifecycle_names: Vec<&'static str> = records_for(MlsVerbosity::Lifecycle)
+        .iter()
+        .map(|r| r.name())
+        .collect();
+    let diagnostic_names: Vec<&'static str> = records_for(MlsVerbosity::Diagnostic)
+        .iter()
+        .map(|r| r.name())
+        .collect();
+
+    assert_eq!(
+        lifecycle_names, diagnostic_names,
+        "Diagnostic must emit the same record names as Lifecycle until the richer stream lands",
+    );
+}
+
+#[test]
+fn test_session_id_stays_consistent_across_install_boundary() {
+    // The `telemetry_fallback_secret` is per-instance and is reused when
+    // `install_telemetry_sink` supplies a config without an explicit
+    // `scrub_secret`. This means an opaque `session_id` that the legacy
+    // emitter sees before install must match what the sink sees after
+    // install for the same (peer, group) pair.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+    let emitter = RecordingMlsEmitter::default();
+    protocol.set_mls_event_emitter(Arc::new(emitter.clone()));
+
+    // Pre-install: drive an MLS session-missing emission. The legacy
+    // emitter records the opaque session_id derived from the pre-install
+    // scrubber.
+    protocol.emit_mls_session_missing(
+        Some("peer-a"),
+        Some("group-b"),
+        MlsOperationContext::SessionLookup,
+        MlsErrorCategory::NotInitialized,
+    );
+    let pre_install = emitter.take();
+    assert_eq!(pre_install.len(), 1);
+    let pre_session_id = match &pre_install[0] {
+        MlsLifecycleEvent::SessionMissing { session_id, .. } => session_id.clone(),
+        other => panic!("unexpected MLS event before install: {other:?}"),
+    };
+
+    // Install the sink with a default config (no scrub_secret) — the
+    // fallback secret is reused, so derived correlation tokens must stay
+    // stable.
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+
+    // Post-install: drive another session-missing emission with the same
+    // inputs. Both the legacy emitter and the sink now observe it.
+    protocol.emit_mls_session_missing(
+        Some("peer-a"),
+        Some("group-b"),
+        MlsOperationContext::SessionLookup,
+        MlsErrorCategory::NotInitialized,
+    );
+
+    let post_legacy = emitter.take();
+    let post_sink: Vec<TelemetryRecord> = sink
+        .take()
+        .into_iter()
+        .filter(|r| matches!(r, TelemetryRecord::Mls(_)))
+        .collect();
+    assert_eq!(post_legacy.len(), 1);
+    assert_eq!(post_sink.len(), 1);
+
+    let post_legacy_id = match &post_legacy[0] {
+        MlsLifecycleEvent::SessionMissing { session_id, .. } => session_id.clone(),
+        other => panic!("unexpected MLS event after install: {other:?}"),
+    };
+    let post_sink_id = match &post_sink[0] {
+        TelemetryRecord::Mls(MlsLifecycleEvent::SessionMissing { session_id, .. }) => {
+            session_id.clone()
+        }
+        other => panic!("unexpected sink record after install: {other:?}"),
+    };
+
+    assert_eq!(
+        pre_session_id, post_legacy_id,
+        "legacy emitter must see a consistent session_id across the install boundary",
+    );
+    assert_eq!(
+        post_legacy_id, post_sink_id,
+        "legacy emitter and sink must see the same session_id post-install",
+    );
+}
+
+#[test]
+fn test_sink_installed_after_initialize_mls_does_not_replay() {
+    // `install_telemetry_sink` is not a replay API — events that fired
+    // before the sink existed stay on the floor. Regression guard for the
+    // documented contract.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+    let storage = Arc::new(crate::mls::InMemoryStorage::new());
+    protocol.initialize_mls(storage).unwrap();
+
+    // Sink installed *after* MLS init.
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+
+    let records = sink.take();
+    assert!(
+        records.iter().all(|r| !matches!(
+            r,
+            TelemetryRecord::Mls(MlsLifecycleEvent::Initialized { .. })
+        )),
+        "initialize_mls firing before install must not replay to the sink, got {records:?}",
+    );
 }
 
 #[test]

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -1,8 +1,10 @@
 use super::*;
 use crate::constants::ACK_FOR_KEY;
 use crate::events::{DecryptionFailureCode, PresenceStatus};
-#[cfg(feature = "mls-observability")]
 use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsLifecycleEvent};
+use crate::telemetry::{
+    MlsVerbosity, NoopTelemetrySink, TelemetryConfig, TelemetryRecord, TelemetrySink,
+};
 use chrono::Duration as ChronoDuration;
 use offline_protocol_core::{AppId, ContentType, MessagePriority, ServiceDescriptor, UserId};
 use offline_protocol_transport::{
@@ -20,23 +22,41 @@ pub(crate) fn create_test_config_for_user(user_id: &str) -> ProtocolConfig {
     ProtocolConfig::new("test-app", user_id)
 }
 
-#[cfg(feature = "mls-observability")]
 #[derive(Default, Clone)]
 struct RecordingMlsEmitter {
     events: Arc<Mutex<Vec<MlsLifecycleEvent>>>,
 }
 
-#[cfg(feature = "mls-observability")]
 impl MlsEventEmitter for RecordingMlsEmitter {
     fn emit(&self, event: MlsLifecycleEvent) {
         self.events.lock().unwrap().push(event);
     }
 }
 
-#[cfg(feature = "mls-observability")]
 impl RecordingMlsEmitter {
     fn take(&self) -> Vec<MlsLifecycleEvent> {
         let mut guard = self.events.lock().unwrap();
+        std::mem::take(&mut *guard)
+    }
+}
+
+/// Minimal [`TelemetrySink`] implementation that records every record it
+/// receives. Cloning the sink clones the shared backing vector, so a caller
+/// keeps a handle to the records after the sink is moved into `Arc`.
+#[derive(Default, Clone)]
+struct RecordingTelemetrySink {
+    records: Arc<Mutex<Vec<TelemetryRecord>>>,
+}
+
+impl TelemetrySink for RecordingTelemetrySink {
+    fn emit(&self, record: &TelemetryRecord) {
+        self.records.lock().unwrap().push(record.clone());
+    }
+}
+
+impl RecordingTelemetrySink {
+    fn take(&self) -> Vec<TelemetryRecord> {
+        let mut guard = self.records.lock().unwrap();
         std::mem::take(&mut *guard)
     }
 }
@@ -454,7 +474,6 @@ fn test_should_auto_encrypt_without_mls() {
     assert!(!protocol.is_mls_initialized());
 }
 
-#[cfg(feature = "mls-observability")]
 #[test]
 fn test_mls_observability_emits_initialized_event() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
@@ -473,7 +492,6 @@ fn test_mls_observability_emits_initialized_event() {
     );
 }
 
-#[cfg(feature = "mls-observability")]
 #[test]
 fn test_mls_observability_emits_session_missing_when_not_initialized() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
@@ -493,7 +511,6 @@ fn test_mls_observability_emits_session_missing_when_not_initialized() {
     )));
 }
 
-#[cfg(feature = "mls-observability")]
 #[test]
 fn test_mls_observability_emits_encryption_used_for_successful_encrypt() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
@@ -529,7 +546,6 @@ fn test_mls_observability_emits_encryption_used_for_successful_encrypt() {
         .any(|event| { matches!(event, MlsLifecycleEvent::EncryptionUsed { .. }) }));
 }
 
-#[cfg(feature = "mls-observability")]
 #[test]
 fn test_mls_observability_emits_decryption_failed_not_initialized() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
@@ -569,7 +585,6 @@ fn test_mls_observability_emits_decryption_failed_not_initialized() {
     )));
 }
 
-#[cfg(feature = "mls-observability")]
 #[test]
 fn test_mls_observability_no_encryption_event_on_aborted_encrypt() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
@@ -601,7 +616,6 @@ fn test_mls_observability_no_encryption_event_on_aborted_encrypt() {
     );
 }
 
-#[cfg(feature = "mls-observability")]
 #[test]
 fn test_mls_observability_session_ready_emits_once_for_idempotent_confirm() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
@@ -646,7 +660,6 @@ fn test_mls_observability_session_ready_emits_once_for_idempotent_confirm() {
     assert_eq!(ready_count, 1);
 }
 
-#[cfg(feature = "mls-observability")]
 #[test]
 fn test_mls_observability_uses_opaque_identifiers() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
@@ -665,6 +678,161 @@ fn test_mls_observability_uses_opaque_identifiers() {
         .unwrap();
     assert_ne!(initialized, "peer=none|group=none");
     assert_eq!(initialized.len(), 32);
+}
+
+// ===========================================================================
+// TelemetrySink integration (unified telemetry surface)
+// ===========================================================================
+
+#[test]
+fn test_telemetry_sink_receives_protocol_events() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol.install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default());
+
+    protocol.emit_event(crate::events::Event::neighbor_lost("alice".into()));
+
+    let records = sink.take();
+    assert_eq!(records.len(), 1, "sink should have received one record");
+    match &records[0] {
+        TelemetryRecord::Protocol(event) => {
+            assert_eq!(event.telemetry_name(), "protocol.neighbor.lost");
+            match event.as_ref() {
+                crate::events::Event::NeighborLost { peer_id } => {
+                    // scrub_ids defaults to true — expect a 32-hex opaque ID.
+                    assert_ne!(peer_id, "alice", "peer_id must be scrubbed by default");
+                    assert_eq!(peer_id.len(), 32);
+                    assert!(peer_id.chars().all(|c| c.is_ascii_hexdigit()));
+                }
+                _ => panic!("unexpected inner variant"),
+            }
+        }
+        other => panic!("expected Protocol variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_telemetry_sink_receives_mls_events() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol.install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default());
+
+    let storage = Arc::new(crate::mls::InMemoryStorage::new());
+    protocol.initialize_mls(storage).unwrap();
+
+    let records = sink.take();
+    assert!(
+        records.iter().any(|r| matches!(
+            r,
+            TelemetryRecord::Mls(MlsLifecycleEvent::Initialized { .. })
+        )),
+        "sink should observe mls.initialized, got {records:?}",
+    );
+}
+
+#[test]
+fn test_mls_verbosity_off_suppresses_both_sink_and_legacy_emitter() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let emitter = RecordingMlsEmitter::default();
+    protocol.set_mls_event_emitter(Arc::new(emitter.clone()));
+    let sink = RecordingTelemetrySink::default();
+    protocol.install_telemetry_sink(
+        Arc::new(sink.clone()),
+        TelemetryConfig::default().with_mls_verbosity(MlsVerbosity::Off),
+    );
+
+    let storage = Arc::new(crate::mls::InMemoryStorage::new());
+    protocol.initialize_mls(storage).unwrap();
+
+    let legacy = emitter.take();
+    let sink_records = sink.take();
+    assert!(
+        legacy.is_empty(),
+        "MlsVerbosity::Off must suppress the legacy emitter, got {legacy:?}",
+    );
+    assert!(
+        sink_records
+            .iter()
+            .all(|r| !matches!(r, TelemetryRecord::Mls(_))),
+        "MlsVerbosity::Off must suppress sink Mls records, got {sink_records:?}",
+    );
+}
+
+#[test]
+fn test_scrub_ids_false_passes_raw_peer_id_to_sink() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol.install_telemetry_sink(
+        Arc::new(sink.clone()),
+        TelemetryConfig::default().with_scrub_ids(false),
+    );
+
+    protocol.emit_event(crate::events::Event::neighbor_lost("alice-raw".into()));
+
+    let records = sink.take();
+    assert_eq!(records.len(), 1);
+    match &records[0] {
+        TelemetryRecord::Protocol(event) => match event.as_ref() {
+            crate::events::Event::NeighborLost { peer_id } => {
+                assert_eq!(
+                    peer_id, "alice-raw",
+                    "scrub_ids(false) must pass raw identifier through",
+                );
+            }
+            _ => panic!("unexpected inner variant"),
+        },
+        other => panic!("expected Protocol variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_legacy_event_callback_still_fires_with_sink_installed() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+    let captured: Arc<Mutex<Vec<crate::events::Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured_handler = captured.clone();
+    protocol.on_event(move |event| {
+        captured_handler.lock().unwrap().push(event);
+    });
+
+    let sink = RecordingTelemetrySink::default();
+    protocol.install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default());
+
+    protocol.emit_event(crate::events::Event::neighbor_lost("alice".into()));
+
+    // Legacy callback receives the raw event.
+    let legacy_events = captured.lock().unwrap().clone();
+    assert_eq!(legacy_events.len(), 1);
+    match &legacy_events[0] {
+        crate::events::Event::NeighborLost { peer_id } => assert_eq!(peer_id, "alice"),
+        _ => panic!("unexpected variant"),
+    }
+
+    // Sink receives the scrubbed event.
+    let sink_records = sink.take();
+    assert_eq!(sink_records.len(), 1);
+    match &sink_records[0] {
+        TelemetryRecord::Protocol(event) => match event.as_ref() {
+            crate::events::Event::NeighborLost { peer_id } => {
+                assert_ne!(peer_id, "alice", "sink should see scrubbed ID");
+                assert_eq!(peer_id.len(), 32);
+            }
+            _ => panic!("unexpected inner variant"),
+        },
+        other => panic!("expected Protocol variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_noop_telemetry_sink_installs_cleanly() {
+    // Guard against regressions where the install path depends on the sink
+    // actually receiving records. `NoopTelemetrySink` is the zero-cost
+    // default apps fall back to when they want install-path wiring without
+    // paying for emission.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol.install_telemetry_sink(Arc::new(NoopTelemetrySink), TelemetryConfig::default());
+    protocol.emit_event(crate::events::Event::neighbor_lost("alice".into()));
+    // If we got here, the install + emit path did not panic.
 }
 
 #[test]

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -1,7 +1,7 @@
 //! Type definitions, constants, and shared state for the protocol engine.
 
 use crate::events::{Event, EventCallback, PresenceStatus};
-use crate::telemetry::TelemetryContext;
+use crate::telemetry::{scrub_event, TelemetryContext, TelemetryRecord};
 use crate::Error;
 use chrono::{DateTime, Utc};
 use offline_protocol_core::{
@@ -387,7 +387,6 @@ pub(crate) struct SharedState {
     /// forwards every protocol event to `ctx.sink` as a
     /// `TelemetryRecord::Protocol`, with identifier scrubbing applied per
     /// `ctx.config`. Set via `OfflineProtocol::install_telemetry_sink`.
-    #[allow(dead_code)]
     pub(crate) telemetry: Option<Arc<TelemetryContext>>,
 }
 
@@ -402,8 +401,22 @@ impl SharedState {
     }
 
     pub(crate) fn emit_event(&self, event: Event) {
+        // Legacy `EventCallback` handlers run first and receive the raw
+        // event. This preserves the pre-telemetry contract — any app that
+        // relied on `on_event` sees exactly what it used to.
         for handler in &self.event_handlers {
             handler(event.clone());
+        }
+        // Sink fan-out runs after, gated on an installed context. Identifier
+        // fields are scrubbed per the installed config before crossing the
+        // sink boundary so long-lived pseudonyms don't leak to third-party
+        // sinks by default. When scrubbing is disabled
+        // (`TelemetryConfig::with_scrub_ids(false)`), `scrub_event` returns
+        // a borrowed reference and the sink sees the raw event.
+        if let Some(ctx) = &self.telemetry {
+            let scrubbed = scrub_event::scrub_event(&event, &ctx.scrubber);
+            let record = TelemetryRecord::Protocol(Box::new(scrubbed.into_owned()));
+            ctx.sink.emit(&record);
         }
     }
 }

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -1,6 +1,7 @@
 //! Type definitions, constants, and shared state for the protocol engine.
 
 use crate::events::{Event, EventCallback, PresenceStatus};
+use crate::telemetry::TelemetryContext;
 use crate::Error;
 use chrono::{DateTime, Utc};
 use offline_protocol_core::{
@@ -381,6 +382,13 @@ pub(crate) struct SharedState {
 
     /// Received messages queue.
     pub(crate) received_messages: VecDeque<Message>,
+
+    /// Installed telemetry context. When present, `emit_event` additionally
+    /// forwards every protocol event to `ctx.sink` as a
+    /// `TelemetryRecord::Protocol`, with identifier scrubbing applied per
+    /// `ctx.config`. Set via `OfflineProtocol::install_telemetry_sink`.
+    #[allow(dead_code)]
+    pub(crate) telemetry: Option<Arc<TelemetryContext>>,
 }
 
 impl SharedState {
@@ -389,6 +397,7 @@ impl SharedState {
             state: ProtocolState::Stopped,
             event_handlers: Vec::new(),
             received_messages: VecDeque::new(),
+            telemetry: None,
         }
     }
 

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -10,23 +10,20 @@ use std::time::Duration;
 
 /// Verbosity tier for MLS lifecycle telemetry.
 ///
-/// Replaces the compile-time `mls-observability` feature flag with a runtime
-/// knob. The SDK emits MLS events at or below the configured tier; apps that
-/// want zero MLS telemetry install `Off`, apps that want the existing
-/// production-grade stream install `Lifecycle`, and apps that want verbose
-/// diagnostic output install `Diagnostic`.
+/// The SDK emits MLS events at or below the configured tier. Apps that want
+/// zero MLS telemetry install `Off`, apps that want the standard operational
+/// stream install `Lifecycle` (the default), and apps that want verbose
+/// per-operation diagnostics install `Diagnostic`. `Off` suppresses both the
+/// [`TelemetrySink`] fan-out and the legacy
+/// [`crate::mls_observability::MlsEventEmitter`] path.
+///
+/// [`TelemetrySink`]: crate::telemetry::TelemetrySink
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum MlsVerbosity {
     /// Suppress all MLS lifecycle telemetry.
     Off,
-    /// Emit the standard lifecycle stream (initialization, session ready,
-    /// decryption failures, etc.) — matches the legacy `mls-observability`
-    /// feature-enabled behavior.
-    ///
-    /// No-op until emission wiring lands: in this release, MLS emit paths
-    /// remain gated by the compile-time `mls-observability` feature, so
-    /// setting this knob (or `Off`/`Diagnostic`) does not yet change what
-    /// the SDK actually emits.
+    /// Emit the standard lifecycle stream: initialization, session ready,
+    /// decryption failures, session missing, encryption used.
     #[default]
     Lifecycle,
     /// Emit the full lifecycle stream plus additional per-operation

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -28,6 +28,15 @@ pub enum MlsVerbosity {
     Lifecycle,
     /// Emit the full lifecycle stream plus additional per-operation
     /// diagnostics intended for local debugging.
+    ///
+    /// # Current behavior
+    ///
+    /// As of this release, `Diagnostic` is accepted by the configuration
+    /// surface but produces the *same* event stream as [`Self::Lifecycle`]
+    /// — the additional per-operation diagnostics are introduced alongside
+    /// the extra emission sites they describe. Apps that select
+    /// `Diagnostic` today are forward-compatible with those follow-ups;
+    /// they will not need to reconfigure when the richer stream lands.
     Diagnostic,
 }
 

--- a/crates/offline-protocol/src/telemetry/context.rs
+++ b/crates/offline-protocol/src/telemetry/context.rs
@@ -1,0 +1,45 @@
+//! Crate-private telemetry context bundling the installed sink, its config,
+//! and the derived identifier scrubber.
+//!
+//! `OfflineProtocol::install_telemetry_sink` constructs an
+//! `Arc<TelemetryContext>` once and shares it between the protocol handle and
+//! `SharedState` so that both emit paths (`SharedState::emit_event` for
+//! protocol events, `OfflineProtocol::emit_mls_lifecycle_event` for MLS
+//! lifecycle events) dispatch through the same configuration.
+
+use std::sync::Arc;
+
+use super::config::TelemetryConfig;
+use super::scrubber::Scrubber;
+use super::sink::TelemetrySink;
+
+/// Installed telemetry surface. The sink, config, and scrubber reach every
+/// emit site through an `Arc<TelemetryContext>`.
+#[allow(dead_code)]
+pub(crate) struct TelemetryContext {
+    pub(crate) sink: Arc<dyn TelemetrySink>,
+    pub(crate) config: TelemetryConfig,
+    pub(crate) scrubber: Scrubber,
+}
+
+impl TelemetryContext {
+    /// Builds a context from an installed sink and config.
+    ///
+    /// `fallback_secret` is the per-instance hashing key used when the
+    /// supplied `config` does not carry its own `scrub_secret`. Passing the
+    /// same fallback across multiple calls on a single protocol instance
+    /// keeps opaque identifiers stable even when the config is re-installed
+    /// without an explicit secret.
+    pub(crate) fn new(
+        sink: Arc<dyn TelemetrySink>,
+        config: TelemetryConfig,
+        fallback_secret: [u8; 16],
+    ) -> Arc<Self> {
+        let scrubber = Scrubber::from_config(&config, fallback_secret);
+        Arc::new(Self {
+            sink,
+            config,
+            scrubber,
+        })
+    }
+}

--- a/crates/offline-protocol/src/telemetry/context.rs
+++ b/crates/offline-protocol/src/telemetry/context.rs
@@ -15,7 +15,6 @@ use super::sink::TelemetrySink;
 
 /// Installed telemetry surface. The sink, config, and scrubber reach every
 /// emit site through an `Arc<TelemetryContext>`.
-#[allow(dead_code)]
 pub(crate) struct TelemetryContext {
     pub(crate) sink: Arc<dyn TelemetrySink>,
     pub(crate) config: TelemetryConfig,

--- a/crates/offline-protocol/src/telemetry/mod.rs
+++ b/crates/offline-protocol/src/telemetry/mod.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub(crate) mod context;
 pub mod record;
 pub mod sampling;
+pub(crate) mod scrub_event;
 pub(crate) mod scrubber;
 pub mod sink;
 

--- a/crates/offline-protocol/src/telemetry/mod.rs
+++ b/crates/offline-protocol/src/telemetry/mod.rs
@@ -10,12 +10,14 @@
 //! point on the protocol engine land in follow-up work.
 
 pub mod config;
+pub(crate) mod context;
 pub mod record;
 pub mod sampling;
 pub(crate) mod scrubber;
 pub mod sink;
 
 pub use config::{MlsVerbosity, TelemetryConfig};
+pub(crate) use context::TelemetryContext;
 pub use record::TelemetryRecord;
 pub use sampling::CategorySampler;
 pub(crate) use scrubber::Scrubber;

--- a/crates/offline-protocol/src/telemetry/scrub_event.rs
+++ b/crates/offline-protocol/src/telemetry/scrub_event.rs
@@ -1,0 +1,969 @@
+//! Per-variant identifier scrubber for [`Event`].
+//!
+//! Runs on the `TelemetryRecord::Protocol` fan-out inside
+//! `SharedState::emit_event`, so long-lived pseudonymous identifiers are
+//! hashed before reaching the installed [`crate::telemetry::TelemetrySink`].
+//! Legacy `EventCallback` handlers still receive the raw event.
+//!
+//! # Scrubbing policy
+//!
+//! - **Actor identifiers** are hashed. These are the values a third-party
+//!   sink could use to profile a party across unrelated events:
+//!   `peer_id`, `sender`, `recipient`, `accepted_by`/`rejected_by`/
+//!   `cancelled_by`, `user_id`, `added_by`/`removed_by`/`created_by`/
+//!   `changed_by`/`renamed_by`, `provider_peer_id`, `group_id`,
+//!   `conversation_id`, entries in `failed_members`/`succeeded_members`,
+//!   [`ForwardInfoEvent::original_sender`], [`GroupInfoMember::user_id`],
+//!   [`UserGroupSummary::group_id`].
+//!
+//! - **Message-scoped IDs are left raw**: `message_id`, `file_id`,
+//!   `query_id`, `request_id`, `service_id`, `ForwardInfoEvent::
+//!   original_message_id`. These are per-event UUIDs playing the same role
+//!   as OpenTelemetry trace/span IDs — correlation tokens, not identity
+//!   markers. Hashing them would break debugging against server logs
+//!   without meaningfully reducing identifiability, because they are
+//!   single-use anyway.
+//!
+//! - **Content and display fields are left raw**: `content`, `file_data`,
+//!   `name`, `new_name`/`old_name`, `group_name`, `sender_name`,
+//!   `accepted_by_name`, `file_name`, `reason`/`reason_detail`, `method`,
+//!   `body`, `version`. Scrubbing payload is out of scope for `scrub_ids`;
+//!   if that ever needs to change it belongs behind a separate `emit_content`
+//!   knob so the two concerns don't get conflated.
+//!
+//! - **Enum-ish string fields are left raw**: `transport`, `content_type`,
+//!   `role`/`new_role`, `priority`, `status` — finite value sets, not
+//!   identities. The `String` entries inside
+//!   [`Event::DorsScoreUpdated::scores`] fall here too (they're transport
+//!   names, not peer IDs).
+//!
+//! # Compile-time coverage
+//!
+//! [`event_variant_exhaustiveness_ward`] mirrors the pattern shipped in
+//! PR #91 (`telemetry::record::tests`). Adding a new variant to [`Event`]
+//! without extending the scrub match below breaks compilation — which is
+//! the point. Silent identifier leaks when someone adds a new variant are
+//! exactly what this ward prevents.
+//!
+//! [`ForwardInfoEvent::original_sender`]: crate::events::ForwardInfoEvent
+//! [`GroupInfoMember::user_id`]: crate::events::GroupInfoMember
+//! [`UserGroupSummary::group_id`]: crate::events::UserGroupSummary
+
+use std::borrow::Cow;
+
+use crate::events::Event;
+use crate::telemetry::scrubber::Scrubber;
+
+/// Returns an event with all long-lived pseudonymous identifiers hashed,
+/// or a borrowed reference when `scrubber` is disabled.
+///
+/// The borrowed path is zero-cost — apps that construct a
+/// [`crate::telemetry::TelemetryConfig`] with `with_scrub_ids(false)` pay no
+/// clone for the sink fan-out.
+pub(crate) fn scrub_event<'a>(event: &'a Event, scrubber: &Scrubber) -> Cow<'a, Event> {
+    if !scrubber.is_enabled() {
+        return Cow::Borrowed(event);
+    }
+    let mut scrubbed = event.clone();
+    scrub_in_place(&mut scrubbed, scrubber);
+    Cow::Owned(scrubbed)
+}
+
+fn hash_string(s: &mut String, scrubber: &Scrubber) {
+    let hashed = scrubber.hash_id(s.as_str()).into_owned();
+    *s = hashed;
+}
+
+fn hash_each(values: &mut [String], scrubber: &Scrubber) {
+    for s in values.iter_mut() {
+        hash_string(s, scrubber);
+    }
+}
+
+fn scrub_in_place(event: &mut Event, scrubber: &Scrubber) {
+    match event {
+        Event::MessageSent {
+            sender,
+            recipient,
+            forward_info,
+            // Non-identifier fields deliberately left raw.
+            message_id: _,
+            content: _,
+            priority: _,
+            requires_ack: _,
+            timestamp: _,
+            lamport_clock: _,
+        } => {
+            hash_string(sender, scrubber);
+            hash_string(recipient, scrubber);
+            if let Some(fi) = forward_info {
+                hash_string(&mut fi.original_sender, scrubber);
+            }
+        }
+        Event::MessageReceived {
+            sender,
+            recipient,
+            forward_info,
+            message_id: _,
+            content: _,
+            hop_count: _,
+            transport: _,
+            timestamp: _,
+            lamport_clock: _,
+            reply_to_msg: _,
+            content_type: _,
+            media_metadata: _,
+        } => {
+            hash_string(sender, scrubber);
+            hash_string(recipient, scrubber);
+            if let Some(fi) = forward_info {
+                hash_string(&mut fi.original_sender, scrubber);
+            }
+        }
+        Event::MessageDelivered {
+            message_id: _,
+            latency_ms: _,
+            hop_count: _,
+            transport: _,
+        } => {}
+        Event::MessageFailed {
+            message_id: _,
+            reason: _,
+            retry_count: _,
+        } => {}
+        Event::MessageDecryptionFailed {
+            sender,
+            message_id: _,
+            code: _,
+            reason: _,
+        } => {
+            hash_string(sender, scrubber);
+        }
+        Event::TransportSwitched {
+            from: _,
+            to: _,
+            reason: _,
+        } => {}
+        Event::RelayPromoted {
+            connection_count: _,
+            battery_level: _,
+        } => {}
+        Event::RelayDemoted { reason: _ } => {}
+        Event::NeighborDiscovered {
+            peer_id,
+            transport: _,
+            rssi: _,
+        } => {
+            hash_string(peer_id, scrubber);
+        }
+        Event::NeighborLost { peer_id } => {
+            hash_string(peer_id, scrubber);
+        }
+        Event::NetworkMetrics {
+            neighbor_count: _,
+            relay_count: _,
+            delivery_ratio: _,
+            avg_latency_ms: _,
+        } => {}
+        Event::FileProgress {
+            file_id: _,
+            chunks_sent: _,
+            total_chunks: _,
+            percentage: _,
+        } => {}
+        Event::FileReceived {
+            sender,
+            file_id: _,
+            file_name: _,
+            file_size: _,
+            content_type: _,
+            media_metadata: _,
+            file_data: _,
+        } => {
+            hash_string(sender, scrubber);
+        }
+        Event::MediaSent {
+            recipient,
+            file_id: _,
+            content_type: _,
+        } => {
+            hash_string(recipient, scrubber);
+        }
+        Event::MessageDeferred {
+            message_id: _,
+            reason: _,
+            retry_count: _,
+            next_retry_at: _,
+        } => {}
+        Event::AckEvicted {
+            message_id: _,
+            priority: _,
+            reason: _,
+        } => {}
+        Event::FragmentAssemblyEvicted {
+            message_id: _,
+            completion_percent: _,
+            reason: _,
+        } => {}
+        Event::RelayDemotedBattery {
+            battery_level: _,
+            min_required: _,
+        } => {}
+        Event::SecureSessionEstablished {
+            peer_id,
+            group_id,
+            is_session: _,
+            initiated_by_local: _,
+        } => {
+            hash_string(peer_id, scrubber);
+            hash_string(group_id, scrubber);
+        }
+        Event::SecureSessionFailed { peer_id, reason: _ } => {
+            hash_string(peer_id, scrubber);
+        }
+        Event::WelcomeSendAttempted {
+            peer_id,
+            group_id,
+            message_id: _,
+            attempt: _,
+        } => {
+            hash_string(peer_id, scrubber);
+            hash_string(group_id, scrubber);
+        }
+        Event::WelcomeSendSucceeded {
+            peer_id,
+            group_id,
+            message_id: _,
+            attempt: _,
+        } => {
+            hash_string(peer_id, scrubber);
+            hash_string(group_id, scrubber);
+        }
+        Event::WelcomeSendFailed {
+            peer_id,
+            group_id,
+            message_id: _,
+            attempt: _,
+            reason_code: _,
+            transport_error: _,
+            retryable: _,
+            next_retry_at: _,
+        } => {
+            hash_string(peer_id, scrubber);
+            hash_string(group_id, scrubber);
+        }
+        Event::WelcomeSendExpired {
+            peer_id,
+            message_id: _,
+            attempt: _,
+            reason_code: _,
+        } => {
+            hash_string(peer_id, scrubber);
+        }
+        Event::ConnectionRequestReceived {
+            sender,
+            sender_name: _,
+            timestamp: _,
+            key_package: _,
+        } => {
+            hash_string(sender, scrubber);
+        }
+        Event::ConnectionAccepted {
+            accepted_by,
+            accepted_by_name: _,
+            timestamp: _,
+            key_package: _,
+        } => {
+            hash_string(accepted_by, scrubber);
+        }
+        Event::ConnectionRejected { rejected_by } => {
+            hash_string(rejected_by, scrubber);
+        }
+        Event::ConnectionRequestCancelled { cancelled_by } => {
+            hash_string(cancelled_by, scrubber);
+        }
+        Event::GroupCreated { group_id, name: _ } => {
+            hash_string(group_id, scrubber);
+        }
+        Event::GroupMessageReceived {
+            group_id,
+            sender,
+            forward_info,
+            content: _,
+            timestamp: _,
+            message_id: _,
+            reply_to_msg: _,
+        } => {
+            hash_string(group_id, scrubber);
+            hash_string(sender, scrubber);
+            if let Some(fi) = forward_info {
+                hash_string(&mut fi.original_sender, scrubber);
+            }
+        }
+        Event::GroupMemberAdded {
+            group_id,
+            user_id,
+            added_by,
+            group_name: _,
+        } => {
+            hash_string(group_id, scrubber);
+            hash_string(user_id, scrubber);
+            hash_string(added_by, scrubber);
+        }
+        Event::GroupMemberRemoved {
+            group_id,
+            user_id,
+            removed_by,
+        } => {
+            hash_string(group_id, scrubber);
+            hash_string(user_id, scrubber);
+            hash_string(removed_by, scrubber);
+        }
+        Event::GroupInfo {
+            group_id,
+            created_by,
+            members,
+            name: _,
+            created_at: _,
+        } => {
+            hash_string(group_id, scrubber);
+            hash_string(created_by, scrubber);
+            for member in members.iter_mut() {
+                hash_string(&mut member.user_id, scrubber);
+            }
+        }
+        Event::UserGroups { groups } => {
+            for summary in groups.iter_mut() {
+                hash_string(&mut summary.group_id, scrubber);
+            }
+        }
+        Event::GroupError { reason: _ } => {}
+        Event::GroupMessageSent {
+            group_id,
+            message_ids: _,
+            member_count: _,
+        } => {
+            hash_string(group_id, scrubber);
+        }
+        Event::GroupMessagePartialFailure {
+            group_id,
+            failed_members,
+            succeeded_members,
+        } => {
+            hash_string(group_id, scrubber);
+            hash_each(failed_members, scrubber);
+            hash_each(succeeded_members, scrubber);
+        }
+        Event::GroupEpochForkDetected {
+            group_id,
+            local_epoch: _,
+        } => {
+            hash_string(group_id, scrubber);
+        }
+        Event::GroupEpochForkResolved {
+            group_id,
+            resolved_epoch: _,
+            failed_members,
+        } => {
+            hash_string(group_id, scrubber);
+            hash_each(failed_members, scrubber);
+        }
+        Event::GroupRoleChanged {
+            group_id,
+            user_id,
+            changed_by,
+            new_role: _,
+        } => {
+            hash_string(group_id, scrubber);
+            hash_string(user_id, scrubber);
+            hash_string(changed_by, scrubber);
+        }
+        Event::GroupRenamed {
+            group_id,
+            renamed_by,
+            new_name: _,
+            old_name: _,
+        } => {
+            hash_string(group_id, scrubber);
+            hash_string(renamed_by, scrubber);
+        }
+        Event::ServiceDiscovered {
+            provider_peer_id,
+            query_id: _,
+            service_id: _,
+            version: _,
+            capabilities: _,
+            hop_count: _,
+        } => {
+            hash_string(provider_peer_id, scrubber);
+        }
+        Event::ServiceRequestReceived {
+            sender,
+            request_id: _,
+            service_id: _,
+            method: _,
+            body: _,
+        } => {
+            hash_string(sender, scrubber);
+        }
+        Event::ServiceResponseReceived {
+            provider_peer_id,
+            request_id: _,
+            service_id: _,
+            status: _,
+            body: _,
+        } => {
+            hash_string(provider_peer_id, scrubber);
+        }
+        Event::PresenceUpdated {
+            peer_id,
+            status: _,
+            timestamp: _,
+        } => {
+            hash_string(peer_id, scrubber);
+        }
+        Event::TypingIndicatorReceived {
+            sender,
+            conversation_id,
+            is_typing: _,
+            timestamp: _,
+        } => {
+            hash_string(sender, scrubber);
+            // `conversation_id` is a recipient username for DMs or a group_id
+            // for groups — both are actor-class identifiers, hash either way.
+            hash_string(conversation_id, scrubber);
+        }
+        Event::ReadReceiptReceived {
+            sender,
+            message_ids: _,
+            timestamp: _,
+        } => {
+            hash_string(sender, scrubber);
+        }
+        Event::DorsScoreUpdated { scores: _ } => {
+            // Inner `String` is a transport name (ble, wifi_direct, ...),
+            // not an identifier. Nothing to scrub.
+        }
+        Event::DorsTransportSelected {
+            from: _,
+            transport: _,
+            reason_code: _,
+            score: _,
+        } => {}
+        Event::DorsTransportSwitched {
+            from: _,
+            to: _,
+            reason_code: _,
+            reason_detail: _,
+        } => {}
+        Event::DorsEscalationTriggered {
+            phase: _,
+            from: _,
+            to: _,
+            reason_code: _,
+            reason_detail: _,
+        } => {}
+        Event::SecurityWarning { peer_id, reason: _ } => {
+            hash_string(peer_id, scrubber);
+        }
+        Event::MessageRelayed {
+            sender,
+            recipient,
+            message_id: _,
+            hop_count: _,
+            remaining_ttl: _,
+        } => {
+            hash_string(sender, scrubber);
+            hash_string(recipient, scrubber);
+        }
+        Event::UserBlocked { user_id } => {
+            hash_string(user_id, scrubber);
+        }
+        Event::UserUnblocked { user_id } => {
+            hash_string(user_id, scrubber);
+        }
+        Event::TofuReset { peer_id } => {
+            hash_string(peer_id, scrubber);
+        }
+    }
+}
+
+/// Compile-time exhaustiveness ward.
+///
+/// This match deliberately omits a wildcard arm, so adding a new variant to
+/// [`Event`] breaks compilation here and forces the author to extend
+/// [`scrub_in_place`]. Without this ward, a new variant could silently ship
+/// with its identifier fields unhashed on the sink fan-out — exactly the
+/// class of privacy regression `scrub_ids` is meant to prevent.
+#[allow(dead_code)]
+fn event_variant_exhaustiveness_ward(e: &Event) {
+    match e {
+        Event::MessageSent { .. }
+        | Event::MessageReceived { .. }
+        | Event::MessageDelivered { .. }
+        | Event::MessageFailed { .. }
+        | Event::MessageDecryptionFailed { .. }
+        | Event::TransportSwitched { .. }
+        | Event::RelayPromoted { .. }
+        | Event::RelayDemoted { .. }
+        | Event::NeighborDiscovered { .. }
+        | Event::NeighborLost { .. }
+        | Event::NetworkMetrics { .. }
+        | Event::FileProgress { .. }
+        | Event::FileReceived { .. }
+        | Event::MediaSent { .. }
+        | Event::MessageDeferred { .. }
+        | Event::AckEvicted { .. }
+        | Event::FragmentAssemblyEvicted { .. }
+        | Event::RelayDemotedBattery { .. }
+        | Event::SecureSessionEstablished { .. }
+        | Event::SecureSessionFailed { .. }
+        | Event::WelcomeSendAttempted { .. }
+        | Event::WelcomeSendSucceeded { .. }
+        | Event::WelcomeSendFailed { .. }
+        | Event::WelcomeSendExpired { .. }
+        | Event::ConnectionRequestReceived { .. }
+        | Event::ConnectionAccepted { .. }
+        | Event::ConnectionRejected { .. }
+        | Event::ConnectionRequestCancelled { .. }
+        | Event::GroupCreated { .. }
+        | Event::GroupMessageReceived { .. }
+        | Event::GroupMemberAdded { .. }
+        | Event::GroupMemberRemoved { .. }
+        | Event::GroupInfo { .. }
+        | Event::UserGroups { .. }
+        | Event::GroupError { .. }
+        | Event::GroupMessageSent { .. }
+        | Event::GroupMessagePartialFailure { .. }
+        | Event::GroupEpochForkDetected { .. }
+        | Event::GroupEpochForkResolved { .. }
+        | Event::GroupRoleChanged { .. }
+        | Event::GroupRenamed { .. }
+        | Event::ServiceDiscovered { .. }
+        | Event::ServiceRequestReceived { .. }
+        | Event::ServiceResponseReceived { .. }
+        | Event::PresenceUpdated { .. }
+        | Event::TypingIndicatorReceived { .. }
+        | Event::ReadReceiptReceived { .. }
+        | Event::DorsScoreUpdated { .. }
+        | Event::DorsTransportSelected { .. }
+        | Event::DorsTransportSwitched { .. }
+        | Event::DorsEscalationTriggered { .. }
+        | Event::SecurityWarning { .. }
+        | Event::MessageRelayed { .. }
+        | Event::UserBlocked { .. }
+        | Event::UserUnblocked { .. }
+        | Event::TofuReset { .. } => (),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::{
+        DecryptionFailureCode, DorsEscalationPhase, DorsEscalationReasonCode, DorsReasonCode,
+        ForwardInfoEvent, GroupInfoMember, PresenceStatus, UserGroupSummary, WelcomeReasonCode,
+    };
+    use std::collections::HashMap;
+
+    const SECRET: [u8; 16] = [0x7a; 16];
+
+    fn scrubber_enabled() -> Scrubber {
+        Scrubber::from_config(&crate::telemetry::TelemetryConfig::default(), SECRET)
+    }
+
+    fn scrubber_disabled() -> Scrubber {
+        Scrubber::from_config(
+            &crate::telemetry::TelemetryConfig::default().with_scrub_ids(false),
+            SECRET,
+        )
+    }
+
+    fn hashed(raw: &str) -> String {
+        // Mirror the scrubber's leaf-identifier hash (enabled path).
+        scrubber_enabled().hash_id(raw).into_owned()
+    }
+
+    #[test]
+    fn disabled_scrubber_returns_borrowed_reference() {
+        let event = Event::NeighborLost {
+            peer_id: "alice".into(),
+        };
+        let scrubbed = scrub_event(&event, &scrubber_disabled());
+        assert!(matches!(scrubbed, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn enabled_scrubber_hashes_peer_id_fields() {
+        let event = Event::NeighborLost {
+            peer_id: "alice".into(),
+        };
+        let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+        match scrubbed {
+            Event::NeighborLost { peer_id } => assert_eq!(peer_id, hashed("alice")),
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn message_received_scrubs_sender_recipient_and_forward_info_but_not_content_or_id() {
+        let event = Event::MessageReceived {
+            message_id: "msg-123".into(),
+            sender: "alice".into(),
+            recipient: "bob".into(),
+            content: "hello".into(),
+            hop_count: 1,
+            transport: "ble".into(),
+            timestamp: 0,
+            lamport_clock: 0,
+            reply_to_msg: None,
+            content_type: "text".into(),
+            media_metadata: None,
+            forward_info: Some(ForwardInfoEvent {
+                original_sender: "carol".into(),
+                original_message_id: "orig-456".into(),
+                original_timestamp: 0,
+                forward_count: 1,
+            }),
+        };
+        let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+        match scrubbed {
+            Event::MessageReceived {
+                message_id,
+                sender,
+                recipient,
+                content,
+                forward_info,
+                ..
+            } => {
+                assert_eq!(message_id, "msg-123", "message_id must stay raw");
+                assert_eq!(content, "hello", "content must stay raw");
+                assert_eq!(sender, hashed("alice"));
+                assert_eq!(recipient, hashed("bob"));
+                let fi = forward_info.expect("forward_info preserved");
+                assert_eq!(fi.original_sender, hashed("carol"));
+                assert_eq!(
+                    fi.original_message_id, "orig-456",
+                    "original_message_id must stay raw",
+                );
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn group_info_scrubs_group_id_creator_and_members() {
+        let event = Event::GroupInfo {
+            group_id: "grp-1".into(),
+            name: "My Group".into(),
+            created_by: "alice".into(),
+            created_at: "2026-04-17T00:00:00Z".into(),
+            members: vec![
+                GroupInfoMember {
+                    user_id: "bob".into(),
+                    role: "admin".into(),
+                    joined_at: "2026-04-17T00:00:00Z".into(),
+                },
+                GroupInfoMember {
+                    user_id: "carol".into(),
+                    role: "member".into(),
+                    joined_at: "2026-04-17T00:00:00Z".into(),
+                },
+            ],
+        };
+        let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+        match scrubbed {
+            Event::GroupInfo {
+                group_id,
+                name,
+                created_by,
+                members,
+                ..
+            } => {
+                assert_eq!(group_id, hashed("grp-1"));
+                assert_eq!(name, "My Group", "group name must stay raw");
+                assert_eq!(created_by, hashed("alice"));
+                assert_eq!(members.len(), 2);
+                assert_eq!(members[0].user_id, hashed("bob"));
+                assert_eq!(members[0].role, "admin", "role must stay raw");
+                assert_eq!(members[1].user_id, hashed("carol"));
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn user_groups_scrubs_every_group_id_but_not_names() {
+        let event = Event::UserGroups {
+            groups: vec![
+                UserGroupSummary {
+                    group_id: "grp-a".into(),
+                    name: "Alpha".into(),
+                    created_at: "2026-04-17T00:00:00Z".into(),
+                },
+                UserGroupSummary {
+                    group_id: "grp-b".into(),
+                    name: "Beta".into(),
+                    created_at: "2026-04-17T00:00:00Z".into(),
+                },
+            ],
+        };
+        let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+        match scrubbed {
+            Event::UserGroups { groups } => {
+                assert_eq!(groups.len(), 2);
+                assert_eq!(groups[0].group_id, hashed("grp-a"));
+                assert_eq!(groups[0].name, "Alpha");
+                assert_eq!(groups[1].group_id, hashed("grp-b"));
+                assert_eq!(groups[1].name, "Beta");
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn group_message_partial_failure_scrubs_all_member_lists() {
+        let event = Event::GroupMessagePartialFailure {
+            group_id: "grp-1".into(),
+            failed_members: vec!["alice".into(), "bob".into()],
+            succeeded_members: vec!["carol".into()],
+        };
+        let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+        match scrubbed {
+            Event::GroupMessagePartialFailure {
+                group_id,
+                failed_members,
+                succeeded_members,
+            } => {
+                assert_eq!(group_id, hashed("grp-1"));
+                assert_eq!(failed_members, vec![hashed("alice"), hashed("bob")]);
+                assert_eq!(succeeded_members, vec![hashed("carol")]);
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn service_discovered_scrubs_provider_peer_id_only() {
+        let event = Event::ServiceDiscovered {
+            query_id: "q-1".into(),
+            service_id: "svc".into(),
+            version: "1.0".into(),
+            provider_peer_id: "alice".into(),
+            capabilities: HashMap::new(),
+            hop_count: 2,
+        };
+        let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+        match scrubbed {
+            Event::ServiceDiscovered {
+                query_id,
+                service_id,
+                provider_peer_id,
+                ..
+            } => {
+                assert_eq!(query_id, "q-1", "query_id must stay raw");
+                assert_eq!(service_id, "svc", "service_id must stay raw");
+                assert_eq!(provider_peer_id, hashed("alice"));
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn typing_indicator_scrubs_sender_and_conversation_id() {
+        let event = Event::TypingIndicatorReceived {
+            sender: "alice".into(),
+            conversation_id: "bob".into(),
+            is_typing: true,
+            timestamp: 0,
+        };
+        let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+        match scrubbed {
+            Event::TypingIndicatorReceived {
+                sender,
+                conversation_id,
+                ..
+            } => {
+                assert_eq!(sender, hashed("alice"));
+                assert_eq!(conversation_id, hashed("bob"));
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn dors_score_updated_leaves_transport_names_raw() {
+        let event = Event::DorsScoreUpdated {
+            scores: vec![("ble".into(), 0.8), ("wifi_direct".into(), 0.6)],
+        };
+        let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+        match scrubbed {
+            Event::DorsScoreUpdated { scores } => {
+                assert_eq!(scores[0].0, "ble");
+                assert_eq!(scores[1].0, "wifi_direct");
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn message_decryption_failed_scrubs_sender_only() {
+        let event = Event::MessageDecryptionFailed {
+            message_id: "m-1".into(),
+            sender: "alice".into(),
+            code: DecryptionFailureCode::InvalidCiphertext,
+            reason: "bad mac".into(),
+        };
+        let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+        match scrubbed {
+            Event::MessageDecryptionFailed {
+                message_id,
+                sender,
+                reason,
+                ..
+            } => {
+                assert_eq!(message_id, "m-1");
+                assert_eq!(sender, hashed("alice"));
+                assert_eq!(reason, "bad mac");
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn connection_events_scrub_party_identifiers() {
+        let req = Event::ConnectionRequestReceived {
+            sender: "alice".into(),
+            sender_name: "Alice A.".into(),
+            timestamp: 0,
+            key_package: None,
+        };
+        let accept = Event::ConnectionAccepted {
+            accepted_by: "bob".into(),
+            accepted_by_name: "Bob B.".into(),
+            timestamp: 0,
+            key_package: None,
+        };
+        let reject = Event::ConnectionRejected {
+            rejected_by: "carol".into(),
+        };
+        let cancel = Event::ConnectionRequestCancelled {
+            cancelled_by: "dan".into(),
+        };
+        for (event, expected_raw, expected_hashed) in [
+            (req, "Alice A.", "alice"),
+            (accept, "Bob B.", "bob"),
+            (reject, "", "carol"),
+            (cancel, "", "dan"),
+        ] {
+            let scrubbed = scrub_event(&event, &scrubber_enabled()).into_owned();
+            match scrubbed {
+                Event::ConnectionRequestReceived {
+                    sender,
+                    sender_name,
+                    ..
+                } => {
+                    assert_eq!(sender, hashed(expected_hashed));
+                    assert_eq!(sender_name, expected_raw);
+                }
+                Event::ConnectionAccepted {
+                    accepted_by,
+                    accepted_by_name,
+                    ..
+                } => {
+                    assert_eq!(accepted_by, hashed(expected_hashed));
+                    assert_eq!(accepted_by_name, expected_raw);
+                }
+                Event::ConnectionRejected { rejected_by } => {
+                    assert_eq!(rejected_by, hashed(expected_hashed));
+                }
+                Event::ConnectionRequestCancelled { cancelled_by } => {
+                    assert_eq!(cancelled_by, hashed(expected_hashed));
+                }
+                _ => panic!("unexpected variant"),
+            }
+        }
+    }
+
+    /// Regression guard: every variant present in the exhaustiveness ward
+    /// must also be present in `scrub_in_place`. If they drift apart (e.g.
+    /// someone adds a new variant + ward arm but forgets to extend the
+    /// scrub match), the inner match goes non-exhaustive and the crate
+    /// fails to compile — which is the whole point. This test simply
+    /// exercises the scrubber against one exemplar per variant.
+    #[test]
+    fn scrub_in_place_handles_every_variant_without_panic() {
+        let exemplars = [
+            Event::MessageSent {
+                message_id: String::new(),
+                sender: "a".into(),
+                recipient: "b".into(),
+                content: String::new(),
+                priority: String::new(),
+                requires_ack: false,
+                timestamp: 0,
+                lamport_clock: 0,
+                forward_info: None,
+            },
+            Event::MessageFailed {
+                message_id: String::new(),
+                reason: String::new(),
+                retry_count: 0,
+            },
+            Event::RelayPromoted {
+                connection_count: 0,
+                battery_level: 0,
+            },
+            Event::NeighborLost {
+                peer_id: "p".into(),
+            },
+            Event::NetworkMetrics {
+                neighbor_count: 0,
+                relay_count: 0,
+                delivery_ratio: 0.0,
+                avg_latency_ms: 0,
+            },
+            Event::DorsScoreUpdated { scores: Vec::new() },
+            Event::DorsTransportSelected {
+                from: None,
+                transport: String::new(),
+                reason_code: DorsReasonCode::InitialSelection,
+                score: 0.0,
+            },
+            Event::DorsTransportSwitched {
+                from: None,
+                to: String::new(),
+                reason_code: DorsReasonCode::PrimarySelected,
+                reason_detail: None,
+            },
+            Event::DorsEscalationTriggered {
+                phase: DorsEscalationPhase::Triggered,
+                from: String::new(),
+                to: String::new(),
+                reason_code: DorsEscalationReasonCode::FallbackSuccess,
+                reason_detail: None,
+            },
+            Event::WelcomeSendFailed {
+                peer_id: "p".into(),
+                message_id: String::new(),
+                group_id: "g".into(),
+                attempt: 0,
+                reason_code: WelcomeReasonCode::InternalError,
+                transport_error: None,
+                retryable: false,
+                next_retry_at: None,
+            },
+            Event::PresenceUpdated {
+                peer_id: "p".into(),
+                status: PresenceStatus::Online,
+                timestamp: 0,
+            },
+        ];
+        let scrubber = scrubber_enabled();
+        for ev in exemplars {
+            // The scrub must not panic for any variant and must produce a
+            // different `Event` when an identifier field was present.
+            let _ = scrub_event(&ev, &scrubber).into_owned();
+        }
+    }
+}

--- a/crates/offline-protocol/src/telemetry/scrub_event.rs
+++ b/crates/offline-protocol/src/telemetry/scrub_event.rs
@@ -37,6 +37,31 @@
 //!   [`Event::DorsScoreUpdated::scores`] fall here too (they're transport
 //!   names, not peer IDs).
 //!
+//! # Out of scope for `scrub_ids`
+//!
+//! Two classes of data are *deliberately* not touched by this scrubber and
+//! need to be handled by sink authors, not here:
+//!
+//! - **Cryptographic blobs that embed identity**: the `key_package` bytes
+//!   on [`Event::ConnectionRequestReceived`] and
+//!   [`Event::ConnectionAccepted`] carry MLS credentials whose leaf
+//!   identity encodes the raw `user_id`. A sink that logs these bytes
+//!   effectively logs an unscrubbed identifier, regardless of the
+//!   `scrub_ids` setting. Treat key packages as sensitive payload, not as
+//!   metadata.
+//!
+//! - **Free-form strings that may interpolate identifiers**: `reason` /
+//!   `reason_detail` fields are produced by upstream error paths. If an
+//!   author ever includes a peer ID in a reason string (e.g. "no session
+//!   for alice"), the identifier passes through unhashed. The SDK
+//!   currently avoids this, but the contract is one-way: sinks should
+//!   assume `reason` fields are free text and apply app-level redaction
+//!   if they ship logs off-device.
+//!
+//! If that ever needs to change globally it belongs behind a separate
+//! `emit_content` knob so the identifier-scrubbing and payload-scrubbing
+//! concerns don't get conflated.
+//!
 //! # Compile-time coverage
 //!
 //! [`event_variant_exhaustiveness_ward`] mirrors the pattern shipped in
@@ -57,9 +82,13 @@ use crate::telemetry::scrubber::Scrubber;
 /// Returns an event with all long-lived pseudonymous identifiers hashed,
 /// or a borrowed reference when `scrubber` is disabled.
 ///
-/// The borrowed path is zero-cost — apps that construct a
-/// [`crate::telemetry::TelemetryConfig`] with `with_scrub_ids(false)` pay no
-/// clone for the sink fan-out.
+/// The borrowed path skips the per-field hashing work and the `Event`
+/// clone performed by `scrub_in_place`. It is *not* zero-cost at the
+/// current sink call site: `SharedState::emit_event` needs owned data to
+/// construct [`crate::telemetry::TelemetryRecord::Protocol`] (which holds
+/// a `Box<Event>`), so that caller always pays a clone via
+/// [`Cow::into_owned`]. The `Cow` return still lets future callers that
+/// can tolerate a borrow (tests, in-process readers) avoid the clone.
 pub(crate) fn scrub_event<'a>(event: &'a Event, scrubber: &Scrubber) -> Cow<'a, Event> {
     if !scrubber.is_enabled() {
         return Cow::Borrowed(event);

--- a/crates/offline-protocol/src/telemetry/scrubber.rs
+++ b/crates/offline-protocol/src/telemetry/scrubber.rs
@@ -70,6 +70,7 @@ impl fmt::Debug for Scrubber {
 
 impl Scrubber {
     /// Constructs a scrubber with the given enabled flag and secret.
+    #[allow(dead_code)]
     pub fn new(enabled: bool, secret: [u8; 16]) -> Self {
         Self { enabled, secret }
     }

--- a/crates/offline-protocol/src/telemetry/scrubber.rs
+++ b/crates/offline-protocol/src/telemetry/scrubber.rs
@@ -28,7 +28,6 @@ use crate::telemetry::config::TelemetryConfig;
 ///
 /// Crate-private: external callers use [`Scrubber::hash_id`] instead so
 /// there is a single public entry point to the hashing operation.
-#[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
 pub(crate) fn opaque_id(raw: &str, secret: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(secret);
@@ -52,7 +51,6 @@ pub(crate) fn opaque_id(raw: &str, secret: &[u8]) -> String {
 #[derive(Clone)]
 pub(crate) struct Scrubber {
     enabled: bool,
-    #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     secret: [u8; 16],
 }
 
@@ -70,6 +68,12 @@ impl fmt::Debug for Scrubber {
 
 impl Scrubber {
     /// Constructs a scrubber with the given enabled flag and secret.
+    ///
+    /// Not currently called from production code — [`Scrubber::from_config`]
+    /// is the construction path the protocol engine uses. Kept crate-private
+    /// and `#[allow(dead_code)]` because the scrubber unit tests use it, and
+    /// because open-coding a scrubber with an explicit secret is the
+    /// shortest route to deterministic fixtures in future tests.
     #[allow(dead_code)]
     pub fn new(enabled: bool, secret: [u8; 16]) -> Self {
         Self { enabled, secret }
@@ -106,7 +110,6 @@ impl Scrubber {
     /// multiple raw identifiers — use [`Scrubber::hash_always`] instead, so
     /// that the composite cannot be disabled by a user-facing scrubbing
     /// preference.
-    #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     pub fn hash_id<'a>(&self, raw: &'a str) -> Cow<'a, str> {
         if self.enabled {
             Cow::Owned(opaque_id(raw, &self.secret))
@@ -125,7 +128,6 @@ impl Scrubber {
     /// preference, because disabling scrubbing is a choice about leaf IDs
     /// the caller already controls, not about derived values the SDK
     /// constructs internally.
-    #[cfg_attr(not(feature = "mls-observability"), allow(dead_code))]
     pub fn hash_always(&self, raw: &str) -> String {
         opaque_id(raw, &self.secret)
     }

--- a/crates/offline-protocol/src/telemetry/sink.rs
+++ b/crates/offline-protocol/src/telemetry/sink.rs
@@ -15,6 +15,24 @@ use super::record::TelemetryRecord;
 /// expensive work (I/O, serialization to external formats) should be
 /// deferred to a background task owned by the implementor.
 ///
+/// # Reentrancy and locking contract
+///
+/// The SDK may invoke [`TelemetrySink::emit`] while holding internal locks
+/// (most notably the shared-state mutex on the `Protocol` fan-out path).
+/// Implementations MUST NOT:
+///
+/// - block on slow I/O (network, disk, logging sinks that fsync),
+/// - reenter SDK methods on the same `OfflineProtocol` instance, or
+/// - panic.
+///
+/// A blocking `emit` stalls every protocol operation that needs the lock;
+/// a panicking `emit` poisons the mutex and degrades the protocol to a
+/// silently-dropping state. Sinks that need to do real work should push
+/// the record onto a bounded channel and return immediately, leaving the
+/// heavy lifting to a background task owned by the implementor.
+///
+/// # Record passing
+///
 /// The record is passed by reference so implementations that only read fields
 /// do not incur a clone. Implementations that need ownership (for example to
 /// forward the record to another thread) should call [`Clone::clone`]


### PR DESCRIPTION
## Summary

Item #5 from the unified-telemetry roadmap. Fans every protocol
`Event` and MLS lifecycle event through the `TelemetrySink`
taxonomy shipped in #91, additively — legacy `EventCallback` and
`MlsEventEmitter` paths remain intact. Retires the
`mls-observability` Cargo feature in favor of runtime
`TelemetryConfig::mls_verbosity`.

Three commits, reviewable independently:

1. **`feat(telemetry): add TelemetryContext and install_telemetry_sink`** — plumbing only, no behavior change. Adds `TelemetryContext` and `OfflineProtocol::install_telemetry_sink`.
2. **`feat(protocol): route Event and MLS streams through TelemetrySink`** — lights up the wiring. Adds `scrub_event.rs` with per-variant identifier hashing and a compile-time exhaustiveness ward. Rewrites `observability.rs` to gate on `MlsVerbosity` instead of `#[cfg]`.
3. **`chore(protocol): retire the mls-observability Cargo feature`** — deletes the now-vestigial feature, un-gates the 7 previously feature-guarded MLS tests, adds 6 sink-focused integration tests.

## Locked decisions consumed

From item #1's decision block:

| # | Decision | Where it shows up |
|---|---|---|
| 2 | \`scrub_ids\` defaults to \`true\` | \`Scrubber::from_config\` in \`install_telemetry_sink\` |
| 3 | OTel-friendly \`snake.dot.case\` names | Already in #91; this PR consumes them |
| 4 | Collapse \`mls-observability\` → \`MlsVerbosity\` | Runtime gate in \`emit_mls_lifecycle_event\` |

## Scrubbing policy (item-5-specific)

- **Scrubbed** (actor identifiers — long-lived pseudonyms): `peer_id`, `sender`, `recipient`, `user_id`, `added_by`/`removed_by`/`created_by`/`changed_by`/`renamed_by`/`accepted_by`/`rejected_by`/`cancelled_by`, `provider_peer_id`, `group_id`, `conversation_id`, member lists, `ForwardInfoEvent::original_sender`.
- **Left raw** (OTel-style correlation tokens): `message_id`, `file_id`, `query_id`, `request_id`, `ForwardInfoEvent::original_message_id`.
- **Left raw** (payload, not identity — out of scope for `scrub_ids`): `content`, `file_data`, display names, reasons.

The `event_variant_exhaustiveness_ward` in `scrub_event.rs` guards against silent leaks when new variants ship.

## Non-goals (deferred to items #6 and #7)

- New telemetry categories: `MetricsSnapshot`, `TransportStateEvent`, `RoutingDecision`, `DeviceCapabilitySnapshot` (#6)
- UniFFI + React Native exposure of `TelemetrySink` (#7)

## Backward compatibility

Zero API breaks. Existing `on_event` / `set_mls_event_emitter` consumers see no behavior change. Apps passing `--features mls-observability` on `cargo build` will get an "unknown feature" warning — no in-tree CI config does.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` — 1027 passing
- [x] New integration tests: 6 sink-focused cases
- [x] Pre-existing fix: gated MLS tests now compile (main never compiled with \`--features mls-observability\`)