### PR TITLE
chore(bindings): fix github slug casing in RN + python metadata

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -41,9 +41,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/nicholasgasior/offline-protocol-sdk"
-Repository = "https://github.com/nicholasgasior/offline-protocol-sdk"
-Issues = "https://github.com/nicholasgasior/offline-protocol-sdk/issues"
+Homepage = "https://github.com/Offline-Protocol/offline-protocol-sdk"
+Repository = "https://github.com/Offline-Protocol/offline-protocol-sdk"
+Issues = "https://github.com/Offline-Protocol/offline-protocol-sdk/issues"
 
 [tool.setuptools.packages.find]
 include = ["offline_protocol_sdk*"]

--- a/bindings/react-native/ios/MeshSdk.podspec
+++ b/bindings/react-native/ios/MeshSdk.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "13.0" }
-  s.source       = { :git => "https://github.com/offline-protocol/offline-protocol-sdk.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/Offline-Protocol/offline-protocol-sdk.git", :tag => "#{s.version}" }
 
   # Source files
   s.source_files = [

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -50,12 +50,12 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/offline-protocol/offline-protocol-sdk",
+    "url": "https://github.com/Offline-Protocol/offline-protocol-sdk",
     "directory": "bindings/react-native"
   },
-  "homepage": "https://github.com/offline-protocol/offline-protocol-sdk#readme",
+  "homepage": "https://github.com/Offline-Protocol/offline-protocol-sdk#readme",
   "bugs": {
-    "url": "https://github.com/offline-protocol/offline-protocol-sdk/issues"
+    "url": "https://github.com/Offline-Protocol/offline-protocol-sdk/issues"
   },
   "peerDependencies": {
     "react": ">=16.8.0",


### PR DESCRIPTION
## Summary

PR #105 canonicalized everything to `Offline-Protocol/offline-protocol-sdk` but missed four spots:

- `bindings/python/pyproject.toml` — three URLs still pointed at `nicholasgasior/offline-protocol-sdk` (a slug that doesn't exist).
- `bindings/react-native/package.json` — `repository.url`, `homepage`, `bugs.url` used lowercase `offline-protocol/...`.
- `bindings/react-native/ios/MeshSdk.podspec` — CocoaPods `:git` source used the lowercase slug.

GitHub redirects mixed-case URLs so nothing is broken today, but these get baked into published npm metadata, the podspec source URL, and (once we ship) PyPI wheel metadata. Worth fixing before the first public release.

Confirmed clean: no remaining `nickthecook` or `offline-protocol/sdk` references anywhere in the tree.

## Test plan

- [x] `grep -rEn "github\.com/[A-Za-z0-9_-]+/offline-protocol-sdk" --exclude-dir={target,node_modules,.git,.venv,Pods,build}` returns only `Offline-Protocol/offline-protocol-sdk` matches.
- [x] CI passes (no functional changes, metadata only).