### PR TITLE
chore: point repo URLs at the actual canonical slug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing! This document provides guidelines f
 ### Clone and Build
 
 ```bash
-git clone https://github.com/offline-protocol/sdk
+git clone https://github.com/Offline-Protocol/offline-protocol-sdk
 cd offline-protocol-sdk
 cargo build --workspace
 cargo test --workspace
@@ -205,8 +205,8 @@ When making significant changes:
 
 ## Questions?
 
-- Open a [Discussion](https://github.com/offline-protocol/sdk/discussions)
-- Ask in [Issues](https://github.com/offline-protocol/sdk/issues)
+- Open a [Discussion](https://github.com/Offline-Protocol/offline-protocol-sdk/discussions)
+- Ask in [Issues](https://github.com/Offline-Protocol/offline-protocol-sdk/issues)
 
 ## License
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Offline Protocol Contributors"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/offline-protocol/sdk"
+repository = "https://github.com/Offline-Protocol/offline-protocol-sdk"
 rust-version = "1.70"
 
 [workspace.dependencies]

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -156,6 +156,6 @@ Link against the Rust static library in Xcode Build Settings.
 - [React Native Example App](examples/react-native-app/README.md) - See complete implementation
 - [React Native Integration Guide](docs/react-native-integration.md) - Full SDK integration walkthrough
 - [Integration Guide](examples/react-native-app/INTEGRATION_GUIDE.md) - Step-by-step project setup
-- [GitHub Issues](https://github.com/offline-protocol/sdk/issues)
+- [GitHub Issues](https://github.com/Offline-Protocol/offline-protocol-sdk/issues)
 - [All Documentation](docs/)
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -6,7 +6,7 @@ All notable changes to the Offline Protocol SDK.\n
 """
 body = """
 {%- macro remote_url() -%}
-  https://github.com/nickthecook/offline-protocol-sdk
+  https://github.com/Offline-Protocol/offline-protocol-sdk
 {%- endmacro -%}
 
 {% if version -%}
@@ -31,7 +31,7 @@ conventional_commits = true
 filter_unconventional = true
 split_commits = false
 commit_preprocessors = [
-    { pattern = '\(#([0-9]+)\)', replace = '([#${1}](https://github.com/nickthecook/offline-protocol-sdk/pull/${1}))' },
+    { pattern = '\(#([0-9]+)\)', replace = '([#${1}](https://github.com/Offline-Protocol/offline-protocol-sdk/pull/${1}))' },
 ]
 commit_parsers = [
     { message = "^feat", group = "<!-- 0 -->Features" },

--- a/docs/ios-integration.md
+++ b/docs/ios-integration.md
@@ -130,7 +130,7 @@ Add to `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/offline-protocol/sdk", from: "0.1.0")
+    .package(url: "https://github.com/Offline-Protocol/offline-protocol-sdk", from: "0.1.0")
 ]
 ```
 


### PR DESCRIPTION
## Summary
- Five files referenced two non-existent GitHub slugs (`offline-protocol/sdk` and `nickthecook/offline-protocol-sdk`). Updated all of them to the real remote, `Offline-Protocol/offline-protocol-sdk`.
- Touches: `Cargo.toml` (workspace `repository`), `cliff.toml` (changelog `remote_url` + PR-link replace pattern), `CONTRIBUTING.md` (clone URL + Discussions/Issues), `QUICKSTART.md` (Issues link), `docs/ios-integration.md` (SwiftPM dependency URL).
- Part of the open-source readiness pass — these dead links would have broken `cargo` metadata, generated changelogs, and copy-pasted clone/SwiftPM instructions the moment the repo went public.

## Test plan
- [x] `grep -rIE 'github\.com/(nickthecook|offline-protocol/sdk)' .` returns no matches
- [x] `cargo metadata --format-version 1 | jq -r '.workspace_members[]'` still resolves cleanly
- [x] Spot-check that the new URL `https://github.com/Offline-Protocol/offline-protocol-sdk` is reachable for whoever opens the PR