### PR TITLE
refactor(transport): add stable error codes to TransportError

### DIFF
--- a/crates/offline-protocol-transport/src/error.rs
+++ b/crates/offline-protocol-transport/src/error.rs
@@ -6,6 +6,10 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors that can occur in the transport layer.
+///
+/// `Display` (the `#[error(...)]` text) is human-facing and free to change.
+/// [`Error::code`] is the stable, machine-readable contract — downstream
+/// telemetry classifies on the code, never on the `Display` wording.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum Error {
     /// Transport is not available or supported.
@@ -49,4 +53,75 @@ pub enum Error {
     /// Generic error.
     #[error("{0}")]
     Other(String),
+}
+
+impl Error {
+    /// Returns a stable, non-localized machine-readable error code.
+    ///
+    /// Unlike [`Display`](std::fmt::Display), this value is a contract:
+    /// downstream consumers (e.g. telemetry classifiers) switch on it instead
+    /// of substring-matching human-readable error text. Keep these strings
+    /// stable — changing one reclassifies every event that carries it.
+    ///
+    /// The match is intentionally exhaustive (no wildcard arm) so that adding
+    /// a new variant fails to compile until it is assigned a code.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::TransportNotAvailable(_) => "TRANSPORT_NOT_AVAILABLE",
+            Self::PeerNotReachable(_) => "PEER_NOT_REACHABLE",
+            Self::SendFailed(_) => "SEND_FAILED",
+            Self::ReceiveFailed(_) => "RECEIVE_FAILED",
+            Self::ConfigurationError(_) => "CONFIGURATION_ERROR",
+            Self::SerializationError(_) => "SERIALIZATION_ERROR",
+            Self::Core(_) => "CORE_ERROR",
+            Self::MessageTooLarge(_, _) => "MESSAGE_TOO_LARGE",
+            Self::CryptoError(_) => "CRYPTO_ERROR",
+            Self::Other(_) => "OTHER",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn transport_error_code_values_are_stable() {
+        assert_eq!(
+            Error::TransportNotAvailable("ble".into()).code(),
+            "TRANSPORT_NOT_AVAILABLE"
+        );
+        assert_eq!(
+            Error::PeerNotReachable("peer".into()).code(),
+            "PEER_NOT_REACHABLE"
+        );
+        assert_eq!(Error::SendFailed("boom".into()).code(), "SEND_FAILED");
+        assert_eq!(Error::ReceiveFailed("boom".into()).code(), "RECEIVE_FAILED");
+        assert_eq!(
+            Error::ConfigurationError("bad".into()).code(),
+            "CONFIGURATION_ERROR"
+        );
+        assert_eq!(
+            Error::SerializationError("bad".into()).code(),
+            "SERIALIZATION_ERROR"
+        );
+        assert_eq!(
+            Error::Core(offline_protocol_core::Error::Other("x".into())).code(),
+            "CORE_ERROR"
+        );
+        assert_eq!(
+            Error::MessageTooLarge(2048, 1024).code(),
+            "MESSAGE_TOO_LARGE"
+        );
+        assert_eq!(Error::CryptoError("kdf".into()).code(), "CRYPTO_ERROR");
+        assert_eq!(Error::Other("opaque".into()).code(), "OTHER");
+    }
+
+    #[test]
+    fn transport_error_code_is_independent_of_display() {
+        // The code must not be derived from the Display text.
+        let err = Error::SendFailed("transient radio failure".into());
+        assert_eq!(err.code(), "SEND_FAILED");
+        assert!(err.to_string().contains("transient radio failure"));
+    }
 }


### PR DESCRIPTION
## What

Adds `offline_protocol_transport::Error::code()` — a stable, machine-readable
`&'static str` discriminant per variant (`SEND_FAILED`, `PEER_NOT_REACHABLE`,
`TRANSPORT_NOT_AVAILABLE`, …), decoupled from the human-readable `Display` text.

## Why

Downstream telemetry (the mesh-analytics `reason_class` classifier) currently
buckets transport failures by **substring-matching `TransportError`'s `Display`
output**. That coupling is invisible from this repo — nothing enforces it — so
any reword of a `#[error("...")]` string silently reclassifies every matching
event into the `other` bucket. The canary fires, but the data is already lost.

This is the OQ #6 follow-up from the mesh-analytics v1 plan (TODO item 2).

## How

- `Error::code()` uses an **exhaustive match (no wildcard arm)**, so adding a
  future variant fails to compile until it's assigned a code.
- A stability test pins every code string — a future reword/rename becomes a
  failing test, not a silent reclassification.
- `Display` stays free to change; it's documented as human-facing only.

Mirrors the existing `SessionStateError::code()` precedent in
`crates/offline-protocol/src/error.rs`.

## Scope / follow-ups

- **FFI surfacing is intentionally out of scope.** Transport errors still
  stringify into `ProtocolError::Other` at the UniFFI boundary; the codes stop
  at the Rust boundary. Surfacing them over UniFFI is a separate ticket for when
  something actually consumes them there.
- Code *names* were chosen descriptively. If the mesh-analytics vocabulary
  expects specific tokens, they should be reconciled — the pinning test makes
  any change deliberate.

## Testing

- `cargo test --package offline-protocol-transport` — new tests pass
- `cargo clippy --package offline-protocol-transport -- -D warnings` — clean
- `cargo fmt --workspace -- --check` — clean