### PR TITLE
ci(cla): add actions: write so CLA bot can update PR check status

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,8 +7,13 @@ on:
     types: [opened, closed, synchronize]
 
 # CLA Assistant Lite needs to comment on PRs and write to the
-# `cla-signatures` branch where signatures are recorded.
+# `cla-signatures` branch where signatures are recorded. `actions: write`
+# is required by contributor-assistant/github-action v2.x — without it the
+# job hits "Resource not accessible by integration" after recognising
+# signatures, leaving the PR check stuck on failure even though the CLA is
+# satisfied.
 permissions:
+  actions: write
   contents: write
   pull-requests: write
   statuses: write


### PR DESCRIPTION
## Summary

`contributor-assistant/github-action` v2.x requires `actions: write` in addition to `contents` / `pull-requests` / `statuses`. Without it, the job logs the success state — `All contributors have signed the CLA ✅` — and then dies at the next API call with:

```
##[error]Resource not accessible by integration
```

The signature is recorded in `signatures/version1/cla.json` (and the bot's PR comment updates correctly), but the PR's CLAAssistant *check status* never flips, leaving the gate stuck on failure even though the CLA is satisfied.

Permission added per the action's own [README](https://github.com/contributor-assistant/github-action#readme), which lists the canonical permission set as:

```yaml
permissions:
  actions: write
  contents: write
  pull-requests: write
  statuses: write
```

## Reproduction

PR #108 — signature written successfully, every `pull_request_target` rerun (attempt 2 at 16:14:34Z, attempt 3 at 16:23:51Z) failed at the status-update step with the same error.

## Test plan

- [ ] After merge, re-trigger the CLAAssistant workflow on PR #108 (push an empty commit or close+reopen) and confirm the check flips to green.
- [ ] On future PRs, the check should resolve cleanly once the contributor signs.