### PR TITLE
fix(bindings): scope python broadcast raise to BLE-only semantics

### DIFF
--- a/bindings/python/offline_protocol_sdk/protocol_manager.py
+++ b/bindings/python/offline_protocol_sdk/protocol_manager.py
@@ -332,28 +332,34 @@ class ProtocolManager:
     ) -> str:
         """Send a text message and return its message ID.
 
-        If *recipient* is ``"*"`` (broadcast), the message is fanned out
-        individually to every known BLE peer.  The Rust core's
+        ``recipient == "*"`` is a **BLE-only convenience** in this
+        wrapper: the message is fanned out one-per-peer to every known
+        BLE peer (``get_known_ble_peers``). The Rust core's
         ``BleTransport::send()`` treats ``"*"`` as a literal peer-ID
-        lookup which always fails; expanding here ensures broadcasts
-        reach all connected devices.
+        lookup which always fails, so the fan-out is required for BLE.
+
+        This wrapper does **not** attempt cross-transport broadcast:
+        other transports (Internet, Nostr, Reticulum, Wi-Fi Direct)
+        accept ``"*"`` into their send queue but their broadcast
+        semantics are platform-layer concerns and are not routed
+        automatically by ``send_message``. If you need Nostr or
+        Internet broadcast, drive those transports directly.
 
         Raises
         ------
         ValueError
             If ``recipient == "*"`` and no BLE peers are currently known.
-            The previous behaviour silently handed ``"*"`` to the Rust
-            core, where it was guaranteed to fail downstream with no
-            surfaced error — masking a real bug class. Callers that want
-            to tolerate an empty peer set should check
-            ``_get_known_ble_peers`` or catch this.
+            To tolerate an empty BLE peer set, query
+            ``get_known_ble_peers`` first or catch this exception.
         """
         if recipient == "*":
-            peers = self._get_known_ble_peers()
+            peers = self.get_known_ble_peers()
             if not peers:
                 raise ValueError(
-                    "Broadcast requested but no BLE peers are known; "
-                    "nothing to send."
+                    "ProtocolManager's '*' broadcast fans out over BLE "
+                    "peers only; no BLE peers are currently known. "
+                    "Use get_known_ble_peers() to check before sending, "
+                    "or address a specific peer directly."
                 )
             last_id = ""
             for peer_id in peers:
@@ -372,8 +378,14 @@ class ProtocolManager:
             reply_to_msg=reply_to,
         )
 
-    def _get_known_ble_peers(self) -> list[str]:
-        """Return user_ids of all BLE-discovered peers."""
+    def get_known_ble_peers(self) -> list[str]:
+        """Return user_ids of all BLE-discovered peers (deduplicated).
+
+        Public because ``send_message("*")`` documents it as the
+        escape hatch for callers that want to check before a broadcast.
+        Union of central-mode (``self.ble``) and peripheral-mode
+        (``self.ble_peripheral``) peer maps.
+        """
         peers: list[str] = []
         if self.ble is not None:
             try:

--- a/bindings/python/tests/test_protocol_manager.py
+++ b/bindings/python/tests/test_protocol_manager.py
@@ -297,24 +297,47 @@ class TestProtocolManagerConvenience:
 
 
 class TestProtocolManagerBroadcast:
-    """Covers `send_message("*")` semantics — #3 in the PR review.
+    """`send_message("*")` is a BLE-only fan-out convenience.
 
-    The previous behaviour silently passed "*" through to the Rust core
-    when no BLE peers were known; the core's BLE transport treats "*" as
-    a literal peer-ID lookup and fails downstream with no surfaced
-    error. We now raise ValueError so callers learn immediately.
+    BLE rejects a literal "*" peer-ID at the transport layer, so the
+    Python wrapper expands "*" into one send per known BLE peer. An
+    empty BLE peer set raises ValueError regardless of whether other
+    transports are enabled — the wrapper does not attempt
+    cross-transport broadcast.
     """
 
     @pytest.mark.asyncio
     async def test_broadcast_with_no_peers_raises(self):
-        config = _make_config(ble_enabled=True)
+        config = _make_config(ble_enabled=True, internet_enabled=False)
         from offline_protocol_sdk.protocol_manager import ProtocolManager
 
         pm = ProtocolManager(config)
         await pm.start()
         try:
             pm._protocol.send_message = MagicMock(return_value="should-not-be-called")
-            with pytest.raises(ValueError, match="no BLE peers"):
+            with pytest.raises(ValueError, match="BLE peers"):
+                pm.send_message("*", "hi")
+            pm._protocol.send_message.assert_not_called()
+        finally:
+            await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_raises_even_when_other_transports_enabled(self):
+        # Pins the BLE-only scope: even with Internet/Nostr enabled, the
+        # wrapper does not route "*" through them. Callers who want
+        # Internet or Nostr broadcast must drive those transports directly.
+        config = _make_config(
+            ble_enabled=True,
+            internet_enabled=True,
+            nostr_enabled=True,
+        )
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        try:
+            pm._protocol.send_message = MagicMock(return_value="should-not-be-called")
+            with pytest.raises(ValueError, match="BLE peers"):
                 pm.send_message("*", "hi")
             pm._protocol.send_message.assert_not_called()
         finally:
@@ -328,8 +351,6 @@ class TestProtocolManagerBroadcast:
         pm = ProtocolManager(config)
         await pm.start()
         try:
-            # Pre-populate the ble manager's peer map so _get_known_ble_peers
-            # returns deterministic results.
             assert pm.ble is not None
             with pm.ble._lock:
                 pm.ble._peer_device_ids.update({
@@ -349,8 +370,42 @@ class TestProtocolManagerBroadcast:
                 for c in pm._protocol.send_message.call_args_list
             )
             assert recipients == ["peer-a", "peer-b"]
-            # Returns the id from the final call.
             assert last_id == "id-b"
+        finally:
+            await pm.stop()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_deduplicates_peers_across_central_and_peripheral(self):
+        # A peer reachable both as a BLE central (discovered by our
+        # scanner) and as a peripheral (connected to our advertised
+        # GATT) must receive the broadcast exactly once.
+        config = _make_config(ble_enabled=True)
+        from offline_protocol_sdk.protocol_manager import ProtocolManager
+
+        pm = ProtocolManager(config)
+        await pm.start()
+        try:
+            assert pm.ble is not None
+            assert pm.ble_peripheral is not None
+            with pm.ble._lock:
+                pm.ble._peer_device_ids.update({
+                    "addr-a": "peer-shared",
+                    "addr-b": "peer-b",
+                })
+            with pm.ble_peripheral._lock:
+                pm.ble_peripheral._central_to_user_id.update({
+                    "central-1": "peer-shared",
+                    "central-2": "peer-c",
+                })
+
+            pm._protocol.send_message = MagicMock(return_value="msg")
+            pm.send_message("*", "hi")
+
+            recipients = sorted(
+                c.kwargs["recipient"]
+                for c in pm._protocol.send_message.call_args_list
+            )
+            assert recipients == ["peer-b", "peer-c", "peer-shared"]
         finally:
             await pm.stop()
 


### PR DESCRIPTION
## Summary

Follow-up to #102. The `ValueError` on empty-BLE broadcast is the right behaviour, but its framing was ambiguous:

- The docstring pointed callers at `_get_known_ble_peers` (private) as the escape hatch.
- The test class docstring referenced \"#3 in the PR review\" — context-free for anyone reading the tests later.
- Nothing in the codebase said *why* the raise still fires when Internet / Nostr / Reticulum are enabled, so a future contributor could reasonably have relaxed it.

This PR keeps the behaviour, tightens the framing, and pins the decision in tests.

## Changes

- `send_message` docstring now states explicitly that `\"*\"` is a **BLE-only convenience** in the Python wrapper. Internet / Nostr / Reticulum / Wi-Fi Direct accept `\"*\"` into their send queue but their broadcast semantics are platform-layer concerns — the wrapper does not route them automatically.
- `ValueError` message rewritten to `\"ProtocolManager's '*' broadcast fans out over BLE peers only; no BLE peers are currently known. Use get_known_ble_peers() to check before sending, or address a specific peer directly.\"` Callers get the scope up front.
- `_get_known_ble_peers` → `get_known_ble_peers` (promoted to public). The raise docstring already named it as the escape hatch; a documented contract should not point at a private method.
- New `test_broadcast_raises_even_when_other_transports_enabled` — locks in the BLE-only scope under Internet+Nostr configs so a future caller cannot silently relax the guard.
- New `test_broadcast_deduplicates_peers_across_central_and_peripheral` — covers the `set()` dedup in `get_known_ble_peers` (a peer reachable both as a BLE central and a peripheral gets the broadcast exactly once).
- Existing `test_broadcast_with_no_peers_raises` now pins `internet_enabled=False` so it genuinely exercises the BLE-only path rather than passing incidentally.
- Stripped the \"#3 in the PR review\" reference from the broadcast test-class docstring.

## Explicitly out of scope

A typed `broadcast(content) -> list[MessageId]` API (per-peer IDs, proper broadcast semantics, potentially cross-transport) is a larger design change and deserves its own PR.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_protocol_manager.py::TestProtocolManagerBroadcast -v` — 4 passed
- [x] `.venv/bin/python -m pytest tests/` — 107 passed