### PR TITLE
feat(protocol): persist per-install telemetry scrub secret

### DIFF
--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -143,6 +143,14 @@ pub struct OfflineProtocol {
     /// after a sink is installed on the same protocol instance.
     telemetry_fallback_secret: [u8; 16],
 
+    /// Whether the persistent per-install scrub secret has been loaded from
+    /// (or initialized into) secure storage yet. Starts `false`; set `true`
+    /// the first time `restore_or_init_scrub_secret` succeeds so the load is
+    /// idempotent across the two storage-entry paths
+    /// (`initialize_mls` also enables persistence, which would otherwise
+    /// re-load and rebuild the scrubber a second time).
+    telemetry_secret_persisted: bool,
+
     /// Installed telemetry context (sink + config + scrubber). `None` until
     /// `install_telemetry_sink` is called; thereafter shared with
     /// `SharedState` via `Arc` clone so both emit paths dispatch through the
@@ -293,6 +301,7 @@ impl OfflineProtocol {
                 telemetry_fallback_secret,
             ),
             telemetry_fallback_secret,
+            telemetry_secret_persisted: false,
             telemetry: None,
             file_transfer_manager: FileTransferManager::new(),
             pending_media_metadata: HashMap::new(),
@@ -350,6 +359,12 @@ impl OfflineProtocol {
         // Also use this storage for pending message persistence
         self.message_storage = Some(storage);
 
+        // Load the persistent scrub secret outside the transactional restore
+        // below: it is independent of MLS state, and a later MLS-restore
+        // rollback must not undo it (the secret is idempotent and reused on
+        // the next attempt).
+        self.restore_or_init_scrub_secret();
+
         // Restore state from previous session
         let restore_result = (|| {
             self.restore_pending_messages()?;
@@ -390,6 +405,7 @@ impl OfflineProtocol {
     /// automatically enabled using the same storage.
     pub fn enable_message_persistence(&mut self, storage: Arc<dyn MlsStorage>) -> Result<()> {
         self.message_storage = Some(storage);
+        self.restore_or_init_scrub_secret();
         self.restore_pending_messages()?;
         self.restore_lamport_clock();
         self.restore_tofu_keys();

--- a/crates/offline-protocol/src/protocol/storage.rs
+++ b/crates/offline-protocol/src/protocol/storage.rs
@@ -488,6 +488,95 @@ impl OfflineProtocol {
     }
 
     // ========================================================================
+    // TELEMETRY SCRUB-SECRET PERSISTENCE
+    // ========================================================================
+
+    /// Loads (or, on first run, generates and persists) the per-install
+    /// telemetry scrub secret, then installs it as the fallback secret used
+    /// for opaque-identifier hashing when no explicit `scrub_secret` is set on
+    /// the installed `TelemetryConfig`.
+    ///
+    /// This makes opaque identifiers stable across process restarts so backend
+    /// telemetry can count distinct devices: the same device hashes to the same
+    /// opaque id every session. Until storage is available (or if storage is
+    /// never provided), the SDK keeps using the random per-instance fallback
+    /// generated at construction — so this is purely an upgrade over the
+    /// random fallback, never a regression.
+    ///
+    /// Secret precedence is unchanged: an explicit
+    /// [`crate::telemetry::TelemetryConfig::with_scrub_secret`] still wins over
+    /// this persistent fallback (see [`crate::telemetry::Scrubber::from_config`]).
+    ///
+    /// Idempotent across the two storage-entry paths (`initialize_mls` and
+    /// `enable_message_persistence`) via `telemetry_secret_persisted`. All
+    /// storage failures degrade gracefully to the in-memory random fallback —
+    /// telemetry pseudonymization must never block protocol initialization.
+    pub(crate) fn restore_or_init_scrub_secret(&mut self) {
+        if self.telemetry_secret_persisted {
+            return;
+        }
+        let Some(storage) = &self.message_storage else {
+            return;
+        };
+
+        let secret: [u8; 16] = match storage
+            .load(storage_keys::SCRUB_SECRET, storage_keys::SCRUB_SECRET_ID)
+        {
+            Ok(Some(bytes)) if bytes.len() == 16 => {
+                let mut secret = [0u8; 16];
+                secret.copy_from_slice(&bytes);
+                debug!("Restored persistent telemetry scrub secret from storage");
+                secret
+            }
+            Ok(other) => {
+                // Absent, or present but corrupt/wrong-length: generate a fresh
+                // secret and persist it. A wrong-length blob is overwritten so a
+                // single corrupt write does not pin every future session to the
+                // random fallback.
+                if other.is_some() {
+                    warn!("Persisted scrub secret had unexpected length; regenerating");
+                }
+                let fresh = *uuid::Uuid::new_v4().as_bytes();
+                if let Err(e) = storage.store(
+                    storage_keys::SCRUB_SECRET,
+                    storage_keys::SCRUB_SECRET_ID,
+                    &fresh,
+                ) {
+                    // Keep the in-memory secret for this session; next launch
+                    // will retry persistence. Opaque ids stay stable within
+                    // this process but may differ next session — strictly no
+                    // worse than the legacy random fallback.
+                    warn!(error = %e, "Failed to persist telemetry scrub secret; using session-local secret");
+                    return self.adopt_fallback_secret(fresh);
+                }
+                info!("Generated and persisted per-install telemetry scrub secret");
+                fresh
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to load telemetry scrub secret; keeping random fallback");
+                return;
+            }
+        };
+
+        self.telemetry_secret_persisted = true;
+        self.adopt_fallback_secret(secret);
+    }
+
+    /// Installs `secret` as the telemetry fallback secret and rebuilds the
+    /// pre-install scrubber so the legacy MLS observability path also hashes
+    /// with the stable secret. Does not touch an already-installed
+    /// [`crate::telemetry::TelemetryContext`] (rebuilding a live context would
+    /// rotate opaque ids mid-run); apps that need stable ids should provide
+    /// storage before installing a telemetry sink.
+    fn adopt_fallback_secret(&mut self, secret: [u8; 16]) {
+        self.telemetry_fallback_secret = secret;
+        self.telemetry_scrubber = crate::telemetry::Scrubber::from_config(
+            &crate::telemetry::TelemetryConfig::default(),
+            secret,
+        );
+    }
+
+    // ========================================================================
     // LAMPORT CLOCK PERSISTENCE
     // ========================================================================
 

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -11071,3 +11071,110 @@ use crate::telemetry::transport_state::TransportStateEvent;
 // `device_battery_from_available` lives in `crate::telemetry::aggregator`
 // and is exercised by the unit tests in that module — including the
 // current-not-in-available fall-through path that was previously uncovered.
+
+// ============================================================================
+// PERSISTENT TELEMETRY SCRUB SECRET
+// ============================================================================
+
+#[test]
+fn scrub_secret_is_persisted_and_stable_across_instances() {
+    // Shared storage stands in for an app's secure store across two launches.
+    let storage = Arc::new(crate::mls::InMemoryStorage::new());
+
+    let mut first = OfflineProtocol::new(create_test_config()).unwrap();
+    first.enable_message_persistence(storage.clone()).unwrap();
+    let first_secret = first.telemetry_fallback_secret;
+    assert!(first.telemetry_secret_persisted);
+
+    // The secret was written to storage under the documented key.
+    let stored = storage
+        .load(storage_keys::SCRUB_SECRET, storage_keys::SCRUB_SECRET_ID)
+        .unwrap()
+        .expect("scrub secret should be persisted");
+    assert_eq!(stored, first_secret.to_vec());
+
+    // A second instance backed by the same storage adopts the same secret, so
+    // the same raw identifier hashes to the same opaque id across sessions.
+    let mut second = OfflineProtocol::new(create_test_config()).unwrap();
+    second.enable_message_persistence(storage.clone()).unwrap();
+    assert_eq!(second.telemetry_fallback_secret, first_secret);
+    assert_eq!(
+        first.telemetry_scrubber.hash_id("peer:alice"),
+        second.telemetry_scrubber.hash_id("peer:alice"),
+    );
+}
+
+#[test]
+fn scrub_secret_load_is_idempotent_across_entry_paths() {
+    let storage = Arc::new(crate::mls::InMemoryStorage::new());
+
+    // initialize_mls also enables persistence; a later explicit
+    // enable_message_persistence must not rotate or rewrite the secret.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol.initialize_mls(storage.clone()).unwrap();
+    let secret_after_init = protocol.telemetry_fallback_secret;
+    assert!(protocol.telemetry_secret_persisted);
+
+    protocol.enable_message_persistence(storage).unwrap();
+    assert_eq!(protocol.telemetry_fallback_secret, secret_after_init);
+}
+
+#[test]
+fn corrupt_persisted_scrub_secret_is_regenerated() {
+    let storage = Arc::new(crate::mls::InMemoryStorage::new());
+    // Pre-seed a wrong-length blob to simulate corruption.
+    storage
+        .store(
+            storage_keys::SCRUB_SECRET,
+            storage_keys::SCRUB_SECRET_ID,
+            &[1, 2, 3],
+        )
+        .unwrap();
+
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+
+    // A fresh 16-byte secret replaces the corrupt entry rather than panicking
+    // or pinning every future session to the random fallback.
+    let stored = storage
+        .load(storage_keys::SCRUB_SECRET, storage_keys::SCRUB_SECRET_ID)
+        .unwrap()
+        .expect("corrupt secret should be overwritten");
+    assert_eq!(stored.len(), 16);
+    assert_eq!(stored, protocol.telemetry_fallback_secret.to_vec());
+    assert!(protocol.telemetry_secret_persisted);
+}
+
+#[test]
+fn explicit_config_secret_wins_over_persistent_fallback() {
+    let storage = Arc::new(crate::mls::InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol.enable_message_persistence(storage).unwrap();
+
+    // Installing a sink with an explicit scrub_secret must use that secret for
+    // opaque-id hashing, not the SDK-managed persistent fallback.
+    let explicit = [0xAB; 16];
+    let cfg = TelemetryConfig::default().with_scrub_secret(Some(explicit));
+    assert_ne!(explicit, protocol.telemetry_fallback_secret);
+    protocol
+        .install_telemetry_sink(Arc::new(NoopTelemetrySink), cfg)
+        .unwrap();
+
+    let installed = protocol.telemetry.as_ref().unwrap();
+    let expected = crate::telemetry::Scrubber::new(true, explicit)
+        .hash_id("peer:alice")
+        .into_owned();
+    assert_eq!(installed.scrubber.hash_id("peer:alice"), expected);
+}
+
+#[test]
+fn scrub_secret_without_storage_keeps_random_per_instance_fallback() {
+    // No storage provided: behavior is unchanged from the legacy random
+    // per-instance fallback — two instances differ and nothing is persisted.
+    let a = OfflineProtocol::new(create_test_config()).unwrap();
+    let b = OfflineProtocol::new(create_test_config()).unwrap();
+    assert!(!a.telemetry_secret_persisted);
+    assert_ne!(a.telemetry_fallback_secret, b.telemetry_fallback_secret);
+}

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -359,6 +359,10 @@ pub(crate) mod storage_keys {
     pub const TOFU_KEYS: &str = "tofu_keys";
     /// Key type for persisted blocked user entries.
     pub const BLOCKED_USERS: &str = "blocked_users";
+    /// Key type for the persistent per-install telemetry scrub secret.
+    pub const SCRUB_SECRET: &str = "scrub_secret";
+    /// Key ID for the single scrub-secret entry.
+    pub const SCRUB_SECRET_ID: &str = "current";
 }
 
 /// Protocol state.

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -116,17 +116,28 @@ impl TelemetryConfig {
 
     /// Sets the opaque-identifier hashing secret.
     ///
-    /// Supplying `Some(secret)` enables cross-session correlation of the
-    /// same peer in backend telemetry; supplying `None` (the default)
-    /// leaves the secret unset in the config, and the SDK falls back to a
-    /// random per-instance secret derived at protocol construction.
-    /// Install-time generation of a stable, per-install secret (so
-    /// correlation survives process restarts) lands with the emission-
-    /// wiring follow-up.
+    /// Supplying `Some(secret)` pins an explicit, caller-owned secret and
+    /// always takes precedence over the SDK-managed fallback below.
+    ///
+    /// Supplying `None` (the default) leaves the secret unset in the config.
+    /// In that case the SDK manages the fallback for you: the first time
+    /// secure storage is provided (via `OfflineProtocol::initialize_mls` or
+    /// `enable_message_persistence`), the SDK loads — or, on first run,
+    /// generates and persists — a stable **per-install** secret. This makes
+    /// opaque identifiers survive process restarts, so backend telemetry can
+    /// count distinct devices across sessions. Until storage is available (or
+    /// if storage is never provided), the SDK uses a random per-instance
+    /// secret derived at protocol construction.
+    ///
+    /// Precedence: explicit config secret > SDK-managed persistent secret >
+    /// random per-instance secret.
     ///
     /// **Do not share the secret across tenants, and do not rotate it
     /// mid-run** — rotation invalidates every previously emitted opaque
-    /// identifier and breaks correlation on the receiving side.
+    /// identifier and breaks correlation on the receiving side. For the
+    /// SDK-managed fallback this means: do not back two tenants with the same
+    /// storage, and do not clear the `scrub_secret` storage entry within a
+    /// measurement window.
     pub fn with_scrub_secret(mut self, secret: Option<[u8; 16]>) -> Self {
         self.scrub_secret = secret;
         self


### PR DESCRIPTION
## What

When a caller doesn't supply an explicit `scrub_secret`, the SDK now loads (or, on first run, generates and persists) a **stable per-install** secret from secure storage and uses it as the opaque-identifier hashing fallback — instead of minting a fresh `uuid::Uuid::new_v4()` at every `OfflineProtocol::new()`.

## Why

The random per-instance fallback meant the *same* physical device hashed to a *different* opaque id every session, so backend telemetry could never recognize a device across sessions. That makes **v2 distinct-device k-anonymity impossible** (you can't aggregate a device you can't count twice). The `with_scrub_secret` doc previously punted on this, declaring install-time secret generation the caller's responsibility — this moves that ownership into the SDK where it belongs. (mesh-analytics v1 plan, OQ #4)

## How

`OfflineProtocol::new()` has no storage to persist to — secure storage only arrives later via `initialize_mls()` / `enable_message_persistence()`. So the load/generate hook lives there: `restore_or_init_scrub_secret()` reads the secret from storage (key `scrub_secret/current`), or generates and writes one on first run, then adopts it as the fallback and rebuilds the pre-install scrubber so the legacy MLS observability path agrees.

Design notes:
- **Precedence unchanged and deliberate:** explicit config secret > SDK-managed persistent secret > random per-instance. An explicit `with_scrub_secret(Some(..))` still wins; this only replaces the *fallback*.
- **Never load-bearing:** every storage failure degrades to the in-memory secret rather than blocking protocol init.
- **Idempotent** across both storage-entry paths (guarded by `telemetry_secret_persisted`), loaded **outside** the `initialize_mls` transactional rollback set since the secret is independent of MLS state.
- A **corrupt / wrong-length** stored blob is regenerated rather than pinning every future session to the random fallback.
- **Constraints respected** (do not share across tenants, do not rotate mid-window): satisfied as long as apps don't back two tenants with one storage or clear the entry mid-window — now documented on `with_scrub_secret`.

No public signature or UDL/FFI changes — the storage that drives this already crosses FFI via `MlsStorageProvider`. Apps that never provide storage keep the old random behavior unchanged; storage-using apps see their opaque ids change once on upgrade (random → stable), then stable forever.

## Tests

6 new tests: cross-session stability, idempotency across entry paths, corrupt-blob regeneration, explicit-secret-wins-over-fallback, and no-storage back-compat.

All gates green: `cargo test -p offline-protocol` (642 passed), `cargo clippy --workspace -- -D warnings` clean, `cargo fmt` clean.