### PR TITLE
fix(bindings): copy uniffi.dll on windows instead of symlinking

### DIFF
--- a/bindings/python/scripts/build-desktop.sh
+++ b/bindings/python/scripts/build-desktop.sh
@@ -134,16 +134,29 @@ mkdir -p "$PKG_DIR"
 cp "$CDYLIB" "$PKG_DIR/$LIB_NAME"
 echo "Copied $LIB_NAME -> $PKG_DIR/"
 
-# Create a symlink with the name the generated Python bindings expect.
-# UniFFI's UDL-mode Python codegen loads "libuniffi.{dylib,so,dll}" — create
-# the appropriately named symlink pointing at the real library.
+# Stage a second copy with the name the generated Python bindings expect.
+# UniFFI's UDL-mode Python codegen loads "libuniffi.{dylib,so,dll}". On
+# macOS and Linux we use a symlink (cheap, space-saving). On Windows we
+# copy, because `ln -sf` under Git Bash / MSYS requires the
+# SeCreateSymbolicLink privilege (admin or Developer Mode) — otherwise
+# it either silently produces a broken file or a regular copy depending
+# on the MSYS2 winsymlinks setting, which CI and end users should not
+# have to configure.
 case "$TARGET" in
     *-apple-darwin)  SYMLINK_NAME="libuniffi.dylib" ;;
     *-linux-*)       SYMLINK_NAME="libuniffi.so" ;;
     *-windows-*)     SYMLINK_NAME="uniffi.dll" ;;
 esac
-(cd "$PKG_DIR" && ln -sf "$LIB_NAME" "$SYMLINK_NAME")
-echo "Symlinked $SYMLINK_NAME -> $LIB_NAME"
+case "$TARGET" in
+    *-windows-*)
+        (cd "$PKG_DIR" && cp -f "$LIB_NAME" "$SYMLINK_NAME")
+        echo "Copied $SYMLINK_NAME <- $LIB_NAME"
+        ;;
+    *)
+        (cd "$PKG_DIR" && ln -sf "$LIB_NAME" "$SYMLINK_NAME")
+        echo "Symlinked $SYMLINK_NAME -> $LIB_NAME"
+        ;;
+esac
 
 # Generate Python bindings
 echo ""


### PR DESCRIPTION
## Summary

- `ln -sf` on Git Bash / MSYS requires the `SeCreateSymbolicLink` privilege (admin or Developer Mode). Without it the symlink either becomes a broken file or a regular copy depending on the MSYS2 `winsymlinks` setting — neither is a configuration CI or end users should have to sort out.
- macOS / Linux keep the symlink (cheap, space-saving). Windows gets a straight `cp -f`.

## Test plan

- [x] `bash -n scripts/build-desktop.sh` — passes
- [x] Manual re-run on macOS produces the same staged library layout
- [ ] Needs a CI / manual run on Windows to confirm the new branch (no local Windows environment on hand — the change is inspection-only)