### PR TITLE
fix(bindings): raise on send_message("*") with no known BLE peers

### DIFF
--- a/bindings/python/offline_protocol_sdk/protocol_manager.py
+++ b/bindings/python/offline_protocol_sdk/protocol_manager.py
@@ -332,24 +332,38 @@ class ProtocolManager:
     ) -> str:
         """Send a text message and return its message ID.
 
-        If *recipient* is ``"*"`` (broadcast), the message is sent
+        If *recipient* is ``"*"`` (broadcast), the message is fanned out
         individually to every known BLE peer.  The Rust core's
         ``BleTransport::send()`` treats ``"*"`` as a literal peer-ID
         lookup which always fails; expanding here ensures broadcasts
         reach all connected devices.
+
+        Raises
+        ------
+        ValueError
+            If ``recipient == "*"`` and no BLE peers are currently known.
+            The previous behaviour silently handed ``"*"`` to the Rust
+            core, where it was guaranteed to fail downstream with no
+            surfaced error — masking a real bug class. Callers that want
+            to tolerate an empty peer set should check
+            ``_get_known_ble_peers`` or catch this.
         """
         if recipient == "*":
             peers = self._get_known_ble_peers()
-            if peers:
-                last_id = ""
-                for peer_id in peers:
-                    last_id = self._protocol.send_message(
-                        recipient=peer_id,
-                        content=content,
-                        priority=priority,
-                        reply_to_msg=reply_to,
-                    )
-                return last_id
+            if not peers:
+                raise ValueError(
+                    "Broadcast requested but no BLE peers are known; "
+                    "nothing to send."
+                )
+            last_id = ""
+            for peer_id in peers:
+                last_id = self._protocol.send_message(
+                    recipient=peer_id,
+                    content=content,
+                    priority=priority,
+                    reply_to_msg=reply_to,
+                )
+            return last_id
 
         return self._protocol.send_message(
             recipient=recipient,

--- a/bindings/python/tests/test_protocol_manager.py
+++ b/bindings/python/tests/test_protocol_manager.py
@@ -296,6 +296,65 @@ class TestProtocolManagerConvenience:
         assert pm.protocol is pm._protocol
 
 
+class TestProtocolManagerBroadcast:
+    """Covers `send_message("*")` semantics — #3 in the PR review.
+
+    The previous behaviour silently passed "*" through to the Rust core
+    when no BLE peers were known; the core's BLE transport treats "*" as
+    a literal peer-ID lookup and fails downstream with no surfaced
+    error. We now raise ValueError so callers learn immediately.
+    """
+
+    @pytest.mark.asyncio
+    async def test_broadcast_with_no_peers_raises(self):
+        config = _make_config(ble_enabled=True)
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        try:
+            pm._protocol.send_message = MagicMock(return_value="should-not-be-called")
+            with pytest.raises(ValueError, match="no BLE peers"):
+                pm.send_message("*", "hi")
+            pm._protocol.send_message.assert_not_called()
+        finally:
+            await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_with_peers_fans_out(self):
+        config = _make_config(ble_enabled=True)
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        try:
+            # Pre-populate the ble manager's peer map so _get_known_ble_peers
+            # returns deterministic results.
+            assert pm.ble is not None
+            with pm.ble._lock:
+                pm.ble._peer_device_ids.update({
+                    "addr-a": "peer-a",
+                    "addr-b": "peer-b",
+                })
+
+            call_ids = iter(["id-a", "id-b"])
+            pm._protocol.send_message = MagicMock(
+                side_effect=lambda **_: next(call_ids)
+            )
+
+            last_id = pm.send_message("*", "hi")
+            assert pm._protocol.send_message.call_count == 2
+            recipients = sorted(
+                c.kwargs["recipient"]
+                for c in pm._protocol.send_message.call_args_list
+            )
+            assert recipients == ["peer-a", "peer-b"]
+            # Returns the id from the final call.
+            assert last_id == "id-b"
+        finally:
+            await pm.stop()
+
+
 class TestProtocolManagerTransportCallbacks:
     @pytest.mark.asyncio
     async def test_nostr_and_reticulum_callbacks_registered_when_enabled(self):


### PR DESCRIPTION
## Summary

- Previously `send_message("*")` fell through to `protocol.send_message(recipient="*", ...)` whenever `_get_known_ble_peers()` returned an empty list. The Rust core's `BleTransport::send()` treats `"*"` as a literal peer-ID lookup and always fails — the caller got a message id back that would never deliver, with no surfaced error.
- Raise `ValueError` in that path. Callers that want to tolerate an empty peer set can query `_get_known_ble_peers` themselves or catch the exception.
- Two tests pin the behaviour: the empty-peers path raises and does not call into the core; the populated path fans out one send per peer.

## Behaviour change

This is a **user-visible behaviour change** for any caller that relied on `send_message("*")` silently no-op'ing when no peers were known. Such a caller was already getting unreliable behaviour (the Rust core would still reject the send), but the failure mode is now loud instead of silent.

## Test plan

- [x] `pytest tests/test_protocol_manager.py::TestProtocolManagerBroadcast -v` — 2 pass
- [x] `pytest tests/` full suite — 102 pass