### PR TITLE
feat(protocol): wire metrics, transport-state, routing, device telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
  "criterion",
  "offline-protocol",
  "offline-protocol-core",
+ "offline-protocol-reliability",
  "offline-protocol-router",
  "offline-protocol-transport",
  "serde_json",

--- a/benches/telemetry_emission.rs
+++ b/benches/telemetry_emission.rs
@@ -1,0 +1,181 @@
+//! Overhead benchmark for the telemetry emission path.
+//!
+//! Budget targets (from TODO item #6):
+//!   - `<5µs`  per emission at the default (Lifecycle) verbosity
+//!   - `<25µs` per emission when `routing_diagnostic` is enabled
+//!
+//! These benches exercise the sink-facing path with `NoopTelemetrySink` so
+//! the measurement isolates the SDK-side work (record construction, enum
+//! dispatch, `sink.emit(&record)` indirect call) from whatever a real sink
+//! would do.
+
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use offline_protocol::telemetry::device::{DeviceCapabilitySnapshot, CHANGED_BATTERY};
+use offline_protocol::telemetry::metrics_snapshot::MetricsFrame;
+use offline_protocol::telemetry::routing::{RoutingDecision, RoutingPhase, RoutingReasonCode};
+use offline_protocol::telemetry::transport_state::TransportStateEvent;
+use offline_protocol::{NoopTelemetrySink, TelemetryRecord, TelemetrySink};
+use offline_protocol_reliability::{DeduplicatorMode, DeduplicatorStats, RetryQueueStats};
+use offline_protocol_router::RelayRole;
+use offline_protocol_transport::{TransportStatus, TransportType};
+
+fn empty_retry_stats() -> RetryQueueStats {
+    RetryQueueStats {
+        total_count: 0,
+        ready_count: 0,
+        critical_priority_count: 0,
+        high_priority_count: 0,
+        medium_priority_count: 0,
+        low_priority_count: 0,
+    }
+}
+
+fn empty_dedup_stats() -> DeduplicatorStats {
+    DeduplicatorStats {
+        total_tracked: 0,
+        recent_tracked: 0,
+        capacity_used_percent: 0,
+        false_positive_rate: None,
+        mode: DeduplicatorMode::HashMap,
+    }
+}
+
+fn sample_metrics_frame() -> MetricsFrame {
+    MetricsFrame {
+        timestamp_ms: 0,
+        transports: Vec::new(),
+        retry_queue: empty_retry_stats(),
+        dedup: empty_dedup_stats(),
+        ack_pending: 0,
+        neighbor_count: 0,
+        relay_count: 0,
+        current_transport: None,
+    }
+}
+
+fn sample_transport_state() -> TransportStateEvent {
+    TransportStateEvent {
+        timestamp_ms: 0,
+        transport: TransportType::BLE,
+        previous: TransportStatus::Disconnected,
+        current: TransportStatus::Available,
+    }
+}
+
+fn sample_routing_decision() -> RoutingDecision {
+    RoutingDecision {
+        timestamp_ms: 0,
+        phase: RoutingPhase::Selected,
+        from: None,
+        to: Some(TransportType::BLE),
+        winning_score: Some(84.0),
+        reason_code: Some(RoutingReasonCode::InitialSelection),
+        scores: Vec::new(),
+        suppression: None,
+    }
+}
+
+fn sample_device_snapshot() -> DeviceCapabilitySnapshot {
+    DeviceCapabilitySnapshot {
+        timestamp_ms: 0,
+        battery_level: Some(80),
+        is_charging: true,
+        relay_role: RelayRole::Regular,
+        changed_fields: CHANGED_BATTERY,
+    }
+}
+
+fn bench_emit_noop_sink(c: &mut Criterion) {
+    let sink: Arc<dyn TelemetrySink> = Arc::new(NoopTelemetrySink);
+    let mut group = c.benchmark_group("telemetry_emit_noop");
+
+    group.bench_function("metrics_snapshot", |b| {
+        b.iter(|| {
+            let record = TelemetryRecord::MetricsSnapshot(Box::new(sample_metrics_frame()));
+            sink.emit(black_box(&record));
+        });
+    });
+
+    group.bench_function("transport_state", |b| {
+        b.iter(|| {
+            let record = TelemetryRecord::TransportState(sample_transport_state());
+            sink.emit(black_box(&record));
+        });
+    });
+
+    group.bench_function("routing_decision_lifecycle", |b| {
+        b.iter(|| {
+            let record = TelemetryRecord::Routing(Box::new(sample_routing_decision()));
+            sink.emit(black_box(&record));
+        });
+    });
+
+    group.bench_function("device_snapshot", |b| {
+        b.iter(|| {
+            let record = TelemetryRecord::Device(sample_device_snapshot());
+            sink.emit(black_box(&record));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_emit_noop_sink_diagnostic(c: &mut Criterion) {
+    // Diagnostic-tier routing carries a populated score vector. We simulate
+    // it here with 5 entries (one per transport) of mock TransportScore.
+    // Even at Diagnostic verbosity the goal is <25µs per emission; the
+    // scoring breakdown itself is all primitives so construction remains cheap.
+    let sink: Arc<dyn TelemetrySink> = Arc::new(NoopTelemetrySink);
+
+    c.bench_function("telemetry_emit_routing_diagnostic", |b| {
+        b.iter(|| {
+            let mut decision = sample_routing_decision();
+            decision.scores = Vec::with_capacity(5);
+            for t in [
+                TransportType::Internet,
+                TransportType::WiFiDirect,
+                TransportType::BLE,
+                TransportType::Reticulum,
+                TransportType::Nostr,
+            ] {
+                decision.scores.push((
+                    t,
+                    offline_protocol_router::TransportScore {
+                        signal: 80.0,
+                        proximity: 70.0,
+                        bandwidth: 60.0,
+                        congestion: 90.0,
+                        energy: 85.0,
+                        reliability: 95.0,
+                        load: 75.0,
+                        total: 82.0,
+                    },
+                ));
+            }
+            let record = TelemetryRecord::Routing(Box::new(decision));
+            sink.emit(black_box(&record));
+        });
+    });
+}
+
+fn bench_build_metrics_frame(c: &mut Criterion) {
+    // Construction cost alone — isolates the cost of building the frame
+    // from the emission cost above. This is what the `process()` tick
+    // pays on each metrics-cadence interval.
+    c.bench_function("telemetry_build_metrics_frame", |b| {
+        b.iter(|| {
+            let frame = sample_metrics_frame();
+            black_box(frame);
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_emit_noop_sink,
+    bench_emit_noop_sink_diagnostic,
+    bench_build_metrics_frame,
+);
+criterion_main!(benches);

--- a/benches/telemetry_emission.rs
+++ b/benches/telemetry_emission.rs
@@ -141,8 +141,17 @@ fn bench_emit_noop_sink_diagnostic(c: &mut Criterion) {
             ] {
                 decision.scores.push((
                     t,
-                    offline_protocol_router::TransportScore::new(
-                        80.0, 70.0, 60.0, 90.0, 85.0, 95.0, 75.0, 82.0,
+                    offline_protocol_router::TransportScore::from_factors(
+                        offline_protocol_router::TransportScoreFactors {
+                            signal: 80.0,
+                            proximity: 70.0,
+                            bandwidth: 60.0,
+                            congestion: 90.0,
+                            energy: 85.0,
+                            reliability: 95.0,
+                            load: 75.0,
+                            total: 82.0,
+                        },
                     ),
                 ));
             }

--- a/benches/telemetry_emission.rs
+++ b/benches/telemetry_emission.rs
@@ -50,7 +50,7 @@ fn sample_metrics_frame() -> MetricsFrame {
         dedup: empty_dedup_stats(),
         ack_pending: 0,
         neighbor_count: 0,
-        relay_count: 0,
+        is_local_relay: false,
         current_transport: None,
     }
 }

--- a/benches/telemetry_emission.rs
+++ b/benches/telemetry_emission.rs
@@ -73,7 +73,6 @@ fn sample_routing_decision() -> RoutingDecision {
         winning_score: Some(84.0),
         reason_code: Some(RoutingReasonCode::InitialSelection),
         scores: Vec::new(),
-        suppression: None,
     }
 }
 
@@ -142,16 +141,9 @@ fn bench_emit_noop_sink_diagnostic(c: &mut Criterion) {
             ] {
                 decision.scores.push((
                     t,
-                    offline_protocol_router::TransportScore {
-                        signal: 80.0,
-                        proximity: 70.0,
-                        bandwidth: 60.0,
-                        congestion: 90.0,
-                        energy: 85.0,
-                        reliability: 95.0,
-                        load: 75.0,
-                        total: 82.0,
-                    },
+                    offline_protocol_router::TransportScore::new(
+                        80.0, 70.0, 60.0, 90.0, 85.0, 95.0, 75.0, 82.0,
+                    ),
                 ));
             }
             let record = TelemetryRecord::Routing(Box::new(decision));

--- a/crates/offline-protocol-bench/Cargo.toml
+++ b/crates/offline-protocol-bench/Cargo.toml
@@ -25,10 +25,16 @@ name = "ble_fragmentation"
 harness = false
 path = "../../benches/ble_fragmentation.rs"
 
+[[bench]]
+name = "telemetry_emission"
+harness = false
+path = "../../benches/telemetry_emission.rs"
+
 [dependencies]
 offline-protocol-core = { workspace = true }
 offline-protocol-transport = { workspace = true }
 offline-protocol-router = { workspace = true }
+offline-protocol-reliability = { workspace = true }
 offline-protocol = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/offline-protocol-reliability/src/lib.rs
+++ b/crates/offline-protocol-reliability/src/lib.rs
@@ -19,4 +19,4 @@ pub use ack_manager::{AckConfig, AckEvictionInfo, AckManager};
 pub use ack_optimization::{AckOptimizationConfig, AckOptimizer, AggregatedAck, PiggybackAckData};
 pub use deduplicator::{Deduplicator, DeduplicatorConfig, DeduplicatorMode, DeduplicatorStats};
 pub use error::{Error, Result};
-pub use retry_queue::{RetryConfig, RetryQueue};
+pub use retry_queue::{RetryConfig, RetryQueue, RetryQueueStats};

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -204,11 +204,37 @@ struct EscalationEvaluation {
 ///
 /// `#[non_exhaustive]` so a future scoring factor can be added without a
 /// breaking-change bump. External callers that need to construct a value
-/// (benchmarks, tests, tooling) should use [`Self::new`] rather than struct
-/// literal syntax.
+/// (benchmarks, tests, tooling) build a [`TransportScoreFactors`] literal
+/// and pass it to [`Self::from_factors`] — the factors struct uses named
+/// fields so adding a factor in the future does not silently misorder
+/// existing call sites.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct TransportScore {
+    /// Signal strength score (0-100).
+    pub signal: f32,
+    /// Proximity/hop distance score (0-100).
+    pub proximity: f32,
+    /// Available bandwidth score (0-100).
+    pub bandwidth: f32,
+    /// Congestion score (0-100, higher is less congested).
+    pub congestion: f32,
+    /// Energy efficiency score (0-100).
+    pub energy: f32,
+    /// Reliability score (0-100).
+    pub reliability: f32,
+    /// Load score (0-100, higher = more capacity available).
+    pub load: f32,
+    /// Total weighted score.
+    pub total: f32,
+}
+
+/// Named-field factors accepted by [`TransportScore::from_factors`].
+///
+/// Using named fields prevents the silent-misorder bug that an N-arg
+/// positional constructor would invite (every factor is `f32`).
+#[derive(Debug, Clone, Default)]
+pub struct TransportScoreFactors {
     /// Signal strength score (0-100).
     pub signal: f32,
     /// Proximity/hop distance score (0-100).
@@ -233,26 +259,16 @@ impl TransportScore {
     /// Intended for callers outside this crate (benchmarks, tooling). The
     /// per-factor weighting is the selector's responsibility; this
     /// constructor performs no validation or recomputation of `total`.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        signal: f32,
-        proximity: f32,
-        bandwidth: f32,
-        congestion: f32,
-        energy: f32,
-        reliability: f32,
-        load: f32,
-        total: f32,
-    ) -> Self {
+    pub fn from_factors(factors: TransportScoreFactors) -> Self {
         Self {
-            signal,
-            proximity,
-            bandwidth,
-            congestion,
-            energy,
-            reliability,
-            load,
-            total,
+            signal: factors.signal,
+            proximity: factors.proximity,
+            bandwidth: factors.bandwidth,
+            congestion: factors.congestion,
+            energy: factors.energy,
+            reliability: factors.reliability,
+            load: factors.load,
+            total: factors.total,
         }
     }
 }

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -201,6 +201,12 @@ struct EscalationEvaluation {
 }
 
 /// Score breakdown for transport selection.
+///
+/// `#[non_exhaustive]` so a future scoring factor can be added without a
+/// breaking-change bump. External callers that need to construct a value
+/// (benchmarks, tests, tooling) should use [`Self::new`] rather than struct
+/// literal syntax.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct TransportScore {
     /// Signal strength score (0-100).
@@ -219,6 +225,36 @@ pub struct TransportScore {
     pub load: f32,
     /// Total weighted score.
     pub total: f32,
+}
+
+impl TransportScore {
+    /// Constructs a score from explicit per-factor values.
+    ///
+    /// Intended for callers outside this crate (benchmarks, tooling). The
+    /// per-factor weighting is the selector's responsibility; this
+    /// constructor performs no validation or recomputation of `total`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        signal: f32,
+        proximity: f32,
+        bandwidth: f32,
+        congestion: f32,
+        energy: f32,
+        reliability: f32,
+        load: f32,
+        total: f32,
+    ) -> Self {
+        Self {
+            signal,
+            proximity,
+            bandwidth,
+            congestion,
+            energy,
+            reliability,
+            load,
+            total,
+        }
+    }
 }
 
 #[derive(Default, Debug)]
@@ -644,60 +680,48 @@ impl TransportSelector {
         message: &Message,
         available_transports: &HashMap<TransportType, TransportMetrics>,
     ) -> Vec<(TransportType, f32)> {
-        let mut scored: Vec<(TransportType, f32)> = Vec::new();
-
-        for (transport_type, metrics) in available_transports.iter() {
-            let score = self.calculate_transport_score(message, *transport_type, metrics);
-            scored.push((*transport_type, score.total));
-        }
-
-        sort_scores_descending(&mut scored, |(_, s)| *s, |(t, _)| *t);
-        scored
+        // Single source of truth: project the detailed breakdown to totals.
+        // Sort order (descending with Internet > WiFiDirect > BLE tie-break)
+        // is preserved by `score_and_rank_detailed`.
+        self.score_and_rank_detailed(message, available_transports)
+            .into_iter()
+            .map(|(t, s)| (t, s.total))
+            .collect()
     }
 
     /// Diagnostic variant of [`Self::score_and_rank`] that returns the full
     /// seven-factor [`TransportScore`] per transport rather than just the
     /// total. Used by telemetry consumers that opted into `routing_diagnostic`.
     ///
-    /// Identical determinism/tie-break contract; identical read-only guarantees.
-    /// Costs one additional `TransportScore` struct per transport (all `f32`),
-    /// which is why it is kept behind a flag — callers that never emit
-    /// diagnostic routing records should stay on `score_and_rank`.
+    /// Sorted descending by `total`; ties resolve via the same priority
+    /// (Internet > WiFiDirect > BLE) used by selection. Identical read-only
+    /// guarantees as `score_and_rank`.
     pub fn score_and_rank_detailed(
         &self,
         message: &Message,
         available_transports: &HashMap<TransportType, TransportMetrics>,
     ) -> Vec<(TransportType, TransportScore)> {
-        let mut scored: Vec<(TransportType, TransportScore)> = Vec::new();
-        for (transport_type, metrics) in available_transports.iter() {
-            let score = self.calculate_transport_score(message, *transport_type, metrics);
-            scored.push((*transport_type, score));
-        }
-        sort_scores_descending(&mut scored, |(_, s)| s.total, |(t, _)| *t);
+        let mut scored: Vec<(TransportType, TransportScore)> = available_transports
+            .iter()
+            .map(|(transport_type, metrics)| {
+                let score = self.calculate_transport_score(message, *transport_type, metrics);
+                (*transport_type, score)
+            })
+            .collect();
+        scored.sort_by(|a, b| {
+            let ord =
+                b.1.total
+                    .partial_cmp(&a.1.total)
+                    .unwrap_or(std::cmp::Ordering::Equal);
+            if ord == std::cmp::Ordering::Equal {
+                tie_break_priority(a.0).cmp(&tie_break_priority(b.0))
+            } else {
+                ord
+            }
+        });
         scored
     }
-}
 
-/// Shared sort implementation for `score_and_rank` and `score_and_rank_detailed`:
-/// descending by score with deterministic tie-break (Internet > WiFiDirect > BLE).
-fn sort_scores_descending<T>(
-    items: &mut [T],
-    total: impl Fn(&T) -> f32,
-    transport: impl Fn(&T) -> TransportType,
-) {
-    items.sort_by(|a, b| {
-        let ord = total(b)
-            .partial_cmp(&total(a))
-            .unwrap_or(std::cmp::Ordering::Equal);
-        if ord == std::cmp::Ordering::Equal {
-            tie_break_priority(transport(a)).cmp(&tie_break_priority(transport(b)))
-        } else {
-            ord
-        }
-    });
-}
-
-impl TransportSelector {
     /// Calculates the transport score based on multiple factors.
     fn calculate_transport_score(
         &self,

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -696,13 +696,37 @@ impl TransportSelector {
         message: &Message,
         available_transports: &HashMap<TransportType, TransportMetrics>,
     ) -> Vec<(TransportType, f32)> {
-        // Single source of truth: project the detailed breakdown to totals.
-        // Sort order (descending with Internet > WiFiDirect > BLE tie-break)
-        // is preserved by `score_and_rank_detailed`.
-        self.score_and_rank_detailed(message, available_transports)
-            .into_iter()
-            .map(|(t, s)| (t, s.total))
-            .collect()
+        // Single-allocation path: the non-diagnostic send() hot path calls
+        // this on every send, so we project scoring to totals directly
+        // rather than going through `score_and_rank_detailed` (which
+        // allocates a `Vec<(TransportType, TransportScore)>` that would
+        // then be mapped to totals — two vecs where one suffices).
+        let mut scored: Vec<(TransportType, f32)> = available_transports
+            .iter()
+            .map(|(transport_type, metrics)| {
+                let score = self.calculate_transport_score(message, *transport_type, metrics);
+                (*transport_type, score.total)
+            })
+            .collect();
+
+        // Contract: ranked by score (descending).
+        //
+        // Determinism: when scores are exactly equal (rare with floats, but
+        // can happen in tests or after rounding), apply the same priority
+        // tie-break used by selection: Internet > WiFiDirect > BLE. See
+        // `score_and_rank_detailed` — the two functions must agree on
+        // ordering, and a regression test (`test_score_and_rank_detailed_\
+        // matches_score_and_rank_order_and_totals`) pins that invariant.
+        scored.sort_by(|a, b| {
+            let ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
+            if ord == std::cmp::Ordering::Equal {
+                tie_break_priority(a.0).cmp(&tie_break_priority(b.0))
+            } else {
+                ord
+            }
+        });
+
+        scored
     }
 
     /// Diagnostic variant of [`Self::score_and_rank`] that returns the full

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -651,23 +651,53 @@ impl TransportSelector {
             scored.push((*transport_type, score.total));
         }
 
-        // Contract: ranked by score (descending).
-        //
-        // Determinism: when scores are exactly equal (rare with floats, but can
-        // happen in tests or after rounding), apply the same priority tie-break
-        // used by selection: Internet > WiFiDirect > BLE.
-        scored.sort_by(|a, b| {
-            let ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
-            if ord == std::cmp::Ordering::Equal {
-                tie_break_priority(a.0).cmp(&tie_break_priority(b.0))
-            } else {
-                ord
-            }
-        });
-
+        sort_scores_descending(&mut scored, |(_, s)| *s, |(t, _)| *t);
         scored
     }
 
+    /// Diagnostic variant of [`Self::score_and_rank`] that returns the full
+    /// seven-factor [`TransportScore`] per transport rather than just the
+    /// total. Used by telemetry consumers that opted into `routing_diagnostic`.
+    ///
+    /// Identical determinism/tie-break contract; identical read-only guarantees.
+    /// Costs one additional `TransportScore` struct per transport (all `f32`),
+    /// which is why it is kept behind a flag — callers that never emit
+    /// diagnostic routing records should stay on `score_and_rank`.
+    pub fn score_and_rank_detailed(
+        &self,
+        message: &Message,
+        available_transports: &HashMap<TransportType, TransportMetrics>,
+    ) -> Vec<(TransportType, TransportScore)> {
+        let mut scored: Vec<(TransportType, TransportScore)> = Vec::new();
+        for (transport_type, metrics) in available_transports.iter() {
+            let score = self.calculate_transport_score(message, *transport_type, metrics);
+            scored.push((*transport_type, score));
+        }
+        sort_scores_descending(&mut scored, |(_, s)| s.total, |(t, _)| *t);
+        scored
+    }
+}
+
+/// Shared sort implementation for `score_and_rank` and `score_and_rank_detailed`:
+/// descending by score with deterministic tie-break (Internet > WiFiDirect > BLE).
+fn sort_scores_descending<T>(
+    items: &mut [T],
+    total: impl Fn(&T) -> f32,
+    transport: impl Fn(&T) -> TransportType,
+) {
+    items.sort_by(|a, b| {
+        let ord = total(b)
+            .partial_cmp(&total(a))
+            .unwrap_or(std::cmp::Ordering::Equal);
+        if ord == std::cmp::Ordering::Equal {
+            tie_break_priority(transport(a)).cmp(&tie_break_priority(transport(b)))
+        } else {
+            ord
+        }
+    });
+}
+
+impl TransportSelector {
     /// Calculates the transport score based on multiple factors.
     fn calculate_transport_score(
         &self,
@@ -2022,6 +2052,50 @@ mod tests {
             s
         };
         assert_eq!(scores, sorted, "score_and_rank returns descending by score");
+    }
+
+    #[test]
+    fn test_score_and_rank_detailed_matches_score_and_rank_order_and_totals() {
+        // Contract: detailed and total variants agree on ordering and on the
+        // `total` field. The detailed variant simply adds the per-factor
+        // breakdown without changing ranking semantics.
+        let selector = TransportSelector::new();
+        let message = create_test_message();
+        let mut transports = HashMap::new();
+        transports.insert(TransportType::Internet, create_test_metrics(None, 0.0, 0));
+        transports.insert(TransportType::BLE, create_test_metrics(Some(-60), 0.2, 10));
+        transports.insert(
+            TransportType::WiFiDirect,
+            create_test_metrics(Some(-55), 0.1, 5),
+        );
+
+        let totals = selector.score_and_rank(&message, &transports);
+        let detailed = selector.score_and_rank_detailed(&message, &transports);
+
+        assert_eq!(totals.len(), detailed.len());
+        for ((t_total, score_total), (t_det, score_det)) in totals.iter().zip(detailed.iter()) {
+            assert_eq!(t_total, t_det, "ordering must match between variants");
+            assert!(
+                (*score_total - score_det.total).abs() < f32::EPSILON,
+                "totals must match: {} vs {}",
+                score_total,
+                score_det.total,
+            );
+            for (label, v) in [
+                ("signal", score_det.signal),
+                ("proximity", score_det.proximity),
+                ("bandwidth", score_det.bandwidth),
+                ("congestion", score_det.congestion),
+                ("energy", score_det.energy),
+                ("reliability", score_det.reliability),
+                ("load", score_det.load),
+            ] {
+                assert!(
+                    v.is_finite(),
+                    "{label} sub-score for {t_det:?} must be finite",
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/offline-protocol-router/src/lib.rs
+++ b/crates/offline-protocol-router/src/lib.rs
@@ -17,9 +17,9 @@ pub mod router;
 pub mod ttl;
 
 pub use congestion::{CongestionConfig, CongestionController, DeliveryOutcome, SendDecision};
-pub use dors::{DorsConfig, EscalationTriggerReason, TransportSelector};
+pub use dors::{DorsConfig, EscalationTriggerReason, TransportScore, TransportSelector};
 pub use error::{Error, Result};
-pub use relay::{RelayConfig, RelayManager};
+pub use relay::{RelayConfig, RelayManager, RelayRole};
 pub use router::{
     ForwardingDecision, GossipConfig, GradientRoutingConfig, GradientRoutingTable, PathConfig,
     PathSelector, RouteEntry,

--- a/crates/offline-protocol-router/src/lib.rs
+++ b/crates/offline-protocol-router/src/lib.rs
@@ -17,7 +17,9 @@ pub mod router;
 pub mod ttl;
 
 pub use congestion::{CongestionConfig, CongestionController, DeliveryOutcome, SendDecision};
-pub use dors::{DorsConfig, EscalationTriggerReason, TransportScore, TransportSelector};
+pub use dors::{
+    DorsConfig, EscalationTriggerReason, TransportScore, TransportScoreFactors, TransportSelector,
+};
 pub use error::{Error, Result};
 pub use relay::{RelayConfig, RelayManager, RelayRole};
 pub use router::{

--- a/crates/offline-protocol-router/src/router.rs
+++ b/crates/offline-protocol-router/src/router.rs
@@ -483,6 +483,14 @@ impl PathSelector {
         self.local_device_id = device_id.into();
     }
 
+    /// Returns a reference to the internal [`RelayManager`].
+    ///
+    /// Exposed for read-only callers (e.g., the telemetry aggregator that
+    /// needs to know the current relay role without duplicating the state).
+    pub fn relay_manager(&self) -> &RelayManager {
+        &self.relay_manager
+    }
+
     /// Computes the forwarding probability based on visible peer count.
     ///
     /// Uses the formula: min(1.0, max(min_probability, target_fanout / peer_count))

--- a/crates/offline-protocol-router/src/router.rs
+++ b/crates/offline-protocol-router/src/router.rs
@@ -5,7 +5,7 @@
 //! based on the number of visible peers to maintain constant message overhead.
 
 use crate::constants::*;
-use crate::relay::{RelayInfo, RelayManager};
+use crate::relay::{RelayInfo, RelayManager, RelayRole};
 use offline_protocol_core::Message;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
@@ -483,12 +483,13 @@ impl PathSelector {
         self.local_device_id = device_id.into();
     }
 
-    /// Returns a reference to the internal [`RelayManager`].
+    /// Returns the current [`RelayRole`] from the internal [`RelayManager`].
     ///
     /// Exposed for read-only callers (e.g., the telemetry aggregator that
-    /// needs to know the current relay role without duplicating the state).
-    pub fn relay_manager(&self) -> &RelayManager {
-        &self.relay_manager
+    /// needs to know the current relay role without widening the surface
+    /// to the full [`RelayManager`] API).
+    pub fn current_relay_role(&self) -> RelayRole {
+        self.relay_manager.current_role()
     }
 
     /// Computes the forwarding probability based on visible peer count.

--- a/crates/offline-protocol-transport/src/mock.rs
+++ b/crates/offline-protocol-transport/src/mock.rs
@@ -74,6 +74,13 @@ impl MockTransport {
     pub fn set_metrics(&self, metrics: TransportMetrics) {
         *self.metrics.lock().unwrap() = metrics;
     }
+
+    /// Overrides the reported status, bypassing `start()`/`stop()`. Used by
+    /// tests that drive status transitions directly (e.g. the telemetry
+    /// aggregator diff).
+    pub fn set_status(&self, status: TransportStatus) {
+        *self.status.lock().unwrap() = status;
+    }
 }
 
 impl Transport for MockTransport {

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -23,7 +23,8 @@ pub(crate) use types::*;
 use crate::file_transfer::{FileTransferManager, OutboundTransferState};
 use crate::mls_observability::{MlsEventEmitter, MlsEventRateLimiter, NoopMlsEventEmitter};
 use crate::telemetry::aggregator::{
-    build_metrics_frame, diff_device_capability, diff_transport_state, DeviceSnap,
+    build_metrics_frame, device_battery_from_available, diff_device_capability,
+    diff_transport_state, DeviceSnap,
 };
 use crate::telemetry::{
     Scrubber, TelemetryConfig, TelemetryContext, TelemetryRecord, TelemetrySink,
@@ -35,7 +36,7 @@ use offline_protocol_mls::{EncryptedMessage, MlsManager, MlsStorage, WelcomeMess
 use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
 use offline_protocol_router::{PathSelector, RelayManager, RelayRole, TransportSelector};
 use offline_protocol_services::MeshServices;
-use offline_protocol_transport::{BleTransport, TransportMetrics, TransportStatus, TransportType};
+use offline_protocol_transport::{BleTransport, TransportStatus, TransportType};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex, RwLock};
@@ -485,12 +486,10 @@ impl OfflineProtocol {
         // reports honest transitions only. Without this, a sink installed
         // after start() would observe a synthetic `Unavailable → Available`
         // transition for every already-running transport on the next tick.
-        self.transport_status_snapshot = self.transport_manager.get_all_transport_statuses();
-        let available = self.transport_manager.get_available_transports();
-        let (battery_level, is_charging) = Self::device_battery_from_available(
-            self.transport_manager.current_transport(),
-            &available,
-        );
+        let (statuses, available) = self.transport_manager.snapshot_status_and_available();
+        self.transport_status_snapshot = statuses;
+        let (battery_level, is_charging) =
+            device_battery_from_available(self.transport_manager.current_transport(), &available);
         let relay_role = self.path_selector.current_relay_role();
         self.device_capability_snapshot = Some(DeviceSnap::from_parts(
             battery_level,
@@ -1337,11 +1336,13 @@ impl OfflineProtocol {
         let now_ms = Utc::now().timestamp_millis();
         let now = Instant::now();
 
-        // Snapshot once per tick, reuse everywhere below.
-        let available = self.transport_manager.get_available_transports();
+        // One lock-per-transport pass: get statuses (for the transition
+        // diff) and the available-only metrics map (for the metrics frame
+        // and the device-capability diff). Reused across every helper
+        // below.
+        let (current_statuses, available) = self.transport_manager.snapshot_status_and_available();
 
         // Transport-status diff: one record per changed transport.
-        let current_statuses = self.transport_manager.get_all_transport_statuses();
         let transitions =
             diff_transport_state(now_ms, &self.transport_status_snapshot, &current_statuses);
         for event in transitions {
@@ -1350,10 +1351,8 @@ impl OfflineProtocol {
         self.transport_status_snapshot = current_statuses;
 
         // Device capability diff.
-        let (battery_level, is_charging) = Self::device_battery_from_available(
-            self.transport_manager.current_transport(),
-            &available,
-        );
+        let (battery_level, is_charging) =
+            device_battery_from_available(self.transport_manager.current_transport(), &available);
         let relay_role = self.path_selector.current_relay_role();
         let device_now = DeviceSnap::from_parts(battery_level, is_charging, relay_role);
         if let Some(snapshot) =
@@ -1388,73 +1387,6 @@ impl OfflineProtocol {
         }
     }
 
-    /// Derives `(battery_level, is_charging)` for the local device from the
-    /// per-transport metrics map.
-    ///
-    /// Selection order:
-    ///   1. Currently selected transport, if it reports `Some(battery_level)`.
-    ///   2. First available transport (deterministic by `TransportType`
-    ///      priority) that reports `Some(battery_level)`.
-    ///   3. `(None, is_charging)` where `is_charging` comes from the current
-    ///      transport if present, else `false`.
-    ///
-    /// `is_charging` is **always** the current transport's reading when a
-    /// current transport is registered — regardless of which transport
-    /// supplied `battery_level`. Mixing `is_charging` from one transport
-    /// with `battery_level` from another produces non-deterministic flips
-    /// across ticks (HashMap iteration order is unspecified) and would
-    /// spuriously trigger `CHANGED_CHARGING` on the device-capability diff.
-    fn device_battery_from_available(
-        current: Option<TransportType>,
-        available: &HashMap<TransportType, TransportMetrics>,
-    ) -> (Option<u8>, bool) {
-        // Deterministic walk order: honour the existing transport-priority
-        // (Internet > WiFiDirect > BLE > everything else) so the choice of
-        // "first with Some(battery)" is stable across ticks.
-        const PRIORITY: &[TransportType] = &[
-            TransportType::Internet,
-            TransportType::WiFiDirect,
-            TransportType::BLE,
-            TransportType::Reticulum,
-            TransportType::Nostr,
-        ];
-        let first_with_battery = |skip: Option<TransportType>| -> Option<u8> {
-            for t in PRIORITY {
-                if skip == Some(*t) {
-                    continue;
-                }
-                if let Some(m) = available.get(t) {
-                    if m.battery_level.is_some() {
-                        return m.battery_level;
-                    }
-                }
-            }
-            // Fallback for transport types not in the priority list.
-            available
-                .iter()
-                .find(|(t, m)| Some(**t) != skip && m.battery_level.is_some())
-                .and_then(|(_, m)| m.battery_level)
-        };
-
-        if let Some(current) = current {
-            if let Some(metrics) = available.get(&current) {
-                let battery = metrics
-                    .battery_level
-                    .or_else(|| first_with_battery(Some(current)));
-                return (battery, metrics.is_charging);
-            }
-            // `current` is set but not present in `available` — fall through
-            // to the no-current branch but without an `is_charging` anchor.
-        }
-        let battery = first_with_battery(None);
-        let is_charging = PRIORITY
-            .iter()
-            .find_map(|t| available.get(t))
-            .or_else(|| available.values().next())
-            .map(|m| m.is_charging)
-            .unwrap_or(false);
-        (battery, is_charging)
-    }
     /// Processes messages ready for retry from the retry queue.
     ///
     /// EDGE CASE HANDLING:

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -451,6 +451,18 @@ impl OfflineProtocol {
     /// window elapses. This is intentional: the dedupe is a property of
     /// the routing engine, not of the observer.
     ///
+    /// # Lifecycle
+    ///
+    /// Installing a sink wires the structured routing-decision callback
+    /// on the underlying [`TransportManager`]. The callback lives for the
+    /// life of the protocol instance or until another
+    /// `install_telemetry_sink` call replaces it — `start()` and `stop()`
+    /// do not toggle it. This means apps can install a sink before
+    /// `start()` and see routing records from the very first `send()`,
+    /// and a `stop() → start()` cycle preserves the wiring so no
+    /// re-install is needed. Conversely, apps that never install a sink
+    /// pay no per-`send()` routing-emission overhead.
+    ///
     /// # Errors
     ///
     /// Returns `Err` if the shared-state mutex is poisoned (indicating an
@@ -481,6 +493,27 @@ impl OfflineProtocol {
         state.telemetry = Some(ctx.clone());
         drop(state);
         self.telemetry = Some(ctx);
+
+        // Wire the structured routing-decision callback here so the
+        // `TransportManager` pays the per-`send()` emission cost only when
+        // a sink is actually installed, and so the wiring persists across
+        // `stop() → start()` cycles (the callback reads `s.telemetry` on
+        // every invocation and that field stays set). A subsequent
+        // `install_telemetry_sink` replaces the closure with one capturing
+        // the fresh `shared_routing` clone; both closures read the same
+        // `SharedState::telemetry` slot, so even a concurrent in-flight
+        // emission from the pre-replace closure would still resolve to
+        // the currently-installed sink.
+        let shared_routing = self.shared_state.clone();
+        self.transport_manager
+            .set_routing_decision_callback(Some(Arc::new(move |decision| {
+                if let Ok(s) = shared_routing.lock() {
+                    if let Some(ctx) = &s.telemetry {
+                        let record = TelemetryRecord::Routing(Box::new(decision));
+                        ctx.sink.emit(&record);
+                    }
+                }
+            })));
 
         // Rearm the per-tick diff snapshots so the first tick after install
         // reports honest transitions only. Without this, a sink installed
@@ -530,19 +563,10 @@ impl OfflineProtocol {
                 }
             })));
 
-        // Wire the structured routing-decision callback so telemetry sinks
-        // receive the richer shape alongside the flattened `Event::Dors*`
-        // stream. The legacy `EventCallback` fan-out is unaffected.
-        let shared_routing = self.shared_state.clone();
-        self.transport_manager
-            .set_routing_decision_callback(Some(Arc::new(move |decision| {
-                if let Ok(s) = shared_routing.lock() {
-                    if let Some(ctx) = &s.telemetry {
-                        let record = TelemetryRecord::Routing(Box::new(decision));
-                        ctx.sink.emit(&record);
-                    }
-                }
-            })));
+        // NOTE: the structured routing-decision callback is wired by
+        // `install_telemetry_sink`, not here. Its lifetime is tied to sink
+        // presence rather than protocol start/stop — see the docstring on
+        // `install_telemetry_sink` for the rationale.
 
         // Wire BLE fragment eviction callback so app receives FragmentAssemblyEvicted.
         if let Some(ble_arc) = self.transport_manager.get_transport(TransportType::BLE) {
@@ -591,8 +615,12 @@ impl OfflineProtocol {
         self.flush_lamport_clock();
 
         // Clear event callbacks to release shared_state references.
+        // NOTE: the routing-decision callback is deliberately NOT cleared
+        // here. Its lifetime is sink-scoped (installed by
+        // `install_telemetry_sink`, replaced by a subsequent install),
+        // not protocol-running-scoped — so a `stop() → start()` cycle
+        // preserves the wiring without requiring the app to re-install.
         self.transport_manager.set_dors_event_callback(None);
-        self.transport_manager.set_routing_decision_callback(None);
         if let Some(ble_arc) = self.transport_manager.get_transport(TransportType::BLE) {
             if let Ok(transport) = ble_arc.lock() {
                 if let Some(ble) = transport.as_any().downcast_ref::<BleTransport>() {
@@ -1329,6 +1357,16 @@ impl OfflineProtocol {
     /// skipped and telemetry emission for that interval is deferred to the
     /// next successful tick — the cadence guarantee relaxes under sustained
     /// partial failure.
+    ///
+    /// # Sink-panic semantics
+    ///
+    /// Each per-tick snapshot field is advanced *before* the emit call
+    /// that observes it. A panicking sink unwinds the rest of the tick
+    /// but leaves the aggregator's cursors at their new positions, so
+    /// the next tick does not re-emit the same transition / capability
+    /// change / metrics frame. At-most-once delivery on panic rather
+    /// than at-least-once with silent duplicates for consumers counting
+    /// transitions.
     fn tick_telemetry_categories(&mut self) {
         let Some(ctx) = self.telemetry.clone() else {
             return;
@@ -1343,26 +1381,29 @@ impl OfflineProtocol {
         let (current_statuses, available) = self.transport_manager.snapshot_status_and_available();
 
         // Transport-status diff: one record per changed transport.
+        // Advance the snapshot *before* emitting so a panicking sink does
+        // not cause re-delivery on the next tick — see the fn-level doc.
         let transitions =
             diff_transport_state(now_ms, &self.transport_status_snapshot, &current_statuses);
+        self.transport_status_snapshot = current_statuses;
         for event in transitions {
             ctx.sink.emit(&TelemetryRecord::TransportState(event));
         }
-        self.transport_status_snapshot = current_statuses;
 
-        // Device capability diff.
+        // Device capability diff. Same ordering discipline as above.
         let (battery_level, is_charging) =
             device_battery_from_available(self.transport_manager.current_transport(), &available);
         let relay_role = self.path_selector.current_relay_role();
         let device_now = DeviceSnap::from_parts(battery_level, is_charging, relay_role);
-        if let Some(snapshot) =
-            diff_device_capability(now_ms, self.device_capability_snapshot, device_now)
-        {
+        let device_change =
+            diff_device_capability(now_ms, self.device_capability_snapshot, device_now);
+        self.device_capability_snapshot = Some(device_now);
+        if let Some(snapshot) = device_change {
             ctx.sink.emit(&TelemetryRecord::Device(snapshot));
         }
-        self.device_capability_snapshot = Some(device_now);
 
-        // Periodic metrics snapshot.
+        // Periodic metrics snapshot. Rearm cadence before emit so a
+        // panicking sink doesn't cause an immediate retry next tick.
         if let Some(cadence) = ctx.config.metrics_cadence() {
             let due = match self.last_metrics_emit_at {
                 None => true,
@@ -1380,9 +1421,9 @@ impl OfflineProtocol {
                     self.known_peers.len(),
                     is_local_relay,
                 );
+                self.last_metrics_emit_at = Some(now);
                 ctx.sink
                     .emit(&TelemetryRecord::MetricsSnapshot(Box::new(frame)));
-                self.last_metrics_emit_at = Some(now);
             }
         }
     }

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -22,7 +22,12 @@ pub(crate) use types::*;
 
 use crate::file_transfer::{FileTransferManager, OutboundTransferState};
 use crate::mls_observability::{MlsEventEmitter, MlsEventRateLimiter, NoopMlsEventEmitter};
-use crate::telemetry::{Scrubber, TelemetryConfig, TelemetryContext, TelemetrySink};
+use crate::telemetry::aggregator::{
+    build_metrics_frame, diff_device_capability, diff_transport_state, DeviceSnap,
+};
+use crate::telemetry::{
+    Scrubber, TelemetryConfig, TelemetryContext, TelemetryRecord, TelemetrySink,
+};
 use crate::{Error, EstablishmentState, Event, ProtocolConfig, Result, TransportManager};
 use chrono::{DateTime, Utc};
 use offline_protocol_core::{LamportClock, Message, MessageId};
@@ -30,7 +35,7 @@ use offline_protocol_mls::{EncryptedMessage, MlsManager, MlsStorage, WelcomeMess
 use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
 use offline_protocol_router::{PathSelector, RelayManager, TransportSelector};
 use offline_protocol_services::MeshServices;
-use offline_protocol_transport::{BleTransport, TransportType};
+use offline_protocol_transport::{BleTransport, TransportStatus, TransportType};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex, RwLock};
@@ -190,6 +195,19 @@ pub struct OfflineProtocol {
     /// (list_sessions → Keychain/Keystore) on every process tick / receive poll.
     last_reconciliation_at: Option<Instant>,
 
+    /// Instant of the last periodic `MetricsFrame` emission, used to rate
+    /// the telemetry aggregator to `TelemetryConfig::metrics_cadence`.
+    last_metrics_emit_at: Option<Instant>,
+
+    /// Last observed per-transport status map, used by the telemetry
+    /// aggregator to diff against the current map and emit one
+    /// `TransportStateEvent` per transition.
+    transport_status_snapshot: HashMap<TransportType, TransportStatus>,
+
+    /// Last observed (battery, charging, relay_role) snapshot, used by the
+    /// telemetry aggregator to fire `DeviceCapabilitySnapshot` on change.
+    device_capability_snapshot: Option<DeviceSnap>,
+
     /// The Lamport clock value at the time of the last storage write.
     /// Used to debounce `persist_lamport_clock()` — only write when the
     /// in-memory value has advanced past this by `LAMPORT_PERSIST_INTERVAL`
@@ -283,6 +301,9 @@ impl OfflineProtocol {
             known_peer_public_keys: HashMap::new(),
             blocked_users: HashSet::new(),
             last_reconciliation_at: None,
+            last_metrics_emit_at: None,
+            transport_status_snapshot: HashMap::new(),
+            device_capability_snapshot: None,
             last_persisted_lamport: 0,
             config,
         })
@@ -466,6 +487,20 @@ impl OfflineProtocol {
                 }
             })));
 
+        // Wire the structured routing-decision callback so telemetry sinks
+        // receive the richer shape alongside the flattened `Event::Dors*`
+        // stream. The legacy `EventCallback` fan-out is unaffected.
+        let shared_routing = self.shared_state.clone();
+        self.transport_manager
+            .set_routing_decision_callback(Some(Arc::new(move |decision| {
+                if let Ok(s) = shared_routing.lock() {
+                    if let Some(ctx) = &s.telemetry {
+                        let record = TelemetryRecord::Routing(Box::new(decision));
+                        ctx.sink.emit(&record);
+                    }
+                }
+            })));
+
         // Wire BLE fragment eviction callback so app receives FragmentAssemblyEvicted.
         if let Some(ble_arc) = self.transport_manager.get_transport(TransportType::BLE) {
             let shared = self.shared_state.clone();
@@ -514,6 +549,7 @@ impl OfflineProtocol {
 
         // Clear event callbacks to release shared_state references.
         self.transport_manager.set_dors_event_callback(None);
+        self.transport_manager.set_routing_decision_callback(None);
         if let Some(ble_arc) = self.transport_manager.get_transport(TransportType::BLE) {
             if let Ok(transport) = ble_arc.lock() {
                 if let Some(ble) = transport.as_any().downcast_ref::<BleTransport>() {
@@ -1232,8 +1268,97 @@ impl OfflineProtocol {
         let _ = self.prune_expired_pending_global_front(Instant::now(), 256);
         self.pump_media_transfers();
         self.cleanup_expired_entries();
+        self.tick_telemetry_categories();
 
         Ok(())
+    }
+
+    /// Per-tick telemetry work: diff transport statuses, diff device
+    /// capability, and emit a `MetricsFrame` when `metrics_cadence` has
+    /// elapsed. No-ops unless a sink has been installed.
+    ///
+    /// Runs at the end of `process()` so reliability/queue state observed
+    /// here is the same state the rest of the tick has already advanced.
+    fn tick_telemetry_categories(&mut self) {
+        let Some(ctx) = self.telemetry.clone() else {
+            return;
+        };
+        let now_ms = Utc::now().timestamp_millis();
+        let now = Instant::now();
+
+        // Transport-status diff: one record per changed transport.
+        let current_statuses = self.transport_manager.get_all_transport_statuses();
+        let transitions =
+            diff_transport_state(now_ms, &self.transport_status_snapshot, &current_statuses);
+        for event in transitions {
+            ctx.sink.emit(&TelemetryRecord::TransportState(event));
+        }
+        self.transport_status_snapshot = current_statuses;
+
+        // Device capability diff.
+        let (battery_level, is_charging) = self.current_device_battery();
+        let relay_role = self.path_selector.relay_manager().current_role();
+        let device_now = DeviceSnap::from_parts(battery_level, is_charging, relay_role);
+        if let Some(snapshot) =
+            diff_device_capability(now_ms, self.device_capability_snapshot, device_now)
+        {
+            ctx.sink.emit(&TelemetryRecord::Device(snapshot));
+        }
+        self.device_capability_snapshot = Some(device_now);
+
+        // Periodic metrics snapshot.
+        if let Some(cadence) = ctx.config.metrics_cadence() {
+            let due = match self.last_metrics_emit_at {
+                None => true,
+                Some(prev) => now.saturating_duration_since(prev) >= cadence,
+            };
+            if due {
+                let frame = build_metrics_frame(
+                    now_ms,
+                    &self.transport_manager,
+                    &self.retry_queue,
+                    &self.deduplicator,
+                    &self.ack_manager,
+                    self.known_peers.len(),
+                    self.relay_neighbor_count(),
+                );
+                ctx.sink
+                    .emit(&TelemetryRecord::MetricsSnapshot(Box::new(frame)));
+                self.last_metrics_emit_at = Some(now);
+            }
+        }
+    }
+
+    /// Returns the battery level and charging state of the currently
+    /// selected transport, if any. Falls back to the first transport's
+    /// metrics when no current transport is selected (e.g. pre-start).
+    fn current_device_battery(&self) -> (Option<u8>, bool) {
+        let available = self.transport_manager.get_available_transports();
+        if let Some(current) = self.transport_manager.current_transport() {
+            if let Some(metrics) = available.get(&current) {
+                return (metrics.battery_level, metrics.is_charging);
+            }
+        }
+        available
+            .values()
+            .next()
+            .map(|metrics| (metrics.battery_level, metrics.is_charging))
+            .unwrap_or((None, false))
+    }
+
+    /// Counts the number of known peers currently acting as relays on this
+    /// node. Today the SDK does not maintain a relay-peer registry separate
+    /// from `known_peers`; relay count falls back to 0 until a dedicated
+    /// accessor is introduced.
+    fn relay_neighbor_count(&self) -> usize {
+        if matches!(
+            self.path_selector.relay_manager().current_role(),
+            offline_protocol_router::RelayRole::Relay
+        ) {
+            1
+        } else {
+            0
+        }
     }
     /// Processes messages ready for retry from the retry queue.
     ///

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -1360,13 +1360,19 @@ impl OfflineProtocol {
     ///
     /// # Sink-panic semantics
     ///
-    /// Each per-tick snapshot field is advanced *before* the emit call
-    /// that observes it. A panicking sink unwinds the rest of the tick
-    /// but leaves the aggregator's cursors at their new positions, so
-    /// the next tick does not re-emit the same transition / capability
-    /// change / metrics frame. At-most-once delivery on panic rather
-    /// than at-least-once with silent duplicates for consumers counting
-    /// transitions.
+    /// Each per-tick cursor is advanced *before* the emit call that
+    /// observes it, so a panicking sink does not cause re-delivery of the
+    /// record it panicked on. The transport-status path advances
+    /// **per-transport**: when multiple transitions fall in a single tick,
+    /// a panic on transition K commits K's entry (at-most-once for K) but
+    /// leaves entries L..N in `transport_status_snapshot` at their previous
+    /// values, so the next tick re-diffs and emits them fresh. This avoids
+    /// silent data loss for transitions that never reached the sink.
+    ///
+    /// The device-capability and metrics-frame paths emit at most one
+    /// record per tick each, so a simpler "advance then emit" discipline
+    /// suffices there: a panic advances the cursor and the same record is
+    /// not re-emitted on the next tick.
     fn tick_telemetry_categories(&mut self) {
         let Some(ctx) = self.telemetry.clone() else {
             return;
@@ -1380,17 +1386,27 @@ impl OfflineProtocol {
         // below.
         let (current_statuses, available) = self.transport_manager.snapshot_status_and_available();
 
-        // Transport-status diff: one record per changed transport.
-        // Advance the snapshot *before* emitting so a panicking sink does
-        // not cause re-delivery on the next tick — see the fn-level doc.
+        // Transport-status diff: one record per changed transport. Commit
+        // each transport's new snapshot entry *before* emitting its event
+        // so a panic on event K is at-most-once for K; untouched entries
+        // L..N stay at their previous values and get re-diffed next tick.
         let transitions =
             diff_transport_state(now_ms, &self.transport_status_snapshot, &current_statuses);
-        self.transport_status_snapshot = current_statuses;
         for event in transitions {
+            let transport = event.transport;
+            match current_statuses.get(&transport) {
+                Some(status) => {
+                    self.transport_status_snapshot.insert(transport, *status);
+                }
+                None => {
+                    self.transport_status_snapshot.remove(&transport);
+                }
+            }
             ctx.sink.emit(&TelemetryRecord::TransportState(event));
         }
 
-        // Device capability diff. Same ordering discipline as above.
+        // Device capability diff. At-most-one emission per tick, so the
+        // simple advance-before-emit pattern preserves at-most-once.
         let (battery_level, is_charging) =
             device_battery_from_available(self.transport_manager.current_transport(), &available);
         let relay_role = self.path_selector.current_relay_role();
@@ -1413,7 +1429,7 @@ impl OfflineProtocol {
                 let is_local_relay = matches!(relay_role, RelayRole::Relay);
                 let frame = build_metrics_frame(
                     now_ms,
-                    &self.transport_manager,
+                    self.transport_manager.current_transport(),
                     &available,
                     &self.retry_queue,
                     &self.deduplicator,

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -33,9 +33,9 @@ use chrono::{DateTime, Utc};
 use offline_protocol_core::{LamportClock, Message, MessageId};
 use offline_protocol_mls::{EncryptedMessage, MlsManager, MlsStorage, WelcomeMessage};
 use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
-use offline_protocol_router::{PathSelector, RelayManager, TransportSelector};
+use offline_protocol_router::{PathSelector, RelayManager, RelayRole, TransportSelector};
 use offline_protocol_services::MeshServices;
-use offline_protocol_transport::{BleTransport, TransportStatus, TransportType};
+use offline_protocol_transport::{BleTransport, TransportMetrics, TransportStatus, TransportType};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex, RwLock};
@@ -435,6 +435,14 @@ impl OfflineProtocol {
     /// opaque identifiers stay stable across the swap when the new config
     /// does not carry its own `scrub_secret`.
     ///
+    /// The per-tick diff snapshots (transport status, device capability,
+    /// metrics cadence) are **rearmed** on every install: the next
+    /// `process()` tick observes the current state as its baseline and emits
+    /// no synthetic transitions for transports that were already available
+    /// at install time. Apps that need the current transport statuses at
+    /// install time should pull them explicitly via
+    /// [`TransportManager::get_all_transport_statuses`].
+    ///
     /// # Errors
     ///
     /// Returns `Err` if the shared-state mutex is poisoned (indicating an
@@ -448,6 +456,12 @@ impl OfflineProtocol {
         sink: Arc<dyn TelemetrySink>,
         config: TelemetryConfig,
     ) -> Result<()> {
+        // Forward the routing-diagnostic preference to the TransportManager
+        // before wiring any callbacks so the very first routing decision
+        // post-install already reflects the requested tier.
+        self.transport_manager
+            .set_routing_diagnostic(config.routing_diagnostic());
+
         let ctx = TelemetryContext::new(sink, config, self.telemetry_fallback_secret);
         let mut state = lock_shared_state(&self.shared_state).map_err(|err| {
             error!(
@@ -459,6 +473,29 @@ impl OfflineProtocol {
         state.telemetry = Some(ctx.clone());
         drop(state);
         self.telemetry = Some(ctx);
+
+        // Rearm the per-tick diff snapshots so the first tick after install
+        // reports honest transitions only. Without this, a sink installed
+        // after start() would observe a synthetic `Unavailable → Available`
+        // transition for every already-running transport on the next tick.
+        self.transport_status_snapshot = self.transport_manager.get_all_transport_statuses();
+        let available = self.transport_manager.get_available_transports();
+        let (battery_level, is_charging) = Self::device_battery_from_available(
+            self.transport_manager.current_transport(),
+            &available,
+        );
+        let relay_role = self.path_selector.relay_manager().current_role();
+        self.device_capability_snapshot = Some(DeviceSnap::from_parts(
+            battery_level,
+            is_charging,
+            relay_role,
+        ));
+        // Leave `last_metrics_emit_at` at None so the first tick after
+        // install fires a fresh metrics snapshot — that is the bootstrap
+        // payload a new sink actually wants (full counter state in one
+        // record).
+        self.last_metrics_emit_at = None;
+
         Ok(())
     }
 
@@ -1279,12 +1316,17 @@ impl OfflineProtocol {
     ///
     /// Runs at the end of `process()` so reliability/queue state observed
     /// here is the same state the rest of the tick has already advanced.
+    /// Snapshots `get_available_transports()` exactly once per tick and
+    /// reuses the map across every downstream helper that needs it.
     fn tick_telemetry_categories(&mut self) {
         let Some(ctx) = self.telemetry.clone() else {
             return;
         };
         let now_ms = Utc::now().timestamp_millis();
         let now = Instant::now();
+
+        // Snapshot once per tick, reuse everywhere below.
+        let available = self.transport_manager.get_available_transports();
 
         // Transport-status diff: one record per changed transport.
         let current_statuses = self.transport_manager.get_all_transport_statuses();
@@ -1296,7 +1338,10 @@ impl OfflineProtocol {
         self.transport_status_snapshot = current_statuses;
 
         // Device capability diff.
-        let (battery_level, is_charging) = self.current_device_battery();
+        let (battery_level, is_charging) = Self::device_battery_from_available(
+            self.transport_manager.current_transport(),
+            &available,
+        );
         let relay_role = self.path_selector.relay_manager().current_role();
         let device_now = DeviceSnap::from_parts(battery_level, is_charging, relay_role);
         if let Some(snapshot) =
@@ -1313,14 +1358,16 @@ impl OfflineProtocol {
                 Some(prev) => now.saturating_duration_since(prev) >= cadence,
             };
             if due {
+                let is_local_relay = matches!(relay_role, RelayRole::Relay);
                 let frame = build_metrics_frame(
                     now_ms,
                     &self.transport_manager,
+                    &available,
                     &self.retry_queue,
                     &self.deduplicator,
                     &self.ack_manager,
                     self.known_peers.len(),
-                    self.relay_neighbor_count(),
+                    is_local_relay,
                 );
                 ctx.sink
                     .emit(&TelemetryRecord::MetricsSnapshot(Box::new(frame)));
@@ -1329,36 +1376,49 @@ impl OfflineProtocol {
         }
     }
 
-    /// Returns the battery level and charging state of the currently
-    /// selected transport, if any. Falls back to the first transport's
-    /// metrics when no current transport is selected (e.g. pre-start).
-    fn current_device_battery(&self) -> (Option<u8>, bool) {
-        let available = self.transport_manager.get_available_transports();
-        if let Some(current) = self.transport_manager.current_transport() {
+    /// Derives `(battery_level, is_charging)` for the local device from the
+    /// per-transport metrics map.
+    ///
+    /// Selection order:
+    ///   1. Currently selected transport, if it reports `Some(battery_level)`.
+    ///   2. First available transport that reports `Some(battery_level)`.
+    ///   3. `(None, is_charging)` where `is_charging` comes from the current
+    ///      transport if present, else `false`.
+    ///
+    /// Skipping past a current transport whose `battery_level` is `None` is
+    /// deliberate: every registered transport reports the hosting device's
+    /// battery, so any `Some` reading is more informative than the default
+    /// `None` on the selected one.
+    fn device_battery_from_available(
+        current: Option<TransportType>,
+        available: &HashMap<TransportType, TransportMetrics>,
+    ) -> (Option<u8>, bool) {
+        if let Some(current) = current {
             if let Some(metrics) = available.get(&current) {
-                return (metrics.battery_level, metrics.is_charging);
+                if metrics.battery_level.is_some() {
+                    return (metrics.battery_level, metrics.is_charging);
+                }
+                // Current transport has no battery reading; try any other.
+                if let Some((_, other)) = available
+                    .iter()
+                    .find(|(t, m)| **t != current && m.battery_level.is_some())
+                {
+                    return (other.battery_level, other.is_charging);
+                }
+                return (None, metrics.is_charging);
             }
         }
         available
             .values()
-            .next()
-            .map(|metrics| (metrics.battery_level, metrics.is_charging))
-            .unwrap_or((None, false))
-    }
-
-    /// Counts the number of known peers currently acting as relays on this
-    /// node. Today the SDK does not maintain a relay-peer registry separate
-    /// from `known_peers`; relay count falls back to 0 until a dedicated
-    /// accessor is introduced.
-    fn relay_neighbor_count(&self) -> usize {
-        if matches!(
-            self.path_selector.relay_manager().current_role(),
-            offline_protocol_router::RelayRole::Relay
-        ) {
-            1
-        } else {
-            0
-        }
+            .find(|m| m.battery_level.is_some())
+            .map(|m| (m.battery_level, m.is_charging))
+            .unwrap_or_else(|| {
+                available
+                    .values()
+                    .next()
+                    .map(|m| (None, m.is_charging))
+                    .unwrap_or((None, false))
+            })
     }
     /// Processes messages ready for retry from the retry queue.
     ///

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -443,6 +443,13 @@ impl OfflineProtocol {
     /// install time should pull them explicitly via
     /// [`TransportManager::get_all_transport_statuses`].
     ///
+    /// The escalation-trigger dedupe window (`ESCALATION_TRIGGER_DEDUPE_SECS`
+    /// inside [`TransportManager`]) is **not** rearmed. A sink installed
+    /// within that window after an escalation event fired to a previous
+    /// sink may miss the next occurrence of the same reason until the
+    /// window elapses. This is intentional: the dedupe is a property of
+    /// the routing engine, not of the observer.
+    ///
     /// # Errors
     ///
     /// Returns `Err` if the shared-state mutex is poisoned (indicating an
@@ -484,7 +491,7 @@ impl OfflineProtocol {
             self.transport_manager.current_transport(),
             &available,
         );
-        let relay_role = self.path_selector.relay_manager().current_role();
+        let relay_role = self.path_selector.current_relay_role();
         self.device_capability_snapshot = Some(DeviceSnap::from_parts(
             battery_level,
             is_charging,
@@ -1318,6 +1325,11 @@ impl OfflineProtocol {
     /// here is the same state the rest of the tick has already advanced.
     /// Snapshots `get_available_transports()` exactly once per tick and
     /// reuses the map across every downstream helper that needs it.
+    ///
+    /// If an earlier step in `process()` returns `Err(...)`, this method is
+    /// skipped and telemetry emission for that interval is deferred to the
+    /// next successful tick — the cadence guarantee relaxes under sustained
+    /// partial failure.
     fn tick_telemetry_categories(&mut self) {
         let Some(ctx) = self.telemetry.clone() else {
             return;
@@ -1342,7 +1354,7 @@ impl OfflineProtocol {
             self.transport_manager.current_transport(),
             &available,
         );
-        let relay_role = self.path_selector.relay_manager().current_role();
+        let relay_role = self.path_selector.current_relay_role();
         let device_now = DeviceSnap::from_parts(battery_level, is_charging, relay_role);
         if let Some(snapshot) =
             diff_device_capability(now_ms, self.device_capability_snapshot, device_now)
@@ -1381,44 +1393,67 @@ impl OfflineProtocol {
     ///
     /// Selection order:
     ///   1. Currently selected transport, if it reports `Some(battery_level)`.
-    ///   2. First available transport that reports `Some(battery_level)`.
+    ///   2. First available transport (deterministic by `TransportType`
+    ///      priority) that reports `Some(battery_level)`.
     ///   3. `(None, is_charging)` where `is_charging` comes from the current
     ///      transport if present, else `false`.
     ///
-    /// Skipping past a current transport whose `battery_level` is `None` is
-    /// deliberate: every registered transport reports the hosting device's
-    /// battery, so any `Some` reading is more informative than the default
-    /// `None` on the selected one.
+    /// `is_charging` is **always** the current transport's reading when a
+    /// current transport is registered — regardless of which transport
+    /// supplied `battery_level`. Mixing `is_charging` from one transport
+    /// with `battery_level` from another produces non-deterministic flips
+    /// across ticks (HashMap iteration order is unspecified) and would
+    /// spuriously trigger `CHANGED_CHARGING` on the device-capability diff.
     fn device_battery_from_available(
         current: Option<TransportType>,
         available: &HashMap<TransportType, TransportMetrics>,
     ) -> (Option<u8>, bool) {
+        // Deterministic walk order: honour the existing transport-priority
+        // (Internet > WiFiDirect > BLE > everything else) so the choice of
+        // "first with Some(battery)" is stable across ticks.
+        const PRIORITY: &[TransportType] = &[
+            TransportType::Internet,
+            TransportType::WiFiDirect,
+            TransportType::BLE,
+            TransportType::Reticulum,
+            TransportType::Nostr,
+        ];
+        let first_with_battery = |skip: Option<TransportType>| -> Option<u8> {
+            for t in PRIORITY {
+                if skip == Some(*t) {
+                    continue;
+                }
+                if let Some(m) = available.get(t) {
+                    if m.battery_level.is_some() {
+                        return m.battery_level;
+                    }
+                }
+            }
+            // Fallback for transport types not in the priority list.
+            available
+                .iter()
+                .find(|(t, m)| Some(**t) != skip && m.battery_level.is_some())
+                .and_then(|(_, m)| m.battery_level)
+        };
+
         if let Some(current) = current {
             if let Some(metrics) = available.get(&current) {
-                if metrics.battery_level.is_some() {
-                    return (metrics.battery_level, metrics.is_charging);
-                }
-                // Current transport has no battery reading; try any other.
-                if let Some((_, other)) = available
-                    .iter()
-                    .find(|(t, m)| **t != current && m.battery_level.is_some())
-                {
-                    return (other.battery_level, other.is_charging);
-                }
-                return (None, metrics.is_charging);
+                let battery = metrics
+                    .battery_level
+                    .or_else(|| first_with_battery(Some(current)));
+                return (battery, metrics.is_charging);
             }
+            // `current` is set but not present in `available` — fall through
+            // to the no-current branch but without an `is_charging` anchor.
         }
-        available
-            .values()
-            .find(|m| m.battery_level.is_some())
-            .map(|m| (m.battery_level, m.is_charging))
-            .unwrap_or_else(|| {
-                available
-                    .values()
-                    .next()
-                    .map(|m| (None, m.is_charging))
-                    .unwrap_or((None, false))
-            })
+        let battery = first_with_battery(None);
+        let is_charging = PRIORITY
+            .iter()
+            .find_map(|t| available.get(t))
+            .or_else(|| available.values().next())
+            .map(|m| m.is_charging)
+            .unwrap_or(false);
+        (battery, is_charging)
     }
     /// Processes messages ready for retry from the retry queue.
     ///

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -10009,11 +10009,44 @@ fn test_process_skips_metrics_snapshot_when_cadence_is_none() {
 }
 
 #[test]
+fn test_install_seeds_transport_state_so_first_tick_emits_no_bootstrap() {
+    // Regression guard: a sink installed after start() must NOT observe a
+    // synthetic `Unavailable → Available` transition on the first tick for
+    // transports that were already running at install time. install_telemetry_sink
+    // seeds `transport_status_snapshot` from the live statuses so the
+    // first tick diff finds nothing changed.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mock = MockTransport::new(TransportType::BLE);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
+
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+
+    protocol.process().unwrap();
+
+    let records = sink.take();
+    let transitions: Vec<&TransportStateEvent> = records
+        .iter()
+        .filter_map(|r| match r {
+            TelemetryRecord::TransportState(e) => Some(e),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        transitions.is_empty(),
+        "install-after-start must not synthesise a bootstrap transition, got {transitions:?}",
+    );
+}
+
+#[test]
 fn test_process_emits_transport_state_on_status_transition() {
-    // Register a mock transport. start() flips it to Available; the first
-    // process() tick records that as the snapshot (emitting one
-    // Unavailable→Available transition). Then flip the mock to
-    // Disconnected and run process() again — expect exactly one
+    // After install seeds the snapshot, only genuine transitions fire.
+    // Flip the mock to Disconnected and verify exactly one
     // Available→Disconnected transition.
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
     let mock = MockTransport::new(TransportType::BLE);
@@ -10021,15 +10054,14 @@ fn test_process_emits_transport_state_on_status_transition() {
     protocol
         .transport_manager_mut()
         .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
 
     let sink = RecordingTelemetrySink::default();
     protocol
         .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
         .unwrap();
-    protocol.start().unwrap();
 
-    // Drain the first-tick snapshot (which includes the Unavailable→Available
-    // transition bootstrap).
+    // First tick — should emit nothing transport-state-wise (seeded).
     protocol.process().unwrap();
     sink.take();
 
@@ -10055,15 +10087,17 @@ fn test_process_emits_transport_state_on_status_transition() {
 }
 
 #[test]
-fn test_process_emits_device_capability_on_first_tick() {
-    // First tick after install always emits a device record (prev == None
-    // is treated as "all fields changed").
+fn test_install_seeds_device_capability_so_first_tick_is_silent() {
+    // install_telemetry_sink seeds `device_capability_snapshot` so the first
+    // tick's diff against the seeded state yields no change record. Apps
+    // that want the current device state at install time pull it
+    // explicitly rather than relying on a bootstrap event.
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
     let sink = RecordingTelemetrySink::default();
+    protocol.start().unwrap();
     protocol
         .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
         .unwrap();
-    protocol.start().unwrap();
 
     protocol.process().unwrap();
 
@@ -10072,10 +10106,9 @@ fn test_process_emits_device_capability_on_first_tick() {
         .iter()
         .filter(|r| matches!(r, TelemetryRecord::Device(_)))
         .collect();
-    assert_eq!(
-        device.len(),
-        1,
-        "first tick must emit exactly one Device snapshot, got {records:?}",
+    assert!(
+        device.is_empty(),
+        "install seeds device snapshot; first tick must not re-emit it, got {records:?}",
     );
 }
 
@@ -10160,4 +10193,211 @@ fn test_process_skips_telemetry_tick_without_sink() {
     );
 }
 
+#[test]
+fn test_metrics_cadence_rate_limits_emission_across_ticks() {
+    // Install with a very long cadence so only the first tick after install
+    // is "due". Subsequent ticks within the cadence window must not emit.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(
+            Arc::new(sink.clone()),
+            TelemetryConfig::default().with_metrics_cadence(Some(Duration::from_secs(3600))),
+        )
+        .unwrap();
+    protocol.start().unwrap();
+
+    for _ in 0..3 {
+        protocol.process().unwrap();
+    }
+
+    let records = sink.take();
+    let snapshots: Vec<_> = records
+        .iter()
+        .filter(|r| matches!(r, TelemetryRecord::MetricsSnapshot(_)))
+        .collect();
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "cadence must rate-limit: three ticks within the window produce exactly one snapshot, got {records:?}",
+    );
+}
+
+#[test]
+fn test_reinstall_rearms_diff_snapshots_and_reemits_metrics_frame() {
+    // Install a sink, tick once to burn the initial metrics snapshot, then
+    // install a second sink. The second install must rearm last_metrics_emit_at
+    // so the next tick emits a bootstrap metrics frame to the new sink,
+    // and must re-seed transport/device snapshots so no fake transition is
+    // reported against state the first sink already acknowledged.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mock = MockTransport::new(TransportType::BLE);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
+
+    let sink1 = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink1.clone()), TelemetryConfig::default())
+        .unwrap();
+    protocol.process().unwrap();
+    let _ = sink1.take();
+
+    let sink2 = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink2.clone()), TelemetryConfig::default())
+        .unwrap();
+    protocol.process().unwrap();
+
+    let records = sink2.take();
+    let snapshots: Vec<_> = records
+        .iter()
+        .filter(|r| matches!(r, TelemetryRecord::MetricsSnapshot(_)))
+        .collect();
+    let transitions: Vec<_> = records
+        .iter()
+        .filter(|r| matches!(r, TelemetryRecord::TransportState(_)))
+        .collect();
+    let devices: Vec<_> = records
+        .iter()
+        .filter(|r| matches!(r, TelemetryRecord::Device(_)))
+        .collect();
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "re-installed sink receives a fresh metrics frame, got {records:?}",
+    );
+    assert!(
+        transitions.is_empty(),
+        "re-install must not synthesise transport transitions against seeded snapshot, got {records:?}",
+    );
+    assert!(
+        devices.is_empty(),
+        "re-install must not re-emit device snapshot against seeded snapshot, got {records:?}",
+    );
+}
+
+#[test]
+fn test_routing_diagnostic_populates_scores_when_enabled() {
+    // With routing_diagnostic=true, every RoutingDecision emitted from a
+    // send() must carry a populated scores vector (one entry per available
+    // transport). Default (false) leaves scores empty — exercised by
+    // test_legacy_dors_events_still_fire_with_routing_callback_wired.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mock = MockTransport::new(TransportType::BLE);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
+
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(
+            Arc::new(sink.clone()),
+            TelemetryConfig::default().with_routing_diagnostic(true),
+        )
+        .unwrap();
+
+    let msg = Message::new(
+        UserId::new("user123").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        "ping",
+    );
+    protocol.transport_manager_mut().send(&msg).unwrap();
+
+    let records = sink.take();
+    let routings: Vec<&RoutingDecision> = records
+        .iter()
+        .filter_map(|r| match r {
+            TelemetryRecord::Routing(d) => Some(d.as_ref()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !routings.is_empty(),
+        "routing records must fire on send, got {records:?}",
+    );
+    for decision in &routings {
+        assert!(
+            !decision.scores.is_empty(),
+            "routing_diagnostic=true must populate scores, got {decision:?}",
+        );
+        // BLE is registered, so it must appear in the breakdown.
+        assert!(
+            decision
+                .scores
+                .iter()
+                .any(|(t, _)| *t == TransportType::BLE),
+            "scores must include every available transport, got {:?}",
+            decision.scores,
+        );
+    }
+}
+
+#[test]
+fn test_routing_diagnostic_default_leaves_scores_empty() {
+    // Default TelemetryConfig has routing_diagnostic=false; the scores
+    // vector must stay empty even when the callback fires on every decision.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mock = MockTransport::new(TransportType::BLE);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
+
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+
+    let msg = Message::new(
+        UserId::new("user123").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        "ping",
+    );
+    protocol.transport_manager_mut().send(&msg).unwrap();
+
+    let records = sink.take();
+    for r in &records {
+        if let TelemetryRecord::Routing(d) = r {
+            assert!(
+                d.scores.is_empty(),
+                "routing_diagnostic=false must leave scores empty, got {:?}",
+                d.scores,
+            );
+        }
+    }
+}
+
+#[test]
+fn test_metrics_frame_is_local_relay_matches_role() {
+    // Regression guard for the renamed field: is_local_relay must reflect
+    // RelayManager::current_role() and nothing else (no stale "peer count"
+    // semantics). Default role is Regular; the flag must be false.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+    protocol.start().unwrap();
+    protocol.process().unwrap();
+
+    let records = sink.take();
+    let frame = records
+        .iter()
+        .find_map(|r| match r {
+            TelemetryRecord::MetricsSnapshot(f) => Some(f.as_ref()),
+            _ => None,
+        })
+        .expect("first tick emits a metrics frame");
+    assert!(
+        !frame.is_local_relay,
+        "default RelayRole::Regular ⇒ is_local_relay=false, got {frame:?}",
+    );
+}
+
+use crate::telemetry::routing::RoutingDecision;
 use crate::telemetry::transport_state::TransportStateEvent;

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -10425,6 +10425,157 @@ fn test_metrics_frame_is_local_relay_matches_role() {
     );
 }
 
+#[test]
+fn test_install_before_start_wires_routing_callback() {
+    // Regression guard for the post-review lifecycle fix: the routing-
+    // decision callback is wired by `install_telemetry_sink`, not by
+    // `start()`. A sink installed BEFORE `start()` must therefore
+    // observe routing records from the very first `send()` — the old
+    // wiring-in-start() path made this silently impossible (install
+    // happened, callback stayed unwired, records were dropped on the
+    // floor until a stop→start cycle ran start() again).
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mock = MockTransport::new(TransportType::BLE);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+    protocol.start().unwrap();
+
+    let msg = Message::new(
+        UserId::new("user123").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        "ping",
+    );
+    protocol.transport_manager_mut().send(&msg).unwrap();
+
+    let records = sink.take();
+    assert!(
+        records
+            .iter()
+            .any(|r| matches!(r, TelemetryRecord::Routing(_))),
+        "install-before-start must wire the routing callback immediately, got {records:?}",
+    );
+}
+
+#[test]
+fn test_routing_callback_persists_across_stop_start_cycle() {
+    // Regression guard for the post-review lifecycle fix: `stop()` no
+    // longer tears down the routing-decision callback. The callback's
+    // lifetime is sink-scoped — wired on install, replaced on re-install
+    // — not protocol-running-scoped. So a `stop() → start()` cycle must
+    // preserve the wiring without the app having to re-install the sink.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mock = MockTransport::new(TransportType::BLE);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+    protocol.start().unwrap();
+    protocol.stop().unwrap();
+    protocol.start().unwrap();
+
+    // Discard anything emitted during the first start/stop cycle so we
+    // can narrow the assertion below to the post-restart send().
+    let _ = sink.take();
+
+    let msg = Message::new(
+        UserId::new("user123").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        "ping",
+    );
+    protocol.transport_manager_mut().send(&msg).unwrap();
+
+    let records = sink.take();
+    assert!(
+        records
+            .iter()
+            .any(|r| matches!(r, TelemetryRecord::Routing(_))),
+        "routing callback must persist across stop→start without re-install, got {records:?}",
+    );
+}
+
+#[test]
+fn test_sink_panic_advances_transport_snapshot_for_at_most_once_delivery() {
+    // Regression guard for the post-review ordering fix in
+    // `tick_telemetry_categories`: each per-tick snapshot advances
+    // BEFORE the emit call that observes it. A panicking sink unwinds
+    // the rest of the tick, but the aggregator's cursors are already at
+    // the post-transition state — so the next tick must NOT re-emit
+    // the same transition. At-most-once over at-least-once.
+    #[derive(Default, Clone)]
+    struct PanickingTransportStateSink;
+    impl TelemetrySink for PanickingTransportStateSink {
+        fn emit(&self, record: &TelemetryRecord) {
+            if matches!(record, TelemetryRecord::TransportState(_)) {
+                panic!("simulated transport-state sink panic");
+            }
+        }
+    }
+
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mock = MockTransport::new(TransportType::BLE);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    // Start first so BLE becomes Available, then install so the sink's
+    // baseline is the current state. This isolates the single synthetic
+    // transition we want to observe the panic against.
+    protocol.start().unwrap();
+    protocol
+        .install_telemetry_sink(
+            Arc::new(PanickingTransportStateSink),
+            TelemetryConfig::default(),
+        )
+        .unwrap();
+
+    // Precondition: install seeded the snapshot with the live status.
+    assert_eq!(
+        protocol
+            .transport_status_snapshot
+            .get(&TransportType::BLE)
+            .copied(),
+        Some(TransportStatus::Available),
+        "install_telemetry_sink must seed the transport-status snapshot",
+    );
+
+    // Remove the transport so the next tick synthesises an
+    // `Available → Unavailable` transition — the sink panics on it.
+    protocol
+        .transport_manager_mut()
+        .remove_transport(TransportType::BLE);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| protocol.process()));
+    assert!(
+        result.is_err(),
+        "sink panic must propagate out of process()",
+    );
+
+    // The snapshot must have been advanced BEFORE the panic. If the
+    // ordering regressed (emit-then-assign), the snapshot would still
+    // contain BLE=Available and the next tick would re-emit the same
+    // transition to the next sink.
+    assert!(
+        !protocol
+            .transport_status_snapshot
+            .contains_key(&TransportType::BLE),
+        "transport_status_snapshot must reflect the post-transition state \
+         even when the emit panicked, got {:?}",
+        protocol.transport_status_snapshot,
+    );
+}
+
 use crate::telemetry::routing::RoutingDecision;
 use crate::telemetry::transport_state::TransportStateEvent;
 

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -10173,23 +10173,49 @@ fn test_legacy_dors_events_still_fire_with_routing_callback_wired() {
 
 #[test]
 fn test_process_skips_telemetry_tick_without_sink() {
-    // With no sink installed, the tick must be a no-op: nothing is emitted
-    // and no snapshots are taken (the existing `EventCallback` stream is
-    // independent and unaffected).
+    // With no sink installed, `tick_telemetry_categories` must early-return
+    // before touching any of the per-tick aggregator state. We assert that
+    // by registering a transport (so a real aggregator pass would observe
+    // an `Unavailable → Available` transition and seed the snapshots) and
+    // then verifying the three state fields the aggregator would mutate
+    // remain at their pre-tick defaults across multiple ticks.
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mut mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
     let captured: Arc<Mutex<Vec<crate::events::Event>>> = Arc::new(Mutex::new(Vec::new()));
     let handler = captured.clone();
     protocol.on_event(move |event| handler.lock().unwrap().push(event));
 
     protocol.start().unwrap();
-    protocol.process().unwrap();
 
-    // The legacy callback may receive DORS events during process(), but
-    // that does not mean the new telemetry tick ran. Sanity: there is no
-    // telemetry context to dispatch into, so the aggregator returned early.
     assert!(
         protocol.telemetry.is_none(),
         "precondition: no sink installed",
+    );
+
+    for _ in 0..5 {
+        protocol.process().unwrap();
+    }
+
+    // The aggregator never ran, so its state is untouched. If the early
+    // return regressed, the BLE transport would have been observed and
+    // these fields would have been populated.
+    assert!(
+        protocol.last_metrics_emit_at.is_none(),
+        "no sink installed; metrics cadence tracker must stay None across ticks",
+    );
+    assert!(
+        protocol.transport_status_snapshot.is_empty(),
+        "no sink installed; transport status snapshot must stay empty across ticks, got {:?}",
+        protocol.transport_status_snapshot,
+    );
+    assert!(
+        protocol.device_capability_snapshot.is_none(),
+        "no sink installed; device capability snapshot must stay None across ticks",
     );
 }
 
@@ -10402,75 +10428,6 @@ fn test_metrics_frame_is_local_relay_matches_role() {
 use crate::telemetry::routing::RoutingDecision;
 use crate::telemetry::transport_state::TransportStateEvent;
 
-#[test]
-fn test_device_battery_walk_is_charging_always_from_current_when_set() {
-    // Regression guard: when `current` is Some, `is_charging` is taken from
-    // the current transport's metrics even if its `battery_level` is None
-    // and the walk has to fall through to another transport for the
-    // battery reading. Mixing is_charging across transports produces
-    // non-deterministic flips on the CHANGED_CHARGING diff bit.
-    let mut available = HashMap::new();
-    available.insert(
-        TransportType::BLE,
-        TransportMetrics {
-            battery_level: None,
-            is_charging: false,
-            ..Default::default()
-        },
-    );
-    available.insert(
-        TransportType::Internet,
-        TransportMetrics {
-            battery_level: Some(73),
-            is_charging: true,
-            ..Default::default()
-        },
-    );
-
-    let (battery, is_charging) =
-        OfflineProtocol::device_battery_from_available(Some(TransportType::BLE), &available);
-    assert_eq!(
-        battery,
-        Some(73),
-        "battery must come from the first transport with Some(battery_level)",
-    );
-    assert!(
-        !is_charging,
-        "is_charging must come from the current transport (BLE → false), not from Internet",
-    );
-}
-
-#[test]
-fn test_device_battery_walk_is_deterministic_when_current_is_none() {
-    // With no current transport, the walk picks by transport priority
-    // (Internet > WiFiDirect > BLE) rather than HashMap order, so the
-    // result is stable across ticks regardless of iteration order.
-    let mut available = HashMap::new();
-    available.insert(
-        TransportType::BLE,
-        TransportMetrics {
-            battery_level: Some(40),
-            is_charging: false,
-            ..Default::default()
-        },
-    );
-    available.insert(
-        TransportType::Internet,
-        TransportMetrics {
-            battery_level: Some(90),
-            is_charging: true,
-            ..Default::default()
-        },
-    );
-
-    let (battery, is_charging) = OfflineProtocol::device_battery_from_available(None, &available);
-    assert_eq!(
-        battery,
-        Some(90),
-        "priority-ordered walk must prefer Internet's battery (90)",
-    );
-    assert!(
-        is_charging,
-        "priority-ordered walk must prefer Internet's is_charging (true)",
-    );
-}
+// `device_battery_from_available` lives in `crate::telemetry::aggregator`
+// and is exercised by the unit tests in that module — including the
+// current-not-in-available fall-through path that was previously uncovered.

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -10576,6 +10576,103 @@ fn test_sink_panic_advances_transport_snapshot_for_at_most_once_delivery() {
     );
 }
 
+#[test]
+fn test_sink_panic_does_not_drop_unemitted_transport_transitions() {
+    // Regression guard for multi-transition panic loss: when a tick
+    // produces multiple TransportState records and the sink panics on the
+    // first, the ONE transport the panic was observed for must be
+    // committed in `transport_status_snapshot` (at-most-once for that
+    // transition), and every OTHER pending transition must remain
+    // un-advanced so the next tick re-diffs and emits it. The old
+    // implementation committed the whole snapshot in a single assignment
+    // before the emit loop, silently dropping every post-panic transition.
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex as StdMutex;
+
+    struct PanicOnFirstTransportState {
+        seen: StdMutex<Option<TransportType>>,
+        count: AtomicUsize,
+    }
+    impl TelemetrySink for PanicOnFirstTransportState {
+        fn emit(&self, record: &TelemetryRecord) {
+            if let TelemetryRecord::TransportState(e) = record {
+                let first = self.count.fetch_add(1, Ordering::SeqCst) == 0;
+                if first {
+                    *self.seen.lock().unwrap() = Some(e.transport);
+                    panic!("simulated transport-state sink panic");
+                }
+            }
+        }
+    }
+
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let ble = MockTransport::new(TransportType::BLE);
+    let net = MockTransport::new(TransportType::Internet);
+    let ble_handle = ble.clone();
+    let net_handle = net.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(ble));
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::Internet, Box::new(net));
+    protocol.start().unwrap();
+
+    let sink = Arc::new(PanicOnFirstTransportState {
+        seen: StdMutex::new(None),
+        count: AtomicUsize::new(0),
+    });
+    protocol
+        .install_telemetry_sink(sink.clone(), TelemetryConfig::default())
+        .unwrap();
+
+    // Flip both transports so the tick produces two TransportState
+    // transitions — iteration order through the diff's HashSet is
+    // unspecified, so either transport may be first.
+    ble_handle.set_status(TransportStatus::Disconnected);
+    net_handle.set_status(TransportStatus::Disconnected);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| protocol.process()));
+    assert!(
+        result.is_err(),
+        "sink panic must propagate out of process()",
+    );
+
+    let panicked_on = sink
+        .seen
+        .lock()
+        .unwrap()
+        .expect("sink recorded which transport it panicked on");
+    let other = if panicked_on == TransportType::BLE {
+        TransportType::Internet
+    } else {
+        TransportType::BLE
+    };
+
+    // The panicking transition must be committed to the snapshot so it
+    // is NOT re-delivered next tick (at-most-once for that entry).
+    assert_eq!(
+        protocol
+            .transport_status_snapshot
+            .get(&panicked_on)
+            .copied(),
+        Some(TransportStatus::Disconnected),
+        "snapshot entry for the panicking transition must be advanced, got {:?}",
+        protocol.transport_status_snapshot,
+    );
+
+    // The OTHER transition never reached the sink; its snapshot entry
+    // must be unchanged so the next tick re-diffs and emits it fresh.
+    // The old per-tick "commit-all-then-iterate" pattern would leave it
+    // at Disconnected here, silently dropping the transition.
+    assert_eq!(
+        protocol.transport_status_snapshot.get(&other).copied(),
+        Some(TransportStatus::Available),
+        "snapshot entry for the un-emitted transition must be preserved for redelivery, got {:?}",
+        protocol.transport_status_snapshot,
+    );
+}
+
 use crate::telemetry::routing::RoutingDecision;
 use crate::telemetry::transport_state::TransportStateEvent;
 

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -10401,3 +10401,76 @@ fn test_metrics_frame_is_local_relay_matches_role() {
 
 use crate::telemetry::routing::RoutingDecision;
 use crate::telemetry::transport_state::TransportStateEvent;
+
+#[test]
+fn test_device_battery_walk_is_charging_always_from_current_when_set() {
+    // Regression guard: when `current` is Some, `is_charging` is taken from
+    // the current transport's metrics even if its `battery_level` is None
+    // and the walk has to fall through to another transport for the
+    // battery reading. Mixing is_charging across transports produces
+    // non-deterministic flips on the CHANGED_CHARGING diff bit.
+    let mut available = HashMap::new();
+    available.insert(
+        TransportType::BLE,
+        TransportMetrics {
+            battery_level: None,
+            is_charging: false,
+            ..Default::default()
+        },
+    );
+    available.insert(
+        TransportType::Internet,
+        TransportMetrics {
+            battery_level: Some(73),
+            is_charging: true,
+            ..Default::default()
+        },
+    );
+
+    let (battery, is_charging) =
+        OfflineProtocol::device_battery_from_available(Some(TransportType::BLE), &available);
+    assert_eq!(
+        battery,
+        Some(73),
+        "battery must come from the first transport with Some(battery_level)",
+    );
+    assert!(
+        !is_charging,
+        "is_charging must come from the current transport (BLE → false), not from Internet",
+    );
+}
+
+#[test]
+fn test_device_battery_walk_is_deterministic_when_current_is_none() {
+    // With no current transport, the walk picks by transport priority
+    // (Internet > WiFiDirect > BLE) rather than HashMap order, so the
+    // result is stable across ticks regardless of iteration order.
+    let mut available = HashMap::new();
+    available.insert(
+        TransportType::BLE,
+        TransportMetrics {
+            battery_level: Some(40),
+            is_charging: false,
+            ..Default::default()
+        },
+    );
+    available.insert(
+        TransportType::Internet,
+        TransportMetrics {
+            battery_level: Some(90),
+            is_charging: true,
+            ..Default::default()
+        },
+    );
+
+    let (battery, is_charging) = OfflineProtocol::device_battery_from_available(None, &available);
+    assert_eq!(
+        battery,
+        Some(90),
+        "priority-ordered walk must prefer Internet's battery (90)",
+    );
+    assert!(
+        is_charging,
+        "priority-ordered walk must prefer Internet's is_charging (true)",
+    );
+}

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -9956,3 +9956,208 @@ fn test_flush_outbox_for_peer_skips_messages_awaiting_ack() {
         "flush_outbox_for_peer should not re-send messages awaiting ACK"
     );
 }
+
+// --- Telemetry categories (metrics snapshot, transport state, device, routing) ---
+
+#[test]
+fn test_process_emits_metrics_snapshot_on_first_tick() {
+    // With cadence defaulted to 5s and `last_metrics_emit_at` starting at
+    // `None`, the first process() tick is unconditionally due and must
+    // emit one MetricsSnapshot.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+    protocol.start().unwrap();
+
+    protocol.process().unwrap();
+
+    let records = sink.take();
+    let snapshots: Vec<_> = records
+        .iter()
+        .filter(|r| matches!(r, TelemetryRecord::MetricsSnapshot(_)))
+        .collect();
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "first process() tick must emit one MetricsSnapshot, got {records:?}",
+    );
+}
+
+#[test]
+fn test_process_skips_metrics_snapshot_when_cadence_is_none() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(
+            Arc::new(sink.clone()),
+            TelemetryConfig::default().with_metrics_cadence(None),
+        )
+        .unwrap();
+    protocol.start().unwrap();
+
+    protocol.process().unwrap();
+
+    let records = sink.take();
+    assert!(
+        records
+            .iter()
+            .all(|r| !matches!(r, TelemetryRecord::MetricsSnapshot(_))),
+        "cadence=None must suppress MetricsSnapshot emission, got {records:?}",
+    );
+}
+
+#[test]
+fn test_process_emits_transport_state_on_status_transition() {
+    // Register a mock transport. start() flips it to Available; the first
+    // process() tick records that as the snapshot (emitting one
+    // Unavailable→Available transition). Then flip the mock to
+    // Disconnected and run process() again — expect exactly one
+    // Available→Disconnected transition.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mock = MockTransport::new(TransportType::BLE);
+    let mock_clone = mock.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+    protocol.start().unwrap();
+
+    // Drain the first-tick snapshot (which includes the Unavailable→Available
+    // transition bootstrap).
+    protocol.process().unwrap();
+    sink.take();
+
+    mock_clone.set_status(TransportStatus::Disconnected);
+    protocol.process().unwrap();
+
+    let records = sink.take();
+    let transitions: Vec<&TransportStateEvent> = records
+        .iter()
+        .filter_map(|r| match r {
+            TelemetryRecord::TransportState(e) => Some(e),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        transitions.len(),
+        1,
+        "exactly one TransportState should fire for the Available→Disconnected transition, got {records:?}",
+    );
+    assert_eq!(transitions[0].transport, TransportType::BLE);
+    assert_eq!(transitions[0].previous, TransportStatus::Available);
+    assert_eq!(transitions[0].current, TransportStatus::Disconnected);
+}
+
+#[test]
+fn test_process_emits_device_capability_on_first_tick() {
+    // First tick after install always emits a device record (prev == None
+    // is treated as "all fields changed").
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+    protocol.start().unwrap();
+
+    protocol.process().unwrap();
+
+    let records = sink.take();
+    let device: Vec<_> = records
+        .iter()
+        .filter(|r| matches!(r, TelemetryRecord::Device(_)))
+        .collect();
+    assert_eq!(
+        device.len(),
+        1,
+        "first tick must emit exactly one Device snapshot, got {records:?}",
+    );
+}
+
+#[test]
+fn test_legacy_dors_events_still_fire_with_routing_callback_wired() {
+    // Regression guard: step 3 (wiring `set_routing_decision_callback`)
+    // must not displace the existing `dors_event_callback` → EventCallback
+    // path. Apps that consume `DorsScoreUpdated`/`DorsTransportSelected`
+    // via `on_event` continue to see them whether or not a telemetry sink
+    // is installed.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+    let captured: Arc<Mutex<Vec<crate::events::Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let handler = captured.clone();
+    protocol.on_event(move |event| handler.lock().unwrap().push(event));
+
+    let mock = MockTransport::new(TransportType::BLE);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
+
+    // Install a telemetry sink AFTER start() so the routing callback is
+    // already wired — exercising the path where both callbacks coexist.
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+
+    // Trigger a DORS scoring pass by sending a message.
+    let msg = Message::new(
+        UserId::new("user123").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        "ping",
+    );
+    protocol.transport_manager_mut().send(&msg).unwrap();
+
+    let legacy_events = captured.lock().unwrap().clone();
+    assert!(
+        legacy_events
+            .iter()
+            .any(|e| matches!(e, crate::events::Event::DorsScoreUpdated { .. })),
+        "Event::DorsScoreUpdated must still reach legacy callback, got {legacy_events:?}",
+    );
+    assert!(
+        legacy_events
+            .iter()
+            .any(|e| matches!(e, crate::events::Event::DorsTransportSelected { .. })),
+        "Event::DorsTransportSelected must still reach legacy callback, got {legacy_events:?}",
+    );
+
+    // And the sink now receives the new Routing records alongside.
+    let sink_records = sink.take();
+    assert!(
+        sink_records
+            .iter()
+            .any(|r| matches!(r, TelemetryRecord::Routing(_))),
+        "sink must observe at least one Routing record, got {sink_records:?}",
+    );
+}
+
+#[test]
+fn test_process_skips_telemetry_tick_without_sink() {
+    // With no sink installed, the tick must be a no-op: nothing is emitted
+    // and no snapshots are taken (the existing `EventCallback` stream is
+    // independent and unaffected).
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let captured: Arc<Mutex<Vec<crate::events::Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let handler = captured.clone();
+    protocol.on_event(move |event| handler.lock().unwrap().push(event));
+
+    protocol.start().unwrap();
+    protocol.process().unwrap();
+
+    // The legacy callback may receive DORS events during process(), but
+    // that does not mean the new telemetry tick ran. Sanity: there is no
+    // telemetry context to dispatch into, so the aggregator returned early.
+    assert!(
+        protocol.telemetry.is_none(),
+        "precondition: no sink installed",
+    );
+}
+
+use crate::telemetry::transport_state::TransportStateEvent;

--- a/crates/offline-protocol/src/telemetry/aggregator.rs
+++ b/crates/offline-protocol/src/telemetry/aggregator.rs
@@ -16,11 +16,13 @@ use crate::telemetry::device::{
 };
 use crate::telemetry::metrics_snapshot::MetricsFrame;
 use crate::telemetry::transport_state::TransportStateEvent;
-use crate::TransportManager;
 
 /// Deterministic walk order: honour the existing transport-priority
 /// (Internet > WiFiDirect > BLE > everything else) so any "first with X"
 /// selection is stable across ticks regardless of HashMap iteration order.
+///
+/// Also used as the stable ordering key for [`MetricsFrame::transports`] so
+/// sinks that index positionally see the same layout on every emission.
 const TRANSPORT_PRIORITY: &[TransportType] = &[
     TransportType::Internet,
     TransportType::WiFiDirect,
@@ -28,6 +30,18 @@ const TRANSPORT_PRIORITY: &[TransportType] = &[
     TransportType::Reticulum,
     TransportType::Nostr,
 ];
+
+/// Returns the priority index for `t`. Transports not present in
+/// [`TRANSPORT_PRIORITY`] sort after every listed transport (stable-sort
+/// ties then fall back to HashMap iteration order — currently impossible
+/// since every [`TransportType`] variant is listed, but future variants
+/// land at the tail without the helper breaking).
+fn priority_index(t: TransportType) -> usize {
+    TRANSPORT_PRIORITY
+        .iter()
+        .position(|p| *p == t)
+        .unwrap_or(TRANSPORT_PRIORITY.len())
+}
 
 /// Local snapshot of device capability fields. Used by the process-tick
 /// diff to decide whether a `DeviceCapabilitySnapshot` record needs to fire.
@@ -57,10 +71,14 @@ impl DeviceSnap {
 /// `available_transports` is borrowed — callers snapshot the map once per
 /// tick and reuse it across the telemetry helpers that need it, avoiding
 /// redundant locking and per-tick HashMap allocations.
+///
+/// The emitted `transports` vec is sorted by [`TRANSPORT_PRIORITY`] so
+/// sinks that index positionally see the same layout on every tick; HashMap
+/// iteration order does not leak into the record.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_metrics_frame(
     now_ms: i64,
-    transport_manager: &TransportManager,
+    current_transport: Option<TransportType>,
     available_transports: &HashMap<TransportType, TransportMetrics>,
     retry_queue: &RetryQueue,
     deduplicator: &Deduplicator,
@@ -68,10 +86,11 @@ pub(crate) fn build_metrics_frame(
     neighbor_count: usize,
     is_local_relay: bool,
 ) -> MetricsFrame {
-    let transports: Vec<(TransportType, TransportMetrics)> = available_transports
+    let mut transports: Vec<(TransportType, TransportMetrics)> = available_transports
         .iter()
         .map(|(t, m)| (*t, m.clone()))
         .collect();
+    transports.sort_by_key(|(t, _)| priority_index(*t));
     MetricsFrame {
         timestamp_ms: now_ms,
         transports,
@@ -80,7 +99,7 @@ pub(crate) fn build_metrics_frame(
         ack_pending: ack_manager.pending_count(),
         neighbor_count,
         is_local_relay,
-        current_transport: transport_manager.current_transport(),
+        current_transport,
     }
 }
 
@@ -358,5 +377,43 @@ mod tests {
         // is_charging anchors on the first priority-ordered transport
         // that exists in `available`.
         assert!(is_charging);
+    }
+
+    #[test]
+    fn build_metrics_frame_orders_transports_by_priority() {
+        // Regression guard: `MetricsFrame::transports` must be ordered by
+        // TRANSPORT_PRIORITY (Internet > WiFiDirect > BLE > ...) so sinks
+        // indexing positionally see a stable layout across ticks. Prior
+        // implementation let HashMap iteration order leak through.
+        use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
+        let mut available = HashMap::new();
+        available.insert(TransportType::BLE, metrics(None, false));
+        available.insert(TransportType::Internet, metrics(Some(50), true));
+        available.insert(TransportType::WiFiDirect, metrics(None, false));
+
+        let retry_queue = RetryQueue::new();
+        let deduplicator = Deduplicator::new();
+        let ack_manager = AckManager::new();
+        let frame = build_metrics_frame(
+            0,
+            Some(TransportType::BLE),
+            &available,
+            &retry_queue,
+            &deduplicator,
+            &ack_manager,
+            0,
+            false,
+        );
+        let order: Vec<TransportType> = frame.transports.iter().map(|(t, _)| *t).collect();
+        assert_eq!(
+            order,
+            vec![
+                TransportType::Internet,
+                TransportType::WiFiDirect,
+                TransportType::BLE
+            ],
+            "metrics frame transports must be ordered by TRANSPORT_PRIORITY",
+        );
+        assert_eq!(frame.current_transport, Some(TransportType::BLE));
     }
 }

--- a/crates/offline-protocol/src/telemetry/aggregator.rs
+++ b/crates/offline-protocol/src/telemetry/aggregator.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
 use offline_protocol_router::RelayRole;
-use offline_protocol_transport::{TransportStatus, TransportType};
+use offline_protocol_transport::{TransportMetrics, TransportStatus, TransportType};
 
 use crate::telemetry::device::{
     DeviceCapabilitySnapshot, CHANGED_BATTERY, CHANGED_CHARGING, CHANGED_RELAY_ROLE,
@@ -42,17 +42,25 @@ impl DeviceSnap {
 }
 
 /// Builds a single [`MetricsFrame`] from the supplied protocol components.
+///
+/// `available_transports` is borrowed — callers snapshot the map once per
+/// tick and reuse it across the telemetry helpers that need it, avoiding
+/// redundant locking and per-tick HashMap allocations.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_metrics_frame(
     now_ms: i64,
     transport_manager: &TransportManager,
+    available_transports: &HashMap<TransportType, TransportMetrics>,
     retry_queue: &RetryQueue,
     deduplicator: &Deduplicator,
     ack_manager: &AckManager,
     neighbor_count: usize,
-    relay_count: usize,
+    is_local_relay: bool,
 ) -> MetricsFrame {
-    let available = transport_manager.get_available_transports();
-    let transports: Vec<(TransportType, _)> = available.into_iter().collect();
+    let transports: Vec<(TransportType, TransportMetrics)> = available_transports
+        .iter()
+        .map(|(t, m)| (*t, m.clone()))
+        .collect();
     MetricsFrame {
         timestamp_ms: now_ms,
         transports,
@@ -60,7 +68,7 @@ pub(crate) fn build_metrics_frame(
         dedup: deduplicator.stats(),
         ack_pending: ack_manager.pending_count(),
         neighbor_count,
-        relay_count,
+        is_local_relay,
         current_transport: transport_manager.current_transport(),
     }
 }

--- a/crates/offline-protocol/src/telemetry/aggregator.rs
+++ b/crates/offline-protocol/src/telemetry/aggregator.rs
@@ -5,7 +5,7 @@
 //! `process()` tick tiny and the build logic unit-testable without spinning
 //! up a full protocol instance.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
 use offline_protocol_router::RelayRole;
@@ -17,6 +17,17 @@ use crate::telemetry::device::{
 use crate::telemetry::metrics_snapshot::MetricsFrame;
 use crate::telemetry::transport_state::TransportStateEvent;
 use crate::TransportManager;
+
+/// Deterministic walk order: honour the existing transport-priority
+/// (Internet > WiFiDirect > BLE > everything else) so any "first with X"
+/// selection is stable across ticks regardless of HashMap iteration order.
+const TRANSPORT_PRIORITY: &[TransportType] = &[
+    TransportType::Internet,
+    TransportType::WiFiDirect,
+    TransportType::BLE,
+    TransportType::Reticulum,
+    TransportType::Nostr,
+];
 
 /// Local snapshot of device capability fields. Used by the process-tick
 /// diff to decide whether a `DeviceCapabilitySnapshot` record needs to fire.
@@ -75,27 +86,102 @@ pub(crate) fn build_metrics_frame(
 
 /// Returns one [`TransportStateEvent`] per transport whose status has
 /// changed since the last snapshot.
+///
+/// Iterates the **union** of `previous` and `current` keys so that a
+/// transport which disappeared between ticks (e.g. `remove_transport()`
+/// called at runtime) emits a `prev_status → Unavailable` transition rather
+/// than being silently forgotten.
 pub(crate) fn diff_transport_state(
     now_ms: i64,
     previous: &HashMap<TransportType, TransportStatus>,
     current: &HashMap<TransportType, TransportStatus>,
 ) -> Vec<TransportStateEvent> {
+    let mut keys: HashSet<TransportType> = HashSet::with_capacity(previous.len() + current.len());
+    keys.extend(previous.keys().copied());
+    keys.extend(current.keys().copied());
+
     let mut out = Vec::new();
-    for (transport, curr_status) in current {
+    for transport in keys {
         let prev_status = previous
-            .get(transport)
+            .get(&transport)
             .copied()
             .unwrap_or(TransportStatus::Unavailable);
-        if prev_status != *curr_status {
+        let curr_status = current
+            .get(&transport)
+            .copied()
+            .unwrap_or(TransportStatus::Unavailable);
+        if prev_status != curr_status {
             out.push(TransportStateEvent {
                 timestamp_ms: now_ms,
-                transport: *transport,
+                transport,
                 previous: prev_status,
-                current: *curr_status,
+                current: curr_status,
             });
         }
     }
     out
+}
+
+/// Derives `(battery_level, is_charging)` for the local device from the
+/// per-transport metrics map.
+///
+/// Selection order:
+///   1. Currently selected transport, if it reports `Some(battery_level)`.
+///   2. First available transport (deterministic by [`TRANSPORT_PRIORITY`])
+///      that reports `Some(battery_level)`.
+///   3. `(None, is_charging)` where `is_charging` comes from the current
+///      transport if present, else from the first transport in priority
+///      order.
+///
+/// `is_charging` is **always** the current transport's reading when a
+/// current transport is registered AND present in `available` —
+/// regardless of which transport supplied `battery_level`. Mixing
+/// `is_charging` from one transport with `battery_level` from another
+/// produces non-deterministic flips across ticks (HashMap iteration order
+/// is unspecified) and would spuriously trigger `CHANGED_CHARGING` on the
+/// device-capability diff. When `current` is set but missing from
+/// `available` (e.g. status flipped mid-tick), the function falls through
+/// to the no-current branch.
+pub(crate) fn device_battery_from_available(
+    current: Option<TransportType>,
+    available: &HashMap<TransportType, TransportMetrics>,
+) -> (Option<u8>, bool) {
+    let first_with_battery = |skip: Option<TransportType>| -> Option<u8> {
+        for t in TRANSPORT_PRIORITY {
+            if skip == Some(*t) {
+                continue;
+            }
+            if let Some(m) = available.get(t) {
+                if m.battery_level.is_some() {
+                    return m.battery_level;
+                }
+            }
+        }
+        // Fallback for transport types not in the priority list.
+        available
+            .iter()
+            .find(|(t, m)| Some(**t) != skip && m.battery_level.is_some())
+            .and_then(|(_, m)| m.battery_level)
+    };
+
+    if let Some(current) = current {
+        if let Some(metrics) = available.get(&current) {
+            let battery = metrics
+                .battery_level
+                .or_else(|| first_with_battery(Some(current)));
+            return (battery, metrics.is_charging);
+        }
+        // `current` is set but not present in `available` — fall through
+        // to the no-current branch but without an `is_charging` anchor.
+    }
+    let battery = first_with_battery(None);
+    let is_charging = TRANSPORT_PRIORITY
+        .iter()
+        .find_map(|t| available.get(t))
+        .or_else(|| available.values().next())
+        .map(|m| m.is_charging)
+        .unwrap_or(false);
+    (battery, is_charging)
 }
 
 /// Returns a [`DeviceCapabilitySnapshot`] when any device-capability field
@@ -166,6 +252,25 @@ mod tests {
     }
 
     #[test]
+    fn diff_emits_unavailable_when_transport_removed() {
+        // A transport that was Available in `previous` but is missing from
+        // `current` (e.g. `remove_transport()` between ticks) must emit a
+        // transition to Unavailable rather than disappear silently.
+        let mut previous = HashMap::new();
+        previous.insert(TransportType::BLE, TransportStatus::Available);
+        previous.insert(TransportType::Internet, TransportStatus::Available);
+        let mut current = HashMap::new();
+        current.insert(TransportType::BLE, TransportStatus::Available); // kept
+
+        let events = diff_transport_state(9, &previous, &current);
+        assert_eq!(events.len(), 1, "got {events:?}");
+        assert_eq!(events[0].transport, TransportType::Internet);
+        assert_eq!(events[0].previous, TransportStatus::Available);
+        assert_eq!(events[0].current, TransportStatus::Unavailable);
+        assert_eq!(events[0].timestamp_ms, 9);
+    }
+
+    #[test]
     fn device_diff_flags_each_changed_field() {
         let previous = DeviceSnap::from_parts(Some(80), false, RelayRole::Regular);
         let current = DeviceSnap::from_parts(Some(79), true, RelayRole::Relay);
@@ -190,5 +295,68 @@ mod tests {
         assert!(snapshot.has_changed(CHANGED_BATTERY));
         assert!(snapshot.has_changed(CHANGED_CHARGING));
         assert!(snapshot.has_changed(CHANGED_RELAY_ROLE));
+    }
+
+    fn metrics(battery: Option<u8>, is_charging: bool) -> TransportMetrics {
+        TransportMetrics {
+            battery_level: battery,
+            is_charging,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn device_battery_uses_current_transport_when_present() {
+        // current = BLE with no battery, fallback by priority must pick
+        // Internet's battery. is_charging stays anchored to BLE because
+        // BLE is the current transport (deterministic across ticks).
+        let mut available = HashMap::new();
+        available.insert(TransportType::BLE, metrics(None, false));
+        available.insert(TransportType::Internet, metrics(Some(73), true));
+
+        let (battery, is_charging) =
+            device_battery_from_available(Some(TransportType::BLE), &available);
+        assert_eq!(battery, Some(73));
+        assert!(!is_charging);
+    }
+
+    #[test]
+    fn device_battery_falls_through_when_current_not_in_available() {
+        // current = BLE but BLE is not in `available` (e.g. status flipped
+        // mid-tick). The current branch is skipped; the no-current branch
+        // walks priority order and returns Internet's reading for both
+        // fields. Regression guard for an untested fall-through path.
+        let mut available = HashMap::new();
+        available.insert(TransportType::Internet, metrics(Some(60), true));
+
+        let (battery, is_charging) =
+            device_battery_from_available(Some(TransportType::BLE), &available);
+        assert_eq!(battery, Some(60));
+        assert!(is_charging);
+    }
+
+    #[test]
+    fn device_battery_priority_walk_is_deterministic_when_current_is_none() {
+        // Priority walk (Internet > WiFiDirect > BLE) makes the choice
+        // stable regardless of HashMap iteration order.
+        let mut available = HashMap::new();
+        available.insert(TransportType::BLE, metrics(Some(40), false));
+        available.insert(TransportType::Internet, metrics(Some(90), true));
+
+        let (battery, is_charging) = device_battery_from_available(None, &available);
+        assert_eq!(battery, Some(90));
+        assert!(is_charging);
+    }
+
+    #[test]
+    fn device_battery_returns_none_when_no_transports_have_battery() {
+        let mut available = HashMap::new();
+        available.insert(TransportType::BLE, metrics(None, true));
+
+        let (battery, is_charging) = device_battery_from_available(None, &available);
+        assert_eq!(battery, None);
+        // is_charging anchors on the first priority-ordered transport
+        // that exists in `available`.
+        assert!(is_charging);
     }
 }

--- a/crates/offline-protocol/src/telemetry/aggregator.rs
+++ b/crates/offline-protocol/src/telemetry/aggregator.rs
@@ -1,0 +1,186 @@
+//! Pure helpers that build telemetry records from protocol state.
+//!
+//! These are allocation-aware but I/O free and lock free — callers hold the
+//! required references. The separation keeps the emit-site code on the
+//! `process()` tick tiny and the build logic unit-testable without spinning
+//! up a full protocol instance.
+
+use std::collections::HashMap;
+
+use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
+use offline_protocol_router::RelayRole;
+use offline_protocol_transport::{TransportStatus, TransportType};
+
+use crate::telemetry::device::{
+    DeviceCapabilitySnapshot, CHANGED_BATTERY, CHANGED_CHARGING, CHANGED_RELAY_ROLE,
+};
+use crate::telemetry::metrics_snapshot::MetricsFrame;
+use crate::telemetry::transport_state::TransportStateEvent;
+use crate::TransportManager;
+
+/// Local snapshot of device capability fields. Used by the process-tick
+/// diff to decide whether a `DeviceCapabilitySnapshot` record needs to fire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DeviceSnap {
+    pub(crate) battery_level: Option<u8>,
+    pub(crate) is_charging: bool,
+    pub(crate) relay_role: RelayRole,
+}
+
+impl DeviceSnap {
+    pub(crate) fn from_parts(
+        battery_level: Option<u8>,
+        is_charging: bool,
+        relay_role: RelayRole,
+    ) -> Self {
+        Self {
+            battery_level,
+            is_charging,
+            relay_role,
+        }
+    }
+}
+
+/// Builds a single [`MetricsFrame`] from the supplied protocol components.
+pub(crate) fn build_metrics_frame(
+    now_ms: i64,
+    transport_manager: &TransportManager,
+    retry_queue: &RetryQueue,
+    deduplicator: &Deduplicator,
+    ack_manager: &AckManager,
+    neighbor_count: usize,
+    relay_count: usize,
+) -> MetricsFrame {
+    let available = transport_manager.get_available_transports();
+    let transports: Vec<(TransportType, _)> = available.into_iter().collect();
+    MetricsFrame {
+        timestamp_ms: now_ms,
+        transports,
+        retry_queue: retry_queue.stats(),
+        dedup: deduplicator.stats(),
+        ack_pending: ack_manager.pending_count(),
+        neighbor_count,
+        relay_count,
+        current_transport: transport_manager.current_transport(),
+    }
+}
+
+/// Returns one [`TransportStateEvent`] per transport whose status has
+/// changed since the last snapshot.
+pub(crate) fn diff_transport_state(
+    now_ms: i64,
+    previous: &HashMap<TransportType, TransportStatus>,
+    current: &HashMap<TransportType, TransportStatus>,
+) -> Vec<TransportStateEvent> {
+    let mut out = Vec::new();
+    for (transport, curr_status) in current {
+        let prev_status = previous
+            .get(transport)
+            .copied()
+            .unwrap_or(TransportStatus::Unavailable);
+        if prev_status != *curr_status {
+            out.push(TransportStateEvent {
+                timestamp_ms: now_ms,
+                transport: *transport,
+                previous: prev_status,
+                current: *curr_status,
+            });
+        }
+    }
+    out
+}
+
+/// Returns a [`DeviceCapabilitySnapshot`] when any device-capability field
+/// has changed since the last snapshot.
+pub(crate) fn diff_device_capability(
+    now_ms: i64,
+    previous: Option<DeviceSnap>,
+    current: DeviceSnap,
+) -> Option<DeviceCapabilitySnapshot> {
+    let changed_fields = match previous {
+        None => CHANGED_BATTERY | CHANGED_CHARGING | CHANGED_RELAY_ROLE,
+        Some(prev) => {
+            let mut bits = 0u8;
+            if prev.battery_level != current.battery_level {
+                bits |= CHANGED_BATTERY;
+            }
+            if prev.is_charging != current.is_charging {
+                bits |= CHANGED_CHARGING;
+            }
+            if prev.relay_role != current.relay_role {
+                bits |= CHANGED_RELAY_ROLE;
+            }
+            bits
+        }
+    };
+    if changed_fields == 0 {
+        return None;
+    }
+    Some(DeviceCapabilitySnapshot {
+        timestamp_ms: now_ms,
+        battery_level: current.battery_level,
+        is_charging: current.is_charging,
+        relay_role: current.relay_role,
+        changed_fields,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diff_reports_only_changed_transports() {
+        let mut previous = HashMap::new();
+        previous.insert(TransportType::BLE, TransportStatus::Available);
+        previous.insert(TransportType::Internet, TransportStatus::Disconnected);
+        let mut current = HashMap::new();
+        current.insert(TransportType::BLE, TransportStatus::Available); // unchanged
+        current.insert(TransportType::Internet, TransportStatus::Available); // changed
+
+        let events = diff_transport_state(42, &previous, &current);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].transport, TransportType::Internet);
+        assert_eq!(events[0].previous, TransportStatus::Disconnected);
+        assert_eq!(events[0].current, TransportStatus::Available);
+        assert_eq!(events[0].timestamp_ms, 42);
+    }
+
+    #[test]
+    fn diff_fills_unavailable_when_previous_missing() {
+        let previous = HashMap::new();
+        let mut current = HashMap::new();
+        current.insert(TransportType::BLE, TransportStatus::Available);
+        let events = diff_transport_state(0, &previous, &current);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].previous, TransportStatus::Unavailable);
+        assert_eq!(events[0].current, TransportStatus::Available);
+    }
+
+    #[test]
+    fn device_diff_flags_each_changed_field() {
+        let previous = DeviceSnap::from_parts(Some(80), false, RelayRole::Regular);
+        let current = DeviceSnap::from_parts(Some(79), true, RelayRole::Relay);
+        let snapshot = diff_device_capability(7, Some(previous), current).expect("changed");
+        assert_eq!(snapshot.timestamp_ms, 7);
+        assert!(snapshot.has_changed(CHANGED_BATTERY));
+        assert!(snapshot.has_changed(CHANGED_CHARGING));
+        assert!(snapshot.has_changed(CHANGED_RELAY_ROLE));
+    }
+
+    #[test]
+    fn device_diff_returns_none_when_unchanged() {
+        let snap = DeviceSnap::from_parts(Some(80), false, RelayRole::Regular);
+        let out = diff_device_capability(0, Some(snap), snap);
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn device_diff_treats_first_snapshot_as_all_changed() {
+        let current = DeviceSnap::from_parts(None, false, RelayRole::Regular);
+        let snapshot = diff_device_capability(0, None, current).expect("always emits first");
+        assert!(snapshot.has_changed(CHANGED_BATTERY));
+        assert!(snapshot.has_changed(CHANGED_CHARGING));
+        assert!(snapshot.has_changed(CHANGED_RELAY_ROLE));
+    }
+}

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -58,6 +58,7 @@ pub struct TelemetryConfig {
     pub(crate) mls_verbosity: MlsVerbosity,
     pub(crate) metrics_cadence: Option<Duration>,
     pub(crate) scrub_secret: Option<[u8; 16]>,
+    pub(crate) routing_diagnostic: bool,
 }
 
 impl fmt::Debug for TelemetryConfig {
@@ -70,6 +71,7 @@ impl fmt::Debug for TelemetryConfig {
                 "scrub_secret",
                 &self.scrub_secret.as_ref().map(|_| "<redacted>"),
             )
+            .field("routing_diagnostic", &self.routing_diagnostic)
             .finish()
     }
 }
@@ -81,6 +83,7 @@ impl Default for TelemetryConfig {
             mls_verbosity: MlsVerbosity::Lifecycle,
             metrics_cadence: Some(Duration::from_secs(5)),
             scrub_secret: None,
+            routing_diagnostic: false,
         }
     }
 }
@@ -144,6 +147,28 @@ impl TelemetryConfig {
         self.metrics_cadence
     }
 
+    /// Sets whether `RoutingDecision` records should carry the full
+    /// per-transport score breakdown.
+    ///
+    /// When `true`, every emitted
+    /// [`crate::telemetry::RoutingDecision::scores`] is populated with the
+    /// seven-factor [`offline_protocol_router::TransportScore`] for each
+    /// ranked transport. When `false` (the default), `scores` is empty —
+    /// the hot path avoids the per-emission vector allocation and
+    /// `Diagnostic`-tier consumers simply see an empty vector.
+    ///
+    /// Leaf identifiers are not affected: this knob only gates the
+    /// scoring-factor detail, not identity fields.
+    pub fn with_routing_diagnostic(mut self, routing_diagnostic: bool) -> Self {
+        self.routing_diagnostic = routing_diagnostic;
+        self
+    }
+
+    /// Returns whether routing records should carry diagnostic score detail.
+    pub fn routing_diagnostic(&self) -> bool {
+        self.routing_diagnostic
+    }
+
     /// Returns the configured opaque-identifier hashing secret, if any.
     ///
     /// Crate-private: the secret feeds `Scrubber` construction and is not
@@ -169,6 +194,7 @@ mod tests {
         assert_eq!(cfg.mls_verbosity(), MlsVerbosity::Lifecycle);
         assert_eq!(cfg.metrics_cadence(), Some(Duration::from_secs(5)));
         assert!(cfg.scrub_secret().is_none());
+        assert!(!cfg.routing_diagnostic());
     }
 
     #[test]
@@ -177,11 +203,13 @@ mod tests {
             .with_scrub_ids(false)
             .with_mls_verbosity(MlsVerbosity::Off)
             .with_metrics_cadence(None)
-            .with_scrub_secret(Some([7; 16]));
+            .with_scrub_secret(Some([7; 16]))
+            .with_routing_diagnostic(true);
         assert!(!cfg.scrub_ids());
         assert_eq!(cfg.mls_verbosity(), MlsVerbosity::Off);
         assert!(cfg.metrics_cadence().is_none());
         assert_eq!(cfg.scrub_secret(), Some([7; 16]));
+        assert!(cfg.routing_diagnostic());
     }
 
     #[test]

--- a/crates/offline-protocol/src/telemetry/device.rs
+++ b/crates/offline-protocol/src/telemetry/device.rs
@@ -1,0 +1,90 @@
+//! Push-based snapshots of local device capability changes.
+//!
+//! Emitted when any of (battery level, charging state, relay role) changes
+//! between consecutive `OfflineProtocol::process()` ticks. Apps that need
+//! "always-on" polling consume this instead of reconstructing the state from
+//! the cumulative `TransportMetrics` stream.
+//!
+//! Advertised services are **not** represented — the SDK does not currently
+//! track an advertised-services list. A later step introduces that surface
+//! with its own dedicated record.
+
+use offline_protocol_router::RelayRole;
+
+/// Bitmask bit indicating `battery_level` changed between ticks.
+pub const CHANGED_BATTERY: u8 = 0b0000_0001;
+/// Bitmask bit indicating `is_charging` changed between ticks.
+pub const CHANGED_CHARGING: u8 = 0b0000_0010;
+/// Bitmask bit indicating `relay_role` changed between ticks.
+pub const CHANGED_RELAY_ROLE: u8 = 0b0000_0100;
+
+/// Snapshot of local device capability at the moment of emission.
+///
+/// The `changed_fields` bitmask identifies which fields triggered emission —
+/// sinks can filter on a specific bit to ignore unrelated churn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeviceCapabilitySnapshot {
+    /// Emission timestamp (milliseconds since Unix epoch).
+    pub timestamp_ms: i64,
+    /// Current battery level (0-100), or `None` if unknown.
+    pub battery_level: Option<u8>,
+    /// Whether the device is charging.
+    pub is_charging: bool,
+    /// Current relay role (regular or relay).
+    pub relay_role: RelayRole,
+    /// Bitmask of the fields that triggered this emission.
+    pub changed_fields: u8,
+}
+
+impl DeviceCapabilitySnapshot {
+    /// Stable OTel-friendly name for this record.
+    pub const NAME: &'static str = "protocol.device.capability_changed";
+
+    /// Returns the stable telemetry name.
+    pub fn telemetry_name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    /// Returns `true` when the given change bit is set.
+    pub fn has_changed(&self, bit: u8) -> bool {
+        self.changed_fields & bit != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        let snapshot = DeviceCapabilitySnapshot {
+            timestamp_ms: 0,
+            battery_level: Some(50),
+            is_charging: false,
+            relay_role: RelayRole::Regular,
+            changed_fields: CHANGED_BATTERY,
+        };
+        assert_eq!(
+            DeviceCapabilitySnapshot::NAME,
+            "protocol.device.capability_changed"
+        );
+        assert_eq!(
+            snapshot.telemetry_name(),
+            "protocol.device.capability_changed"
+        );
+    }
+
+    #[test]
+    fn has_changed_respects_bits() {
+        let snapshot = DeviceCapabilitySnapshot {
+            timestamp_ms: 0,
+            battery_level: None,
+            is_charging: true,
+            relay_role: RelayRole::Regular,
+            changed_fields: CHANGED_CHARGING | CHANGED_RELAY_ROLE,
+        };
+        assert!(snapshot.has_changed(CHANGED_CHARGING));
+        assert!(snapshot.has_changed(CHANGED_RELAY_ROLE));
+        assert!(!snapshot.has_changed(CHANGED_BATTERY));
+    }
+}

--- a/crates/offline-protocol/src/telemetry/metrics_snapshot.rs
+++ b/crates/offline-protocol/src/telemetry/metrics_snapshot.rs
@@ -31,8 +31,13 @@ pub struct MetricsFrame {
     pub ack_pending: usize,
     /// Number of currently known neighbors.
     pub neighbor_count: usize,
-    /// Number of currently known active relays.
-    pub relay_count: usize,
+    /// Whether this node is currently acting as a relay on the mesh.
+    ///
+    /// Reflects `RelayManager::current_role()` at the moment of emission.
+    /// Named deliberately — this is a local-role flag, not a peer count.
+    /// A future record with an explicit per-peer-relay registry may add a
+    /// `relay_peer_count` field alongside; those semantics are orthogonal.
+    pub is_local_relay: bool,
     /// Currently selected transport, if any.
     pub current_transport: Option<TransportType>,
 }
@@ -73,7 +78,7 @@ mod tests {
             },
             ack_pending: 0,
             neighbor_count: 0,
-            relay_count: 0,
+            is_local_relay: false,
             current_transport: None,
         }
     }

--- a/crates/offline-protocol/src/telemetry/metrics_snapshot.rs
+++ b/crates/offline-protocol/src/telemetry/metrics_snapshot.rs
@@ -1,0 +1,86 @@
+//! Periodic snapshot of protocol-wide counters and per-transport metrics.
+//!
+//! Emitted on the cadence configured by
+//! [`crate::telemetry::TelemetryConfig::metrics_cadence`] from
+//! `OfflineProtocol::process()`. When cadence is `None`, no periodic emission
+//! occurs — apps fall back to pull-based access via `TransportManager::metrics()`.
+//!
+//! The frame reuses [`TransportMetrics`] verbatim; there is no parallel
+//! "rich" struct. Extending that struct (when UniFFI bindings catch up)
+//! automatically widens the frame.
+
+use offline_protocol_reliability::{DeduplicatorStats, RetryQueueStats};
+use offline_protocol_transport::{TransportMetrics, TransportType};
+
+/// Snapshot of every push-able counter the SDK exposes.
+///
+/// The inner collections are pre-materialized at aggregation time so the sink
+/// receives owned-but-cheap data — no iteration, no locking on the sink side.
+#[derive(Debug, Clone)]
+pub struct MetricsFrame {
+    /// Emission timestamp (milliseconds since Unix epoch).
+    pub timestamp_ms: i64,
+    /// Per-transport metrics for every transport currently reporting
+    /// `TransportStatus::Available`.
+    pub transports: Vec<(TransportType, TransportMetrics)>,
+    /// Retry-queue statistics (pending + ready + per-priority counts).
+    pub retry_queue: RetryQueueStats,
+    /// Deduplicator statistics (tracked ids, capacity, mode).
+    pub dedup: DeduplicatorStats,
+    /// Number of messages awaiting acknowledgement.
+    pub ack_pending: usize,
+    /// Number of currently known neighbors.
+    pub neighbor_count: usize,
+    /// Number of currently known active relays.
+    pub relay_count: usize,
+    /// Currently selected transport, if any.
+    pub current_transport: Option<TransportType>,
+}
+
+impl MetricsFrame {
+    /// Stable OTel-friendly name for this record.
+    pub const NAME: &'static str = "protocol.metrics.snapshot";
+
+    /// Returns the stable telemetry name.
+    pub fn telemetry_name(&self) -> &'static str {
+        Self::NAME
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use offline_protocol_reliability::DeduplicatorMode;
+
+    fn sample_frame() -> MetricsFrame {
+        MetricsFrame {
+            timestamp_ms: 0,
+            transports: Vec::new(),
+            retry_queue: RetryQueueStats {
+                total_count: 0,
+                ready_count: 0,
+                critical_priority_count: 0,
+                high_priority_count: 0,
+                medium_priority_count: 0,
+                low_priority_count: 0,
+            },
+            dedup: DeduplicatorStats {
+                total_tracked: 0,
+                recent_tracked: 0,
+                capacity_used_percent: 0,
+                false_positive_rate: None,
+                mode: DeduplicatorMode::HashMap,
+            },
+            ack_pending: 0,
+            neighbor_count: 0,
+            relay_count: 0,
+            current_transport: None,
+        }
+    }
+
+    #[test]
+    fn name_is_stable() {
+        assert_eq!(MetricsFrame::NAME, "protocol.metrics.snapshot");
+        assert_eq!(sample_frame().telemetry_name(), "protocol.metrics.snapshot");
+    }
+}

--- a/crates/offline-protocol/src/telemetry/mod.rs
+++ b/crates/offline-protocol/src/telemetry/mod.rs
@@ -9,17 +9,26 @@
 //! This PR ships the types only — emit-path wiring and the `install_*` entry
 //! point on the protocol engine land in follow-up work.
 
+pub(crate) mod aggregator;
 pub mod config;
 pub(crate) mod context;
+pub mod device;
+pub mod metrics_snapshot;
 pub mod record;
+pub mod routing;
 pub mod sampling;
 pub(crate) mod scrub_event;
 pub(crate) mod scrubber;
 pub mod sink;
+pub mod transport_state;
 
 pub use config::{MlsVerbosity, TelemetryConfig};
 pub(crate) use context::TelemetryContext;
+pub use device::{DeviceCapabilitySnapshot, CHANGED_BATTERY, CHANGED_CHARGING, CHANGED_RELAY_ROLE};
+pub use metrics_snapshot::MetricsFrame;
 pub use record::TelemetryRecord;
+pub use routing::{RoutingDecision, RoutingPhase, RoutingReasonCode, SuppressionReason};
 pub use sampling::CategorySampler;
 pub(crate) use scrubber::Scrubber;
 pub use sink::{NoopTelemetrySink, TelemetrySink};
+pub use transport_state::TransportStateEvent;

--- a/crates/offline-protocol/src/telemetry/mod.rs
+++ b/crates/offline-protocol/src/telemetry/mod.rs
@@ -1,13 +1,10 @@
 //! Telemetry primitives for the Offline Protocol SDK.
 //!
 //! This module is the unified observer surface for everything the SDK emits:
-//! protocol events and MLS lifecycle events flow as [`TelemetryRecord`]
-//! values through a single [`TelemetrySink`]. Additional categories
-//! (transport state, metrics snapshots, routing decisions, device-capability
-//! snapshots) are introduced alongside the emit sites that populate them.
-//!
-//! This PR ships the types only — emit-path wiring and the `install_*` entry
-//! point on the protocol engine land in follow-up work.
+//! protocol events, MLS lifecycle events, periodic metrics snapshots,
+//! transport-status transitions, structured routing decisions, and
+//! device-capability snapshots all flow as [`TelemetryRecord`] values
+//! through a single [`TelemetrySink`].
 
 pub(crate) mod aggregator;
 pub mod config;
@@ -27,7 +24,7 @@ pub(crate) use context::TelemetryContext;
 pub use device::{DeviceCapabilitySnapshot, CHANGED_BATTERY, CHANGED_CHARGING, CHANGED_RELAY_ROLE};
 pub use metrics_snapshot::MetricsFrame;
 pub use record::TelemetryRecord;
-pub use routing::{RoutingDecision, RoutingPhase, RoutingReasonCode, SuppressionReason};
+pub use routing::{RoutingDecision, RoutingPhase, RoutingReasonCode};
 pub use sampling::CategorySampler;
 pub(crate) use scrubber::Scrubber;
 pub use sink::{NoopTelemetrySink, TelemetrySink};

--- a/crates/offline-protocol/src/telemetry/record.rs
+++ b/crates/offline-protocol/src/telemetry/record.rs
@@ -22,6 +22,10 @@
 
 use crate::events::Event;
 use crate::mls_observability::MlsLifecycleEvent;
+use crate::telemetry::device::DeviceCapabilitySnapshot;
+use crate::telemetry::metrics_snapshot::MetricsFrame;
+use crate::telemetry::routing::RoutingDecision;
+use crate::telemetry::transport_state::TransportStateEvent;
 
 /// A single typed telemetry emission.
 ///
@@ -39,6 +43,21 @@ pub enum TelemetryRecord {
     Protocol(Box<Event>),
     /// An MLS lifecycle event — wraps the existing [`MlsLifecycleEvent`].
     Mls(MlsLifecycleEvent),
+    /// A periodic snapshot of protocol-wide counters and per-transport
+    /// metrics. Boxed to keep the enum footprint flat — the frame carries
+    /// inline `Vec`/stat structs that would otherwise dominate the enum
+    /// size and tax every non-snapshot variant.
+    MetricsSnapshot(Box<MetricsFrame>),
+    /// A single transport-status transition (per-transport, unlike the
+    /// protocol-level `Event::TransportSwitched`).
+    TransportState(TransportStateEvent),
+    /// A structured routing decision (supersets `Event::Dors*`).
+    ///
+    /// Boxed because the score-breakdown vector can carry per-transport
+    /// factor details at the `Diagnostic` verbosity tier.
+    Routing(Box<RoutingDecision>),
+    /// A snapshot of local device capability (battery, charging, relay role).
+    Device(DeviceCapabilitySnapshot),
 }
 
 impl TelemetryRecord {
@@ -48,6 +67,10 @@ impl TelemetryRecord {
         match self {
             TelemetryRecord::Protocol(event) => event.telemetry_name(),
             TelemetryRecord::Mls(event) => event.telemetry_name(),
+            TelemetryRecord::MetricsSnapshot(frame) => frame.telemetry_name(),
+            TelemetryRecord::TransportState(event) => event.telemetry_name(),
+            TelemetryRecord::Routing(decision) => decision.telemetry_name(),
+            TelemetryRecord::Device(snapshot) => snapshot.telemetry_name(),
         }
     }
 }
@@ -146,6 +169,18 @@ mod tests {
         "mls.decryption_failed",
         "mls.session_missing",
         "mls.session_ready",
+        // Non-Event, non-MLS TelemetryRecord variants.
+        //
+        // These names are not covered by the Event/MlsLifecycleEvent
+        // exhaustiveness wards above because their source types are simple
+        // structs — there is no multi-variant enum to stay in sync with.
+        // The dedicated coverage check below
+        // (`simple_record_variant_names_are_stable`) exercises each one's
+        // `telemetry_name()` against the value inlined here.
+        "protocol.metrics.snapshot",
+        "protocol.transport.state_changed",
+        "protocol.routing.decision",
+        "protocol.device.capability_changed",
     ];
 
     /// Returns `true` when `name` matches the documented grammar
@@ -673,6 +708,22 @@ mod tests {
         ]
     }
 
+    /// Names emitted by simple-struct telemetry records (non-enum inner
+    /// types). Extends the Event/MLS-derived name lists used by the
+    /// uniqueness and catalogue-match checks.
+    fn simple_record_names() -> Vec<&'static str> {
+        use crate::telemetry::device::DeviceCapabilitySnapshot;
+        use crate::telemetry::metrics_snapshot::MetricsFrame;
+        use crate::telemetry::routing::RoutingDecision;
+        use crate::telemetry::transport_state::TransportStateEvent;
+        vec![
+            MetricsFrame::NAME,
+            TransportStateEvent::NAME,
+            RoutingDecision::NAME,
+            DeviceCapabilitySnapshot::NAME,
+        ]
+    }
+
     /// Real implementation-level uniqueness check.
     ///
     /// Feeds every exemplar through [`Event::telemetry_name`] and
@@ -689,6 +740,7 @@ mod tests {
         for e in mls_lifecycle_exemplars() {
             names.push(e.telemetry_name());
         }
+        names.extend(simple_record_names());
         let unique: HashSet<&&'static str> = names.iter().collect();
         assert_eq!(
             unique.len(),
@@ -713,6 +765,7 @@ mod tests {
         for e in mls_lifecycle_exemplars() {
             impl_names.push(e.telemetry_name());
         }
+        impl_names.extend(simple_record_names());
 
         let impl_set: HashSet<&&'static str> = impl_names.iter().collect();
         let catalogue_set: HashSet<&&str> = ALL_TELEMETRY_NAMES.iter().collect();

--- a/crates/offline-protocol/src/telemetry/routing.rs
+++ b/crates/offline-protocol/src/telemetry/routing.rs
@@ -3,8 +3,8 @@
 //! Where the `Event::DorsScoreUpdated` / `Event::DorsTransportSelected` /
 //! `Event::DorsTransportSwitched` / `Event::DorsEscalationTriggered` variants
 //! report a flattened subset (transport name + score + reason code), this
-//! record carries the full scoring breakdown and the gate-suppression context
-//! that DORS evaluates before it decides whether to switch.
+//! record carries the full per-factor scoring breakdown that DORS evaluates
+//! before it decides which transport to use.
 //!
 //! The legacy `Event::Dors*` path continues to fire for back-compat — apps
 //! that want the richer shape consume [`crate::telemetry::TelemetrySink`] and
@@ -28,8 +28,6 @@ pub enum RoutingPhase {
     Switched,
     /// BLE→WiFi escalation triggered or applied.
     Escalated,
-    /// A switch candidate was suppressed by hysteresis/cooldown/stability.
-    Suppressed,
 }
 
 /// Top-level reason space for routing decisions.
@@ -63,37 +61,20 @@ pub enum RoutingReasonCode {
     LowTtl,
     /// Sustained low success rate tripped escalation.
     LowSuccessRate,
-    /// Candidate score improvement below `switch_hysteresis`.
-    HysteresisNotMet,
-    /// `switch_cooldown_secs` has not elapsed since last switch.
-    InCooldown,
-    /// Candidate has not held superiority over `stability_window_secs`.
-    StabilityWindowUnmet,
-}
-
-/// Structured explanation of *why* a candidate switch was suppressed.
-///
-/// All fields are populated best-effort — a suppressed decision may have
-/// multiple overlapping reasons (e.g. hysteresis AND cooldown); fields
-/// unrelated to the primary reason are left as their defaults.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct SuppressionReason {
-    /// Required score delta vs. observed delta (observed < required ⇒ block).
-    pub hysteresis_delta: Option<f32>,
-    /// Seconds remaining until `switch_cooldown_secs` elapses.
-    pub cooldown_remaining_secs: Option<u64>,
-    /// `true` when the candidate has not held superiority across
-    /// `stability_window_secs`.
-    pub stability_unmet: bool,
 }
 
 /// A single structured routing decision.
 ///
-/// Populated by the DORS callback installed via
-/// `TransportManager::set_routing_decision_callback`. The `scores` field is
-/// only populated when `TelemetryConfig::routing_diagnostic` is `true`; at the
+/// Populated by the DORS callback installed by
+/// `OfflineProtocol::install_telemetry_sink`. The `scores` field is only
+/// populated when `TelemetryConfig::routing_diagnostic` is `true`; at the
 /// default verbosity the vector is empty, keeping the hot-path allocation
 /// free.
+///
+/// A future PR will introduce a `Suppressed` phase carrying hysteresis /
+/// cooldown / stability detail; that variant and its payload were excluded
+/// from this record on purpose so the shape can be designed alongside the
+/// emit sites that produce it.
 #[derive(Debug, Clone)]
 pub struct RoutingDecision {
     /// Emission timestamp (milliseconds since Unix epoch).
@@ -111,8 +92,6 @@ pub struct RoutingDecision {
     /// Full per-transport score breakdown. Empty unless
     /// `TelemetryConfig::routing_diagnostic` is enabled.
     pub scores: Vec<(TransportType, TransportScore)>,
-    /// Present only when `phase == Suppressed`.
-    pub suppression: Option<SuppressionReason>,
 }
 
 impl RoutingDecision {
@@ -139,17 +118,8 @@ mod tests {
             winning_score: Some(84.0),
             reason_code: Some(RoutingReasonCode::InitialSelection),
             scores: Vec::new(),
-            suppression: None,
         };
         assert_eq!(RoutingDecision::NAME, "protocol.routing.decision");
         assert_eq!(decision.telemetry_name(), "protocol.routing.decision");
-    }
-
-    #[test]
-    fn suppression_default_is_empty() {
-        let suppression = SuppressionReason::default();
-        assert!(suppression.hysteresis_delta.is_none());
-        assert!(suppression.cooldown_remaining_secs.is_none());
-        assert!(!suppression.stability_unmet);
     }
 }

--- a/crates/offline-protocol/src/telemetry/routing.rs
+++ b/crates/offline-protocol/src/telemetry/routing.rs
@@ -1,0 +1,155 @@
+//! Structured superset of the legacy `Event::Dors*` events.
+//!
+//! Where the `Event::DorsScoreUpdated` / `Event::DorsTransportSelected` /
+//! `Event::DorsTransportSwitched` / `Event::DorsEscalationTriggered` variants
+//! report a flattened subset (transport name + score + reason code), this
+//! record carries the full scoring breakdown and the gate-suppression context
+//! that DORS evaluates before it decides whether to switch.
+//!
+//! The legacy `Event::Dors*` path continues to fire for back-compat — apps
+//! that want the richer shape consume [`crate::telemetry::TelemetrySink`] and
+//! opt into score populating via
+//! [`crate::telemetry::TelemetryConfig::with_routing_diagnostic`].
+
+use offline_protocol_router::TransportScore;
+use offline_protocol_transport::TransportType;
+
+/// Which kind of routing decision this record describes.
+///
+/// `#[non_exhaustive]` so new phases can be added without a breaking-change bump.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoutingPhase {
+    /// DORS recomputed per-transport scores without switching.
+    ScoreUpdated,
+    /// DORS picked a transport (initial selection or post-switch).
+    Selected,
+    /// DORS changed the active transport.
+    Switched,
+    /// BLE→WiFi escalation triggered or applied.
+    Escalated,
+    /// A switch candidate was suppressed by hysteresis/cooldown/stability.
+    Suppressed,
+}
+
+/// Top-level reason space for routing decisions.
+///
+/// Unifies the legacy `DorsReasonCode` (selection/switch reasons) and
+/// `DorsEscalationReasonCode` (escalation reasons) into a single flat enum
+/// that a sink can match on without juggling multiple legacy code spaces.
+/// `#[non_exhaustive]` so new reasons can be added.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoutingReasonCode {
+    /// Initial selection at protocol start.
+    InitialSelection,
+    /// Primary transport selected on merit.
+    PrimarySelected,
+    /// Primary transport's last send succeeded.
+    PrimarySuccess,
+    /// Fallback transport's last send succeeded.
+    FallbackSuccess,
+    /// Escalation fallback was applied end-to-end.
+    EscalationApplied,
+    /// Current transport became unavailable.
+    CurrentUnavailable,
+    /// Retry-failure threshold tripped escalation.
+    RetryThreshold,
+    /// Sustained poor signal tripped escalation.
+    PoorSignal,
+    /// Sustained congestion tripped escalation.
+    Congestion,
+    /// Low TTL headroom tripped escalation.
+    LowTtl,
+    /// Sustained low success rate tripped escalation.
+    LowSuccessRate,
+    /// Candidate score improvement below `switch_hysteresis`.
+    HysteresisNotMet,
+    /// `switch_cooldown_secs` has not elapsed since last switch.
+    InCooldown,
+    /// Candidate has not held superiority over `stability_window_secs`.
+    StabilityWindowUnmet,
+}
+
+/// Structured explanation of *why* a candidate switch was suppressed.
+///
+/// All fields are populated best-effort — a suppressed decision may have
+/// multiple overlapping reasons (e.g. hysteresis AND cooldown); fields
+/// unrelated to the primary reason are left as their defaults.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SuppressionReason {
+    /// Required score delta vs. observed delta (observed < required ⇒ block).
+    pub hysteresis_delta: Option<f32>,
+    /// Seconds remaining until `switch_cooldown_secs` elapses.
+    pub cooldown_remaining_secs: Option<u64>,
+    /// `true` when the candidate has not held superiority across
+    /// `stability_window_secs`.
+    pub stability_unmet: bool,
+}
+
+/// A single structured routing decision.
+///
+/// Populated by the DORS callback installed via
+/// `TransportManager::set_routing_decision_callback`. The `scores` field is
+/// only populated when `TelemetryConfig::routing_diagnostic` is `true`; at the
+/// default verbosity the vector is empty, keeping the hot-path allocation
+/// free.
+#[derive(Debug, Clone)]
+pub struct RoutingDecision {
+    /// Emission timestamp (milliseconds since Unix epoch).
+    pub timestamp_ms: i64,
+    /// Which kind of decision this is.
+    pub phase: RoutingPhase,
+    /// Previous transport, when applicable.
+    pub from: Option<TransportType>,
+    /// Chosen / target transport, when applicable.
+    pub to: Option<TransportType>,
+    /// Total score of the winning transport, when applicable.
+    pub winning_score: Option<f32>,
+    /// Reason for the decision, when one applies.
+    pub reason_code: Option<RoutingReasonCode>,
+    /// Full per-transport score breakdown. Empty unless
+    /// `TelemetryConfig::routing_diagnostic` is enabled.
+    pub scores: Vec<(TransportType, TransportScore)>,
+    /// Present only when `phase == Suppressed`.
+    pub suppression: Option<SuppressionReason>,
+}
+
+impl RoutingDecision {
+    /// Stable OTel-friendly name for this record.
+    pub const NAME: &'static str = "protocol.routing.decision";
+
+    /// Returns the stable telemetry name.
+    pub fn telemetry_name(&self) -> &'static str {
+        Self::NAME
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        let decision = RoutingDecision {
+            timestamp_ms: 0,
+            phase: RoutingPhase::Selected,
+            from: None,
+            to: Some(TransportType::BLE),
+            winning_score: Some(84.0),
+            reason_code: Some(RoutingReasonCode::InitialSelection),
+            scores: Vec::new(),
+            suppression: None,
+        };
+        assert_eq!(RoutingDecision::NAME, "protocol.routing.decision");
+        assert_eq!(decision.telemetry_name(), "protocol.routing.decision");
+    }
+
+    #[test]
+    fn suppression_default_is_empty() {
+        let suppression = SuppressionReason::default();
+        assert!(suppression.hysteresis_delta.is_none());
+        assert!(suppression.cooldown_remaining_secs.is_none());
+        assert!(!suppression.stability_unmet);
+    }
+}

--- a/crates/offline-protocol/src/telemetry/transport_state.rs
+++ b/crates/offline-protocol/src/telemetry/transport_state.rs
@@ -1,0 +1,64 @@
+//! Push-based `TransportStatus` transition records.
+//!
+//! Complementary to the existing `Event::TransportSwitched`, which reports the
+//! currently-selected transport at the protocol level. This record reports the
+//! underlying connection status of a *single* transport (BLE connected,
+//! internet disconnected, ...) and fires on every observed transition rather
+//! than only on the selection switchover.
+
+use offline_protocol_transport::{TransportStatus, TransportType};
+
+/// A single `TransportStatus` transition observed by the protocol engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransportStateEvent {
+    /// Emission timestamp (milliseconds since Unix epoch).
+    pub timestamp_ms: i64,
+    /// The transport whose status changed.
+    pub transport: TransportType,
+    /// Previous status as last observed by the protocol engine.
+    pub previous: TransportStatus,
+    /// Current status.
+    pub current: TransportStatus,
+}
+
+impl TransportStateEvent {
+    /// Stable OTel-friendly name for this record.
+    pub const NAME: &'static str = "protocol.transport.state_changed";
+
+    /// Returns the stable telemetry name.
+    pub fn telemetry_name(&self) -> &'static str {
+        Self::NAME
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_stable() {
+        let event = TransportStateEvent {
+            timestamp_ms: 0,
+            transport: TransportType::BLE,
+            previous: TransportStatus::Disconnected,
+            current: TransportStatus::Available,
+        };
+        assert_eq!(
+            TransportStateEvent::NAME,
+            "protocol.transport.state_changed"
+        );
+        assert_eq!(event.telemetry_name(), "protocol.transport.state_changed");
+    }
+
+    #[test]
+    fn transitions_are_comparable() {
+        let a = TransportStateEvent {
+            timestamp_ms: 1,
+            transport: TransportType::BLE,
+            previous: TransportStatus::Disconnected,
+            current: TransportStatus::Available,
+        };
+        let b = a;
+        assert_eq!(a, b);
+    }
+}

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -763,6 +763,50 @@ impl TransportManager {
         out
     }
 
+    /// Returns the per-transport status map AND the available-only metrics
+    /// map in a single lock-per-transport pass.
+    ///
+    /// Equivalent to calling [`Self::get_all_transport_statuses`] and
+    /// [`Self::get_available_transports`] back-to-back, but takes each
+    /// transport's mutex once instead of twice. Used by the per-tick
+    /// telemetry aggregator.
+    pub fn snapshot_status_and_available(
+        &self,
+    ) -> (
+        HashMap<TransportType, TransportStatus>,
+        HashMap<TransportType, TransportMetrics>,
+    ) {
+        let mut statuses = HashMap::with_capacity(self.transports.len());
+        let mut available = HashMap::new();
+
+        for (transport_type, transport) in &self.transports {
+            let (status, metrics) = match transport.lock() {
+                Ok(lock) => {
+                    let status = lock.status();
+                    let metrics = if status == TransportStatus::Available {
+                        Some(lock.metrics())
+                    } else {
+                        None
+                    };
+                    (status, metrics)
+                }
+                Err(_) => {
+                    warn!(transport = ?transport_type, "Transport mutex poisoned, reporting Error");
+                    (TransportStatus::Error, None)
+                }
+            };
+            statuses.insert(*transport_type, status);
+            if let Some(mut metrics) = metrics {
+                if let Some(stats) = self.observations.get(transport_type) {
+                    stats.apply_to_metrics(&mut metrics);
+                }
+                available.insert(*transport_type, metrics);
+            }
+        }
+
+        (statuses, available)
+    }
+
     /// Starts all transports.
     pub fn start(&mut self) -> Result<()> {
         for (transport_type, transport) in &self.transports {

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -10,7 +10,9 @@ use crate::telemetry::routing::{RoutingDecision, RoutingPhase, RoutingReasonCode
 use crate::{Error, Result};
 use chrono::Utc;
 use offline_protocol_core::Message;
-use offline_protocol_router::{DorsConfig, EscalationTriggerReason, TransportSelector};
+use offline_protocol_router::{
+    DorsConfig, EscalationTriggerReason, TransportScore, TransportSelector,
+};
 use offline_protocol_transport::{
     Error as TransportError, Transport, TransportMetrics, TransportStatus, TransportType,
 };
@@ -41,6 +43,12 @@ pub struct TransportManager {
     /// receives the richer `RoutingDecision` shape while `EventCallback`
     /// consumers continue to see the flattened `Event::Dors*` variants.
     routing_decision_callback: Option<Arc<dyn Fn(RoutingDecision) + Send + Sync>>,
+
+    /// When `true`, every emitted [`RoutingDecision`] carries the full
+    /// per-transport [`TransportScore`] breakdown in its `scores` field.
+    /// Mirrors `TelemetryConfig::routing_diagnostic` and is toggled by
+    /// `OfflineProtocol::install_telemetry_sink`.
+    routing_diagnostic: bool,
 
     /// Last escalation trigger event emitted (reason, time) for dedupe window.
     last_escalation_trigger_emitted: Option<(DorsEscalationReasonCode, std::time::Instant)>,
@@ -150,6 +158,7 @@ impl TransportManager {
             observations: HashMap::new(),
             dors_event_callback: None,
             routing_decision_callback: None,
+            routing_diagnostic: false,
             last_escalation_trigger_emitted: None,
         }
     }
@@ -171,15 +180,29 @@ impl TransportManager {
         self.routing_decision_callback = callback;
     }
 
+    /// Enables or disables the routing-diagnostic detail level.
+    ///
+    /// When `true`, [`RoutingDecision::scores`] is populated with the full
+    /// seven-factor [`TransportScore`] for every ranked transport on every
+    /// emission. When `false` (default), the vector is empty and the hot
+    /// path avoids the per-emission allocation. Mirrors
+    /// `TelemetryConfig::routing_diagnostic`.
+    pub fn set_routing_diagnostic(&mut self, enabled: bool) {
+        self.routing_diagnostic = enabled;
+    }
+
     fn emit_dors_event(&self, event: Event) {
         if let Some(ref cb) = self.dors_event_callback {
             cb(event);
         }
     }
 
-    fn emit_routing_decision(&self, decision: RoutingDecision) {
+    /// Lazy-emit a [`RoutingDecision`]. The `build` closure only runs when a
+    /// callback is actually installed, so the no-sink path pays only an
+    /// `Option::is_some` check — not a `Utc::now()` call and struct build.
+    fn emit_routing_decision<F: FnOnce() -> RoutingDecision>(&self, build: F) {
         if let Some(ref cb) = self.routing_decision_callback {
-            cb(decision);
+            cb(build());
         }
     }
 
@@ -215,13 +238,22 @@ impl TransportManager {
         }
     }
 
+    /// Builds a [`RoutingDecision`]. The `detailed_scores` slice is cloned
+    /// into `scores` when `routing_diagnostic` is enabled on the manager;
+    /// otherwise the vector stays empty (allocation-free).
     fn build_routing_decision(
+        &self,
         phase: RoutingPhase,
         from: Option<TransportType>,
         to: Option<TransportType>,
         winning_score: Option<f32>,
         reason_code: Option<RoutingReasonCode>,
+        detailed_scores: Option<&[(TransportType, TransportScore)]>,
     ) -> RoutingDecision {
+        let scores = match (self.routing_diagnostic, detailed_scores) {
+            (true, Some(detailed)) => detailed.to_vec(),
+            _ => Vec::new(),
+        };
         RoutingDecision {
             timestamp_ms: Utc::now().timestamp_millis(),
             phase,
@@ -229,12 +261,7 @@ impl TransportManager {
             to,
             winning_score,
             reason_code,
-            // Per-transport score breakdown is populated only when
-            // `TelemetryConfig::routing_diagnostic` is set; populating it
-            // requires a read-only detailed-scoring accessor on
-            // `TransportSelector` that is not yet exposed. Left empty here
-            // so default-verbosity emission remains allocation-free.
-            scores: Vec::new(),
+            scores,
             suppression: None,
         }
     }
@@ -243,9 +270,10 @@ impl TransportManager {
     fn emit_escalation_trigger_if_deduped(
         &mut self,
         reason_code: DorsEscalationReasonCode,
-        from: String,
-        to: String,
+        from: TransportType,
+        to: TransportType,
         reason_detail: Option<String>,
+        detailed_scores: Option<&[(TransportType, TransportScore)]>,
     ) {
         let now = std::time::Instant::now();
         let emit = match &self.last_escalation_trigger_emitted {
@@ -257,22 +285,23 @@ impl TransportManager {
         };
         if emit {
             self.last_escalation_trigger_emitted = Some((reason_code, now));
-            let routing_from = TransportType::from_label(&from);
-            let routing_to = TransportType::from_label(&to);
             self.emit_dors_event(Event::dors_escalation_triggered(
                 DorsEscalationPhase::Triggered,
-                from,
-                to,
+                from.to_string(),
+                to.to_string(),
                 reason_code,
                 reason_detail,
             ));
-            self.emit_routing_decision(Self::build_routing_decision(
-                RoutingPhase::Escalated,
-                Some(routing_from),
-                Some(routing_to),
-                None,
-                Some(Self::escalation_reason_code_to_routing(reason_code)),
-            ));
+            self.emit_routing_decision(|| {
+                self.build_routing_decision(
+                    RoutingPhase::Escalated,
+                    Some(from),
+                    Some(to),
+                    None,
+                    Some(Self::escalation_reason_code_to_routing(reason_code)),
+                    detailed_scores,
+                )
+            });
         }
     }
 
@@ -333,13 +362,29 @@ impl TransportManager {
         let scored = self.selector.score_and_rank(message, &available);
         let scores: Vec<(String, f32)> = scored.iter().map(|(t, s)| (t.to_string(), *s)).collect();
         self.emit_dors_event(Event::dors_score_updated(scores));
-        self.emit_routing_decision(Self::build_routing_decision(
-            RoutingPhase::ScoreUpdated,
-            previous,
-            None,
-            None,
-            None,
-        ));
+
+        // Compute the detailed per-transport score breakdown only when a
+        // consumer has (a) installed a routing_decision_callback AND
+        // (b) opted into the diagnostic tier. Without both, the breakdown
+        // is never materialised.
+        let detailed_scores: Option<Vec<(TransportType, TransportScore)>> =
+            if self.routing_diagnostic && self.routing_decision_callback.is_some() {
+                Some(self.selector.score_and_rank_detailed(message, &available))
+            } else {
+                None
+            };
+        let detailed_slice = detailed_scores.as_deref();
+
+        self.emit_routing_decision(|| {
+            self.build_routing_decision(
+                RoutingPhase::ScoreUpdated,
+                previous,
+                None,
+                None,
+                None,
+                detailed_slice,
+            )
+        });
         let primary_score = scored
             .iter()
             .find(|(t, _)| *t == primary)
@@ -356,13 +401,16 @@ impl TransportManager {
             selection_reason,
             primary_score,
         ));
-        self.emit_routing_decision(Self::build_routing_decision(
-            RoutingPhase::Selected,
-            previous,
-            Some(primary),
-            Some(primary_score),
-            Some(Self::dors_reason_code_to_routing(selection_reason)),
-        ));
+        self.emit_routing_decision(|| {
+            self.build_routing_decision(
+                RoutingPhase::Selected,
+                previous,
+                Some(primary),
+                Some(primary_score),
+                Some(Self::dors_reason_code_to_routing(selection_reason)),
+                detailed_slice,
+            )
+        });
 
         // Try the primary transport first.
         let primary_result = {
@@ -391,13 +439,16 @@ impl TransportManager {
                         reason_code,
                         None,
                     ));
-                    self.emit_routing_decision(Self::build_routing_decision(
-                        RoutingPhase::Switched,
-                        previous,
-                        Some(primary),
-                        Some(primary_score),
-                        Some(Self::dors_reason_code_to_routing(reason_code)),
-                    ));
+                    self.emit_routing_decision(|| {
+                        self.build_routing_decision(
+                            RoutingPhase::Switched,
+                            previous,
+                            Some(primary),
+                            Some(primary_score),
+                            Some(Self::dors_reason_code_to_routing(reason_code)),
+                            detailed_slice,
+                        )
+                    });
                 }
                 return Ok(());
             }
@@ -437,9 +488,10 @@ impl TransportManager {
                     let reason_code = Self::escalation_trigger_reason_to_code(trigger_reason);
                     self.emit_escalation_trigger_if_deduped(
                         reason_code,
-                        primary.to_string(),
-                        transport_type.to_string(),
+                        primary,
+                        *transport_type,
                         None,
+                        detailed_slice,
                     );
                 }
             }
@@ -478,13 +530,17 @@ impl TransportManager {
                             reason_code,
                             Some("primary send failed, fallback succeeded".to_string()),
                         ));
-                        self.emit_routing_decision(Self::build_routing_decision(
-                            RoutingPhase::Switched,
-                            previous,
-                            Some(*transport_type),
-                            None,
-                            Some(Self::dors_reason_code_to_routing(reason_code)),
-                        ));
+                        let fallback = *transport_type;
+                        self.emit_routing_decision(|| {
+                            self.build_routing_decision(
+                                RoutingPhase::Switched,
+                                previous,
+                                Some(fallback),
+                                None,
+                                Some(Self::dors_reason_code_to_routing(reason_code)),
+                                detailed_slice,
+                            )
+                        });
                     }
                     // Escalation applied only when BLE→WiFi fallback actually succeeded.
                     if primary == TransportType::BLE && *transport_type == TransportType::WiFiDirect
@@ -496,15 +552,19 @@ impl TransportManager {
                             DorsEscalationReasonCode::FallbackSuccess,
                             Some("primary BLE send failed, fallback to WiFi succeeded".to_string()),
                         ));
-                        self.emit_routing_decision(Self::build_routing_decision(
-                            RoutingPhase::Escalated,
-                            Some(primary),
-                            Some(*transport_type),
-                            None,
-                            Some(Self::escalation_reason_code_to_routing(
-                                DorsEscalationReasonCode::FallbackSuccess,
-                            )),
-                        ));
+                        let escalated = *transport_type;
+                        self.emit_routing_decision(|| {
+                            self.build_routing_decision(
+                                RoutingPhase::Escalated,
+                                Some(primary),
+                                Some(escalated),
+                                None,
+                                Some(Self::escalation_reason_code_to_routing(
+                                    DorsEscalationReasonCode::FallbackSuccess,
+                                )),
+                                detailed_slice,
+                            )
+                        });
                     }
                     return Ok(());
                 }

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -6,7 +6,9 @@
 
 use crate::constants::{HOP_COUNT_EMA_ALPHA, LATENCY_EMA_ALPHA, OBSERVED_STATS_COMPACT_THRESHOLD};
 use crate::events::{DorsEscalationPhase, DorsEscalationReasonCode, DorsReasonCode, Event};
+use crate::telemetry::routing::{RoutingDecision, RoutingPhase, RoutingReasonCode};
 use crate::{Error, Result};
+use chrono::Utc;
 use offline_protocol_core::Message;
 use offline_protocol_router::{DorsConfig, EscalationTriggerReason, TransportSelector};
 use offline_protocol_transport::{
@@ -33,6 +35,12 @@ pub struct TransportManager {
 
     /// Optional callback for DORS lifecycle/decision events (OFF-258).
     dors_event_callback: Option<Arc<dyn Fn(Event) + Send + Sync>>,
+
+    /// Optional callback for structured routing decisions. Fires alongside
+    /// every legacy `dors_event_callback` emission so the telemetry sink
+    /// receives the richer `RoutingDecision` shape while `EventCallback`
+    /// consumers continue to see the flattened `Event::Dors*` variants.
+    routing_decision_callback: Option<Arc<dyn Fn(RoutingDecision) + Send + Sync>>,
 
     /// Last escalation trigger event emitted (reason, time) for dedupe window.
     last_escalation_trigger_emitted: Option<(DorsEscalationReasonCode, std::time::Instant)>,
@@ -141,6 +149,7 @@ impl TransportManager {
             selector,
             observations: HashMap::new(),
             dors_event_callback: None,
+            routing_decision_callback: None,
             last_escalation_trigger_emitted: None,
         }
     }
@@ -150,9 +159,27 @@ impl TransportManager {
         self.dors_event_callback = callback;
     }
 
+    /// Sets the callback that receives structured
+    /// [`crate::telemetry::RoutingDecision`] records.
+    ///
+    /// Fires at the same sites as `dors_event_callback`, carrying a richer
+    /// shape suitable for the unified telemetry sink.
+    pub fn set_routing_decision_callback(
+        &mut self,
+        callback: Option<Arc<dyn Fn(RoutingDecision) + Send + Sync>>,
+    ) {
+        self.routing_decision_callback = callback;
+    }
+
     fn emit_dors_event(&self, event: Event) {
         if let Some(ref cb) = self.dors_event_callback {
             cb(event);
+        }
+    }
+
+    fn emit_routing_decision(&self, decision: RoutingDecision) {
+        if let Some(ref cb) = self.routing_decision_callback {
+            cb(decision);
         }
     }
 
@@ -163,6 +190,52 @@ impl TransportManager {
             EscalationTriggerReason::Congestion => DorsEscalationReasonCode::Congestion,
             EscalationTriggerReason::LowTtl => DorsEscalationReasonCode::LowTtl,
             EscalationTriggerReason::LowSuccessRate => DorsEscalationReasonCode::LowSuccessRate,
+        }
+    }
+
+    fn dors_reason_code_to_routing(code: DorsReasonCode) -> RoutingReasonCode {
+        match code {
+            DorsReasonCode::InitialSelection => RoutingReasonCode::InitialSelection,
+            DorsReasonCode::PrimarySelected => RoutingReasonCode::PrimarySelected,
+            DorsReasonCode::PrimarySuccess => RoutingReasonCode::PrimarySuccess,
+            DorsReasonCode::FallbackSuccess => RoutingReasonCode::FallbackSuccess,
+            DorsReasonCode::EscalationApplied => RoutingReasonCode::EscalationApplied,
+            DorsReasonCode::CurrentUnavailable => RoutingReasonCode::CurrentUnavailable,
+        }
+    }
+
+    fn escalation_reason_code_to_routing(code: DorsEscalationReasonCode) -> RoutingReasonCode {
+        match code {
+            DorsEscalationReasonCode::FallbackSuccess => RoutingReasonCode::FallbackSuccess,
+            DorsEscalationReasonCode::RetryThreshold => RoutingReasonCode::RetryThreshold,
+            DorsEscalationReasonCode::PoorSignal => RoutingReasonCode::PoorSignal,
+            DorsEscalationReasonCode::Congestion => RoutingReasonCode::Congestion,
+            DorsEscalationReasonCode::LowTtl => RoutingReasonCode::LowTtl,
+            DorsEscalationReasonCode::LowSuccessRate => RoutingReasonCode::LowSuccessRate,
+        }
+    }
+
+    fn build_routing_decision(
+        phase: RoutingPhase,
+        from: Option<TransportType>,
+        to: Option<TransportType>,
+        winning_score: Option<f32>,
+        reason_code: Option<RoutingReasonCode>,
+    ) -> RoutingDecision {
+        RoutingDecision {
+            timestamp_ms: Utc::now().timestamp_millis(),
+            phase,
+            from,
+            to,
+            winning_score,
+            reason_code,
+            // Per-transport score breakdown is populated only when
+            // `TelemetryConfig::routing_diagnostic` is set; populating it
+            // requires a read-only detailed-scoring accessor on
+            // `TransportSelector` that is not yet exposed. Left empty here
+            // so default-verbosity emission remains allocation-free.
+            scores: Vec::new(),
+            suppression: None,
         }
     }
 
@@ -184,12 +257,21 @@ impl TransportManager {
         };
         if emit {
             self.last_escalation_trigger_emitted = Some((reason_code, now));
+            let routing_from = TransportType::from_label(&from);
+            let routing_to = TransportType::from_label(&to);
             self.emit_dors_event(Event::dors_escalation_triggered(
                 DorsEscalationPhase::Triggered,
                 from,
                 to,
                 reason_code,
                 reason_detail,
+            ));
+            self.emit_routing_decision(Self::build_routing_decision(
+                RoutingPhase::Escalated,
+                Some(routing_from),
+                Some(routing_to),
+                None,
+                Some(Self::escalation_reason_code_to_routing(reason_code)),
             ));
         }
     }
@@ -251,6 +333,13 @@ impl TransportManager {
         let scored = self.selector.score_and_rank(message, &available);
         let scores: Vec<(String, f32)> = scored.iter().map(|(t, s)| (t.to_string(), *s)).collect();
         self.emit_dors_event(Event::dors_score_updated(scores));
+        self.emit_routing_decision(Self::build_routing_decision(
+            RoutingPhase::ScoreUpdated,
+            previous,
+            None,
+            None,
+            None,
+        ));
         let primary_score = scored
             .iter()
             .find(|(t, _)| *t == primary)
@@ -266,6 +355,13 @@ impl TransportManager {
             primary.to_string(),
             selection_reason,
             primary_score,
+        ));
+        self.emit_routing_decision(Self::build_routing_decision(
+            RoutingPhase::Selected,
+            previous,
+            Some(primary),
+            Some(primary_score),
+            Some(Self::dors_reason_code_to_routing(selection_reason)),
         ));
 
         // Try the primary transport first.
@@ -294,6 +390,13 @@ impl TransportManager {
                         primary.to_string(),
                         reason_code,
                         None,
+                    ));
+                    self.emit_routing_decision(Self::build_routing_decision(
+                        RoutingPhase::Switched,
+                        previous,
+                        Some(primary),
+                        Some(primary_score),
+                        Some(Self::dors_reason_code_to_routing(reason_code)),
                     ));
                 }
                 return Ok(());
@@ -375,6 +478,13 @@ impl TransportManager {
                             reason_code,
                             Some("primary send failed, fallback succeeded".to_string()),
                         ));
+                        self.emit_routing_decision(Self::build_routing_decision(
+                            RoutingPhase::Switched,
+                            previous,
+                            Some(*transport_type),
+                            None,
+                            Some(Self::dors_reason_code_to_routing(reason_code)),
+                        ));
                     }
                     // Escalation applied only when BLE→WiFi fallback actually succeeded.
                     if primary == TransportType::BLE && *transport_type == TransportType::WiFiDirect
@@ -385,6 +495,15 @@ impl TransportManager {
                             transport_type.to_string(),
                             DorsEscalationReasonCode::FallbackSuccess,
                             Some("primary BLE send failed, fallback to WiFi succeeded".to_string()),
+                        ));
+                        self.emit_routing_decision(Self::build_routing_decision(
+                            RoutingPhase::Escalated,
+                            Some(primary),
+                            Some(*transport_type),
+                            None,
+                            Some(Self::escalation_reason_code_to_routing(
+                                DorsEscalationReasonCode::FallbackSuccess,
+                            )),
                         ));
                     }
                     return Ok(());
@@ -534,6 +653,28 @@ impl TransportManager {
     /// Gets the current active transport type.
     pub fn current_transport(&self) -> Option<TransportType> {
         self.current_transport
+    }
+
+    /// Returns the current status of every registered transport, including
+    /// those not currently [`TransportStatus::Available`].
+    ///
+    /// Used by the telemetry aggregator to detect state transitions; unlike
+    /// [`TransportManager::get_available_transports`], this does not take
+    /// per-transport metrics and therefore does a single lock per transport
+    /// with no downstream work under the guard.
+    pub fn get_all_transport_statuses(&self) -> HashMap<TransportType, TransportStatus> {
+        let mut out = HashMap::with_capacity(self.transports.len());
+        for (transport_type, transport) in &self.transports {
+            let status = match transport.lock() {
+                Ok(lock) => lock.status(),
+                Err(_) => {
+                    warn!(transport = ?transport_type, "Transport mutex poisoned, reporting Error");
+                    TransportStatus::Error
+                }
+            };
+            out.insert(*transport_type, status);
+        }
+        out
     }
 
     /// Starts all transports.

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -173,7 +173,12 @@ impl TransportManager {
     ///
     /// Fires at the same sites as `dors_event_callback`, carrying a richer
     /// shape suitable for the unified telemetry sink.
-    pub fn set_routing_decision_callback(
+    ///
+    /// Crate-private: apps must drive routing telemetry through
+    /// [`crate::OfflineProtocol::install_telemetry_sink`] rather than wiring
+    /// the callback directly. This keeps [`crate::telemetry::TelemetryConfig`]
+    /// the single source of truth for sink configuration.
+    pub(crate) fn set_routing_decision_callback(
         &mut self,
         callback: Option<Arc<dyn Fn(RoutingDecision) + Send + Sync>>,
     ) {
@@ -187,7 +192,9 @@ impl TransportManager {
     /// emission. When `false` (default), the vector is empty and the hot
     /// path avoids the per-emission allocation. Mirrors
     /// `TelemetryConfig::routing_diagnostic`.
-    pub fn set_routing_diagnostic(&mut self, enabled: bool) {
+    ///
+    /// Crate-private: see [`Self::set_routing_decision_callback`].
+    pub(crate) fn set_routing_diagnostic(&mut self, enabled: bool) {
         self.routing_diagnostic = enabled;
     }
 
@@ -241,8 +248,15 @@ impl TransportManager {
     /// Builds a [`RoutingDecision`]. The `detailed_scores` slice is cloned
     /// into `scores` when `routing_diagnostic` is enabled on the manager;
     /// otherwise the vector stays empty (allocation-free).
+    ///
+    /// Takes `now_ms` by argument rather than calling `Utc::now()` per
+    /// build so every decision emitted from a single `send()` cycle shares
+    /// one timestamp — easier to correlate downstream and saves three to
+    /// four syscalls on the send hot path.
+    #[allow(clippy::too_many_arguments)]
     fn build_routing_decision(
         &self,
+        now_ms: i64,
         phase: RoutingPhase,
         from: Option<TransportType>,
         to: Option<TransportType>,
@@ -255,20 +269,20 @@ impl TransportManager {
             _ => Vec::new(),
         };
         RoutingDecision {
-            timestamp_ms: Utc::now().timestamp_millis(),
+            timestamp_ms: now_ms,
             phase,
             from,
             to,
             winning_score,
             reason_code,
             scores,
-            suppression: None,
         }
     }
 
     /// Emit dors_escalation_triggered at trigger boundary (typed reason), deduped by reason + time window.
     fn emit_escalation_trigger_if_deduped(
         &mut self,
+        now_ms: i64,
         reason_code: DorsEscalationReasonCode,
         from: TransportType,
         to: TransportType,
@@ -294,6 +308,7 @@ impl TransportManager {
             ));
             self.emit_routing_decision(|| {
                 self.build_routing_decision(
+                    now_ms,
                     RoutingPhase::Escalated,
                     Some(from),
                     Some(to),
@@ -345,6 +360,11 @@ impl TransportManager {
             )));
         }
 
+        // Single timestamp shared by every RoutingDecision emitted from this
+        // send cycle — cheaper than per-emit `Utc::now()` and lets downstream
+        // consumers group decisions by timestamp.
+        let now_ms = Utc::now().timestamp_millis();
+
         let previous = self.current_transport;
 
         // DORS selects the primary transport (applies hysteresis/cooldown/stability).
@@ -358,15 +378,9 @@ impl TransportManager {
             })?;
 
         // Emit DORS observability: scores and selection (before send attempt).
-        // Compute once and reuse for both observability and fallback ordering.
-        let scored = self.selector.score_and_rank(message, &available);
-        let scores: Vec<(String, f32)> = scored.iter().map(|(t, s)| (t.to_string(), *s)).collect();
-        self.emit_dors_event(Event::dors_score_updated(scores));
-
-        // Compute the detailed per-transport score breakdown only when a
-        // consumer has (a) installed a routing_decision_callback AND
-        // (b) opted into the diagnostic tier. Without both, the breakdown
-        // is never materialised.
+        // At the default (non-diagnostic) tier we project the detailed
+        // breakdown down to `(transport, total)` — a single scoring pass
+        // feeds both the legacy event and the routing record.
         let detailed_scores: Option<Vec<(TransportType, TransportScore)>> =
             if self.routing_diagnostic && self.routing_decision_callback.is_some() {
                 Some(self.selector.score_and_rank_detailed(message, &available))
@@ -374,9 +388,16 @@ impl TransportManager {
                 None
             };
         let detailed_slice = detailed_scores.as_deref();
+        let scored: Vec<(TransportType, f32)> = match detailed_slice {
+            Some(d) => d.iter().map(|(t, s)| (*t, s.total)).collect(),
+            None => self.selector.score_and_rank(message, &available),
+        };
+        let scores: Vec<(String, f32)> = scored.iter().map(|(t, s)| (t.to_string(), *s)).collect();
+        self.emit_dors_event(Event::dors_score_updated(scores));
 
         self.emit_routing_decision(|| {
             self.build_routing_decision(
+                now_ms,
                 RoutingPhase::ScoreUpdated,
                 previous,
                 None,
@@ -403,6 +424,7 @@ impl TransportManager {
         ));
         self.emit_routing_decision(|| {
             self.build_routing_decision(
+                now_ms,
                 RoutingPhase::Selected,
                 previous,
                 Some(primary),
@@ -441,6 +463,7 @@ impl TransportManager {
                     ));
                     self.emit_routing_decision(|| {
                         self.build_routing_decision(
+                            now_ms,
                             RoutingPhase::Switched,
                             previous,
                             Some(primary),
@@ -487,6 +510,7 @@ impl TransportManager {
                 if let Some(trigger_reason) = self.selector.escalation_trigger_reason() {
                     let reason_code = Self::escalation_trigger_reason_to_code(trigger_reason);
                     self.emit_escalation_trigger_if_deduped(
+                        now_ms,
                         reason_code,
                         primary,
                         *transport_type,
@@ -533,6 +557,7 @@ impl TransportManager {
                         let fallback = *transport_type;
                         self.emit_routing_decision(|| {
                             self.build_routing_decision(
+                                now_ms,
                                 RoutingPhase::Switched,
                                 previous,
                                 Some(fallback),
@@ -555,6 +580,7 @@ impl TransportManager {
                         let escalated = *transport_type;
                         self.emit_routing_decision(|| {
                             self.build_routing_decision(
+                                now_ms,
                                 RoutingPhase::Escalated,
                                 Some(primary),
                                 Some(escalated),


### PR DESCRIPTION
## Summary

Closes TODO item #6 — wires the four remaining `TelemetryRecord` variants (`MetricsSnapshot`, `TransportState`, `Routing`, `Device`) defined as type-only stubs in #91 and unreached by #92. All four now flow through the installed `TelemetrySink`, gated by the existing `TelemetryConfig`.

- **`MetricsFrame`** emits on `TelemetryConfig::metrics_cadence` (default 5s, `None` disables). Carries per-transport `TransportMetrics` plus `RetryQueueStats`, `DeduplicatorStats`, ACK/neighbor counts, current transport, and a local `is_local_relay` flag. No parallel `RichTransportMetrics` — reuses the existing struct verbatim (decision #1).
- **`TransportStateEvent`** fires on every observed per-transport status transition, via poll-and-diff inside `OfflineProtocol::process()`. Zero changes to the transport crate; ~30 assignment sites would have been painful to instrument directly. The diff iterates the union of previous and current keys so a `remove_transport()` between ticks emits a `prev → Unavailable` transition rather than disappearing silently.
- **`RoutingDecision`** is emitted from a new `TransportManager::set_routing_decision_callback` that fires at the same sites as the existing `dors_event_callback`. Legacy `Event::Dors*` stream is untouched — purely additive. At the **Diagnostic** tier, `RoutingDecision.scores` is populated with the full seven-factor `TransportScore` breakdown via the new `TransportSelector::score_and_rank_detailed` accessor; at the default tier the vector stays empty and the hot path avoids the per-emission allocation.
- **`DeviceCapabilitySnapshot`** emits when `(battery_level, is_charging, relay_role)` change between ticks, with a bitmask identifying which fields triggered emission.

### Design choices

- **No background thread.** `process()` is already the host-driven tick for retry, dedup expiry, and reconciliation — folded telemetry-category emission in there instead of adding tokio.
- **No scrubbing on these paths.** The four new records carry no long-lived identifiers (transport names, enum codes, battery %, relay role). The scrubber from #92 doesn't apply.
- **`routing_diagnostic: bool`** added to `TelemetryConfig` (default false). Gate for populating `RoutingDecision.scores` with the seven-factor `TransportScore` breakdown; left empty at the default tier to keep the hot path allocation-free.
- **`scrub_ids` stays on by default** (unchanged from #91).
- **`TransportScore` constructor is named-field via `TransportScoreFactors`.** External callers (benchmarks, tooling) build a `TransportScoreFactors { signal, proximity, ... }` literal rather than calling an N-arg positional constructor — same-typed `f32` factors made the positional shape a silent-misorder footgun.
- **One lock per transport per tick.** `TransportManager::snapshot_status_and_available()` returns the full status map AND the available-only metrics map in a single lock-per-transport pass, replacing the old `get_all_transport_statuses` + `get_available_transports` pair on the hot tick path.

### Out of scope

- UDL / UniFFI exposure of the new records — that's item #7.
- Relay promotion/demotion as a distinct `RoutingPhase` — deferred (relay role already surfaces via `DeviceCapabilitySnapshot`).
- `RoutingPhase::Suppressed` + structured suppression-reason payload — deferred so the shape can be designed alongside the emit sites that produce it.

### Files

- New: `crates/offline-protocol/src/telemetry/{metrics_snapshot,transport_state,routing,device,aggregator}.rs`
- New: `benches/telemetry_emission.rs` + `[[bench]]` entry in `crates/offline-protocol-bench/Cargo.toml`
- Modified: `telemetry/{mod,record,config}.rs`, `protocol/mod.rs`, `protocol/tests/mod.rs`, `transport_manager.rs`, router lib re-exports + `PathSelector::current_relay_role()` accessor + `TransportSelector::score_and_rank_detailed()` accessor + `TransportScoreFactors` type, reliability lib `RetryQueueStats` re-export, `MockTransport::set_status` test helper.

## Test plan

- [x] `cargo test --workspace` — 620 protocol tests pass, zero regressions
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo bench -p offline-protocol-bench --bench telemetry_emission -- --quick`
  - emit (Lifecycle): **2.1 – 15 ns** vs <5 µs budget
  - emit (Diagnostic routing with 5-entry score vec): **29 ns** vs <25 µs budget
  - `build_metrics_frame`: **3.5 ns**
- [x] New integration tests in `protocol/tests/mod.rs`:
  - `test_process_emits_metrics_snapshot_on_first_tick`
  - `test_process_skips_metrics_snapshot_when_cadence_is_none`
  - `test_process_emits_transport_state_on_status_transition`
  - `test_process_emits_device_capability_on_first_tick`
  - `test_process_skips_telemetry_tick_without_sink` (asserts aggregator state fields stay untouched across multiple ticks)
  - `test_legacy_dors_events_still_fire_with_routing_callback_wired` (back-compat guard)
  - `test_routing_diagnostic_populates_scores_when_enabled` / `..._default_leaves_scores_empty`
- [x] New unit tests for each record's `telemetry_name()` + catalogue drift guard extended in `telemetry/record.rs`
- [x] New unit tests in `telemetry/aggregator.rs` for diff semantics, transport removal, and `device_battery_from_available` (including the current-not-in-available fall-through path)

## Follow-ups

- Item #7: expose `TelemetrySink` + the four new typed dicts across UniFFI + React Native.