### PR TITLE
feat(bindings): telemetry-driven diagnostics in demo app

### DIFF
--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -3825,10 +3825,10 @@ extension OfflineProtocolModule {
     // The TS `TelemetryConfig` type (bindings/react-native/src/types.ts)
     // only emits camelCase keys — this parser matches that contract.
     //
-    // On unrecognised `mlsVerbosity` strings we log via RCTLogWarn and
-    // fall back to `nil` (Rust default). Silent fallback would have hid
-    // integrator typos behind "it just applies Lifecycle", which is
-    // indistinguishable from "my config took effect".
+    // On unrecognised `mlsVerbosity` strings we log a warning and fall back
+    // to `nil` (Rust default). Silent fallback would have hid integrator
+    // typos behind "it just applies Lifecycle", which is indistinguishable
+    // from "my config took effect".
     fileprivate func parseTelemetryConfig(_ dict: [String: Any]?) -> TelemetryConfig {
         guard let dict = dict else {
             return TelemetryConfig(
@@ -3844,7 +3844,7 @@ extension OfflineProtocolModule {
             case "diagnostic": verbosity = .diagnostic
             case "lifecycle": verbosity = .lifecycle
             default:
-                RCTLogWarn("OfflineProtocol telemetry: unknown mlsVerbosity '\(raw)' — expected 'off', 'lifecycle', or 'diagnostic'. Falling back to the Rust default (lifecycle).")
+                print("[OfflineProtocolModule] telemetry: unknown mlsVerbosity '\(raw)' — expected 'off', 'lifecycle', or 'diagnostic'. Falling back to the Rust default (lifecycle).")
                 verbosity = nil
             }
         } else {

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
 | [Mesh Networking](mesh.md) | Peer discovery, connection management, message delivery, and routing |
 | [MLS Encryption](mls-integration.md) | End-to-end encryption with auto-encryption and manual MLS APIs |
 | [Service Discovery](service-discovery.md) | Decentralized service registration, discovery, and request/response |
+| [Telemetry](telemetry.md) | Wire up a telemetry sink for metrics, routing decisions, and MLS lifecycle |
 | [Transport Architecture](transport-architecture.md) | Transport abstraction layer and how to add new transports |
 | [Reticulum Transport](reticulum.md) | Reticulum mesh transport setup, architecture, and platform integration |
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,242 @@
+# Telemetry
+
+Runtime observability for the Offline Protocol SDK. Telemetry is opt-in: the SDK emits nothing until an app installs a sink. Once installed, a single stream carries protocol events, MLS lifecycle, periodic metrics, transport-state transitions, routing decisions, and device-capability changes.
+
+This guide covers how to wire a sink up from React Native, Rust, and the native iOS/Android layers, plus the configuration knobs that control cadence, verbosity, and identifier scrubbing.
+
+## What you get
+
+A telemetry sink receives a stream of `TelemetryRecord`s. Each record is one of:
+
+| Category | When it fires | Payload |
+|----------|---------------|---------|
+| `metricsFrame` | Periodic (`metricsCadenceMs`) | Per-transport metrics, retry-queue depth, dedup stats, ACK-pending count, neighbor count, current transport |
+| `transportState` | A transport changes status | `{previous, current}` for a single `TransportType` |
+| `routingDecision` | DORS selects/switches/escalates | Phase, from/to, winning score, reason code, per-transport score breakdowns (diagnostic tier only) |
+| `deviceCapability` | Battery / charging / relay-role change | Current values + changed-fields bitmask |
+| `mls` | MLS session lifecycle | JSON event string (gated by `mlsVerbosity`) |
+| `protocol` | Legacy protocol events | JSON event string |
+| `extension` | Forward-compat fallback | `{name, payloadJson}` for variants added after the client's binding was built |
+
+The stream is **push-based by default** (your listener is called synchronously from the Rust side) with an optional **bounded pull queue** (1024 slots, FIFO, drops oldest on overflow) for consumers that prefer polling.
+
+## React Native
+
+Install the sink after `start()` and pass a listener. The listener is registered before the native install resolves, so no records can slip past.
+
+```typescript
+import {
+  OfflineProtocol,
+  type TelemetryRecord,
+  type TelemetryConfig,
+} from 'offline-protocol-react-native';
+
+const proto = new OfflineProtocol(config);
+await proto.start();
+
+const handleTelemetry = (rec: TelemetryRecord) => {
+  switch (rec.category) {
+    case 'metricsFrame':
+      // rec.frame.retryQueue.totalCount, rec.frame.transports, ...
+      break;
+    case 'transportState':
+      // rec.event.previous, rec.event.current
+      break;
+    case 'routingDecision':
+      // rec.decision.phase, rec.decision.reasonCode, rec.decision.scores
+      break;
+    case 'deviceCapability':
+      // rec.snapshot.batteryLevel, rec.snapshot.relayRole
+      break;
+    case 'mls':
+      // JSON.parse(rec.eventJson)
+      break;
+    case 'protocol':
+      // JSON.parse(rec.eventJson)
+      break;
+    case 'extension':
+      // forward-compat — newer SDK emitted a variant this client doesn't type yet
+      break;
+  }
+};
+
+const telemetryConfig: TelemetryConfig = {
+  metricsCadenceMs: 5000,
+  mlsVerbosity: 'lifecycle',
+  routingDiagnostic: false,
+  scrubIds: true,
+  enablePollQueue: false, // push-only; skip the per-emit JSON envelope cost
+};
+
+const unsubscribe = await proto.installTelemetrySink(
+  telemetryConfig,
+  handleTelemetry,
+);
+
+// later, during teardown:
+unsubscribe();                    // drop the JS listener
+await proto.uninstallTelemetrySink(); // detach the native sink + drain pull queue
+```
+
+### Pull mode
+
+Leave `enablePollQueue` at its default (`true` / omitted) and drain the buffer on a timer instead of using a push listener:
+
+```typescript
+await proto.installTelemetrySink({ metricsCadenceMs: 5000 });
+
+setInterval(async () => {
+  let rec;
+  while ((rec = await proto.pollTelemetry()) !== null) {
+    process(rec);
+  }
+}, 1000);
+```
+
+Mix-and-match works too: a push listener plus `pollTelemetry()` will see the same records.
+
+## Rust (core)
+
+Implement `TelemetrySink` and hand it to the protocol:
+
+```rust
+use std::sync::Arc;
+use offline_protocol::telemetry::{
+    MlsVerbosity, TelemetryConfig, TelemetryRecord, TelemetrySink,
+};
+use offline_protocol::OfflineProtocol;
+
+struct StdoutSink;
+
+impl TelemetrySink for StdoutSink {
+    fn emit(&self, record: &TelemetryRecord) {
+        match record {
+            TelemetryRecord::MetricsSnapshot(frame) => {
+                println!("retry_queue={}", frame.retry_queue.total_count);
+            }
+            TelemetryRecord::Routing(decision) => {
+                println!("routing {:?} -> {:?}", decision.from, decision.to);
+            }
+            _ => {}
+        }
+    }
+}
+
+let mut proto = OfflineProtocol::new(config)?;
+let sink: Arc<dyn TelemetrySink> = Arc::new(StdoutSink);
+let cfg = TelemetryConfig::default()
+    .with_metrics_cadence(Some(std::time::Duration::from_secs(5)))
+    .with_mls_verbosity(MlsVerbosity::Lifecycle)
+    .with_routing_diagnostic(false);
+
+proto.install_telemetry_sink(sink, cfg)?;
+proto.start()?;
+```
+
+`emit()` runs on SDK hot paths. It must not block, panic, or re-enter the SDK. Do any heavy work on a channel and handle it elsewhere.
+
+You can install the sink **before or after** `start()`. The wiring persists across `stop() → start()` cycles, so you don't need to re-install.
+
+## Native (Swift / Kotlin)
+
+The React Native bindings already install a `TelemetrySink` implementation that forwards to JS — most apps don't need to touch this layer. If you're integrating UniFFI directly from Swift or Kotlin, implement the UniFFI-exported `TelemetrySink` trait and pass it to `installTelemetrySink`. The callbacks are:
+
+```
+on_protocol_event(event_json: String)
+on_mls_event(event_json: String)
+on_metrics_frame(frame: MetricsFrame)
+on_transport_state(event: TransportStateEvent)
+on_routing_decision(decision: RoutingDecision)
+on_device_capability(snapshot: DeviceCapabilitySnapshot)
+on_extension(name: String, payload_json: String)
+```
+
+Implementations must be thread-safe and non-blocking. See `bindings/react-native/ios/OfflineProtocolModule.swift` (`TelemetrySinkImpl`) and `android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt` (`TelemetrySinkImpl`) for reference implementations that forward to the RN event emitter.
+
+## TelemetryConfig reference
+
+| Field | Type | Default | Effect |
+|-------|------|---------|--------|
+| `metricsCadenceMs` | number | `5000` | Period for `metricsFrame` emission. Pass `null` in Rust (`None`) to disable periodic metrics entirely. |
+| `mlsVerbosity` | `'off'` \| `'lifecycle'` \| `'diagnostic'` | `'lifecycle'` | Gates MLS record emission. See below. |
+| `routingDiagnostic` | boolean | `false` | When `true`, `RoutingDecision.scores` carries per-factor breakdowns (signal, proximity, bandwidth, congestion, energy, reliability, load). Off by default to avoid per-emit allocation on the DORS hot path. |
+| `scrubIds` | boolean | `true` | Hash long-lived identifiers (`peer_id`, `user_id`, `group_id`, actor fields) with SHA-256 before emission. |
+| `enablePollQueue` | boolean | `true` | When `false`, the Rust adapter skips the per-emit JSON envelope used by `pollTelemetry()`. Push listeners still fire. Leave `true` if any consumer calls `pollTelemetry()`. |
+
+Rust also exposes `with_scrub_secret([u8; 16])` for a deterministic hashing key — without it, the SDK generates a random per-instance fallback so scrubbed IDs are stable for the lifetime of one protocol instance but not across restarts.
+
+### MLS verbosity
+
+| Level | What's emitted |
+|-------|----------------|
+| `off` | No MLS records at all. |
+| `lifecycle` *(default)* | Session init, session ready, decrypt failures, session-missing events. Enough to trace handshake and key-rotation health. |
+| `diagnostic` | Lifecycle plus per-operation diagnostics. Use when investigating MLS-specific issues; noisier. |
+
+Before this runtime knob existed, MLS telemetry was gated by the `mls-observability` Cargo feature — that feature is retired. Set `mlsVerbosity` at install time instead.
+
+## MetricsFrame quick reference
+
+`MetricsFrame` is emitted on `metricsCadenceMs` and is the main surface most dashboards consume.
+
+| Field | Meaning |
+|-------|---------|
+| `timestampMs` | Emission timestamp (ms since epoch). |
+| `currentTransport` | Transport DORS has selected right now (may be absent if nothing is viable). |
+| `transports[]` | Per-transport `TransportMetrics` — counters plus RSSI, congestion, queue depth, battery, relay state, delivery ratio, etc. |
+| `retryQueue.{total,ready,critical,high,medium,low}Count` | Current heap depth, broken down by priority. `total` is instantaneous, not cumulative. |
+| `dedup` | Dedup window size, capacity used, mode. |
+| `ackPending` | Messages sent but awaiting ACK. |
+| `neighborCount` | Known neighbors in the mesh. |
+| `isLocalRelay` | Whether this device is currently acting as a relay. |
+
+See [Message Delivery](message-delivery.md) for retry-queue semantics and [DORS Deep Dive](dors.md) for what the per-transport scores mean.
+
+## Identifier scrubbing
+
+With `scrubIds: true` (the default), identifiers that persist across sessions are hashed before they reach your sink:
+
+- **Scrubbed**: `peer_id`, `user_id`, `group_id`, `sender`, `recipient`, `added_by`, `removed_by`, and similar actor fields.
+- **Not scrubbed**: `message_id`, `file_id` (single-use UUIDs), message `content`, enum values (`transport`, `status`, etc.).
+
+The hash is `SHA-256(secret || raw)` truncated to 16 bytes / 32 hex chars. The same raw ID always maps to the same hash within one protocol instance, so you can still correlate events for a given peer without ever seeing the raw identifier. Session-derived tokens are always hashed regardless of this flag.
+
+Turn scrubbing off only when debugging on a trusted device with a trusted sink.
+
+## Tips
+
+- **Install before `start()` when possible.** You'll see routing records from the very first send. Install-after-start is supported; the next tick re-arms diff snapshots so you only see real transitions, not synthetic ones.
+- **Replace vs. reinstall.** Calling `installTelemetrySink` again atomically replaces the sink but does not drain the pull queue — a consumer polling immediately after replace will see the previous sink's buffered records first. Call `uninstallTelemetrySink()` first if you need a clean slate.
+- **Don't block in `emit`.** Forward heavy work (file I/O, network upload) to a channel or background queue. The sink runs on SDK hot paths.
+- **Pick a cadence that matches your UI.** A 2s cadence is fine for a live diagnostics screen; 30s is plenty for background metric shipping. Lower cadence = less JSON serialization on the device.
+- **`routingDiagnostic: true` is for debugging.** The per-factor score breakdowns are useful when tuning DORS or investigating transport flapping, but carry per-emit allocation cost. Keep it off in production unless you're actively investigating.
+
+## Worked example
+
+The demo app (`examples/demo-app/src/context/ProtocolContext.tsx`) installs a sink on start with push delivery, a 2-second cadence, and routing diagnostics enabled so its Diagnostics screen can render per-transport score bars. The telemetry handler lives alongside the protocol-event handler and fans records into UI state:
+
+```typescript
+const handleTelemetry = useCallback((rec: TelemetryRecord) => {
+  switch (rec.category) {
+    case 'metricsFrame':
+      setLatestMetrics(rec.frame);
+      break;
+    case 'routingDecision':
+      appendRoutingHistory(rec.decision);
+      break;
+    // ...
+  }
+}, []);
+
+await proto.installTelemetrySink(
+  {
+    routingDiagnostic: true,
+    metricsCadenceMs: 2000,
+    mlsVerbosity: 'lifecycle',
+    enablePollQueue: false,
+  },
+  handleTelemetry,
+);
+```
+
+Browse `examples/demo-app/src/screens/DiagnosticsScreen.tsx` to see how each record category maps to UI.

--- a/examples/demo-app/src/App.tsx
+++ b/examples/demo-app/src/App.tsx
@@ -8,6 +8,8 @@ import {PeopleScreen} from './screens/PeopleScreen';
 import {ChatsScreen} from './screens/ChatsScreen';
 import {GroupsScreen} from './screens/GroupsScreen';
 import {ServicesScreen} from './screens/ServicesScreen';
+import {DiagnosticsScreen} from './screens/DiagnosticsScreen';
+import {StatusPill} from './components/StatusPill';
 import type {TabName} from './types';
 import {formatUserId} from './utils';
 
@@ -44,7 +46,10 @@ function MainApp() {
 
       {/* Top Bar */}
       <View style={styles.topBar}>
-        <Text style={styles.topBarTitle}>Offline Demo</Text>
+        <View style={styles.topBarLeft}>
+          <Text style={styles.topBarTitle}>Offline Demo</Text>
+          <StatusPill onPress={() => setActiveTab('diagnostics')} />
+        </View>
         <View style={styles.topBarRight}>
           <Text style={styles.topBarUser}>{userName}</Text>
           <Text style={styles.topBarId}>{formatUserId(userId)}</Text>
@@ -64,6 +69,7 @@ function MainApp() {
         )}
         {activeTab === 'groups' && <GroupsScreen />}
         {activeTab === 'services' && <ServicesScreen />}
+        {activeTab === 'diagnostics' && <DiagnosticsScreen />}
       </View>
 
       {/* Bottom Tab Bar */}
@@ -100,6 +106,12 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: '#E5E5E5',
+  },
+  topBarLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    flexShrink: 1,
   },
   topBarTitle: {
     fontSize: 18,

--- a/examples/demo-app/src/components/StatusPill.tsx
+++ b/examples/demo-app/src/components/StatusPill.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import {View, Text, TouchableOpacity, StyleSheet} from 'react-native';
+import {useProtocol} from '../context/ProtocolContext';
+import {transportColor, transportLabel} from '../telemetryFormat';
+
+interface Props {
+  onPress?: () => void;
+}
+
+/**
+ * Persistent ambient indicator wired to the live TelemetrySink stream.
+ * Reads `latestMetrics.currentTransport` and `deviceCapability` (battery,
+ * charging, relay role). Invisible until the first MetricsFrame arrives so it
+ * doesn't show stale defaults during onboarding.
+ */
+export function StatusPill({onPress}: Props) {
+  const {latestMetrics, deviceCapability, neighbors} = useProtocol();
+
+  if (!latestMetrics) {
+    return null;
+  }
+
+  const transport = latestMetrics.currentTransport;
+  const battery = deviceCapability?.batteryLevel;
+  const charging = deviceCapability?.isCharging ?? false;
+  const isRelay = latestMetrics.isLocalRelay;
+  const peers = neighbors.size;
+
+  const dotColor = transport ? transportColor(transport) : '#C7C7CC';
+
+  const Wrapper: any = onPress ? TouchableOpacity : View;
+  const wrapperProps = onPress ? {onPress, activeOpacity: 0.7} : {};
+
+  return (
+    <Wrapper {...wrapperProps} style={styles.pill}>
+      <View style={[styles.dot, {backgroundColor: dotColor}]} />
+      <Text style={styles.transport}>
+        {transport ? transportLabel(transport) : '—'}
+      </Text>
+      <View style={styles.divider} />
+      <Text style={styles.peers}>{peers}</Text>
+      <Text style={styles.peersIcon}>👥</Text>
+      {battery !== undefined && battery !== null && (
+        <>
+          <View style={styles.divider} />
+          <BatteryGlyph level={battery} charging={charging} />
+          <Text style={styles.battery}>{battery}%</Text>
+        </>
+      )}
+      {isRelay && (
+        <>
+          <View style={styles.divider} />
+          <Text style={styles.relay}>RELAY</Text>
+        </>
+      )}
+    </Wrapper>
+  );
+}
+
+function BatteryGlyph({level, charging}: {level: number; charging: boolean}) {
+  const fill = Math.max(0, Math.min(100, level));
+  const color =
+    charging ? '#34C759' : fill <= 20 ? '#FF3B30' : fill <= 40 ? '#FF9500' : '#34C759';
+  return (
+    <View style={styles.batteryGlyph}>
+      <View style={styles.batteryBody}>
+        <View style={[styles.batteryFill, {width: `${fill}%`, backgroundColor: color}]} />
+      </View>
+      <View style={styles.batteryTip} />
+      {charging && <Text style={styles.bolt}>⚡</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F2F2F7',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 999,
+    gap: 6,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  transport: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#1C1C1E',
+    letterSpacing: 0.5,
+  },
+  divider: {
+    width: StyleSheet.hairlineWidth,
+    height: 12,
+    backgroundColor: '#C7C7CC',
+  },
+  peers: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#1C1C1E',
+  },
+  peersIcon: {
+    fontSize: 10,
+    marginLeft: -4,
+  },
+  battery: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#1C1C1E',
+  },
+  batteryGlyph: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  batteryBody: {
+    width: 18,
+    height: 9,
+    borderWidth: 1,
+    borderColor: '#1C1C1E',
+    borderRadius: 2,
+    overflow: 'hidden',
+    justifyContent: 'center',
+  },
+  batteryFill: {
+    height: '100%',
+  },
+  batteryTip: {
+    width: 2,
+    height: 4,
+    backgroundColor: '#1C1C1E',
+    marginLeft: 1,
+    borderTopRightRadius: 1,
+    borderBottomRightRadius: 1,
+  },
+  bolt: {
+    position: 'absolute',
+    fontSize: 8,
+    left: 5,
+    top: -2,
+  },
+  relay: {
+    fontSize: 9,
+    fontWeight: '800',
+    color: '#FFFFFF',
+    backgroundColor: '#5856D6',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    overflow: 'hidden',
+    letterSpacing: 0.5,
+  },
+});

--- a/examples/demo-app/src/components/TabBar.tsx
+++ b/examples/demo-app/src/components/TabBar.tsx
@@ -13,6 +13,7 @@ const TABS: {key: TabName; label: string; icon: string}[] = [
   {key: 'chats', label: 'Chats', icon: '💬'},
   {key: 'groups', label: 'Groups', icon: '👨‍👩‍👧‍👦'},
   {key: 'services', label: 'Services', icon: '⚡'},
+  {key: 'diagnostics', label: 'Diagnostics', icon: '📊'},
 ];
 
 export function TabBar({activeTab, onTabChange, unreadChats}: TabBarProps) {

--- a/examples/demo-app/src/components/TelemetryViz.tsx
+++ b/examples/demo-app/src/components/TelemetryViz.tsx
@@ -1,0 +1,395 @@
+import React from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+import type {RoutingScoreEntry} from '@offline-protocol/mesh-sdk';
+import {transportColor, transportLabel} from '../telemetryFormat';
+
+// ─── MetricCard — section frame ──────────────────────────────
+
+export function MetricCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={cardStyles.card}>
+      <View style={cardStyles.header}>
+        <Text style={cardStyles.title}>{title}</Text>
+        {subtitle && <Text style={cardStyles.subtitle}>{subtitle}</Text>}
+      </View>
+      <View style={cardStyles.body}>{children}</View>
+    </View>
+  );
+}
+
+const cardStyles = StyleSheet.create({
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    marginHorizontal: 12,
+    marginTop: 12,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    paddingHorizontal: 14,
+    paddingTop: 12,
+    paddingBottom: 6,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#1C1C1E',
+    letterSpacing: 0.2,
+  },
+  subtitle: {
+    fontSize: 11,
+    color: '#8E8E93',
+    fontWeight: '500',
+  },
+  body: {
+    paddingHorizontal: 14,
+    paddingBottom: 12,
+  },
+});
+
+// ─── StatTile — small KPI tile in a row of 4 ─────────────────
+
+export function StatTile({
+  label,
+  value,
+  accent,
+  hint,
+}: {
+  label: string;
+  value: string | number;
+  accent?: string;
+  hint?: string;
+}) {
+  return (
+    <View style={tileStyles.tile}>
+      <Text style={[tileStyles.value, accent ? {color: accent} : null]}>{value}</Text>
+      <Text style={tileStyles.label}>{label}</Text>
+      {hint && <Text style={tileStyles.hint}>{hint}</Text>}
+    </View>
+  );
+}
+
+export function TileRow({children}: {children: React.ReactNode}) {
+  return <View style={tileStyles.row}>{children}</View>;
+}
+
+const tileStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  tile: {
+    flex: 1,
+    backgroundColor: '#F2F2F7',
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 8,
+    alignItems: 'center',
+  },
+  value: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#1C1C1E',
+    fontVariant: ['tabular-nums'],
+  },
+  label: {
+    fontSize: 10,
+    color: '#8E8E93',
+    fontWeight: '600',
+    marginTop: 2,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  hint: {
+    fontSize: 10,
+    color: '#8E8E93',
+    marginTop: 2,
+  },
+});
+
+// ─── Bar — labelled horizontal bar ───────────────────────────
+
+export function Bar({
+  label,
+  value,
+  max = 1,
+  color = '#007AFF',
+  rightLabel,
+  height = 6,
+}: {
+  label?: string;
+  value: number;
+  max?: number;
+  color?: string;
+  rightLabel?: string;
+  height?: number;
+}) {
+  const ratio = max > 0 ? Math.max(0, Math.min(1, value / max)) : 0;
+  return (
+    <View style={barStyles.row}>
+      {label !== undefined && (
+        <Text style={barStyles.label} numberOfLines={1}>
+          {label}
+        </Text>
+      )}
+      <View style={[barStyles.track, {height}]}>
+        <View
+          style={[
+            barStyles.fill,
+            {width: `${ratio * 100}%`, backgroundColor: color, height},
+          ]}
+        />
+      </View>
+      {rightLabel !== undefined && (
+        <Text style={barStyles.rightLabel}>{rightLabel}</Text>
+      )}
+    </View>
+  );
+}
+
+const barStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 3,
+    gap: 8,
+  },
+  label: {
+    fontSize: 11,
+    color: '#3C3C43',
+    width: 78,
+    fontWeight: '500',
+  },
+  track: {
+    flex: 1,
+    backgroundColor: '#E5E5EA',
+    borderRadius: 999,
+    overflow: 'hidden',
+  },
+  fill: {
+    borderRadius: 999,
+  },
+  rightLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#1C1C1E',
+    width: 56,
+    textAlign: 'right',
+    fontVariant: ['tabular-nums'],
+  },
+});
+
+// ─── KeyValueRow — 2-col table row ───────────────────────────
+
+export function KeyValueRow({
+  k,
+  v,
+  accent,
+}: {
+  k: string;
+  v: string | number;
+  accent?: string;
+}) {
+  return (
+    <View style={kvStyles.row}>
+      <Text style={kvStyles.k}>{k}</Text>
+      <Text style={[kvStyles.v, accent ? {color: accent} : null]}>{v}</Text>
+    </View>
+  );
+}
+
+const kvStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  k: {
+    fontSize: 12,
+    color: '#8E8E93',
+    fontWeight: '500',
+  },
+  v: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#1C1C1E',
+    fontVariant: ['tabular-nums'],
+  },
+});
+
+// ─── Sparkline — bar-style mini chart ────────────────────────
+
+export function Sparkline({
+  values,
+  color = '#007AFF',
+  height = 28,
+}: {
+  values: number[];
+  color?: string;
+  height?: number;
+}) {
+  if (values.length === 0) {
+    return <View style={[sparkStyles.row, {height}]} />;
+  }
+  const max = Math.max(1, ...values);
+  return (
+    <View style={[sparkStyles.row, {height}]}>
+      {values.map((v, i) => {
+        const ratio = max > 0 ? v / max : 0;
+        return (
+          <View
+            key={i}
+            style={[
+              sparkStyles.bar,
+              {
+                height: Math.max(1, ratio * height),
+                backgroundColor: color,
+                opacity: 0.35 + 0.65 * (i / Math.max(1, values.length - 1)),
+              },
+            ]}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+const sparkStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 1,
+  },
+  bar: {
+    flex: 1,
+    minWidth: 2,
+    borderRadius: 1,
+  },
+});
+
+// ─── TransportBadge — colored chip ───────────────────────────
+
+export function TransportBadge({
+  transport,
+  small,
+}: {
+  transport: string;
+  small?: boolean;
+}) {
+  const color = transportColor(transport);
+  return (
+    <View
+      style={[
+        badgeStyles.badge,
+        {backgroundColor: color},
+        small && badgeStyles.badgeSmall,
+      ]}>
+      <Text style={[badgeStyles.text, small && badgeStyles.textSmall]}>
+        {transportLabel(transport)}
+      </Text>
+    </View>
+  );
+}
+
+const badgeStyles = StyleSheet.create({
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+    alignSelf: 'flex-start',
+  },
+  badgeSmall: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  text: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    letterSpacing: 0.4,
+  },
+  textSmall: {
+    fontSize: 9,
+  },
+});
+
+// ─── RoutingScoreBars — full DORS breakdown for one row ──────
+
+const SCORE_DIMENSIONS: Array<{key: keyof RoutingScoreEntry; label: string; color: string}> = [
+  {key: 'signal', label: 'Signal', color: '#007AFF'},
+  {key: 'proximity', label: 'Proximity', color: '#5AC8FA'},
+  {key: 'bandwidth', label: 'Bandwidth', color: '#34C759'},
+  {key: 'congestion', label: 'Congestion', color: '#FF9500'},
+  {key: 'energy', label: 'Energy', color: '#FFCC00'},
+  {key: 'reliability', label: 'Reliability', color: '#5856D6'},
+  {key: 'load', label: 'Load', color: '#AF52DE'},
+];
+
+export function RoutingScoreBars({entry}: {entry: RoutingScoreEntry}) {
+  const max = Math.max(
+    1,
+    ...SCORE_DIMENSIONS.map(d => Math.abs(Number(entry[d.key]) || 0)),
+    Math.abs(entry.total),
+  );
+  return (
+    <View style={scoreStyles.wrap}>
+      <View style={scoreStyles.header}>
+        <TransportBadge transport={entry.transport} small />
+        <Text style={scoreStyles.total}>total {entry.total.toFixed(2)}</Text>
+      </View>
+      {SCORE_DIMENSIONS.map(d => {
+        const v = Number(entry[d.key]) || 0;
+        return (
+          <Bar
+            key={d.key as string}
+            label={d.label}
+            value={Math.abs(v)}
+            max={max}
+            color={d.color}
+            rightLabel={v.toFixed(2)}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+const scoreStyles = StyleSheet.create({
+  wrap: {
+    backgroundColor: '#F2F2F7',
+    borderRadius: 8,
+    padding: 10,
+    marginTop: 8,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  total: {
+    fontSize: 11,
+    color: '#8E8E93',
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+  },
+});
+
+// ─── Section divider for headings inside a card ──────────────
+
+export function CardDivider() {
+  return <View style={{height: StyleSheet.hairlineWidth, backgroundColor: '#E5E5EA', marginVertical: 8}} />;
+}

--- a/examples/demo-app/src/components/TelemetryViz.tsx
+++ b/examples/demo-app/src/components/TelemetryViz.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {View, Text, StyleSheet} from 'react-native';
-import type {RoutingScoreEntry} from '@offline-protocol/mesh-sdk';
 import {transportColor, transportLabel} from '../telemetryFormat';
 
 // ─── MetricCard — section frame ──────────────────────────────
@@ -326,40 +325,39 @@ const badgeStyles = StyleSheet.create({
   },
 });
 
-// ─── RoutingScoreBars — full DORS breakdown for one row ──────
+// ─── Segmented bar — stacked segments for share-of-total views ───
 
-const SCORE_DIMENSIONS: Array<{key: keyof RoutingScoreEntry; label: string; color: string}> = [
-  {key: 'signal', label: 'Signal', color: '#007AFF'},
-  {key: 'proximity', label: 'Proximity', color: '#5AC8FA'},
-  {key: 'bandwidth', label: 'Bandwidth', color: '#34C759'},
-  {key: 'congestion', label: 'Congestion', color: '#FF9500'},
-  {key: 'energy', label: 'Energy', color: '#FFCC00'},
-  {key: 'reliability', label: 'Reliability', color: '#5856D6'},
-  {key: 'load', label: 'Load', color: '#AF52DE'},
-];
+export interface SegmentedBarSegment {
+  key: string;
+  value: number;
+  color: string;
+  label?: string;
+}
 
-export function RoutingScoreBars({entry}: {entry: RoutingScoreEntry}) {
-  const max = Math.max(
-    1,
-    ...SCORE_DIMENSIONS.map(d => Math.abs(Number(entry[d.key]) || 0)),
-    Math.abs(entry.total),
-  );
+/**
+ * A single horizontal bar split into colored segments proportional to each
+ * segment's value. Used by the transport-distribution card.
+ * Renders nothing when `total <= 0` so callers can inline it without guards.
+ */
+export function SegmentedBar({
+  segments,
+  height = 14,
+}: {
+  segments: SegmentedBarSegment[];
+  height?: number;
+}) {
+  const total = segments.reduce((s, seg) => s + Math.max(0, seg.value), 0);
+  if (total <= 0) {return null;}
   return (
-    <View style={scoreStyles.wrap}>
-      <View style={scoreStyles.header}>
-        <TransportBadge transport={entry.transport} small />
-        <Text style={scoreStyles.total}>total {entry.total.toFixed(2)}</Text>
-      </View>
-      {SCORE_DIMENSIONS.map(d => {
-        const v = Number(entry[d.key]) || 0;
+    <View style={[segmentStyles.track, {height}]}>
+      {segments.map(seg => {
+        const v = Math.max(0, seg.value);
+        if (v === 0) {return null;}
+        const pct = (v / total) * 100;
         return (
-          <Bar
-            key={d.key as string}
-            label={d.label}
-            value={Math.abs(v)}
-            max={max}
-            color={d.color}
-            rightLabel={v.toFixed(2)}
+          <View
+            key={seg.key}
+            style={{width: `${pct}%`, backgroundColor: seg.color, height}}
           />
         );
       })}
@@ -367,23 +365,103 @@ export function RoutingScoreBars({entry}: {entry: RoutingScoreEntry}) {
   );
 }
 
-const scoreStyles = StyleSheet.create({
-  wrap: {
-    backgroundColor: '#F2F2F7',
-    borderRadius: 8,
-    padding: 10,
-    marginTop: 8,
-  },
-  header: {
+const segmentStyles = StyleSheet.create({
+  track: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 4,
+    width: '100%',
+    backgroundColor: '#E5E5EA',
+    borderRadius: 999,
+    overflow: 'hidden',
   },
-  total: {
-    fontSize: 11,
-    color: '#8E8E93',
+});
+
+// ─── VerticalHistogram — vertical bar distribution ──────────────
+
+/**
+ * Vertical bar histogram for distributions keyed by integer bucket
+ * (hop count, retry count, etc.). Labels each column with its bucket
+ * key and renders count below. Empty buckets are shown as empty columns
+ * so the shape of the distribution is visible.
+ */
+export function VerticalHistogram({
+  buckets,
+  color = '#007AFF',
+  height = 60,
+}: {
+  buckets: Array<{key: string | number; value: number}>;
+  color?: string;
+  height?: number;
+}) {
+  const max = Math.max(1, ...buckets.map(b => b.value));
+  return (
+    <View style={histoStyles.wrap}>
+      <View style={[histoStyles.row, {height}]}>
+        {buckets.map(b => {
+          const ratio = b.value / max;
+          return (
+            <View key={String(b.key)} style={histoStyles.col}>
+              <View style={histoStyles.barWrap}>
+                <View
+                  style={[
+                    histoStyles.bar,
+                    {height: Math.max(b.value > 0 ? 2 : 0, ratio * height), backgroundColor: color},
+                  ]}
+                />
+              </View>
+            </View>
+          );
+        })}
+      </View>
+      <View style={histoStyles.labelRow}>
+        {buckets.map(b => (
+          <View key={`l-${b.key}`} style={histoStyles.col}>
+            <Text style={histoStyles.bucketLabel}>{b.key}</Text>
+            <Text style={histoStyles.bucketValue}>{b.value}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const histoStyles = StyleSheet.create({
+  wrap: {
+    marginTop: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 3,
+  },
+  col: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  barWrap: {
+    width: '100%',
+    flex: 1,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  bar: {
+    width: '80%',
+    borderTopLeftRadius: 2,
+    borderTopRightRadius: 2,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    gap: 3,
+    marginTop: 4,
+  },
+  bucketLabel: {
+    fontSize: 10,
+    color: '#3C3C43',
     fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+  },
+  bucketValue: {
+    fontSize: 9,
+    color: '#8E8E93',
     fontVariant: ['tabular-nums'],
   },
 });

--- a/examples/demo-app/src/context/ProtocolContext.tsx
+++ b/examples/demo-app/src/context/ProtocolContext.tsx
@@ -18,7 +18,7 @@ import type {
   RoutingDecision,
   DeviceCapabilitySnapshot,
 } from '@offline-protocol/mesh-sdk';
-import type {Contact, Neighbor, ConnectionRequest, ChatMessage, Chat, Group, GroupRole, DiscoveredService, ServiceLogEntry, ForwardInfo, PresenceStatus, MlsLogEntry} from '../types';
+import type {Contact, Neighbor, ConnectionRequest, ChatMessage, Chat, Group, GroupRole, DiscoveredService, ServiceLogEntry, ForwardInfo, PresenceStatus} from '../types';
 import {
   PRESENCE_BROADCAST_INTERVAL_MS,
   TYPING_INDICATOR_TIMEOUT_MS,
@@ -46,15 +46,17 @@ interface ProtocolContextValue {
   /** Map of peerId → timestamp when they started typing */
   typingPeers: Map<string, number>;
 
-  // Telemetry state (populated by installed TelemetrySink)
+  // Telemetry state (populated by installed TelemetrySink).
+  // Shape is intentionally narrow: only fields that feed aggregate,
+  // anonymized visualizations in DiagnosticsScreen are persisted.
   latestMetrics: MetricsFrame | null;
   metricsHistory: MetricsFrame[];
   transportTimeline: TransportStateTelemetryEvent[];
   routingDecisions: RoutingDecision[];
   deviceCapability: DeviceCapabilitySnapshot | null;
-  mlsLog: MlsLogEntry[];
-  eventCounts: Record<string, number>;
-  totalProtocolEvents: number;
+  deviceCapabilityHistory: DeviceCapabilitySnapshot[];
+  /** Count of received/delivered messages keyed by observed hop_count. */
+  hopCountHistogram: Record<number, number>;
 
   // Actions
   initialize: (userId: string, userName: string) => Promise<void>;
@@ -82,6 +84,30 @@ interface ProtocolContextValue {
   unblockUser: (peerId: string) => Promise<void>;
   sendTypingIndicator: (recipientId: string, isTyping: boolean) => Promise<void>;
 }
+
+// Bounded-buffer caps for telemetry streams. Hoisted to module scope so they
+// don't need to live in the `useCallback([])` dep array of `handleTelemetry`.
+//
+// Sizing rationale:
+// - METRICS_HISTORY: 60 frames × 2 s cadence = 120 s. Long enough that
+//   partition/transport-time distributions have signal but short enough to
+//   stay fresh on a phone.
+// - TIMELINE/DECISIONS: 50 is enough to compute stable link-flap and DORS
+//   driver aggregates without growing unbounded under flap storms.
+// - DEVICE_HISTORY: deviceCapability only emits on change; 60 samples covers
+//   an entire battery cycle comfortably.
+const MAX_METRICS_HISTORY = 60;
+const MAX_TIMELINE = 50;
+const MAX_DECISIONS = 50;
+const MAX_DEVICE_HISTORY = 60;
+const MAX_SERVICE_LOG = 100;
+
+// Protocol event types whose payload carries a final-delivery `hop_count` we
+// want to fold into the anonymized hop-count distribution.
+const HOP_COUNT_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'message_received',
+  'message_delivered',
+]);
 
 const ProtocolContext = createContext<ProtocolContextValue | null>(null);
 
@@ -117,16 +143,9 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
   const [transportTimeline, setTransportTimeline] = useState<TransportStateTelemetryEvent[]>([]);
   const [routingDecisions, setRoutingDecisions] = useState<RoutingDecision[]>([]);
   const [deviceCapability, setDeviceCapability] = useState<DeviceCapabilitySnapshot | null>(null);
-  const [mlsLog, setMlsLog] = useState<MlsLogEntry[]>([]);
-  const [eventCounts, setEventCounts] = useState<Record<string, number>>({});
-  const [totalProtocolEvents, setTotalProtocolEvents] = useState(0);
+  const [deviceCapabilityHistory, setDeviceCapabilityHistory] = useState<DeviceCapabilitySnapshot[]>([]);
+  const [hopCountHistogram, setHopCountHistogram] = useState<Record<number, number>>({});
 
-  const MAX_METRICS_HISTORY = 30;
-  const MAX_TIMELINE = 50;
-  const MAX_DECISIONS = 50;
-  const MAX_MLS_LOG = 50;
-
-  const MAX_SERVICE_LOG = 100;
   const appendServiceLog = useCallback((entry: ServiceLogEntry) => {
     setServiceLog(prev => {
       const next = [...prev, entry];
@@ -135,6 +154,7 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
   }, []);
 
   const protocolRef = useRef<OfflineProtocol | null>(null);
+  const telemetryUnsubscribeRef = useRef<(() => void) | null>(null);
   const processedMessagesRef = useRef<Set<string>>(new Set());
   const contactsRef = useRef<Map<string, Contact>>(contacts);
   const neighborsRef = useRef<Map<string, Neighbor>>(neighbors);
@@ -884,38 +904,38 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
       }
       case 'deviceCapability': {
         setDeviceCapability(rec.snapshot);
-        break;
-      }
-      case 'mls': {
-        let parsed: any = null;
-        let evType = 'unknown';
-        try {
-          parsed = JSON.parse(rec.eventJson);
-          evType = parsed?.type || parsed?.event || 'unknown';
-        } catch {
-          /* ignore — keep raw */
-        }
-        setMlsLog(prev => {
-          const entry: MlsLogEntry = {ts: Date.now(), type: evType, raw: parsed ?? rec.eventJson};
-          const next = [entry, ...prev];
-          return next.length > MAX_MLS_LOG ? next.slice(0, MAX_MLS_LOG) : next;
+        setDeviceCapabilityHistory(prev => {
+          const next = [...prev, rec.snapshot];
+          return next.length > MAX_DEVICE_HISTORY ? next.slice(-MAX_DEVICE_HISTORY) : next;
         });
         break;
       }
       case 'protocol': {
-        let evType = 'unknown';
+        // Only fold events that carry a final-delivery hop_count into the
+        // hop-distribution histogram — everything else is dropped here to
+        // avoid per-event context re-renders (every useProtocol() consumer
+        // would otherwise re-render on every message).
         try {
           const parsed = JSON.parse(rec.eventJson);
-          evType = parsed?.type || parsed?.event || 'unknown';
+          if (HOP_COUNT_EVENT_TYPES.has(parsed?.type)) {
+            const hop = parsed.hop_count;
+            if (typeof hop === 'number' && Number.isFinite(hop) && hop >= 0) {
+              const bucket = Math.min(Math.floor(hop), 15);
+              setHopCountHistogram(prev => ({
+                ...prev,
+                [bucket]: (prev[bucket] ?? 0) + 1,
+              }));
+            }
+          }
         } catch {
-          /* ignore */
+          /* malformed envelope — skip silently, not actionable in UI */
         }
-        setEventCounts(prev => ({...prev, [evType]: (prev[evType] || 0) + 1}));
-        setTotalProtocolEvents(n => n + 1);
         break;
       }
+      case 'mls':
       case 'extension':
       default:
+        // Unused in aggregate diagnostics. Intentional no-op.
         break;
     }
   }, []);
@@ -952,7 +972,10 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
     // / decryption-failed without per-op spam; pull queue disabled because we
     // consume via callback only.
     try {
-      await proto.installTelemetrySink(
+      // Capture the unsubscribe so cleanup can drop the JS-side listener —
+      // `uninstallTelemetrySink()` detaches the native sink but leaves
+      // listeners bound by design (see SDK docstring).
+      const unsubscribe = await proto.installTelemetrySink(
         {
           routingDiagnostic: true,
           metricsCadenceMs: 2000,
@@ -961,6 +984,7 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
         },
         handleTelemetry,
       );
+      telemetryUnsubscribeRef.current = unsubscribe;
     } catch (err) {
       console.warn('[ProtocolContext] installTelemetrySink failed:', err);
     }
@@ -1050,6 +1074,8 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
   useEffect(() => {
     return () => {
       if (protocolRef.current) {
+        telemetryUnsubscribeRef.current?.();
+        telemetryUnsubscribeRef.current = null;
         protocolRef.current.uninstallTelemetrySink().catch(() => {});
         protocolRef.current.removeAllListeners();
         protocolRef.current.stop().catch(console.warn);
@@ -1568,9 +1594,8 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
     transportTimeline,
     routingDecisions,
     deviceCapability,
-    mlsLog,
-    eventCounts,
-    totalProtocolEvents,
+    deviceCapabilityHistory,
+    hopCountHistogram,
     initialize,
     sendMessage,
     sendConnectionRequest: sendConnectionRequestAction,

--- a/examples/demo-app/src/context/ProtocolContext.tsx
+++ b/examples/demo-app/src/context/ProtocolContext.tsx
@@ -11,7 +11,14 @@ import {
   MeshServices,
   MessagePriority,
 } from '@offline-protocol/mesh-sdk';
-import type {Contact, Neighbor, ConnectionRequest, ChatMessage, Chat, Group, GroupRole, DiscoveredService, ServiceLogEntry, ForwardInfo, PresenceStatus} from '../types';
+import type {
+  TelemetryRecord,
+  MetricsFrame,
+  TransportStateTelemetryEvent,
+  RoutingDecision,
+  DeviceCapabilitySnapshot,
+} from '@offline-protocol/mesh-sdk';
+import type {Contact, Neighbor, ConnectionRequest, ChatMessage, Chat, Group, GroupRole, DiscoveredService, ServiceLogEntry, ForwardInfo, PresenceStatus, MlsLogEntry} from '../types';
 import {
   PRESENCE_BROADCAST_INTERVAL_MS,
   TYPING_INDICATOR_TIMEOUT_MS,
@@ -38,6 +45,16 @@ interface ProtocolContextValue {
   serviceLog: ServiceLogEntry[];
   /** Map of peerId → timestamp when they started typing */
   typingPeers: Map<string, number>;
+
+  // Telemetry state (populated by installed TelemetrySink)
+  latestMetrics: MetricsFrame | null;
+  metricsHistory: MetricsFrame[];
+  transportTimeline: TransportStateTelemetryEvent[];
+  routingDecisions: RoutingDecision[];
+  deviceCapability: DeviceCapabilitySnapshot | null;
+  mlsLog: MlsLogEntry[];
+  eventCounts: Record<string, number>;
+  totalProtocolEvents: number;
 
   // Actions
   initialize: (userId: string, userName: string) => Promise<void>;
@@ -93,6 +110,21 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
   const [discoveredServices, setDiscoveredServices] = useState<DiscoveredService[]>([]);
   const [serviceLog, setServiceLog] = useState<ServiceLogEntry[]>([]);
   const [typingPeers, setTypingPeers] = useState<Map<string, number>>(new Map());
+
+  // ─── Telemetry state ──────────────────────────────────────
+  const [latestMetrics, setLatestMetrics] = useState<MetricsFrame | null>(null);
+  const [metricsHistory, setMetricsHistory] = useState<MetricsFrame[]>([]);
+  const [transportTimeline, setTransportTimeline] = useState<TransportStateTelemetryEvent[]>([]);
+  const [routingDecisions, setRoutingDecisions] = useState<RoutingDecision[]>([]);
+  const [deviceCapability, setDeviceCapability] = useState<DeviceCapabilitySnapshot | null>(null);
+  const [mlsLog, setMlsLog] = useState<MlsLogEntry[]>([]);
+  const [eventCounts, setEventCounts] = useState<Record<string, number>>({});
+  const [totalProtocolEvents, setTotalProtocolEvents] = useState(0);
+
+  const MAX_METRICS_HISTORY = 30;
+  const MAX_TIMELINE = 50;
+  const MAX_DECISIONS = 50;
+  const MAX_MLS_LOG = 50;
 
   const MAX_SERVICE_LOG = 100;
   const appendServiceLog = useCallback((entry: ServiceLogEntry) => {
@@ -824,6 +856,70 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
     }
   }, []);
 
+  // ─── Telemetry handler ───────────────────────────────────
+
+  const handleTelemetry = useCallback((rec: TelemetryRecord) => {
+    switch (rec.category) {
+      case 'metricsFrame': {
+        setLatestMetrics(rec.frame);
+        setMetricsHistory(prev => {
+          const next = [...prev, rec.frame];
+          return next.length > MAX_METRICS_HISTORY ? next.slice(-MAX_METRICS_HISTORY) : next;
+        });
+        break;
+      }
+      case 'transportState': {
+        setTransportTimeline(prev => {
+          const next = [rec.event, ...prev];
+          return next.length > MAX_TIMELINE ? next.slice(0, MAX_TIMELINE) : next;
+        });
+        break;
+      }
+      case 'routingDecision': {
+        setRoutingDecisions(prev => {
+          const next = [rec.decision, ...prev];
+          return next.length > MAX_DECISIONS ? next.slice(0, MAX_DECISIONS) : next;
+        });
+        break;
+      }
+      case 'deviceCapability': {
+        setDeviceCapability(rec.snapshot);
+        break;
+      }
+      case 'mls': {
+        let parsed: any = null;
+        let evType = 'unknown';
+        try {
+          parsed = JSON.parse(rec.eventJson);
+          evType = parsed?.type || parsed?.event || 'unknown';
+        } catch {
+          /* ignore — keep raw */
+        }
+        setMlsLog(prev => {
+          const entry: MlsLogEntry = {ts: Date.now(), type: evType, raw: parsed ?? rec.eventJson};
+          const next = [entry, ...prev];
+          return next.length > MAX_MLS_LOG ? next.slice(0, MAX_MLS_LOG) : next;
+        });
+        break;
+      }
+      case 'protocol': {
+        let evType = 'unknown';
+        try {
+          const parsed = JSON.parse(rec.eventJson);
+          evType = parsed?.type || parsed?.event || 'unknown';
+        } catch {
+          /* ignore */
+        }
+        setEventCounts(prev => ({...prev, [evType]: (prev[evType] || 0) + 1}));
+        setTotalProtocolEvents(n => n + 1);
+        break;
+      }
+      case 'extension':
+      default:
+        break;
+    }
+  }, []);
+
   // ─── Initialize Protocol ─────────────────────────────────
 
   const initialize = useCallback(async (uid: string, uname: string) => {
@@ -849,7 +945,26 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
     // Initialize mesh services
     const svc = new MeshServices();
     setMeshServices(svc);
-  }, [handleEvent]);
+
+    // Install telemetry sink — push delivery, fast cadence, full DORS detail.
+    // routingDiagnostic gives per-transport score breakdowns the demo renders
+    // as bar charts; mls verbosity stays at 'lifecycle' so we get session ready
+    // / decryption-failed without per-op spam; pull queue disabled because we
+    // consume via callback only.
+    try {
+      await proto.installTelemetrySink(
+        {
+          routingDiagnostic: true,
+          metricsCadenceMs: 2000,
+          mlsVerbosity: 'lifecycle',
+          enablePollQueue: false,
+        },
+        handleTelemetry,
+      );
+    } catch (err) {
+      console.warn('[ProtocolContext] installTelemetrySink failed:', err);
+    }
+  }, [handleEvent, handleTelemetry]);
 
   // ─── Presence Broadcasting ───────────────────────────────
 
@@ -935,6 +1050,7 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
   useEffect(() => {
     return () => {
       if (protocolRef.current) {
+        protocolRef.current.uninstallTelemetrySink().catch(() => {});
         protocolRef.current.removeAllListeners();
         protocolRef.current.stop().catch(console.warn);
       }
@@ -1447,6 +1563,14 @@ export function ProtocolProvider({children}: {children: React.ReactNode}) {
     discoveredServices,
     serviceLog,
     typingPeers,
+    latestMetrics,
+    metricsHistory,
+    transportTimeline,
+    routingDecisions,
+    deviceCapability,
+    mlsLog,
+    eventCounts,
+    totalProtocolEvents,
     initialize,
     sendMessage,
     sendConnectionRequest: sendConnectionRequestAction,

--- a/examples/demo-app/src/screens/DiagnosticsScreen.tsx
+++ b/examples/demo-app/src/screens/DiagnosticsScreen.tsx
@@ -1,5 +1,5 @@
-import React, {useMemo, useState} from 'react';
-import {View, Text, ScrollView, StyleSheet, TouchableOpacity} from 'react-native';
+import React, {useMemo} from 'react';
+import {View, Text, ScrollView, StyleSheet} from 'react-native';
 import {useProtocol} from '../context/ProtocolContext';
 import {
   MetricCard,
@@ -9,22 +9,34 @@ import {
   KeyValueRow,
   Sparkline,
   TransportBadge,
-  RoutingScoreBars,
+  SegmentedBar,
+  VerticalHistogram,
   CardDivider,
 } from '../components/TelemetryViz';
 import {
   transportColor,
   transportLabel,
-  transportStatusColor,
-  routingPhaseColor,
   reasonLabel,
-  formatBytes,
-  formatCount,
-  formatPercent,
   formatRelative,
 } from '../telemetryFormat';
-import type {RoutingDecision, MetricsFrame} from '@offline-protocol/mesh-sdk';
+import type {
+  MetricsFrame,
+  TransportStateTelemetryEvent,
+  RoutingDecision,
+  DeviceCapabilitySnapshot,
+  TransportType,
+  RoutingReasonCode,
+} from '@offline-protocol/mesh-sdk';
 
+/**
+ * Diagnostics screen.
+ *
+ * Visualizes only the ethical, aggregate, anonymized observations the SDK
+ * emits: no peer IDs, no message content, no per-decision internals — just
+ * the shape of the mesh from this device's vantage point. Every card is
+ * either (a) directly wired to a SDK-emitted field, or (b) a pure derivation
+ * over a telemetry buffer already populated by ProtocolContext.
+ */
 export function DiagnosticsScreen() {
   const {
     latestMetrics,
@@ -32,9 +44,8 @@ export function DiagnosticsScreen() {
     transportTimeline,
     routingDecisions,
     deviceCapability,
-    mlsLog,
-    eventCounts,
-    totalProtocolEvents,
+    deviceCapabilityHistory,
+    hopCountHistogram,
   } = useProtocol();
 
   return (
@@ -42,602 +53,635 @@ export function DiagnosticsScreen() {
       style={styles.scroll}
       contentContainerStyle={styles.content}
       showsVerticalScrollIndicator={false}>
-      <HeroCard metrics={latestMetrics} history={metricsHistory} />
-      <NetworkAtAGlance metrics={latestMetrics} />
-      <DeviceCapabilityCard
-        snapshot={deviceCapability}
-        isLocalRelay={latestMetrics?.isLocalRelay ?? false}
+      <MeshHealthCard metrics={latestMetrics} history={metricsHistory} />
+      <TransportDistributionCard history={metricsHistory} />
+      <DorsDriversCard decisions={routingDecisions} />
+      <LinkStabilityCard timeline={transportTimeline} />
+      <ReliabilityCard metrics={latestMetrics} />
+      <HopDistributionCard histogram={hopCountHistogram} />
+      <RetryQueueCard metrics={latestMetrics} />
+      <PartitionCard history={metricsHistory} />
+      <BatteryImpactCard
+        latest={deviceCapability}
+        history={deviceCapabilityHistory}
+        relayActiveNow={latestMetrics?.isLocalRelay ?? false}
       />
-      <PerTransportCard metrics={latestMetrics} history={metricsHistory} />
-      <RetryDedupCard metrics={latestMetrics} />
-      <RoutingDecisionsCard decisions={routingDecisions} />
-      <TransportTimelineCard timeline={transportTimeline} />
-      <MlsLogCard log={mlsLog} />
-      <EventCountersCard counts={eventCounts} total={totalProtocolEvents} />
       <View style={styles.footer}>
         <Text style={styles.footerText}>
-          Live stream from TelemetrySink · push delivery · 2s metrics cadence
+          Aggregate, anonymized observations · live from TelemetrySink · 2s cadence
         </Text>
       </View>
     </ScrollView>
   );
 }
 
-// ─── Hero ────────────────────────────────────────────────────
+// ─── Mesh Health ─────────────────────────────────────────────
 
-function HeroCard({
+function MeshHealthCard({
   metrics,
   history,
 }: {
   metrics: MetricsFrame | null;
   history: MetricsFrame[];
 }) {
+  const neighborSeries = useMemo(
+    () => history.map(f => f.neighborCount),
+    [history],
+  );
+
   if (!metrics) {
     return (
-      <View style={styles.hero}>
-        <Text style={styles.heroEmpty}>Waiting for first telemetry frame…</Text>
-      </View>
+      <MetricCard title="Mesh Health" subtitle="waiting for first frame">
+        <Text style={styles.empty}>No telemetry frames received yet.</Text>
+      </MetricCard>
     );
   }
+
   const transport = metrics.currentTransport;
   const color = transport ? transportColor(transport) : '#8E8E93';
   const label = transport ? transportLabel(transport) : 'NONE';
-
-  // Aggregate packets-per-frame across all transports for a hero sparkline
-  const series = useMemo(() => {
-    if (history.length < 2) {return [];}
-    const totals = history.map(f =>
-      f.transports.reduce((s, t) => s + t.metrics.packetsSent + t.metrics.packetsReceived, 0),
-    );
-    const deltas: number[] = [];
-    for (let i = 1; i < totals.length; i++) {
-      deltas.push(Math.max(0, totals[i] - totals[i - 1]));
-    }
-    return deltas;
-  }, [history]);
+  const connected = metrics.neighborCount > 0;
 
   return (
-    <View style={[styles.hero, {borderLeftColor: color}]}>
-      <View style={styles.heroTop}>
+    <MetricCard title="Mesh Health" subtitle={formatRelative(metrics.timestampMs)}>
+      <View style={styles.heroRow}>
         <View>
-          <Text style={styles.heroLabel}>ACTIVE TRANSPORT</Text>
-          <View style={styles.heroRow}>
+          <Text style={styles.heroKicker}>ACTIVE TRANSPORT</Text>
+          <View style={styles.heroLine}>
             <View style={[styles.heroDot, {backgroundColor: color}]} />
             <Text style={[styles.heroValue, {color}]}>{label}</Text>
           </View>
         </View>
-        <View>
-          <Text style={styles.heroLabel}>UPDATED</Text>
-          <Text style={styles.heroSecondary}>{formatRelative(metrics.timestampMs)}</Text>
+        <View style={styles.heroRight}>
+          <Text style={styles.heroKicker}>REACHABILITY</Text>
+          <Text
+            style={[
+              styles.heroReach,
+              {color: connected ? '#34C759' : '#FF3B30'},
+            ]}>
+            {connected ? 'CONNECTED' : 'PARTITIONED'}
+          </Text>
         </View>
       </View>
-      {series.length > 0 && (
-        <View style={styles.heroSpark}>
-          <Sparkline values={series} color={color} height={36} />
-          <Text style={styles.heroSparkLabel}>packets / 2s · last {series.length} frames</Text>
-        </View>
-      )}
-    </View>
-  );
-}
-
-// ─── Network at a glance ─────────────────────────────────────
-
-function NetworkAtAGlance({metrics}: {metrics: MetricsFrame | null}) {
-  if (!metrics) {return null;}
-  const dedupPct = Math.round(metrics.dedup.capacityUsedPercent);
-  return (
-    <MetricCard title="Network at a Glance">
       <TileRow>
+        <StatTile label="Neighbors" value={metrics.neighborCount} />
         <StatTile
-          label="Neighbors"
+          label="Role"
+          value={metrics.isLocalRelay ? 'RELAY' : 'LEAF'}
+          accent={metrics.isLocalRelay ? '#5856D6' : undefined}
+        />
+        <StatTile
+          label="Degree"
           value={metrics.neighborCount}
-          accent={metrics.neighborCount > 0 ? '#34C759' : undefined}
-        />
-        <StatTile
-          label="ACK Pend"
-          value={metrics.ackPending}
-          accent={metrics.ackPending > 10 ? '#FF9500' : undefined}
-        />
-        <StatTile
-          label="Retry Q"
-          value={metrics.retryQueue.totalCount}
-          hint={`${metrics.retryQueue.readyCount} ready`}
-          accent={metrics.retryQueue.totalCount > 0 ? '#FF9500' : undefined}
-        />
-        <StatTile
-          label="Dedup"
-          value={`${dedupPct}%`}
-          hint={metrics.dedup.mode}
-          accent={dedupPct >= 80 ? '#FF3B30' : undefined}
+          hint="local"
         />
       </TileRow>
-    </MetricCard>
-  );
-}
-
-// ─── Device capability ───────────────────────────────────────
-
-function DeviceCapabilityCard({
-  snapshot,
-  isLocalRelay,
-}: {
-  snapshot: ReturnType<typeof useProtocol>['deviceCapability'];
-  isLocalRelay: boolean;
-}) {
-  if (!snapshot) {return null;}
-  const battery = snapshot.batteryLevel;
-  const batteryColor =
-    snapshot.isCharging
-      ? '#34C759'
-      : battery !== undefined && battery !== null && battery <= 20
-      ? '#FF3B30'
-      : battery !== undefined && battery !== null && battery <= 40
-      ? '#FF9500'
-      : '#34C759';
-
-  return (
-    <MetricCard title="Device" subtitle={formatRelative(snapshot.timestampMs)}>
-      {battery !== undefined && battery !== null ? (
-        <Bar
-          label="Battery"
-          value={battery}
-          max={100}
-          color={batteryColor}
-          rightLabel={`${battery}%${snapshot.isCharging ? ' ⚡' : ''}`}
-        />
-      ) : (
-        <KeyValueRow k="Battery" v="unknown" />
-      )}
-      <View style={styles.chipRow}>
-        <View
-          style={[
-            styles.chip,
-            {backgroundColor: snapshot.relayRole === 'relay' ? '#5856D6' : '#E5E5EA'},
-          ]}>
-          <Text
-            style={[
-              styles.chipText,
-              {color: snapshot.relayRole === 'relay' ? '#FFFFFF' : '#3C3C43'},
-            ]}>
-            {snapshot.relayRole === 'relay' ? 'RELAY ROLE' : 'REGULAR ROLE'}
-          </Text>
+      {neighborSeries.length > 1 && (
+        <View style={styles.sparkWrap}>
+          <Text style={styles.sparkLabel}>neighbor count · last {neighborSeries.length * 2}s</Text>
+          <Sparkline values={neighborSeries} color={color} height={28} />
         </View>
-        {isLocalRelay && (
-          <View style={[styles.chip, {backgroundColor: '#34C759'}]}>
-            <Text style={[styles.chipText, {color: '#FFFFFF'}]}>ACTIVE RELAY</Text>
-          </View>
-        )}
-        <View
-          style={[
-            styles.chip,
-            {backgroundColor: snapshot.isCharging ? '#34C759' : '#E5E5EA'},
-          ]}>
-          <Text
-            style={[
-              styles.chipText,
-              {color: snapshot.isCharging ? '#FFFFFF' : '#3C3C43'},
-            ]}>
-            {snapshot.isCharging ? 'CHARGING' : 'ON BATTERY'}
-          </Text>
-        </View>
-      </View>
-      {snapshot.changedFields !== 0 && (
-        <Text style={styles.changedHint}>
-          changed: {decodeChangedFields(snapshot.changedFields)}
-        </Text>
       )}
     </MetricCard>
   );
 }
 
-function decodeChangedFields(mask: number): string {
-  const out: string[] = [];
-  if (mask & 0x01) {out.push('battery');}
-  if (mask & 0x02) {out.push('charging');}
-  if (mask & 0x04) {out.push('relay-role');}
-  return out.join(', ') || 'none';
-}
+// ─── Transport time distribution ─────────────────────────────
 
-// ─── Per-transport metrics ───────────────────────────────────
-
-function PerTransportCard({
-  metrics,
-  history,
-}: {
-  metrics: MetricsFrame | null;
-  history: MetricsFrame[];
-}) {
-  if (!metrics || metrics.transports.length === 0) {return null;}
+function TransportDistributionCard({history}: {history: MetricsFrame[]}) {
+  const dist = useMemo(() => computeTransportDistribution(history), [history]);
   return (
     <MetricCard
-      title="Per-Transport Metrics"
-      subtitle={`${metrics.transports.length} transport${metrics.transports.length === 1 ? '' : 's'}`}>
-      {metrics.transports.map((entry, i) => (
-        <View key={entry.transport}>
-          {i > 0 && <CardDivider />}
-          <TransportRow entry={entry} history={history} />
+      title="Transport Distribution"
+      subtitle={dist.total > 0 ? `${dist.windowSec}s window` : 'no samples'}>
+      {dist.total === 0 ? (
+        <Text style={styles.empty}>
+          Waiting for metrics frames. Each frame contributes its active transport
+          to the distribution.
+        </Text>
+      ) : (
+        <>
+          <SegmentedBar
+            segments={dist.entries.map(e => ({
+              key: e.transport,
+              value: e.count,
+              color: transportColor(e.transport),
+            }))}
+          />
+          <View style={styles.legendRow}>
+            {dist.entries.map(e => (
+              <View key={e.transport} style={styles.legendItem}>
+                <View
+                  style={[styles.legendDot, {backgroundColor: transportColor(e.transport)}]}
+                />
+                <Text style={styles.legendText}>
+                  {transportLabel(e.transport)} · {Math.round((e.count / dist.total) * 100)}%
+                </Text>
+              </View>
+            ))}
+          </View>
+        </>
+      )}
+    </MetricCard>
+  );
+}
+
+interface TransportDistribution {
+  entries: Array<{transport: TransportType; count: number}>;
+  total: number;
+  windowSec: number;
+}
+
+function computeTransportDistribution(history: MetricsFrame[]): TransportDistribution {
+  const counts = new Map<TransportType, number>();
+  let total = 0;
+  let windowStart = history[0]?.timestampMs ?? 0;
+  let windowEnd = history[0]?.timestampMs ?? 0;
+  for (const frame of history) {
+    windowEnd = frame.timestampMs;
+    if (windowStart === 0) {windowStart = frame.timestampMs;}
+    if (frame.currentTransport) {
+      counts.set(
+        frame.currentTransport,
+        (counts.get(frame.currentTransport) ?? 0) + 1,
+      );
+      total += 1;
+    }
+  }
+  const entries = Array.from(counts.entries())
+    .map(([transport, count]) => ({transport, count}))
+    .sort((a, b) => b.count - a.count);
+  const windowSec = Math.max(0, Math.round((windowEnd - windowStart) / 1000));
+  return {entries, total, windowSec};
+}
+
+// ─── DORS switch drivers ─────────────────────────────────────
+
+function DorsDriversCard({decisions}: {decisions: RoutingDecision[]}) {
+  const drivers = useMemo(() => computeDorsDrivers(decisions), [decisions]);
+  const totalSwitches = drivers.reduce((s, d) => s + d.count, 0);
+  const max = Math.max(1, ...drivers.map(d => d.count));
+  return (
+    <MetricCard
+      title="DORS Switch Drivers"
+      subtitle={totalSwitches > 0 ? `${totalSwitches} switches observed` : 'no switches yet'}>
+      {totalSwitches === 0 ? (
+        <Text style={styles.empty}>
+          Transport switches appear here once DORS moves between transports.
+          Reason codes tell you what triggered the switch — signal, congestion,
+          unavailability, etc.
+        </Text>
+      ) : (
+        drivers.map(d => (
+          <Bar
+            key={d.reason}
+            label={reasonLabel(d.reason)}
+            value={d.count}
+            max={max}
+            color="#5856D6"
+            rightLabel={String(d.count)}
+          />
+        ))
+      )}
+    </MetricCard>
+  );
+}
+
+function computeDorsDrivers(
+  decisions: RoutingDecision[],
+): Array<{reason: RoutingReasonCode; count: number}> {
+  const counts = new Map<RoutingReasonCode, number>();
+  for (const d of decisions) {
+    if (d.phase !== 'switched' || !d.reasonCode) {continue;}
+    counts.set(d.reasonCode, (counts.get(d.reasonCode) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([reason, count]) => ({reason, count}))
+    .sort((a, b) => b.count - a.count);
+}
+
+// ─── Link stability ──────────────────────────────────────────
+
+function LinkStabilityCard({
+  timeline,
+}: {
+  timeline: TransportStateTelemetryEvent[];
+}) {
+  const stability = useMemo(() => computeLinkStability(timeline), [timeline]);
+
+  if (stability.length === 0) {
+    return (
+      <MetricCard title="Link Stability" subtitle="no transitions yet">
+        <Text style={styles.empty}>
+          Every connect/disconnect on a transport is recorded here. With no
+          transitions observed, every link has been stable since startup.
+        </Text>
+      </MetricCard>
+    );
+  }
+
+  return (
+    <MetricCard title="Link Stability" subtitle={`${stability.length} transports observed`}>
+      {stability.map(s => (
+        <View key={s.transport} style={styles.linkRow}>
+          <TransportBadge transport={s.transport} small />
+          <View style={styles.linkMeta}>
+            <Text style={styles.linkMetaValue}>{s.flaps} transitions</Text>
+            <Text style={styles.linkMetaHint}>
+              {s.avgGapMs > 0
+                ? `avg gap ${formatDuration(s.avgGapMs)}`
+                : 'single event'}
+            </Text>
+          </View>
         </View>
       ))}
     </MetricCard>
   );
 }
 
-function TransportRow({
-  entry,
-  history,
-}: {
-  entry: MetricsFrame['transports'][number];
-  history: MetricsFrame[];
-}) {
-  const m = entry.metrics;
-  const isCurrent = false; // visual emphasis is via the badge color already
-  void isCurrent;
+interface LinkStabilityEntry {
+  transport: TransportType;
+  flaps: number;
+  avgGapMs: number;
+}
 
-  // Per-transport packet sparkline (last N frames)
-  const packetSeries = useMemo(() => {
-    if (history.length < 2) {return [];}
-    const totals = history.map(f => {
-      const t = f.transports.find(x => x.transport === entry.transport);
-      return t ? t.metrics.packetsSent + t.metrics.packetsReceived : 0;
-    });
-    const deltas: number[] = [];
-    for (let i = 1; i < totals.length; i++) {
-      deltas.push(Math.max(0, totals[i] - totals[i - 1]));
-    }
-    return deltas;
-  }, [history, entry.transport]);
+function computeLinkStability(
+  timeline: TransportStateTelemetryEvent[],
+): LinkStabilityEntry[] {
+  const byTransport = new Map<TransportType, number[]>();
+  for (const ev of timeline) {
+    const arr = byTransport.get(ev.transport) ?? [];
+    arr.push(ev.timestampMs);
+    byTransport.set(ev.transport, arr);
+  }
+  return Array.from(byTransport.entries())
+    .map(([transport, timestamps]) => {
+      const sorted = [...timestamps].sort((a, b) => a - b);
+      let totalGap = 0;
+      for (let i = 1; i < sorted.length; i++) {
+        totalGap += sorted[i] - sorted[i - 1];
+      }
+      const avgGapMs = sorted.length > 1 ? totalGap / (sorted.length - 1) : 0;
+      return {transport, flaps: sorted.length, avgGapMs};
+    })
+    .sort((a, b) => b.flaps - a.flaps);
+}
 
-  const errorPct = m.errorRate * 100;
-  const errorColor = errorPct >= 10 ? '#FF3B30' : errorPct >= 2 ? '#FF9500' : '#34C759';
+// ─── Reliability by transport ────────────────────────────────
 
+function ReliabilityCard({metrics}: {metrics: MetricsFrame | null}) {
+  if (!metrics || metrics.transports.length === 0) {
+    return (
+      <MetricCard title="Reliability by Transport" subtitle="no data">
+        <Text style={styles.empty}>
+          Per-transport delivery, error, and latency metrics will appear once a
+          transport becomes active.
+        </Text>
+      </MetricCard>
+    );
+  }
   return (
-    <View>
-      <View style={styles.transportHeader}>
-        <TransportBadge transport={entry.transport} />
-        <Sparkline
-          values={packetSeries}
-          color={transportColor(entry.transport)}
-          height={20}
-        />
-      </View>
-
-      <View style={styles.kvGrid}>
-        <View style={styles.kvCol}>
-          <KeyValueRow k="Sent" v={`${formatCount(m.packetsSent)} pkt`} />
-          <KeyValueRow k="Bytes ↑" v={formatBytes(m.bytesSent)} />
-          <KeyValueRow k="Latency" v={`${m.avgLatencyMs.toFixed(0)} ms`} />
-          {m.bandwidthBps !== undefined && (
-            <KeyValueRow k="Bandwidth" v={`${formatBytes(m.bandwidthBps)}/s`} />
-          )}
-          {m.queueDepth !== undefined && (
-            <KeyValueRow k="Queue" v={m.queueDepth} />
-          )}
-        </View>
-        <View style={styles.kvCol}>
-          <KeyValueRow k="Recv" v={`${formatCount(m.packetsReceived)} pkt`} />
-          <KeyValueRow k="Bytes ↓" v={formatBytes(m.bytesReceived)} />
-          <KeyValueRow
-            k="Errors"
-            v={`${errorPct.toFixed(1)}%`}
-            accent={errorColor}
+    <MetricCard
+      title="Reliability by Transport"
+      subtitle={`${metrics.transports.length} transport${metrics.transports.length === 1 ? '' : 's'}`}>
+      {metrics.transports.map((entry, i) => (
+        <View key={entry.transport}>
+          {i > 0 && <CardDivider />}
+          <View style={styles.reliabilityHeader}>
+            <TransportBadge transport={entry.transport} small />
+          </View>
+          <Bar
+            label="Delivery"
+            value={entry.metrics.deliveryRatio ?? 0}
+            max={1}
+            color="#34C759"
+            rightLabel={
+              entry.metrics.deliveryRatio !== undefined
+                ? `${(entry.metrics.deliveryRatio * 100).toFixed(1)}%`
+                : '—'
+            }
           />
-          {m.deliveryRatio !== undefined && (
-            <KeyValueRow k="Delivery" v={formatPercent(m.deliveryRatio, 1)} />
-          )}
-          {m.averageHopCount !== undefined && (
-            <KeyValueRow k="Hops" v={m.averageHopCount.toFixed(1)} />
+          <Bar
+            label="Error rate"
+            value={entry.metrics.errorRate}
+            max={1}
+            color={
+              entry.metrics.errorRate >= 0.1
+                ? '#FF3B30'
+                : entry.metrics.errorRate >= 0.02
+                ? '#FF9500'
+                : '#34C759'
+            }
+            rightLabel={`${(entry.metrics.errorRate * 100).toFixed(2)}%`}
+          />
+          <Bar
+            label="Avg latency"
+            value={Math.min(entry.metrics.avgLatencyMs, 1000)}
+            max={1000}
+            color="#007AFF"
+            rightLabel={`${Math.round(entry.metrics.avgLatencyMs)} ms`}
+          />
+          {entry.metrics.averageHopCount !== undefined && (
+            <KeyValueRow
+              k="Avg hop count"
+              v={entry.metrics.averageHopCount.toFixed(2)}
+            />
           )}
         </View>
-      </View>
-
-      {m.rssi !== undefined && (
-        <Bar
-          label="RSSI"
-          value={Math.max(0, m.rssi + 100)}
-          max={70}
-          color="#007AFF"
-          rightLabel={`${m.rssi} dBm`}
-        />
-      )}
-      {m.congestion !== undefined && (
-        <Bar
-          label="Congestion"
-          value={m.congestion}
-          max={1}
-          color={m.congestion > 0.7 ? '#FF3B30' : m.congestion > 0.4 ? '#FF9500' : '#34C759'}
-          rightLabel={formatPercent(m.congestion, 0)}
-        />
-      )}
-      {m.energyCost !== undefined && (
-        <Bar
-          label="Energy"
-          value={m.energyCost}
-          max={1}
-          color="#FFCC00"
-          rightLabel={m.energyCost.toFixed(2)}
-        />
-      )}
-    </View>
+      ))}
+    </MetricCard>
   );
 }
 
-// ─── Retry queue + dedup ─────────────────────────────────────
+// ─── Hop count distribution ──────────────────────────────────
 
-function RetryDedupCard({metrics}: {metrics: MetricsFrame | null}) {
+function HopDistributionCard({
+  histogram,
+}: {
+  histogram: Record<number, number>;
+}) {
+  const {buckets, total, max} = useMemo(() => {
+    const observed = Object.keys(histogram)
+      .map(k => Number(k))
+      .filter(n => Number.isFinite(n));
+    const maxHop = observed.length > 0 ? Math.max(...observed) : 0;
+    const upper = Math.min(Math.max(maxHop, 7), 15);
+    const arr: Array<{key: string | number; value: number}> = [];
+    let runningTotal = 0;
+    for (let h = 0; h <= upper; h++) {
+      const v = histogram[h] ?? 0;
+      runningTotal += v;
+      arr.push({key: h === 15 ? '15+' : h, value: v});
+    }
+    return {buckets: arr, total: runningTotal, max: upper};
+  }, [histogram]);
+
+  if (total === 0) {
+    return (
+      <MetricCard title="Hop Count Distribution" subtitle="no samples">
+        <Text style={styles.empty}>
+          Sampled from every received and delivered message's final hop count.
+          Direct deliveries land at 0; mesh-routed deliveries climb from there.
+        </Text>
+      </MetricCard>
+    );
+  }
+
+  return (
+    <MetricCard
+      title="Hop Count Distribution"
+      subtitle={`${total} message${total === 1 ? '' : 's'} sampled · max observed ${max}`}>
+      <VerticalHistogram buckets={buckets} color="#007AFF" height={70} />
+    </MetricCard>
+  );
+}
+
+// ─── Retry queue ─────────────────────────────────────────────
+
+function RetryQueueCard({metrics}: {metrics: MetricsFrame | null}) {
   if (!metrics) {return null;}
   const r = metrics.retryQueue;
   const total = Math.max(
     1,
     r.criticalPriorityCount + r.highPriorityCount + r.mediumPriorityCount + r.lowPriorityCount,
   );
-  return (
-    <MetricCard title="Reliability" subtitle="retry queue · deduplicator">
-      <Text style={styles.subhead}>RETRY QUEUE BY PRIORITY</Text>
-      <Bar
-        label="Critical"
-        value={r.criticalPriorityCount}
-        max={total}
-        color="#FF3B30"
-        rightLabel={String(r.criticalPriorityCount)}
-      />
-      <Bar
-        label="High"
-        value={r.highPriorityCount}
-        max={total}
-        color="#FF9500"
-        rightLabel={String(r.highPriorityCount)}
-      />
-      <Bar
-        label="Medium"
-        value={r.mediumPriorityCount}
-        max={total}
-        color="#007AFF"
-        rightLabel={String(r.mediumPriorityCount)}
-      />
-      <Bar
-        label="Low"
-        value={r.lowPriorityCount}
-        max={total}
-        color="#8E8E93"
-        rightLabel={String(r.lowPriorityCount)}
-      />
-      <CardDivider />
-      <Text style={styles.subhead}>DEDUPLICATOR</Text>
-      <KeyValueRow k="Mode" v={metrics.dedup.mode} />
-      <KeyValueRow k="Tracked" v={formatCount(metrics.dedup.totalTracked)} />
-      <KeyValueRow k="Recent" v={formatCount(metrics.dedup.recentTracked)} />
-      <Bar
-        label="Capacity"
-        value={metrics.dedup.capacityUsedPercent}
-        max={100}
-        color={
-          metrics.dedup.capacityUsedPercent >= 80
-            ? '#FF3B30'
-            : metrics.dedup.capacityUsedPercent >= 50
-            ? '#FF9500'
-            : '#34C759'
-        }
-        rightLabel={`${metrics.dedup.capacityUsedPercent.toFixed(0)}%`}
-      />
-      {metrics.dedup.falsePositiveRate !== undefined && (
-        <KeyValueRow
-          k="False-pos rate"
-          v={`${(metrics.dedup.falsePositiveRate * 100).toFixed(3)}%`}
-        />
-      )}
-    </MetricCard>
-  );
-}
-
-// ─── DORS decisions ──────────────────────────────────────────
-
-function RoutingDecisionsCard({decisions}: {decisions: RoutingDecision[]}) {
-  const [expanded, setExpanded] = useState<number | null>(null);
+  const anyPending = total > 1 || r.totalCount > 0;
   return (
     <MetricCard
-      title="DORS Decisions"
-      subtitle={decisions.length > 0 ? `${decisions.length} recent` : 'no decisions yet'}>
-      {decisions.length === 0 && (
-        <Text style={styles.empty}>
-          No routing decisions emitted yet. They appear when DORS scores or switches transports.
-        </Text>
-      )}
-      {decisions.slice(0, 8).map((d, i) => {
-        const isOpen = expanded === i;
-        return (
-          <View key={i} style={styles.decisionRow}>
-            <TouchableOpacity
-              activeOpacity={0.7}
-              onPress={() => setExpanded(isOpen ? null : i)}>
-              <View style={styles.decisionHeader}>
-                <View
-                  style={[
-                    styles.phaseBadge,
-                    {backgroundColor: routingPhaseColor(d.phase)},
-                  ]}>
-                  <Text style={styles.phaseText}>{d.phase}</Text>
-                </View>
-                <Text style={styles.reason}>{reasonLabel(d.reasonCode)}</Text>
-                <Text style={styles.decisionTime}>{formatRelative(d.timestampMs)}</Text>
-              </View>
-              <View style={styles.decisionBody}>
-                {d.from && (
-                  <>
-                    <TransportBadge transport={d.from} small />
-                    <Text style={styles.arrow}>→</Text>
-                  </>
-                )}
-                {d.to ? (
-                  <TransportBadge transport={d.to} small />
-                ) : (
-                  <Text style={styles.noTo}>—</Text>
-                )}
-                {d.winningScore !== undefined && (
-                  <Text style={styles.score}>score {d.winningScore.toFixed(2)}</Text>
-                )}
-                {d.scores.length > 0 && (
-                  <Text style={styles.expandHint}>{isOpen ? '▾' : '▸'} scores</Text>
-                )}
-              </View>
-            </TouchableOpacity>
-            {isOpen && d.scores.length > 0 && (
-              <View>
-                {d.scores.map(s => (
-                  <RoutingScoreBars key={s.transport} entry={s} />
-                ))}
-              </View>
-            )}
-          </View>
-        );
-      })}
-    </MetricCard>
-  );
-}
-
-// ─── Transport state timeline ────────────────────────────────
-
-function TransportTimelineCard({
-  timeline,
-}: {
-  timeline: ReturnType<typeof useProtocol>['transportTimeline'];
-}) {
-  return (
-    <MetricCard
-      title="Transport State Timeline"
-      subtitle={timeline.length > 0 ? `${timeline.length} transitions` : 'no transitions'}>
-      {timeline.length === 0 && (
-        <Text style={styles.empty}>
-          Transitions appear when a transport's connection status changes.
-        </Text>
-      )}
-      {timeline.slice(0, 12).map((ev, i) => (
-        <View key={`${ev.timestampMs}-${i}`} style={styles.timelineRow}>
-          <View
-            style={[
-              styles.timelineDot,
-              {backgroundColor: transportStatusColor(ev.current)},
-            ]}
+      title="Retry Queue"
+      subtitle={
+        anyPending
+          ? `${r.totalCount} pending · ${r.readyCount} ready`
+          : 'queue empty'
+      }>
+      {anyPending ? (
+        <>
+          <Bar
+            label="Critical"
+            value={r.criticalPriorityCount}
+            max={total}
+            color="#FF3B30"
+            rightLabel={String(r.criticalPriorityCount)}
           />
-          <View style={styles.timelineBody}>
-            <View style={styles.timelineTopRow}>
-              <TransportBadge transport={ev.transport} small />
-              <Text style={styles.timelineTime}>{formatRelative(ev.timestampMs)}</Text>
-            </View>
-            <View style={styles.timelineTransition}>
-              <Text style={[styles.statusText, {color: transportStatusColor(ev.previous)}]}>
-                {ev.previous}
-              </Text>
-              <Text style={styles.arrow}>→</Text>
-              <Text style={[styles.statusText, {color: transportStatusColor(ev.current)}]}>
-                {ev.current}
-              </Text>
-            </View>
-          </View>
-        </View>
-      ))}
-    </MetricCard>
-  );
-}
-
-// ─── MLS lifecycle log ───────────────────────────────────────
-
-const MLS_TYPE_COLORS: Record<string, string> = {
-  initialized: '#34C759',
-  encryption_used: '#007AFF',
-  session_ready: '#34C759',
-  session_missing: '#FF9500',
-  decryption_failed: '#FF3B30',
-};
-
-function MlsLogCard({log}: {log: ReturnType<typeof useProtocol>['mlsLog']}) {
-  return (
-    <MetricCard
-      title="MLS Lifecycle"
-      subtitle={log.length > 0 ? `${log.length} events` : 'no MLS activity yet'}>
-      {log.length === 0 && (
+          <Bar
+            label="High"
+            value={r.highPriorityCount}
+            max={total}
+            color="#FF9500"
+            rightLabel={String(r.highPriorityCount)}
+          />
+          <Bar
+            label="Medium"
+            value={r.mediumPriorityCount}
+            max={total}
+            color="#007AFF"
+            rightLabel={String(r.mediumPriorityCount)}
+          />
+          <Bar
+            label="Low"
+            value={r.lowPriorityCount}
+            max={total}
+            color="#8E8E93"
+            rightLabel={String(r.lowPriorityCount)}
+          />
+        </>
+      ) : (
         <Text style={styles.empty}>
-          MLS lifecycle events appear when a session initializes, encrypts, or fails.
+          No messages are waiting for retry. Queue fills under intermittent
+          connectivity or ACK timeouts.
         </Text>
       )}
-      {log.slice(0, 10).map((entry, i) => {
-        const color = MLS_TYPE_COLORS[entry.type] ?? '#8E8E93';
-        return (
-          <View key={i} style={styles.mlsRow}>
-            <View style={[styles.mlsDot, {backgroundColor: color}]} />
-            <View style={styles.mlsBody}>
-              <View style={styles.mlsTopRow}>
-                <Text style={[styles.mlsType, {color}]}>{entry.type}</Text>
-                <Text style={styles.mlsTime}>{formatRelative(entry.ts)}</Text>
-              </View>
-              {renderMlsDetail(entry.raw)}
-            </View>
-          </View>
-        );
-      })}
     </MetricCard>
   );
 }
 
-function renderMlsDetail(raw: any): React.ReactNode {
-  if (!raw || typeof raw !== 'object') {return null;}
-  const interesting = ['groupId', 'group_id', 'peerId', 'peer_id', 'ciphersuite', 'reason', 'epoch'];
-  const lines: string[] = [];
-  for (const k of interesting) {
-    if (raw[k] !== undefined && raw[k] !== null) {
-      lines.push(`${k}=${String(raw[k])}`);
+// ─── Partition & recovery ────────────────────────────────────
+
+function PartitionCard({history}: {history: MetricsFrame[]}) {
+  const partition = useMemo(() => computePartitionStats(history), [history]);
+
+  return (
+    <MetricCard
+      title="Partition & Recovery"
+      subtitle={
+        partition.observed === 0
+          ? 'no partitions observed'
+          : `${partition.observed} resolved · ${formatDuration(partition.avgDurationMs)} avg`
+      }>
+      <TileRow>
+        <StatTile
+          label="State"
+          value={partition.currentMs !== null ? 'PARTITIONED' : 'CONNECTED'}
+          accent={partition.currentMs !== null ? '#FF3B30' : '#34C759'}
+        />
+        <StatTile
+          label="Current"
+          value={partition.currentMs !== null ? formatDuration(partition.currentMs) : '—'}
+          hint={partition.currentMs !== null ? 'in progress' : ''}
+        />
+        <StatTile label="Resolved" value={partition.observed} hint="in window" />
+      </TileRow>
+      {partition.observed > 0 && (
+        <View style={{marginTop: 6}}>
+          <KeyValueRow k="Avg duration" v={formatDuration(partition.avgDurationMs)} />
+          <KeyValueRow k="Longest" v={formatDuration(partition.maxDurationMs)} />
+          <KeyValueRow
+            k="Last ended"
+            v={
+              partition.lastEndedMs !== null
+                ? formatRelative(partition.lastEndedMs)
+                : '—'
+            }
+          />
+        </View>
+      )}
+    </MetricCard>
+  );
+}
+
+interface PartitionStats {
+  observed: number;
+  avgDurationMs: number;
+  maxDurationMs: number;
+  currentMs: number | null;
+  lastEndedMs: number | null;
+}
+
+function computePartitionStats(history: MetricsFrame[]): PartitionStats {
+  const completed: Array<{startMs: number; endMs: number}> = [];
+  let partitionStart: number | null = null;
+  let lastEndedMs: number | null = null;
+  for (const frame of history) {
+    if (frame.neighborCount === 0 && partitionStart === null) {
+      partitionStart = frame.timestampMs;
+    } else if (frame.neighborCount > 0 && partitionStart !== null) {
+      completed.push({startMs: partitionStart, endMs: frame.timestampMs});
+      lastEndedMs = frame.timestampMs;
+      partitionStart = null;
     }
   }
-  if (lines.length === 0) {return null;}
-  return <Text style={styles.mlsDetail}>{lines.join(' · ')}</Text>;
+  const currentMs =
+    partitionStart !== null ? Math.max(0, Date.now() - partitionStart) : null;
+  const durations = completed.map(p => p.endMs - p.startMs);
+  const avgDurationMs = durations.length
+    ? durations.reduce((s, d) => s + d, 0) / durations.length
+    : 0;
+  const maxDurationMs = durations.length ? Math.max(...durations) : 0;
+  return {
+    observed: completed.length,
+    avgDurationMs,
+    maxDurationMs,
+    currentMs,
+    lastEndedMs,
+  };
 }
 
-// ─── Event counters ──────────────────────────────────────────
+// ─── Battery impact ──────────────────────────────────────────
 
-function EventCountersCard({
-  counts,
-  total,
+function BatteryImpactCard({
+  latest,
+  history,
+  relayActiveNow,
 }: {
-  counts: Record<string, number>;
-  total: number;
+  latest: DeviceCapabilitySnapshot | null;
+  history: DeviceCapabilitySnapshot[];
+  relayActiveNow: boolean;
 }) {
-  const sorted = useMemo(
-    () =>
-      Object.entries(counts)
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 12),
-    [counts],
-  );
-  if (sorted.length === 0) {
+  const drain = useMemo(() => computeBatteryDrain(history), [history]);
+
+  if (!latest || latest.batteryLevel === undefined || latest.batteryLevel === null) {
     return (
-      <MetricCard title="Protocol Event Stream" subtitle="0 total">
-        <Text style={styles.empty}>No protocol events received yet.</Text>
+      <MetricCard title="Battery Impact" subtitle="no samples">
+        <Text style={styles.empty}>
+          Device capability snapshots are emitted when battery level, charging
+          state, or relay role changes. Nothing to plot yet.
+        </Text>
       </MetricCard>
     );
   }
-  const max = Math.max(...sorted.map(([, n]) => n));
+
+  const level = latest.batteryLevel;
+  const batteryColor = latest.isCharging
+    ? '#34C759'
+    : level <= 20
+    ? '#FF3B30'
+    : level <= 40
+    ? '#FF9500'
+    : '#34C759';
+
+  const levelSeries = history
+    .map(s => s.batteryLevel)
+    .filter((n): n is number => typeof n === 'number');
+
   return (
-    <MetricCard
-      title="Protocol Event Stream"
-      subtitle={`${formatCount(total)} total · top ${sorted.length}`}>
-      {sorted.map(([type, n]) => (
-        <Bar
-          key={type}
-          label={shortenEventType(type)}
-          value={n}
-          max={max}
-          color="#007AFF"
-          rightLabel={String(n)}
+    <MetricCard title="Battery Impact" subtitle={formatRelative(latest.timestampMs)}>
+      <Bar
+        label="Level"
+        value={level}
+        max={100}
+        color={batteryColor}
+        rightLabel={`${level}%${latest.isCharging ? ' ⚡' : ''}`}
+      />
+      <TileRow>
+        <StatTile
+          label="Drain"
+          value={drain ? `${drain.ratePerHour.toFixed(1)}%/h` : '—'}
+          hint={drain ? `${drain.samples} samples` : 'need ≥2 samples'}
+          accent={drain && drain.ratePerHour > 10 ? '#FF3B30' : undefined}
         />
-      ))}
+        <StatTile
+          label="Role"
+          value={latest.relayRole === 'relay' ? 'RELAY' : 'LEAF'}
+          accent={latest.relayRole === 'relay' ? '#5856D6' : undefined}
+        />
+        <StatTile
+          label="Relay active"
+          value={relayActiveNow ? 'YES' : 'NO'}
+          accent={relayActiveNow ? '#5856D6' : undefined}
+        />
+      </TileRow>
+      {levelSeries.length > 1 && (
+        <View style={styles.sparkWrap}>
+          <Text style={styles.sparkLabel}>
+            battery level · last {levelSeries.length} samples
+          </Text>
+          <Sparkline values={levelSeries} color={batteryColor} height={28} />
+        </View>
+      )}
     </MetricCard>
   );
 }
 
-function shortenEventType(t: string): string {
-  // Strip any common prefixes for readability while keeping uniqueness
-  return t.replace(/^protocol_/, '').replace(/_/g, ' ');
+interface BatteryDrain {
+  ratePerHour: number;
+  samples: number;
 }
+
+function computeBatteryDrain(history: DeviceCapabilitySnapshot[]): BatteryDrain | null {
+  const levels = history.filter(
+    (s): s is DeviceCapabilitySnapshot & {batteryLevel: number} =>
+      typeof s.batteryLevel === 'number' && !s.isCharging,
+  );
+  if (levels.length < 2) {return null;}
+  const first = levels[0];
+  const last = levels[levels.length - 1];
+  const dMs = last.timestampMs - first.timestampMs;
+  if (dMs <= 0) {return null;}
+  const dLevel = first.batteryLevel - last.batteryLevel; // positive = draining
+  const hours = dMs / 3_600_000;
+  return {ratePerHour: dLevel / hours, samples: levels.length};
+}
+
+// ─── Formatters ──────────────────────────────────────────────
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) {return `${Math.round(ms)} ms`;}
+  if (ms < 60_000) {return `${(ms / 1000).toFixed(1)} s`;}
+  if (ms < 3_600_000) {return `${Math.floor(ms / 60_000)} min`;}
+  return `${(ms / 3_600_000).toFixed(1)} h`;
+}
+
+// ─── Styles ──────────────────────────────────────────────────
 
 const styles = StyleSheet.create({
   scroll: {
@@ -647,33 +691,29 @@ const styles = StyleSheet.create({
   content: {
     paddingBottom: 24,
   },
-  hero: {
-    backgroundColor: '#FFFFFF',
-    marginHorizontal: 12,
-    marginTop: 12,
-    borderRadius: 12,
-    padding: 14,
-    borderLeftWidth: 4,
-    borderLeftColor: '#C7C7CC',
-  },
-  heroEmpty: {
+  empty: {
+    fontSize: 12,
     color: '#8E8E93',
     fontStyle: 'italic',
-    textAlign: 'center',
-    paddingVertical: 16,
+    paddingVertical: 4,
+    lineHeight: 16,
   },
-  heroTop: {
+  heroRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 10,
+  },
+  heroRight: {
     alignItems: 'flex-end',
   },
-  heroLabel: {
+  heroKicker: {
     fontSize: 10,
     fontWeight: '700',
     color: '#8E8E93',
     letterSpacing: 0.6,
   },
-  heroRow: {
+  heroLine: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
@@ -685,206 +725,71 @@ const styles = StyleSheet.create({
     borderRadius: 5,
   },
   heroValue: {
-    fontSize: 28,
+    fontSize: 22,
     fontWeight: '800',
+    letterSpacing: 0.4,
+  },
+  heroReach: {
+    fontSize: 16,
+    fontWeight: '800',
+    marginTop: 4,
     letterSpacing: 0.5,
   },
-  heroSecondary: {
-    fontSize: 14,
-    color: '#1C1C1E',
-    fontWeight: '600',
-    marginTop: 4,
-    fontVariant: ['tabular-nums'],
-  },
-  heroSpark: {
-    marginTop: 12,
-  },
-  heroSparkLabel: {
-    fontSize: 10,
-    color: '#8E8E93',
-    marginTop: 4,
-    textAlign: 'right',
-  },
-  chipRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 6,
+  sparkWrap: {
     marginTop: 10,
   },
-  chip: {
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 6,
-  },
-  chipText: {
-    fontSize: 10,
-    fontWeight: '700',
-    letterSpacing: 0.4,
-  },
-  changedHint: {
+  sparkLabel: {
     fontSize: 10,
     color: '#8E8E93',
-    marginTop: 6,
-    fontStyle: 'italic',
-  },
-  transportHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    marginBottom: 6,
-  },
-  kvGrid: {
-    flexDirection: 'row',
-    gap: 16,
-    marginVertical: 4,
-  },
-  kvCol: {
-    flex: 1,
-  },
-  subhead: {
-    fontSize: 10,
-    fontWeight: '700',
-    color: '#8E8E93',
-    letterSpacing: 0.6,
     marginBottom: 4,
   },
-  empty: {
-    fontSize: 12,
-    color: '#8E8E93',
-    fontStyle: 'italic',
-    paddingVertical: 4,
-  },
-  decisionRow: {
-    paddingVertical: 8,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#E5E5EA',
-  },
-  decisionHeader: {
+  legendRow: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  phaseBadge: {
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: 4,
-  },
-  phaseText: {
-    fontSize: 10,
-    fontWeight: '700',
-    color: '#FFFFFF',
-    letterSpacing: 0.4,
-  },
-  reason: {
-    fontSize: 11,
-    color: '#3C3C43',
-    fontWeight: '600',
-    flex: 1,
-  },
-  decisionTime: {
-    fontSize: 10,
-    color: '#8E8E93',
-    fontVariant: ['tabular-nums'],
-  },
-  decisionBody: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginTop: 6,
-  },
-  arrow: {
-    fontSize: 14,
-    color: '#8E8E93',
-    fontWeight: '700',
-  },
-  noTo: {
-    fontSize: 12,
-    color: '#8E8E93',
-  },
-  score: {
-    fontSize: 11,
-    color: '#1C1C1E',
-    fontWeight: '600',
-    fontVariant: ['tabular-nums'],
-    marginLeft: 'auto',
-  },
-  expandHint: {
-    fontSize: 10,
-    color: '#007AFF',
-    fontWeight: '600',
-  },
-  timelineRow: {
-    flexDirection: 'row',
-    paddingVertical: 8,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#E5E5EA',
+    flexWrap: 'wrap',
     gap: 10,
+    marginTop: 8,
   },
-  timelineDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    marginTop: 4,
-  },
-  timelineBody: {
-    flex: 1,
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
     gap: 4,
   },
-  timelineTopRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  timelineTime: {
-    fontSize: 10,
-    color: '#8E8E93',
-    fontVariant: ['tabular-nums'],
-  },
-  timelineTransition: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  statusText: {
-    fontSize: 11,
-    fontWeight: '600',
-  },
-  mlsRow: {
-    flexDirection: 'row',
-    paddingVertical: 8,
-    gap: 10,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#E5E5EA',
-  },
-  mlsDot: {
+  legendDot: {
     width: 8,
     height: 8,
     borderRadius: 4,
-    marginTop: 6,
   },
-  mlsBody: {
-    flex: 1,
-  },
-  mlsTopRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  mlsType: {
-    fontSize: 12,
-    fontWeight: '700',
-    letterSpacing: 0.3,
-  },
-  mlsTime: {
-    fontSize: 10,
-    color: '#8E8E93',
-    fontVariant: ['tabular-nums'],
-  },
-  mlsDetail: {
+  legendText: {
     fontSize: 11,
     color: '#3C3C43',
+    fontWeight: '600',
+  },
+  linkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    gap: 10,
+  },
+  linkMeta: {
+    flex: 1,
+    alignItems: 'flex-end',
+  },
+  linkMetaValue: {
+    fontSize: 12,
+    color: '#1C1C1E',
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  linkMetaHint: {
+    fontSize: 10,
+    color: '#8E8E93',
     marginTop: 2,
-    fontFamily: 'Courier',
+  },
+  reliabilityHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 4,
+    marginTop: 2,
   },
   footer: {
     paddingVertical: 16,

--- a/examples/demo-app/src/screens/DiagnosticsScreen.tsx
+++ b/examples/demo-app/src/screens/DiagnosticsScreen.tsx
@@ -1,0 +1,898 @@
+import React, {useMemo, useState} from 'react';
+import {View, Text, ScrollView, StyleSheet, TouchableOpacity} from 'react-native';
+import {useProtocol} from '../context/ProtocolContext';
+import {
+  MetricCard,
+  StatTile,
+  TileRow,
+  Bar,
+  KeyValueRow,
+  Sparkline,
+  TransportBadge,
+  RoutingScoreBars,
+  CardDivider,
+} from '../components/TelemetryViz';
+import {
+  transportColor,
+  transportLabel,
+  transportStatusColor,
+  routingPhaseColor,
+  reasonLabel,
+  formatBytes,
+  formatCount,
+  formatPercent,
+  formatRelative,
+} from '../telemetryFormat';
+import type {RoutingDecision, MetricsFrame} from '@offline-protocol/mesh-sdk';
+
+export function DiagnosticsScreen() {
+  const {
+    latestMetrics,
+    metricsHistory,
+    transportTimeline,
+    routingDecisions,
+    deviceCapability,
+    mlsLog,
+    eventCounts,
+    totalProtocolEvents,
+  } = useProtocol();
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}>
+      <HeroCard metrics={latestMetrics} history={metricsHistory} />
+      <NetworkAtAGlance metrics={latestMetrics} />
+      <DeviceCapabilityCard
+        snapshot={deviceCapability}
+        isLocalRelay={latestMetrics?.isLocalRelay ?? false}
+      />
+      <PerTransportCard metrics={latestMetrics} history={metricsHistory} />
+      <RetryDedupCard metrics={latestMetrics} />
+      <RoutingDecisionsCard decisions={routingDecisions} />
+      <TransportTimelineCard timeline={transportTimeline} />
+      <MlsLogCard log={mlsLog} />
+      <EventCountersCard counts={eventCounts} total={totalProtocolEvents} />
+      <View style={styles.footer}>
+        <Text style={styles.footerText}>
+          Live stream from TelemetrySink · push delivery · 2s metrics cadence
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+// ─── Hero ────────────────────────────────────────────────────
+
+function HeroCard({
+  metrics,
+  history,
+}: {
+  metrics: MetricsFrame | null;
+  history: MetricsFrame[];
+}) {
+  if (!metrics) {
+    return (
+      <View style={styles.hero}>
+        <Text style={styles.heroEmpty}>Waiting for first telemetry frame…</Text>
+      </View>
+    );
+  }
+  const transport = metrics.currentTransport;
+  const color = transport ? transportColor(transport) : '#8E8E93';
+  const label = transport ? transportLabel(transport) : 'NONE';
+
+  // Aggregate packets-per-frame across all transports for a hero sparkline
+  const series = useMemo(() => {
+    if (history.length < 2) {return [];}
+    const totals = history.map(f =>
+      f.transports.reduce((s, t) => s + t.metrics.packetsSent + t.metrics.packetsReceived, 0),
+    );
+    const deltas: number[] = [];
+    for (let i = 1; i < totals.length; i++) {
+      deltas.push(Math.max(0, totals[i] - totals[i - 1]));
+    }
+    return deltas;
+  }, [history]);
+
+  return (
+    <View style={[styles.hero, {borderLeftColor: color}]}>
+      <View style={styles.heroTop}>
+        <View>
+          <Text style={styles.heroLabel}>ACTIVE TRANSPORT</Text>
+          <View style={styles.heroRow}>
+            <View style={[styles.heroDot, {backgroundColor: color}]} />
+            <Text style={[styles.heroValue, {color}]}>{label}</Text>
+          </View>
+        </View>
+        <View>
+          <Text style={styles.heroLabel}>UPDATED</Text>
+          <Text style={styles.heroSecondary}>{formatRelative(metrics.timestampMs)}</Text>
+        </View>
+      </View>
+      {series.length > 0 && (
+        <View style={styles.heroSpark}>
+          <Sparkline values={series} color={color} height={36} />
+          <Text style={styles.heroSparkLabel}>packets / 2s · last {series.length} frames</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ─── Network at a glance ─────────────────────────────────────
+
+function NetworkAtAGlance({metrics}: {metrics: MetricsFrame | null}) {
+  if (!metrics) {return null;}
+  const dedupPct = Math.round(metrics.dedup.capacityUsedPercent);
+  return (
+    <MetricCard title="Network at a Glance">
+      <TileRow>
+        <StatTile
+          label="Neighbors"
+          value={metrics.neighborCount}
+          accent={metrics.neighborCount > 0 ? '#34C759' : undefined}
+        />
+        <StatTile
+          label="ACK Pend"
+          value={metrics.ackPending}
+          accent={metrics.ackPending > 10 ? '#FF9500' : undefined}
+        />
+        <StatTile
+          label="Retry Q"
+          value={metrics.retryQueue.totalCount}
+          hint={`${metrics.retryQueue.readyCount} ready`}
+          accent={metrics.retryQueue.totalCount > 0 ? '#FF9500' : undefined}
+        />
+        <StatTile
+          label="Dedup"
+          value={`${dedupPct}%`}
+          hint={metrics.dedup.mode}
+          accent={dedupPct >= 80 ? '#FF3B30' : undefined}
+        />
+      </TileRow>
+    </MetricCard>
+  );
+}
+
+// ─── Device capability ───────────────────────────────────────
+
+function DeviceCapabilityCard({
+  snapshot,
+  isLocalRelay,
+}: {
+  snapshot: ReturnType<typeof useProtocol>['deviceCapability'];
+  isLocalRelay: boolean;
+}) {
+  if (!snapshot) {return null;}
+  const battery = snapshot.batteryLevel;
+  const batteryColor =
+    snapshot.isCharging
+      ? '#34C759'
+      : battery !== undefined && battery !== null && battery <= 20
+      ? '#FF3B30'
+      : battery !== undefined && battery !== null && battery <= 40
+      ? '#FF9500'
+      : '#34C759';
+
+  return (
+    <MetricCard title="Device" subtitle={formatRelative(snapshot.timestampMs)}>
+      {battery !== undefined && battery !== null ? (
+        <Bar
+          label="Battery"
+          value={battery}
+          max={100}
+          color={batteryColor}
+          rightLabel={`${battery}%${snapshot.isCharging ? ' ⚡' : ''}`}
+        />
+      ) : (
+        <KeyValueRow k="Battery" v="unknown" />
+      )}
+      <View style={styles.chipRow}>
+        <View
+          style={[
+            styles.chip,
+            {backgroundColor: snapshot.relayRole === 'relay' ? '#5856D6' : '#E5E5EA'},
+          ]}>
+          <Text
+            style={[
+              styles.chipText,
+              {color: snapshot.relayRole === 'relay' ? '#FFFFFF' : '#3C3C43'},
+            ]}>
+            {snapshot.relayRole === 'relay' ? 'RELAY ROLE' : 'REGULAR ROLE'}
+          </Text>
+        </View>
+        {isLocalRelay && (
+          <View style={[styles.chip, {backgroundColor: '#34C759'}]}>
+            <Text style={[styles.chipText, {color: '#FFFFFF'}]}>ACTIVE RELAY</Text>
+          </View>
+        )}
+        <View
+          style={[
+            styles.chip,
+            {backgroundColor: snapshot.isCharging ? '#34C759' : '#E5E5EA'},
+          ]}>
+          <Text
+            style={[
+              styles.chipText,
+              {color: snapshot.isCharging ? '#FFFFFF' : '#3C3C43'},
+            ]}>
+            {snapshot.isCharging ? 'CHARGING' : 'ON BATTERY'}
+          </Text>
+        </View>
+      </View>
+      {snapshot.changedFields !== 0 && (
+        <Text style={styles.changedHint}>
+          changed: {decodeChangedFields(snapshot.changedFields)}
+        </Text>
+      )}
+    </MetricCard>
+  );
+}
+
+function decodeChangedFields(mask: number): string {
+  const out: string[] = [];
+  if (mask & 0x01) {out.push('battery');}
+  if (mask & 0x02) {out.push('charging');}
+  if (mask & 0x04) {out.push('relay-role');}
+  return out.join(', ') || 'none';
+}
+
+// ─── Per-transport metrics ───────────────────────────────────
+
+function PerTransportCard({
+  metrics,
+  history,
+}: {
+  metrics: MetricsFrame | null;
+  history: MetricsFrame[];
+}) {
+  if (!metrics || metrics.transports.length === 0) {return null;}
+  return (
+    <MetricCard
+      title="Per-Transport Metrics"
+      subtitle={`${metrics.transports.length} transport${metrics.transports.length === 1 ? '' : 's'}`}>
+      {metrics.transports.map((entry, i) => (
+        <View key={entry.transport}>
+          {i > 0 && <CardDivider />}
+          <TransportRow entry={entry} history={history} />
+        </View>
+      ))}
+    </MetricCard>
+  );
+}
+
+function TransportRow({
+  entry,
+  history,
+}: {
+  entry: MetricsFrame['transports'][number];
+  history: MetricsFrame[];
+}) {
+  const m = entry.metrics;
+  const isCurrent = false; // visual emphasis is via the badge color already
+  void isCurrent;
+
+  // Per-transport packet sparkline (last N frames)
+  const packetSeries = useMemo(() => {
+    if (history.length < 2) {return [];}
+    const totals = history.map(f => {
+      const t = f.transports.find(x => x.transport === entry.transport);
+      return t ? t.metrics.packetsSent + t.metrics.packetsReceived : 0;
+    });
+    const deltas: number[] = [];
+    for (let i = 1; i < totals.length; i++) {
+      deltas.push(Math.max(0, totals[i] - totals[i - 1]));
+    }
+    return deltas;
+  }, [history, entry.transport]);
+
+  const errorPct = m.errorRate * 100;
+  const errorColor = errorPct >= 10 ? '#FF3B30' : errorPct >= 2 ? '#FF9500' : '#34C759';
+
+  return (
+    <View>
+      <View style={styles.transportHeader}>
+        <TransportBadge transport={entry.transport} />
+        <Sparkline
+          values={packetSeries}
+          color={transportColor(entry.transport)}
+          height={20}
+        />
+      </View>
+
+      <View style={styles.kvGrid}>
+        <View style={styles.kvCol}>
+          <KeyValueRow k="Sent" v={`${formatCount(m.packetsSent)} pkt`} />
+          <KeyValueRow k="Bytes ↑" v={formatBytes(m.bytesSent)} />
+          <KeyValueRow k="Latency" v={`${m.avgLatencyMs.toFixed(0)} ms`} />
+          {m.bandwidthBps !== undefined && (
+            <KeyValueRow k="Bandwidth" v={`${formatBytes(m.bandwidthBps)}/s`} />
+          )}
+          {m.queueDepth !== undefined && (
+            <KeyValueRow k="Queue" v={m.queueDepth} />
+          )}
+        </View>
+        <View style={styles.kvCol}>
+          <KeyValueRow k="Recv" v={`${formatCount(m.packetsReceived)} pkt`} />
+          <KeyValueRow k="Bytes ↓" v={formatBytes(m.bytesReceived)} />
+          <KeyValueRow
+            k="Errors"
+            v={`${errorPct.toFixed(1)}%`}
+            accent={errorColor}
+          />
+          {m.deliveryRatio !== undefined && (
+            <KeyValueRow k="Delivery" v={formatPercent(m.deliveryRatio, 1)} />
+          )}
+          {m.averageHopCount !== undefined && (
+            <KeyValueRow k="Hops" v={m.averageHopCount.toFixed(1)} />
+          )}
+        </View>
+      </View>
+
+      {m.rssi !== undefined && (
+        <Bar
+          label="RSSI"
+          value={Math.max(0, m.rssi + 100)}
+          max={70}
+          color="#007AFF"
+          rightLabel={`${m.rssi} dBm`}
+        />
+      )}
+      {m.congestion !== undefined && (
+        <Bar
+          label="Congestion"
+          value={m.congestion}
+          max={1}
+          color={m.congestion > 0.7 ? '#FF3B30' : m.congestion > 0.4 ? '#FF9500' : '#34C759'}
+          rightLabel={formatPercent(m.congestion, 0)}
+        />
+      )}
+      {m.energyCost !== undefined && (
+        <Bar
+          label="Energy"
+          value={m.energyCost}
+          max={1}
+          color="#FFCC00"
+          rightLabel={m.energyCost.toFixed(2)}
+        />
+      )}
+    </View>
+  );
+}
+
+// ─── Retry queue + dedup ─────────────────────────────────────
+
+function RetryDedupCard({metrics}: {metrics: MetricsFrame | null}) {
+  if (!metrics) {return null;}
+  const r = metrics.retryQueue;
+  const total = Math.max(
+    1,
+    r.criticalPriorityCount + r.highPriorityCount + r.mediumPriorityCount + r.lowPriorityCount,
+  );
+  return (
+    <MetricCard title="Reliability" subtitle="retry queue · deduplicator">
+      <Text style={styles.subhead}>RETRY QUEUE BY PRIORITY</Text>
+      <Bar
+        label="Critical"
+        value={r.criticalPriorityCount}
+        max={total}
+        color="#FF3B30"
+        rightLabel={String(r.criticalPriorityCount)}
+      />
+      <Bar
+        label="High"
+        value={r.highPriorityCount}
+        max={total}
+        color="#FF9500"
+        rightLabel={String(r.highPriorityCount)}
+      />
+      <Bar
+        label="Medium"
+        value={r.mediumPriorityCount}
+        max={total}
+        color="#007AFF"
+        rightLabel={String(r.mediumPriorityCount)}
+      />
+      <Bar
+        label="Low"
+        value={r.lowPriorityCount}
+        max={total}
+        color="#8E8E93"
+        rightLabel={String(r.lowPriorityCount)}
+      />
+      <CardDivider />
+      <Text style={styles.subhead}>DEDUPLICATOR</Text>
+      <KeyValueRow k="Mode" v={metrics.dedup.mode} />
+      <KeyValueRow k="Tracked" v={formatCount(metrics.dedup.totalTracked)} />
+      <KeyValueRow k="Recent" v={formatCount(metrics.dedup.recentTracked)} />
+      <Bar
+        label="Capacity"
+        value={metrics.dedup.capacityUsedPercent}
+        max={100}
+        color={
+          metrics.dedup.capacityUsedPercent >= 80
+            ? '#FF3B30'
+            : metrics.dedup.capacityUsedPercent >= 50
+            ? '#FF9500'
+            : '#34C759'
+        }
+        rightLabel={`${metrics.dedup.capacityUsedPercent.toFixed(0)}%`}
+      />
+      {metrics.dedup.falsePositiveRate !== undefined && (
+        <KeyValueRow
+          k="False-pos rate"
+          v={`${(metrics.dedup.falsePositiveRate * 100).toFixed(3)}%`}
+        />
+      )}
+    </MetricCard>
+  );
+}
+
+// ─── DORS decisions ──────────────────────────────────────────
+
+function RoutingDecisionsCard({decisions}: {decisions: RoutingDecision[]}) {
+  const [expanded, setExpanded] = useState<number | null>(null);
+  return (
+    <MetricCard
+      title="DORS Decisions"
+      subtitle={decisions.length > 0 ? `${decisions.length} recent` : 'no decisions yet'}>
+      {decisions.length === 0 && (
+        <Text style={styles.empty}>
+          No routing decisions emitted yet. They appear when DORS scores or switches transports.
+        </Text>
+      )}
+      {decisions.slice(0, 8).map((d, i) => {
+        const isOpen = expanded === i;
+        return (
+          <View key={i} style={styles.decisionRow}>
+            <TouchableOpacity
+              activeOpacity={0.7}
+              onPress={() => setExpanded(isOpen ? null : i)}>
+              <View style={styles.decisionHeader}>
+                <View
+                  style={[
+                    styles.phaseBadge,
+                    {backgroundColor: routingPhaseColor(d.phase)},
+                  ]}>
+                  <Text style={styles.phaseText}>{d.phase}</Text>
+                </View>
+                <Text style={styles.reason}>{reasonLabel(d.reasonCode)}</Text>
+                <Text style={styles.decisionTime}>{formatRelative(d.timestampMs)}</Text>
+              </View>
+              <View style={styles.decisionBody}>
+                {d.from && (
+                  <>
+                    <TransportBadge transport={d.from} small />
+                    <Text style={styles.arrow}>→</Text>
+                  </>
+                )}
+                {d.to ? (
+                  <TransportBadge transport={d.to} small />
+                ) : (
+                  <Text style={styles.noTo}>—</Text>
+                )}
+                {d.winningScore !== undefined && (
+                  <Text style={styles.score}>score {d.winningScore.toFixed(2)}</Text>
+                )}
+                {d.scores.length > 0 && (
+                  <Text style={styles.expandHint}>{isOpen ? '▾' : '▸'} scores</Text>
+                )}
+              </View>
+            </TouchableOpacity>
+            {isOpen && d.scores.length > 0 && (
+              <View>
+                {d.scores.map(s => (
+                  <RoutingScoreBars key={s.transport} entry={s} />
+                ))}
+              </View>
+            )}
+          </View>
+        );
+      })}
+    </MetricCard>
+  );
+}
+
+// ─── Transport state timeline ────────────────────────────────
+
+function TransportTimelineCard({
+  timeline,
+}: {
+  timeline: ReturnType<typeof useProtocol>['transportTimeline'];
+}) {
+  return (
+    <MetricCard
+      title="Transport State Timeline"
+      subtitle={timeline.length > 0 ? `${timeline.length} transitions` : 'no transitions'}>
+      {timeline.length === 0 && (
+        <Text style={styles.empty}>
+          Transitions appear when a transport's connection status changes.
+        </Text>
+      )}
+      {timeline.slice(0, 12).map((ev, i) => (
+        <View key={`${ev.timestampMs}-${i}`} style={styles.timelineRow}>
+          <View
+            style={[
+              styles.timelineDot,
+              {backgroundColor: transportStatusColor(ev.current)},
+            ]}
+          />
+          <View style={styles.timelineBody}>
+            <View style={styles.timelineTopRow}>
+              <TransportBadge transport={ev.transport} small />
+              <Text style={styles.timelineTime}>{formatRelative(ev.timestampMs)}</Text>
+            </View>
+            <View style={styles.timelineTransition}>
+              <Text style={[styles.statusText, {color: transportStatusColor(ev.previous)}]}>
+                {ev.previous}
+              </Text>
+              <Text style={styles.arrow}>→</Text>
+              <Text style={[styles.statusText, {color: transportStatusColor(ev.current)}]}>
+                {ev.current}
+              </Text>
+            </View>
+          </View>
+        </View>
+      ))}
+    </MetricCard>
+  );
+}
+
+// ─── MLS lifecycle log ───────────────────────────────────────
+
+const MLS_TYPE_COLORS: Record<string, string> = {
+  initialized: '#34C759',
+  encryption_used: '#007AFF',
+  session_ready: '#34C759',
+  session_missing: '#FF9500',
+  decryption_failed: '#FF3B30',
+};
+
+function MlsLogCard({log}: {log: ReturnType<typeof useProtocol>['mlsLog']}) {
+  return (
+    <MetricCard
+      title="MLS Lifecycle"
+      subtitle={log.length > 0 ? `${log.length} events` : 'no MLS activity yet'}>
+      {log.length === 0 && (
+        <Text style={styles.empty}>
+          MLS lifecycle events appear when a session initializes, encrypts, or fails.
+        </Text>
+      )}
+      {log.slice(0, 10).map((entry, i) => {
+        const color = MLS_TYPE_COLORS[entry.type] ?? '#8E8E93';
+        return (
+          <View key={i} style={styles.mlsRow}>
+            <View style={[styles.mlsDot, {backgroundColor: color}]} />
+            <View style={styles.mlsBody}>
+              <View style={styles.mlsTopRow}>
+                <Text style={[styles.mlsType, {color}]}>{entry.type}</Text>
+                <Text style={styles.mlsTime}>{formatRelative(entry.ts)}</Text>
+              </View>
+              {renderMlsDetail(entry.raw)}
+            </View>
+          </View>
+        );
+      })}
+    </MetricCard>
+  );
+}
+
+function renderMlsDetail(raw: any): React.ReactNode {
+  if (!raw || typeof raw !== 'object') {return null;}
+  const interesting = ['groupId', 'group_id', 'peerId', 'peer_id', 'ciphersuite', 'reason', 'epoch'];
+  const lines: string[] = [];
+  for (const k of interesting) {
+    if (raw[k] !== undefined && raw[k] !== null) {
+      lines.push(`${k}=${String(raw[k])}`);
+    }
+  }
+  if (lines.length === 0) {return null;}
+  return <Text style={styles.mlsDetail}>{lines.join(' · ')}</Text>;
+}
+
+// ─── Event counters ──────────────────────────────────────────
+
+function EventCountersCard({
+  counts,
+  total,
+}: {
+  counts: Record<string, number>;
+  total: number;
+}) {
+  const sorted = useMemo(
+    () =>
+      Object.entries(counts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 12),
+    [counts],
+  );
+  if (sorted.length === 0) {
+    return (
+      <MetricCard title="Protocol Event Stream" subtitle="0 total">
+        <Text style={styles.empty}>No protocol events received yet.</Text>
+      </MetricCard>
+    );
+  }
+  const max = Math.max(...sorted.map(([, n]) => n));
+  return (
+    <MetricCard
+      title="Protocol Event Stream"
+      subtitle={`${formatCount(total)} total · top ${sorted.length}`}>
+      {sorted.map(([type, n]) => (
+        <Bar
+          key={type}
+          label={shortenEventType(type)}
+          value={n}
+          max={max}
+          color="#007AFF"
+          rightLabel={String(n)}
+        />
+      ))}
+    </MetricCard>
+  );
+}
+
+function shortenEventType(t: string): string {
+  // Strip any common prefixes for readability while keeping uniqueness
+  return t.replace(/^protocol_/, '').replace(/_/g, ' ');
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    flex: 1,
+    backgroundColor: '#F2F2F7',
+  },
+  content: {
+    paddingBottom: 24,
+  },
+  hero: {
+    backgroundColor: '#FFFFFF',
+    marginHorizontal: 12,
+    marginTop: 12,
+    borderRadius: 12,
+    padding: 14,
+    borderLeftWidth: 4,
+    borderLeftColor: '#C7C7CC',
+  },
+  heroEmpty: {
+    color: '#8E8E93',
+    fontStyle: 'italic',
+    textAlign: 'center',
+    paddingVertical: 16,
+  },
+  heroTop: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+  },
+  heroLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#8E8E93',
+    letterSpacing: 0.6,
+  },
+  heroRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 4,
+  },
+  heroDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  heroValue: {
+    fontSize: 28,
+    fontWeight: '800',
+    letterSpacing: 0.5,
+  },
+  heroSecondary: {
+    fontSize: 14,
+    color: '#1C1C1E',
+    fontWeight: '600',
+    marginTop: 4,
+    fontVariant: ['tabular-nums'],
+  },
+  heroSpark: {
+    marginTop: 12,
+  },
+  heroSparkLabel: {
+    fontSize: 10,
+    color: '#8E8E93',
+    marginTop: 4,
+    textAlign: 'right',
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 10,
+  },
+  chip: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+  },
+  chipText: {
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 0.4,
+  },
+  changedHint: {
+    fontSize: 10,
+    color: '#8E8E93',
+    marginTop: 6,
+    fontStyle: 'italic',
+  },
+  transportHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 6,
+  },
+  kvGrid: {
+    flexDirection: 'row',
+    gap: 16,
+    marginVertical: 4,
+  },
+  kvCol: {
+    flex: 1,
+  },
+  subhead: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#8E8E93',
+    letterSpacing: 0.6,
+    marginBottom: 4,
+  },
+  empty: {
+    fontSize: 12,
+    color: '#8E8E93',
+    fontStyle: 'italic',
+    paddingVertical: 4,
+  },
+  decisionRow: {
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E5E5EA',
+  },
+  decisionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  phaseBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  phaseText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    letterSpacing: 0.4,
+  },
+  reason: {
+    fontSize: 11,
+    color: '#3C3C43',
+    fontWeight: '600',
+    flex: 1,
+  },
+  decisionTime: {
+    fontSize: 10,
+    color: '#8E8E93',
+    fontVariant: ['tabular-nums'],
+  },
+  decisionBody: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 6,
+  },
+  arrow: {
+    fontSize: 14,
+    color: '#8E8E93',
+    fontWeight: '700',
+  },
+  noTo: {
+    fontSize: 12,
+    color: '#8E8E93',
+  },
+  score: {
+    fontSize: 11,
+    color: '#1C1C1E',
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+    marginLeft: 'auto',
+  },
+  expandHint: {
+    fontSize: 10,
+    color: '#007AFF',
+    fontWeight: '600',
+  },
+  timelineRow: {
+    flexDirection: 'row',
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E5E5EA',
+    gap: 10,
+  },
+  timelineDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    marginTop: 4,
+  },
+  timelineBody: {
+    flex: 1,
+    gap: 4,
+  },
+  timelineTopRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  timelineTime: {
+    fontSize: 10,
+    color: '#8E8E93',
+    fontVariant: ['tabular-nums'],
+  },
+  timelineTransition: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  statusText: {
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  mlsRow: {
+    flexDirection: 'row',
+    paddingVertical: 8,
+    gap: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E5E5EA',
+  },
+  mlsDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginTop: 6,
+  },
+  mlsBody: {
+    flex: 1,
+  },
+  mlsTopRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  mlsType: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+  },
+  mlsTime: {
+    fontSize: 10,
+    color: '#8E8E93',
+    fontVariant: ['tabular-nums'],
+  },
+  mlsDetail: {
+    fontSize: 11,
+    color: '#3C3C43',
+    marginTop: 2,
+    fontFamily: 'Courier',
+  },
+  footer: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  footerText: {
+    fontSize: 10,
+    color: '#8E8E93',
+    fontStyle: 'italic',
+  },
+});

--- a/examples/demo-app/src/telemetryFormat.ts
+++ b/examples/demo-app/src/telemetryFormat.ts
@@ -1,0 +1,96 @@
+import type {TransportType} from '@offline-protocol/mesh-sdk';
+
+const TRANSPORT_COLORS: Record<string, string> = {
+  ble: '#007AFF',
+  wifiDirect: '#34C759',
+  internet: '#5856D6',
+  reticulum: '#FF9500',
+  nostr: '#AF52DE',
+};
+
+const TRANSPORT_LABELS: Record<string, string> = {
+  ble: 'BLE',
+  wifiDirect: 'WiFi-D',
+  internet: 'NET',
+  reticulum: 'RNS',
+  nostr: 'NOSTR',
+};
+
+export function transportColor(t: TransportType | string): string {
+  return TRANSPORT_COLORS[t as string] ?? '#8E8E93';
+}
+
+export function transportLabel(t: TransportType | string): string {
+  return TRANSPORT_LABELS[t as string] ?? String(t).toUpperCase();
+}
+
+const TRANSPORT_STATUS_COLORS: Record<string, string> = {
+  available: '#34C759',
+  connecting: '#FF9500',
+  unavailable: '#8E8E93',
+  disconnected: '#8E8E93',
+  error: '#FF3B30',
+};
+
+export function transportStatusColor(s: string): string {
+  return TRANSPORT_STATUS_COLORS[s] ?? '#8E8E93';
+}
+
+const ROUTING_PHASE_COLORS: Record<string, string> = {
+  scoreUpdated: '#8E8E93',
+  selected: '#007AFF',
+  switched: '#5856D6',
+  escalated: '#FF9500',
+  unknown: '#C7C7CC',
+};
+
+export function routingPhaseColor(p: string): string {
+  return ROUTING_PHASE_COLORS[p] ?? '#8E8E93';
+}
+
+const REASON_LABELS: Record<string, string> = {
+  initialSelection: 'initial',
+  primarySelected: 'primary',
+  primarySuccess: 'primary ok',
+  fallbackSuccess: 'fallback ok',
+  escalationApplied: 'escalation',
+  currentUnavailable: 'unavailable',
+  retryThreshold: 'retry',
+  poorSignal: 'poor signal',
+  congestion: 'congestion',
+  lowTtl: 'low ttl',
+  lowSuccessRate: 'low success',
+  unknown: 'unknown',
+};
+
+export function reasonLabel(r?: string | null): string {
+  if (!r) {return '—';}
+  return REASON_LABELS[r] ?? r;
+}
+
+/** Compact human-readable byte count: 12.4 KB / 1.2 MB / 4.5 GB. */
+export function formatBytes(n: number): string {
+  if (n < 1024) {return `${n} B`;}
+  if (n < 1024 * 1024) {return `${(n / 1024).toFixed(1)} KB`;}
+  if (n < 1024 * 1024 * 1024) {return `${(n / 1024 / 1024).toFixed(1)} MB`;}
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+/** Compact integer count: 1.2K / 4.5M. */
+export function formatCount(n: number): string {
+  if (n < 1000) {return String(n);}
+  if (n < 1_000_000) {return `${(n / 1000).toFixed(1)}K`;}
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+export function formatPercent(n: number, digits = 0): string {
+  return `${(n * 100).toFixed(digits)}%`;
+}
+
+export function formatRelative(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 1000) {return 'now';}
+  if (diff < 60_000) {return `${Math.floor(diff / 1000)}s`;}
+  if (diff < 3_600_000) {return `${Math.floor(diff / 60_000)}m`;}
+  return `${Math.floor(diff / 3_600_000)}h`;
+}

--- a/examples/demo-app/src/telemetryFormat.ts
+++ b/examples/demo-app/src/telemetryFormat.ts
@@ -24,30 +24,6 @@ export function transportLabel(t: TransportType | string): string {
   return TRANSPORT_LABELS[t as string] ?? String(t).toUpperCase();
 }
 
-const TRANSPORT_STATUS_COLORS: Record<string, string> = {
-  available: '#34C759',
-  connecting: '#FF9500',
-  unavailable: '#8E8E93',
-  disconnected: '#8E8E93',
-  error: '#FF3B30',
-};
-
-export function transportStatusColor(s: string): string {
-  return TRANSPORT_STATUS_COLORS[s] ?? '#8E8E93';
-}
-
-const ROUTING_PHASE_COLORS: Record<string, string> = {
-  scoreUpdated: '#8E8E93',
-  selected: '#007AFF',
-  switched: '#5856D6',
-  escalated: '#FF9500',
-  unknown: '#C7C7CC',
-};
-
-export function routingPhaseColor(p: string): string {
-  return ROUTING_PHASE_COLORS[p] ?? '#8E8E93';
-}
-
 const REASON_LABELS: Record<string, string> = {
   initialSelection: 'initial',
   primarySelected: 'primary',
@@ -66,25 +42,6 @@ const REASON_LABELS: Record<string, string> = {
 export function reasonLabel(r?: string | null): string {
   if (!r) {return '—';}
   return REASON_LABELS[r] ?? r;
-}
-
-/** Compact human-readable byte count: 12.4 KB / 1.2 MB / 4.5 GB. */
-export function formatBytes(n: number): string {
-  if (n < 1024) {return `${n} B`;}
-  if (n < 1024 * 1024) {return `${(n / 1024).toFixed(1)} KB`;}
-  if (n < 1024 * 1024 * 1024) {return `${(n / 1024 / 1024).toFixed(1)} MB`;}
-  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
-}
-
-/** Compact integer count: 1.2K / 4.5M. */
-export function formatCount(n: number): string {
-  if (n < 1000) {return String(n);}
-  if (n < 1_000_000) {return `${(n / 1000).toFixed(1)}K`;}
-  return `${(n / 1_000_000).toFixed(1)}M`;
-}
-
-export function formatPercent(n: number, digits = 0): string {
-  return `${(n * 100).toFixed(digits)}%`;
 }
 
 export function formatRelative(ts: number): string {

--- a/examples/demo-app/src/types.ts
+++ b/examples/demo-app/src/types.ts
@@ -81,14 +81,3 @@ export interface ServiceLogEntry {
 }
 
 export type TabName = 'people' | 'chats' | 'groups' | 'services' | 'diagnostics';
-
-export interface MlsLogEntry {
-  ts: number;
-  type: string;
-  raw: any;
-}
-
-export interface ProtocolEventLogEntry {
-  ts: number;
-  type: string;
-}

--- a/examples/demo-app/src/types.ts
+++ b/examples/demo-app/src/types.ts
@@ -80,4 +80,15 @@ export interface ServiceLogEntry {
   timestamp: number;
 }
 
-export type TabName = 'people' | 'chats' | 'groups' | 'services';
+export type TabName = 'people' | 'chats' | 'groups' | 'services' | 'diagnostics';
+
+export interface MlsLogEntry {
+  ts: number;
+  type: string;
+  raw: any;
+}
+
+export interface ProtocolEventLogEntry {
+  ts: number;
+  type: string;
+}


### PR DESCRIPTION
## Summary
- Wires the SDK's `TelemetrySink` push stream into the demo app's `ProtocolContext`, with bounded buffers for metrics / transport state / routing decisions / MLS lifecycle / device capability and a rolling protocol-event counter.
- Adds an always-on **StatusPill** in the top bar (current transport, peer count, battery + charging, RELAY chip) that taps through to a new **Diagnostics** tab.
- Diagnostics tab visualizes everything the SDK already produces but the user couldn't see: hero card with packet sparkline, network KPI tiles, per-transport metrics with sparklines + RSSI/congestion/energy bars, retry queue & dedup, **DORS decision feed with per-transport score breakdowns** (`signal/proximity/bandwidth/congestion/energy/reliability/load`), transport state timeline, MLS lifecycle log, and a top-N protocol event counter.
- Drive-by fix: replaces `RCTLogWarn(...)` in the iOS Swift module with `print(...)`. `RCTLogWarn` is a C variadic macro and cannot be imported into Swift, so the iOS bridge currently fails to compile (`cannot find 'RCTLogWarn' in scope`). The rest of the file already uses `print(...)` for diagnostic output.

No Rust or UDL changes — consumes the `TelemetryRecord` union and `installTelemetrySink` / `uninstallTelemetrySink` / `onTelemetry` API surface added in #94.

## Telemetry config
The demo installs the sink with `routingDiagnostic: true` (so the score-breakdown bars get populated), `metricsCadenceMs: 2000`, `mlsVerbosity: 'lifecycle'`, and `enablePollQueue: false` (push-only).

## Test plan
- [ ] `npm run build:uniffi:ios` (refreshes Swift bindings + `.a`s with the telemetry FFI symbols, which the published prebuilts didn't have)
- [ ] `npm run ios` from `examples/demo-app` — verify the app builds, the StatusPill appears in the top bar after init, and the Diagnostics tab populates within 2s
- [ ] `npm run build:uniffi:android` then `npm run android` — same verification on Android
- [ ] On Diagnostics: confirm metrics sparklines move when traffic flows, DORS rows expand to show per-transport score bars, transport-state timeline records BLE/WiFi transitions, MLS lifecycle log shows `session_ready` after a key exchange
- [ ] Tap the StatusPill — should jump to Diagnostics
- [ ] Background/kill the app — `uninstallTelemetrySink` should run without errors (covered by `useEffect` cleanup)