### PR TITLE
fix(core): saturate forward_count to close MAX_FORWARD_COUNT bypass

### DIFF
--- a/crates/offline-protocol-core/src/message.rs
+++ b/crates/offline-protocol-core/src/message.rs
@@ -168,7 +168,7 @@ impl ForwardInfo {
                 original_sender: existing.original_sender.clone(),
                 original_message_id: existing.original_message_id.clone(),
                 original_timestamp: existing.original_timestamp,
-                forward_count: existing.forward_count + 1,
+                forward_count: existing.forward_count.saturating_add(1),
             },
             None => ForwardInfo {
                 original_sender: message.sender.clone(),
@@ -719,5 +719,29 @@ mod tests {
         assert_eq!(second_forward.original_sender.as_str(), "alice");
         assert_eq!(second_forward.forward_count, 2);
         assert_eq!(second_forward.original_message_id, original_msg.id);
+    }
+
+    #[test]
+    fn test_forward_count_saturates_at_max() {
+        use crate::types::Timestamp;
+
+        let saturated = ForwardInfo {
+            original_sender: UserId::new("alice").unwrap(),
+            original_message_id: MessageId::new(),
+            original_timestamp: Timestamp::now(),
+            forward_count: u32::MAX,
+        };
+
+        let msg = Message::builder(
+            UserId::new("bob").unwrap(),
+            UserId::new("charlie").unwrap(),
+            AppId::new("test-app").unwrap(),
+        )
+        .content("Hello")
+        .forwarded_from(saturated)
+        .build();
+
+        let next = ForwardInfo::from_message(&msg);
+        assert_eq!(next.forward_count, u32::MAX);
     }
 }

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -9317,6 +9317,87 @@ fn test_forward_message_rejects_excessive_forward_count() {
 }
 
 #[test]
+fn test_forward_message_rejects_overflow_forward_count() {
+    use offline_protocol_core::ForwardInfo;
+
+    let config = create_test_config();
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    let mut transport = MockTransport::new(TransportType::BLE);
+    transport.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(transport));
+    protocol.start().unwrap();
+
+    // A peer-supplied forward_count of u32::MAX must not wrap past the cap.
+    // Pre-fix: `+ 1` wrapped to 0, slipping past `forward_count > MAX_FORWARD_COUNT`.
+    // Post-fix: `saturating_add(1)` clamps to u32::MAX, which the cap then rejects.
+    let forward_info = ForwardInfo {
+        original_sender: UserId::new("alice").unwrap(),
+        original_message_id: MessageId::new(),
+        original_timestamp: offline_protocol_core::Timestamp::now(),
+        forward_count: u32::MAX,
+    };
+    let original = offline_protocol_core::Message::builder(
+        UserId::new("bob").unwrap(),
+        UserId::new("user123").unwrap(),
+        AppId::new("test-app").unwrap(),
+    )
+    .content("Hello")
+    .forwarded_from(forward_info)
+    .build();
+
+    let result = protocol.forward_message(&original, "charlie", None);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("exceeds maximum"),
+        "Expected forward count cap error, got: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn test_forward_message_to_group_rejects_overflow_forward_count() {
+    use offline_protocol_core::ForwardInfo;
+
+    let config = create_test_config();
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    let mut transport = MockTransport::new(TransportType::BLE);
+    transport.start().unwrap();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(transport));
+    protocol.start().unwrap();
+
+    // The group-forward path has its own cap check (group_mesh.rs:1620) that runs
+    // before any MLS work; an overflow seed must trip it before group_id is used.
+    let forward_info = ForwardInfo {
+        original_sender: UserId::new("alice").unwrap(),
+        original_message_id: MessageId::new(),
+        original_timestamp: offline_protocol_core::Timestamp::now(),
+        forward_count: u32::MAX,
+    };
+    let original = offline_protocol_core::Message::builder(
+        UserId::new("bob").unwrap(),
+        UserId::new("user123").unwrap(),
+        AppId::new("test-app").unwrap(),
+    )
+    .content("Hello")
+    .forwarded_from(forward_info)
+    .build();
+
+    let result = protocol.forward_message_to_group(&original, "any-group", None);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("exceeds maximum"),
+        "Expected forward count cap error, got: {}",
+        err_msg
+    );
+}
+
+#[test]
 fn test_send_message_returns_ok_and_emits_deferred_when_transport_fails() {
     let mut config = create_test_config();
     config.reliability.retry.initial_delay_ms = 60_000; // long delay so nothing retries during test


### PR DESCRIPTION
## Summary

`ForwardInfo::from_message` did `existing.forward_count + 1` on a peer-controlled `u32`, with the `MAX_FORWARD_COUNT` (= 100) cap check running *after* the increment at `protocol/send.rs:203` and `group_mesh.rs:1620`. The workspace `Cargo.toml` does not override `overflow-checks`, so:

| Profile | `u32::MAX + 1` behavior | Cap check sees | Outcome |
|---|---|---|---|
| `dev` (default `overflow-checks = true`) | panics | — | DoS in dev/CI |
| `release` (default `overflow-checks = false`) | wraps to `0` | `0 > 100` → false | **bypass** — message forwarded with `forward_count = 0` |
| `minisize` (inherits release, `panic = "abort"`) | wraps to `0` | same | same bypass |

The receive path at `protocol/receive.rs:154` does not bounds-check `forward_count`, so a peer can deliver a message with `forwarded_from.forward_count = u32::MAX` and have it reach `forward_message` / `forward_message_to_group` unaltered.

Severity: low in production (cap-bypass on a forgeable display-level hint already declared untrusted by the trust model in `crates/offline-protocol-core/src/message.rs:142-146`; mesh routing depth is bounded by TTL/HopCount, not this counter), medium in dev/CI (panic).

## Fix

Replace `+ 1` with `saturating_add(1)` at the single increment site. Now `u32::MAX → u32::MAX`, which the existing post-increment cap check correctly rejects (`u32::MAX > 100`).

This matches the convention already used elsewhere in the workspace for monotonic counters: Lamport clock (`core/types.rs:320`), transport metrics (`transport_manager.rs:71/87`), decryption queue (`decryption_queue.rs:250+`), retry counts (`protocol/mod.rs:850/1493`). Line 171 was the outlier.

## Tests added

- `test_forward_count_saturates_at_max` (unit, `crates/offline-protocol-core/src/message.rs`) — asserts `ForwardInfo::from_message` over a Message with `forward_count = u32::MAX` returns `forward_count = u32::MAX`.
- `test_forward_message_rejects_overflow_forward_count` (integration, `crates/offline-protocol/src/protocol/tests/mod.rs`) — asserts the 1:1 forward path rejects with "exceeds maximum".
- `test_forward_message_to_group_rejects_overflow_forward_count` (integration, same file) — asserts the parallel group-forward path's cap check closes the same bypass.

## Blast radius

- **Files**: 2 — one production line, three new tests.
- **API/wire/schema changes**: none. `ForwardInfo` signature unchanged.
- **Migration / rollout**: none.
- **Rollback**: `git revert` is safe; single-line behavior change with no state migration.

## Test plan

- [x] `cargo test --package offline-protocol-core test_forward_count_saturates_at_max`
- [x] `cargo test --package offline-protocol test_forward_message_rejects_overflow_forward_count`
- [x] `cargo test --package offline-protocol test_forward_message_to_group_rejects_overflow_forward_count`
- [x] `cargo test --workspace` (all related tests pass; one unrelated time-race flake in `offline-protocol-reliability::ack_optimization::test_drain_timed_out` passes in isolation)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`