### PR TITLE
feat(router): emit relay role transition events

### DIFF
--- a/crates/offline-protocol-router/src/lib.rs
+++ b/crates/offline-protocol-router/src/lib.rs
@@ -21,7 +21,7 @@ pub use dors::{
     DorsConfig, EscalationTriggerReason, TransportScore, TransportScoreFactors, TransportSelector,
 };
 pub use error::{Error, Result};
-pub use relay::{RelayConfig, RelayManager, RelayRole};
+pub use relay::{RelayConfig, RelayDemotionReason, RelayManager, RelayRole, RelayTransition};
 pub use router::{
     ForwardingDecision, GossipConfig, GradientRoutingConfig, GradientRoutingTable, PathConfig,
     PathSelector, RouteEntry,

--- a/crates/offline-protocol-router/src/relay.rs
+++ b/crates/offline-protocol-router/src/relay.rs
@@ -51,6 +51,35 @@ pub enum RelayRole {
     Relay,
 }
 
+/// Reason a device was demoted from relay role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayDemotionReason {
+    /// Active connection count fell below the relay threshold.
+    LowConnections,
+    /// Battery dropped below the level required to keep relaying.
+    LowBattery {
+        /// Minimum battery level required to remain a relay.
+        min_required: u8,
+    },
+}
+
+/// A relay-role transition produced by [`RelayManager::evaluate_transition`].
+///
+/// `None` from `evaluate_transition` means the role did not change; a `Some`
+/// value is emitted exactly once, at the tick the transition happens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayTransition {
+    /// The device became a relay.
+    Promoted {
+        /// Active connection count at the time of promotion.
+        connection_count: usize,
+        /// Battery level at the time of promotion.
+        battery_level: u8,
+    },
+    /// The device stopped being a relay.
+    Demoted(RelayDemotionReason),
+}
+
 /// Information about a potential relay.
 #[derive(Debug, Clone)]
 pub struct RelayInfo {
@@ -154,11 +183,17 @@ impl RelayManager {
     ///
     /// * `connection_count` - Number of active connections
     /// * `battery_level` - Current battery level (0-100)
+    /// * `is_charging` - Whether the device is charging
     ///
     /// # Returns
     ///
     /// Returns `true` if the device should stop being a relay.
-    pub fn should_demote_from_relay(&self, connection_count: usize, battery_level: u8) -> bool {
+    pub fn should_demote_from_relay(
+        &self,
+        connection_count: usize,
+        battery_level: u8,
+        is_charging: bool,
+    ) -> bool {
         // If priority is Always, stay as relay unless critical battery
         if matches!(self.config.relay_priority, RelayPriority::Always) {
             return battery_level < 15;
@@ -169,12 +204,76 @@ impl RelayManager {
             return true;
         }
 
-        // Demote if battery is too low
-        if battery_level < self.config.min_battery_for_relay {
+        // Demote if battery is too low. A charging device is held to the same
+        // relaxed floor as `should_promote_to_relay` (which favors a charging
+        // device even below `min_battery_for_relay`): only a *critical* level
+        // forces demotion. Without this symmetry a charging device sitting just
+        // below the soft minimum would oscillate promote → demote every tick.
+        if battery_level < self.demotion_battery_floor(is_charging) {
             return true;
         }
 
         false
+    }
+
+    /// Battery level below which a relay must demote, given charging state.
+    ///
+    /// Mirrors the battery branches of [`should_demote_from_relay`] so the
+    /// transition classifier and the demotion decision never disagree.
+    fn demotion_battery_floor(&self, is_charging: bool) -> u8 {
+        if matches!(self.config.relay_priority, RelayPriority::Always) || is_charging {
+            15
+        } else {
+            self.config.min_battery_for_relay
+        }
+    }
+
+    /// Evaluates whether the relay role should change and, if so, applies the
+    /// change and returns the transition that occurred.
+    ///
+    /// This is the single entry point that mutates [`RelayRole`]: it compares
+    /// the promote/demote decision against the current role and only returns
+    /// `Some` when the role actually flips, so callers can emit a role-change
+    /// event exactly once per transition. A stable role returns `None`.
+    pub fn evaluate_transition(
+        &mut self,
+        connection_count: usize,
+        battery_level: u8,
+        is_charging: bool,
+    ) -> Option<RelayTransition> {
+        match self.current_role {
+            RelayRole::Regular => {
+                if self.should_promote_to_relay(connection_count, battery_level, is_charging) {
+                    self.set_role(RelayRole::Relay);
+                    Some(RelayTransition::Promoted {
+                        connection_count,
+                        battery_level,
+                    })
+                } else {
+                    None
+                }
+            }
+            RelayRole::Relay => {
+                if self.should_demote_from_relay(connection_count, battery_level, is_charging) {
+                    self.set_role(RelayRole::Regular);
+                    // Battery takes precedence: a relay that is both
+                    // connection-starved and battery-starved is reported as a
+                    // battery demotion, which is the signal the analytics
+                    // panel tracks distinctly.
+                    let floor = self.demotion_battery_floor(is_charging);
+                    let reason = if battery_level < floor {
+                        RelayDemotionReason::LowBattery {
+                            min_required: floor,
+                        }
+                    } else {
+                        RelayDemotionReason::LowConnections
+                    };
+                    Some(RelayTransition::Demoted(reason))
+                } else {
+                    None
+                }
+            }
+        }
     }
 
     /// Calculates a score for a potential relay.
@@ -295,13 +394,131 @@ mod tests {
         let manager = RelayManager::new();
 
         // Should demote if connections drop
-        assert!(manager.should_demote_from_relay(2, 80));
+        assert!(manager.should_demote_from_relay(2, 80, false));
 
         // Should demote if battery too low
-        assert!(manager.should_demote_from_relay(5, 25));
+        assert!(manager.should_demote_from_relay(5, 25, false));
 
         // Should stay as relay with good conditions
-        assert!(!manager.should_demote_from_relay(5, 80));
+        assert!(!manager.should_demote_from_relay(5, 80, false));
+    }
+
+    #[test]
+    fn test_should_demote_charging_exempt_from_soft_floor() {
+        let manager = RelayManager::new(); // min_battery_for_relay = 30
+
+        // Not charging, battery below the soft minimum -> demote.
+        assert!(manager.should_demote_from_relay(5, 25, false));
+
+        // Charging at the same level -> stay (mirrors promotion); only a
+        // critical battery level forces demotion while charging.
+        assert!(!manager.should_demote_from_relay(5, 25, true));
+        assert!(manager.should_demote_from_relay(5, 10, true));
+    }
+
+    #[test]
+    fn test_evaluate_transition_promote_then_idempotent() {
+        let mut manager = RelayManager::new();
+        assert_eq!(manager.current_role(), RelayRole::Regular);
+
+        // Good conditions promote, returning the transition exactly once.
+        assert_eq!(
+            manager.evaluate_transition(5, 80, false),
+            Some(RelayTransition::Promoted {
+                connection_count: 5,
+                battery_level: 80,
+            })
+        );
+        assert_eq!(manager.current_role(), RelayRole::Relay);
+
+        // Stable conditions on the next tick produce no transition.
+        assert_eq!(manager.evaluate_transition(5, 80, false), None);
+        assert_eq!(manager.current_role(), RelayRole::Relay);
+    }
+
+    #[test]
+    fn test_evaluate_transition_no_promote_stays_regular() {
+        let mut manager = RelayManager::new();
+        // Too few connections: no promotion, role unchanged.
+        assert_eq!(manager.evaluate_transition(1, 80, false), None);
+        assert_eq!(manager.current_role(), RelayRole::Regular);
+    }
+
+    #[test]
+    fn test_evaluate_transition_demote_low_connections() {
+        let mut manager = RelayManager::new();
+        manager.set_role(RelayRole::Relay);
+
+        // Battery healthy, connections collapsed -> connection demotion.
+        assert_eq!(
+            manager.evaluate_transition(1, 80, false),
+            Some(RelayTransition::Demoted(
+                RelayDemotionReason::LowConnections
+            ))
+        );
+        assert_eq!(manager.current_role(), RelayRole::Regular);
+    }
+
+    #[test]
+    fn test_evaluate_transition_demote_low_battery() {
+        let mut manager = RelayManager::new(); // min_battery_for_relay = 30
+        manager.set_role(RelayRole::Relay);
+
+        // Enough connections, battery below minimum -> battery demotion,
+        // reporting the soft floor as the required level.
+        assert_eq!(
+            manager.evaluate_transition(5, 25, false),
+            Some(RelayTransition::Demoted(RelayDemotionReason::LowBattery {
+                min_required: 30,
+            }))
+        );
+        assert_eq!(manager.current_role(), RelayRole::Regular);
+    }
+
+    #[test]
+    fn test_evaluate_transition_battery_precedence_over_connections() {
+        let mut manager = RelayManager::new();
+        manager.set_role(RelayRole::Relay);
+
+        // Both connection-starved and battery-starved: classified as battery.
+        assert_eq!(
+            manager.evaluate_transition(1, 10, false),
+            Some(RelayTransition::Demoted(RelayDemotionReason::LowBattery {
+                min_required: 30,
+            }))
+        );
+    }
+
+    #[test]
+    fn test_evaluate_transition_always_critical_battery_floor() {
+        let config = RelayConfig {
+            relay_priority: RelayPriority::Always,
+            ..Default::default()
+        };
+        let mut manager = RelayManager::with_config(config);
+        manager.set_role(RelayRole::Relay);
+
+        // Always priority demotes only at critical battery, reporting 15.
+        assert_eq!(
+            manager.evaluate_transition(1, 10, false),
+            Some(RelayTransition::Demoted(RelayDemotionReason::LowBattery {
+                min_required: 15,
+            }))
+        );
+    }
+
+    #[test]
+    fn test_evaluate_transition_no_flap_while_charging() {
+        let mut manager = RelayManager::new(); // min_battery_for_relay = 30
+
+        // Charging device just below the soft minimum: promotes, then holds
+        // (no promote → demote oscillation that would emit fake churn).
+        assert!(matches!(
+            manager.evaluate_transition(5, 25, true),
+            Some(RelayTransition::Promoted { .. })
+        ));
+        assert_eq!(manager.evaluate_transition(5, 25, true), None);
+        assert_eq!(manager.current_role(), RelayRole::Relay);
     }
 
     #[test]

--- a/crates/offline-protocol-router/src/router.rs
+++ b/crates/offline-protocol-router/src/router.rs
@@ -5,7 +5,7 @@
 //! based on the number of visible peers to maintain constant message overhead.
 
 use crate::constants::*;
-use crate::relay::{RelayInfo, RelayManager, RelayRole};
+use crate::relay::{RelayInfo, RelayManager, RelayRole, RelayTransition};
 use offline_protocol_core::Message;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
@@ -490,6 +490,21 @@ impl PathSelector {
     /// to the full [`RelayManager`] API).
     pub fn current_relay_role(&self) -> RelayRole {
         self.relay_manager.current_role()
+    }
+
+    /// Re-evaluates the local relay role against current connectivity and
+    /// battery, applying any change to the internal [`RelayManager`].
+    ///
+    /// Returns `Some(transition)` only when the role actually changes, so the
+    /// caller can emit a role-transition event exactly once per transition.
+    pub fn evaluate_relay_transition(
+        &mut self,
+        connection_count: usize,
+        battery_level: u8,
+        is_charging: bool,
+    ) -> Option<RelayTransition> {
+        self.relay_manager
+            .evaluate_transition(connection_count, battery_level, is_charging)
     }
 
     /// Computes the forwarding probability based on visible peer count.

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -286,9 +286,6 @@ pub enum Event {
         reason: String,
     },
 
-    // TODO: RelayPromoted, RelayDemoted, and RelayDemotedBattery are not yet
-    // emitted — wire RelayManager::should_promote_to_relay / should_demote_from_relay
-    // into the protocol engine so these fire on actual role transitions.
     /// This device was promoted to relay role.
     RelayPromoted {
         /// Number of connections when promoted.

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -34,7 +34,9 @@ use chrono::{DateTime, Utc};
 use offline_protocol_core::{LamportClock, Message, MessageId};
 use offline_protocol_mls::{EncryptedMessage, MlsManager, MlsStorage, WelcomeMessage};
 use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
-use offline_protocol_router::{PathSelector, RelayManager, RelayRole, TransportSelector};
+use offline_protocol_router::{
+    PathSelector, RelayDemotionReason, RelayManager, RelayRole, RelayTransition, TransportSelector,
+};
 use offline_protocol_services::MeshServices;
 use offline_protocol_transport::{BleTransport, TransportStatus, TransportType};
 use std::collections::HashMap;
@@ -1342,9 +1344,54 @@ impl OfflineProtocol {
         let _ = self.prune_expired_pending_global_front(Instant::now(), 256);
         self.pump_media_transfers();
         self.cleanup_expired_entries();
+        self.evaluate_relay_role();
         self.tick_telemetry_categories();
 
         Ok(())
+    }
+
+    /// Re-evaluates the local relay role against current connectivity and
+    /// battery and emits the corresponding transition event when the role
+    /// actually changes (`RelayPromoted`, `RelayDemoted`, or
+    /// `RelayDemotedBattery`).
+    ///
+    /// Runs every tick independently of telemetry: these are app-facing
+    /// events delivered through the `EventCallback` channel, which is live
+    /// whether or not a telemetry sink is installed. Mutating the role here
+    /// also keeps the `DeviceCapabilitySnapshot.relay_role` signal honest,
+    /// since `tick_telemetry_categories` reads the role immediately after.
+    ///
+    /// Skipped when the battery level is unknown: the promote/demote policy
+    /// is battery-dependent, and transitioning on a phantom level would emit
+    /// dishonest churn.
+    fn evaluate_relay_role(&mut self) {
+        let (_statuses, available) = self.transport_manager.snapshot_status_and_available();
+        let (battery_level, is_charging) =
+            device_battery_from_available(self.transport_manager.current_transport(), &available);
+        let Some(battery_level) = battery_level else {
+            return;
+        };
+        let connection_count = self.known_peers.len();
+        let Some(transition) = self.path_selector.evaluate_relay_transition(
+            connection_count,
+            battery_level,
+            is_charging,
+        ) else {
+            return;
+        };
+        let event = match transition {
+            RelayTransition::Promoted {
+                connection_count,
+                battery_level,
+            } => Event::relay_promoted(connection_count, battery_level),
+            RelayTransition::Demoted(RelayDemotionReason::LowConnections) => {
+                Event::relay_demoted("connections below relay threshold".to_string())
+            }
+            RelayTransition::Demoted(RelayDemotionReason::LowBattery { min_required }) => {
+                Event::relay_demoted_battery(battery_level, min_required)
+            }
+        };
+        self.emit_event(event);
     }
 
     /// Per-tick telemetry work: diff transport statuses, diff device

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -10506,6 +10506,80 @@ fn test_metrics_frame_is_local_relay_matches_role() {
     );
 }
 
+/// Drives a real `process()` tick with enough connections and healthy
+/// battery and asserts the engine emits `RelayPromoted` on the role
+/// transition, then `RelayDemotedBattery` once the battery falls below the
+/// relay minimum. Guards the OQ #12 wiring: the three relay-role events must
+/// fire on actual transitions, not just exist as unreachable variants.
+#[test]
+fn test_relay_role_transitions_emit_events() {
+    fn battery_metrics(level: u8) -> TransportMetrics {
+        TransportMetrics {
+            battery_level: Some(level),
+            is_charging: false,
+            ..TransportMetrics::default()
+        }
+    }
+
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mock = MockTransport::new(TransportType::BLE);
+    mock.set_status(TransportStatus::Available);
+    mock.set_metrics(battery_metrics(80));
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock.clone()));
+
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+    protocol.start().unwrap();
+
+    // Default relay_threshold is 3; give it enough neighbors to promote.
+    for i in 0..3 {
+        protocol.on_neighbor_discovered(&format!("peer-{i}"));
+    }
+
+    protocol.process().unwrap();
+    let promoted = sink.take();
+    assert!(
+        promoted.iter().any(|r| matches!(
+            r,
+            TelemetryRecord::Protocol(ev)
+                if matches!(ev.as_ref(), Event::RelayPromoted { .. })
+        )),
+        "healthy battery + enough connections must emit RelayPromoted, got {promoted:?}",
+    );
+
+    // A second stable tick must NOT re-emit (transition fired once).
+    protocol.process().unwrap();
+    let stable = sink.take();
+    assert!(
+        !stable.iter().any(|r| matches!(
+            r,
+            TelemetryRecord::Protocol(ev) if matches!(ev.as_ref(), Event::RelayPromoted { .. })
+        )),
+        "a stable relay role must not re-emit RelayPromoted, got {stable:?}",
+    );
+
+    // Drop the battery below the relay minimum (default 30, not charging):
+    // the next tick must demote with the battery-specific event.
+    mock.set_metrics(battery_metrics(20));
+    protocol.process().unwrap();
+    let demoted = sink.take();
+    assert!(
+        demoted.iter().any(|r| matches!(
+            r,
+            TelemetryRecord::Protocol(ev)
+                if matches!(
+                    ev.as_ref(),
+                    Event::RelayDemotedBattery { battery_level: 20, min_required: 30 }
+                )
+        )),
+        "battery below minimum must emit RelayDemotedBattery{{20, 30}}, got {demoted:?}",
+    );
+}
+
 #[test]
 fn test_install_before_start_wires_routing_callback() {
     // Regression guard for the post-review lifecycle fix: the routing-


### PR DESCRIPTION
## What

Wires the three relay-role telemetry events — `RelayPromoted`, `RelayDemoted`, `RelayDemotedBattery` — into the protocol engine so they fire on **actual** role transitions. They were defined but never emitted (there was an explicit `// TODO: ... not yet emitted` marker in `events.rs`).

Filed from the mesh-analytics v1 plan (OQ #12): until these fire, the Relay Economy panel can't measure real relay churn and substitutes "relay candidate density" derived from `capability_changed.relay_role` — an approximation that, since the role never actually changed, was measuring nothing.

## How

- **`RelayManager::evaluate_transition`** is the single entry point that mutates `RelayRole`: it compares the promote/demote decision against the current role and returns `Some` only when the role actually flips, so an event is emitted exactly once per transition (stable role → no event).
- The engine calls it every `process()` tick with live battery + connection state and emits via the normal `emit_event` path, so both the app `EventCallback` and the telemetry sink receive it. It runs **regardless of whether a telemetry sink is installed** — these are app-facing events, not a telemetry-only concept.
- Evaluation is **skipped when battery level is unknown** — the promote/demote policy is battery-dependent, and transitioning on a phantom level would emit dishonest churn.
- Mutating the role here also makes the existing `DeviceCapabilitySnapshot.relay_role` signal honest for free (the tick reads the role right after).

## Anti-flap fix (called out for review)

`should_promote_to_relay` favors a *charging* device below the battery minimum, but `should_demote_from_relay` ignored charging entirely. Once the events went live, a charging device parked just under the minimum would promote → demote on **every tick**, emitting fake churn — defeating the whole point.

`should_demote_from_relay` now takes `is_charging` and only forces demotion at a critical level while charging, mirroring the promotion side. **This changes a `pub` signature, but the only callers were tests** — no external breakage.

## Demotion classification

When a relay is both connection-starved and battery-starved, it's reported as `RelayDemotedBattery` (battery takes precedence), since that's the distinct signal the analytics panel tracks.

## Tests

- 7 new `RelayManager` unit tests: promote, idempotence, both demotion reasons, battery-precedence, the `Always`/critical-battery floor, and the no-flap-while-charging guard.
- Engine integration test driving a real `process()` tick: asserts `RelayPromoted` on promotion, no re-emit while stable, and `RelayDemotedBattery { 20, 30 }` when battery drops below the minimum.

No FFI/wire/scrub changes were needed — `scrub_event` already passes these variants through, and both delivery channels serialize via `Event::to_json()`.

## Verification

- `cargo test --workspace` — all pass (0 failures)
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all --check` — clean