### PR TITLE
fix(bindings): guard BlePeripheral peer maps with existing lock

### DIFF
--- a/bindings/python/offline_protocol_sdk/ble_peripheral.py
+++ b/bindings/python/offline_protocol_sdk/ble_peripheral.py
@@ -113,10 +113,20 @@ class BlePeripheral(TransportManager):
         # user_id so the Rust BLE transport can route outgoing messages.
         self._central_to_user_id: dict[str, str] = {}
 
+        # Sticky "last known" central for single-peer sender attribution —
+        # see _resolve_sender. Held to survive brief windows where the
+        # peer monitor loop has not yet populated _connected_centrals.
+        self._last_known_central: str | None = None
+
         # Event loop — captured in start() for thread-safe callback scheduling
         self._loop: asyncio.AbstractEventLoop | None = None
 
-        # Lock protecting metrics — _on_write runs on bless's delegate thread
+        # Lock protecting state shared between bless's delegate thread
+        # (_on_write / _resolve_sender) and the asyncio event loop
+        # (_peer_monitor_loop, resolve_sender_identity, stop). Guards:
+        # metrics counters, _connected_centrals, _central_to_user_id,
+        # _last_known_central. Follow "snapshot under lock, FFI outside"
+        # so threading.Lock is never held across an await.
         self._lock = threading.Lock()
 
         # Metrics
@@ -216,20 +226,27 @@ class BlePeripheral(TransportManager):
             self._server = None
         self._is_advertising = False
 
-        # Notify protocol about all lost peers (both raw UUID and resolved user_id)
-        for central_uuid in list(self._connected_centrals):
+        # Snapshot under the lock so the delegate thread can't mutate
+        # these maps concurrently, then emit FFI notifications outside
+        # the lock (never hold threading.Lock across FFI).
+        with self._lock:
+            centrals_snapshot = list(self._connected_centrals.keys())
+            resolved_snapshot = dict(self._central_to_user_id)
+            self._connected_centrals.clear()
+            self._central_to_user_id.clear()
+            self._last_known_central = None
+
+        for central_uuid in centrals_snapshot:
             try:
                 self._protocol.ble_peer_lost(peer_id=central_uuid)
             except Exception:
                 logger.debug("ble_peer_lost failed for %s", central_uuid)
-            resolved_uid = self._central_to_user_id.get(central_uuid)
+            resolved_uid = resolved_snapshot.get(central_uuid)
             if resolved_uid:
                 try:
                     self._protocol.ble_peer_lost(peer_id=resolved_uid)
                 except Exception:
                     logger.debug("ble_peer_lost failed for resolved %s", resolved_uid)
-        self._connected_centrals.clear()
-        self._central_to_user_id.clear()
 
         try:
             self._protocol.ble_status_changed(is_available=False)
@@ -366,21 +383,22 @@ class BlePeripheral(TransportManager):
     def _resolve_sender(self) -> str:
         """Best-effort identification of the writing central.
 
-        Returns a stable sender ID so that the Rust core can group
-        fragments from the same source.  If the peer monitor hasn't
-        detected the subscription yet (``_connected_centrals`` is empty),
-        fall back to the last known central UUID.  This prevents the
-        sender flipping between ``"ble-peer"`` and a UUID within the
-        same message's fragments, which breaks reassembly.
+        Called from the bless delegate thread, so state reads/writes must
+        take `self._lock` — the asyncio `_peer_monitor_loop` mutates
+        `_connected_centrals` / `_last_known_central` from a different
+        thread. Returns a stable sender ID so the Rust core can group
+        fragments from the same source.
         """
-        if len(self._connected_centrals) == 1:
-            central = next(iter(self._connected_centrals))
-            self._last_known_central = central
-            return central
-        if len(self._connected_centrals) > 1:
-            return "ble-peer"
-        # No centrals currently tracked — use last known if available
-        return getattr(self, '_last_known_central', 'ble-peer')
+        with self._lock:
+            count = len(self._connected_centrals)
+            if count == 1:
+                central = next(iter(self._connected_centrals))
+                self._last_known_central = central
+                return central
+            if count > 1:
+                return "ble-peer"
+            # No centrals currently tracked — use last known if available.
+            return self._last_known_central or "ble-peer"
 
     def resolve_sender_identity(self, sender_user_id: str) -> None:
         """Associate a sender's user_id with the currently connected central.
@@ -395,25 +413,23 @@ class BlePeripheral(TransportManager):
         Rust core under its real user_id so that ``send_message(user_id, ...)``
         can route back through the BLE peripheral.
         """
-        if not self._connected_centrals:
-            return
+        with self._lock:
+            count = len(self._connected_centrals)
+            if count == 0:
+                return
+            if count != 1:
+                # With multiple centrals we can't attribute unambiguously.
+                logger.debug(
+                    "resolve_sender_identity: %d centrals connected, skipping",
+                    count,
+                )
+                return
+            central_uuid = next(iter(self._connected_centrals))
+            # Avoid redundant re-registration.
+            if self._central_to_user_id.get(central_uuid) == sender_user_id:
+                return
+            self._central_to_user_id[central_uuid] = sender_user_id
 
-        # With one central connected the mapping is unambiguous.
-        # With multiple, we can't reliably attribute — skip.
-        if len(self._connected_centrals) != 1:
-            logger.debug(
-                "resolve_sender_identity: %d centrals connected, skipping",
-                len(self._connected_centrals),
-            )
-            return
-
-        central_uuid = next(iter(self._connected_centrals))
-
-        # Avoid redundant re-registration
-        if self._central_to_user_id.get(central_uuid) == sender_user_id:
-            return
-
-        self._central_to_user_id[central_uuid] = sender_user_id
         logger.info(
             "Resolved central %s -> user_id %s — re-registering peer",
             central_uuid, sender_user_id,
@@ -527,17 +543,38 @@ class BlePeripheral(TransportManager):
                     )
                     continue
 
-                # New centrals
-                for central_uuid in current - known:
-                    if len(self._connected_centrals) >= self._max_connections:
-                        self._emit_diagnostic(
-                            "warning",
-                            f"Max connections ({self._max_connections}) reached, "
-                            f"ignoring {central_uuid}",
-                        )
-                        continue
+                # Classify under the lock (the delegate thread races us on
+                # _connected_centrals / _central_to_user_id). FFI + diagnostic
+                # notifications happen afterward, outside the lock.
+                now = time.monotonic()
+                added: list[str] = []
+                rejected: list[str] = []
+                removed: list[tuple[str, str | None]] = []
 
-                    self._connected_centrals[central_uuid] = time.monotonic()
+                with self._lock:
+                    capacity = self._max_connections
+                    for central_uuid in current - known:
+                        if len(self._connected_centrals) >= capacity:
+                            rejected.append(central_uuid)
+                            continue
+                        self._connected_centrals[central_uuid] = now
+                        added.append(central_uuid)
+
+                    for central_uuid in known - current:
+                        self._connected_centrals.pop(central_uuid, None)
+                        resolved_uid = self._central_to_user_id.pop(
+                            central_uuid, None
+                        )
+                        removed.append((central_uuid, resolved_uid))
+
+                for central_uuid in rejected:
+                    self._emit_diagnostic(
+                        "warning",
+                        f"Max connections ({self._max_connections}) reached, "
+                        f"ignoring {central_uuid}",
+                    )
+
+                for central_uuid in added:
                     try:
                         self._protocol.ble_peer_discovered(
                             peer_id=central_uuid, rssi=-50
@@ -548,13 +585,7 @@ class BlePeripheral(TransportManager):
                         "info", "Central connected", {"central": central_uuid}
                     )
 
-                # Lost centrals
-                for central_uuid in known - current:
-                    self._connected_centrals.pop(central_uuid, None)
-                    # Notify peer lost for both the raw UUID and the
-                    # resolved user_id (if any) so the Rust core removes
-                    # both routing entries.
-                    resolved_uid = self._central_to_user_id.pop(central_uuid, None)
+                for central_uuid, resolved_uid in removed:
                     try:
                         self._protocol.ble_peer_lost(peer_id=central_uuid)
                     except Exception:
@@ -563,7 +594,9 @@ class BlePeripheral(TransportManager):
                         try:
                             self._protocol.ble_peer_lost(peer_id=resolved_uid)
                         except Exception:
-                            logger.debug("ble_peer_lost failed for resolved %s", resolved_uid)
+                            logger.debug(
+                                "ble_peer_lost failed for resolved %s", resolved_uid
+                            )
                     self._emit_diagnostic(
                         "info", "Central disconnected", {"central": central_uuid}
                     )

--- a/bindings/python/tests/test_ble_peripheral.py
+++ b/bindings/python/tests/test_ble_peripheral.py
@@ -282,3 +282,124 @@ class TestPeerMonitoring:
             await task
         except asyncio.CancelledError:
             pass
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety — #4 in the PR review.
+# `_on_write` / `_resolve_sender` run on bless's delegate thread while the
+# asyncio loop mutates the same state from `_peer_monitor_loop`,
+# `resolve_sender_identity`, and `stop`. Without the lock widening,
+# concurrent iteration could fail mid-loop or return stale reads.
+# ---------------------------------------------------------------------------
+
+class TestConcurrentAccess:
+    def test_resolve_sender_survives_concurrent_monitor_mutation(
+        self, peripheral, mock_protocol
+    ):
+        """Hammering _resolve_sender from a worker thread while the event
+        loop mutates _connected_centrals must not raise or return garbage."""
+        import threading
+
+        errors: list[BaseException] = []
+
+        def reader() -> None:
+            try:
+                for _ in range(500):
+                    peripheral._resolve_sender()
+            except BaseException as exc:
+                errors.append(exc)
+
+        def writer() -> None:
+            try:
+                for i in range(500):
+                    with peripheral._lock:
+                        peripheral._connected_centrals[f"c{i}"] = 0.0
+                    with peripheral._lock:
+                        peripheral._connected_centrals.pop(f"c{i}", None)
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(3)] + [
+            threading.Thread(target=writer) for _ in range(3)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+
+    def test_resolve_sender_identity_holds_lock_around_mutations(
+        self, peripheral, mock_protocol
+    ):
+        """resolve_sender_identity must not leave _central_to_user_id in
+        an inconsistent state under concurrent callers."""
+        import threading
+
+        peripheral._connected_centrals["only-central"] = 0.0
+        errors: list[BaseException] = []
+
+        def caller(uid: str) -> None:
+            try:
+                for _ in range(200):
+                    peripheral.resolve_sender_identity(uid)
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=caller, args=(f"user-{i}",))
+            for i in range(4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        # Exactly one entry for the single central; value is whichever
+        # thread won the last write.
+        assert list(peripheral._central_to_user_id) == ["only-central"]
+
+    def test_stop_clears_maps_under_lock(self, peripheral, mock_protocol):
+        """stop() must snapshot-and-clear atomically: a delegate-thread
+        reader running concurrently must never see a partially-mutated dict."""
+        import threading
+
+        peripheral._connected_centrals.update(
+            {f"c{i}": 0.0 for i in range(50)}
+        )
+        peripheral._central_to_user_id.update(
+            {f"c{i}": f"u{i}" for i in range(50)}
+        )
+
+        # Force stop to take the running-state branch.
+        peripheral._state = TransportState.RUNNING
+        peripheral._server = None  # skip the server.stop path
+
+        errors: list[BaseException] = []
+        stop_raised = threading.Event()
+
+        def reader() -> None:
+            try:
+                while not stop_raised.is_set():
+                    peripheral._resolve_sender()
+            except BaseException as exc:
+                errors.append(exc)
+
+        t = threading.Thread(target=reader)
+        t.start()
+
+        # Run stop on a fresh loop — this test is sync so pytest-asyncio
+        # isn't driving an event loop for us.
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(peripheral.stop())
+        finally:
+            loop.close()
+
+        stop_raised.set()
+        t.join()
+
+        assert errors == []
+        assert peripheral._connected_centrals == {}
+        assert peripheral._central_to_user_id == {}


### PR DESCRIPTION
## Summary

- `self._lock` was only protecting the metrics counters. The bless delegate thread (`_on_write` → `_resolve_sender`) and the asyncio loop (`_peer_monitor_loop`, `resolve_sender_identity`, `stop`) read and write `_connected_centrals`, `_central_to_user_id`, and `_last_known_central` concurrently — iteration-during-mutation would eventually surface as a RuntimeError in production; single-peer sender attribution could also flip between threads on the same message.
- Widen the lock's responsibilities to cover those three fields, with a strict "snapshot under lock, FFI outside" rule so `threading.Lock` is never held across an `await`. `_last_known_central` is now initialized in `__init__` (previously `getattr(..., default)`).
- Three regression tests exercise the hot paths under multi-thread load: concurrent `_resolve_sender` vs. monitor mutation, concurrent `resolve_sender_identity` callers, and `stop()` clearing maps while a delegate-thread reader hammers `_resolve_sender`.

## Test plan

- [x] `pytest tests/test_ble_peripheral.py -v` — 20 pass (includes the 3 new concurrency tests)
- [x] `pytest tests/` full suite — 103 pass