### PR TITLE
feat(protocol): sampling-bypass flag for telemetry-grade MLS sinks

### DIFF
--- a/bindings/python/offline_protocol_sdk/offline_protocol.py
+++ b/bindings/python/offline_protocol_sdk/offline_protocol.py
@@ -5943,18 +5943,19 @@ class _UniffiFfiConverterOptionalTypeMlsVerbosity(_UniffiConverterRustBuffer):
 
 @dataclass
 class TelemetryConfig:
-    def __init__(self, *, scrub_ids:typing.Optional[bool], mls_verbosity:typing.Optional[MlsVerbosity], metrics_cadence_ms:typing.Optional[int], routing_diagnostic:typing.Optional[bool], enable_poll_queue:typing.Optional[bool]):
+    def __init__(self, *, scrub_ids:typing.Optional[bool], mls_verbosity:typing.Optional[MlsVerbosity], metrics_cadence_ms:typing.Optional[int], routing_diagnostic:typing.Optional[bool], enable_poll_queue:typing.Optional[bool], mls_sampling_bypass:typing.Optional[bool]):
         self.scrub_ids = scrub_ids
         self.mls_verbosity = mls_verbosity
         self.metrics_cadence_ms = metrics_cadence_ms
         self.routing_diagnostic = routing_diagnostic
         self.enable_poll_queue = enable_poll_queue
+        self.mls_sampling_bypass = mls_sampling_bypass
         
         
 
     
     def __str__(self):
-        return "TelemetryConfig(scrub_ids={}, mls_verbosity={}, metrics_cadence_ms={}, routing_diagnostic={}, enable_poll_queue={})".format(self.scrub_ids, self.mls_verbosity, self.metrics_cadence_ms, self.routing_diagnostic, self.enable_poll_queue)
+        return "TelemetryConfig(scrub_ids={}, mls_verbosity={}, metrics_cadence_ms={}, routing_diagnostic={}, enable_poll_queue={}, mls_sampling_bypass={})".format(self.scrub_ids, self.mls_verbosity, self.metrics_cadence_ms, self.routing_diagnostic, self.enable_poll_queue, self.mls_sampling_bypass)
     def __eq__(self, other):
         if self.scrub_ids != other.scrub_ids:
             return False
@@ -5965,6 +5966,8 @@ class TelemetryConfig:
         if self.routing_diagnostic != other.routing_diagnostic:
             return False
         if self.enable_poll_queue != other.enable_poll_queue:
+            return False
+        if self.mls_sampling_bypass != other.mls_sampling_bypass:
             return False
         return True
 
@@ -5977,6 +5980,7 @@ class _UniffiFfiConverterTypeTelemetryConfig(_UniffiConverterRustBuffer):
             metrics_cadence_ms=_UniffiFfiConverterOptionalUInt64.read(buf),
             routing_diagnostic=_UniffiFfiConverterOptionalBoolean.read(buf),
             enable_poll_queue=_UniffiFfiConverterOptionalBoolean.read(buf),
+            mls_sampling_bypass=_UniffiFfiConverterOptionalBoolean.read(buf),
         )
 
     @staticmethod
@@ -5986,6 +5990,7 @@ class _UniffiFfiConverterTypeTelemetryConfig(_UniffiConverterRustBuffer):
         _UniffiFfiConverterOptionalUInt64.check_lower(value.metrics_cadence_ms)
         _UniffiFfiConverterOptionalBoolean.check_lower(value.routing_diagnostic)
         _UniffiFfiConverterOptionalBoolean.check_lower(value.enable_poll_queue)
+        _UniffiFfiConverterOptionalBoolean.check_lower(value.mls_sampling_bypass)
 
     @staticmethod
     def write(value, buf):
@@ -5994,6 +5999,7 @@ class _UniffiFfiConverterTypeTelemetryConfig(_UniffiConverterRustBuffer):
         _UniffiFfiConverterOptionalUInt64.write(value.metrics_cadence_ms, buf)
         _UniffiFfiConverterOptionalBoolean.write(value.routing_diagnostic, buf)
         _UniffiFfiConverterOptionalBoolean.write(value.enable_poll_queue, buf)
+        _UniffiFfiConverterOptionalBoolean.write(value.mls_sampling_bypass, buf)
 
 
 

--- a/bindings/python/offline_protocol_sdk/protocol_manager.py
+++ b/bindings/python/offline_protocol_sdk/protocol_manager.py
@@ -424,7 +424,7 @@ class ProtocolManager:
         a field left as ``None``) uses the Rust-side defaults:
         ``scrub_ids=True``, ``mls_verbosity=Lifecycle``,
         ``metrics_cadence_ms=5000``, ``routing_diagnostic=False``,
-        ``enable_poll_queue=True``.
+        ``enable_poll_queue=True``, ``mls_sampling_bypass=False``.
         """
         effective = config if config is not None else TelemetryConfig(
             scrub_ids=None,
@@ -432,6 +432,7 @@ class ProtocolManager:
             metrics_cadence_ms=None,
             routing_diagnostic=None,
             enable_poll_queue=None,
+            mls_sampling_bypass=None,
         )
         # Pin the new sink BEFORE the FFI call so a successful Rust-side
         # swap never observes an unpinned new sink. If the FFI call raises

--- a/bindings/python/tests/test_protocol_manager.py
+++ b/bindings/python/tests/test_protocol_manager.py
@@ -499,6 +499,7 @@ class TestProtocolManagerTelemetry:
                     metrics_cadence_ms=500,
                     routing_diagnostic=True,
                     enable_poll_queue=True,
+                    mls_sampling_bypass=None,
                 ),
             )
             assert pm._telemetry_sink is sink
@@ -632,6 +633,7 @@ class TestProtocolManagerTelemetry:
                     metrics_cadence_ms=None,
                     routing_diagnostic=None,
                     enable_poll_queue=False,
+                    mls_sampling_bypass=None,
                 ),
             )
             pm._protocol.install_telemetry_sink.assert_called_once()

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -629,6 +629,7 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
                 metricsCadenceMs = null,
                 routingDiagnostic = null,
                 enablePollQueue = null,
+                mlsSamplingBypass = null,
             )
         }
         val scrubIds = readOptionalBoolean(map, "scrubIds")
@@ -649,12 +650,14 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         val cadence = readOptionalNonNegativeLong(map, "metricsCadenceMs")?.toULong()
         val routingDiag = readOptionalBoolean(map, "routingDiagnostic")
         val enablePollQueue = readOptionalBoolean(map, "enablePollQueue")
+        val mlsSamplingBypass = readOptionalBoolean(map, "mlsSamplingBypass")
         return TelemetryConfig(
             scrubIds = scrubIds,
             mlsVerbosity = verbosity,
             metricsCadenceMs = cadence,
             routingDiagnostic = routingDiag,
             enablePollQueue = enablePollQueue,
+            mlsSamplingBypass = mlsSamplingBypass,
         )
     }
 

--- a/bindings/react-native/android/src/main/java/uniffi/offline_protocol/offline_protocol.kt
+++ b/bindings/react-native/android/src/main/java/uniffi/offline_protocol/offline_protocol.kt
@@ -7338,6 +7338,8 @@ data class TelemetryConfig (
     var `routingDiagnostic`: kotlin.Boolean?
     , 
     var `enablePollQueue`: kotlin.Boolean?
+    , 
+    var `mlsSamplingBypass`: kotlin.Boolean?
     
 ){
     
@@ -7357,6 +7359,7 @@ public object FfiConverterTypeTelemetryConfig: FfiConverterRustBuffer<TelemetryC
             FfiConverterOptionalULong.read(buf),
             FfiConverterOptionalBoolean.read(buf),
             FfiConverterOptionalBoolean.read(buf),
+            FfiConverterOptionalBoolean.read(buf),
         )
     }
 
@@ -7365,7 +7368,8 @@ public object FfiConverterTypeTelemetryConfig: FfiConverterRustBuffer<TelemetryC
             FfiConverterOptionalTypeMlsVerbosity.allocationSize(value.`mlsVerbosity`) +
             FfiConverterOptionalULong.allocationSize(value.`metricsCadenceMs`) +
             FfiConverterOptionalBoolean.allocationSize(value.`routingDiagnostic`) +
-            FfiConverterOptionalBoolean.allocationSize(value.`enablePollQueue`)
+            FfiConverterOptionalBoolean.allocationSize(value.`enablePollQueue`) +
+            FfiConverterOptionalBoolean.allocationSize(value.`mlsSamplingBypass`)
     )
 
     override fun write(value: TelemetryConfig, buf: ByteBuffer) {
@@ -7374,6 +7378,7 @@ public object FfiConverterTypeTelemetryConfig: FfiConverterRustBuffer<TelemetryC
             FfiConverterOptionalULong.write(value.`metricsCadenceMs`, buf)
             FfiConverterOptionalBoolean.write(value.`routingDiagnostic`, buf)
             FfiConverterOptionalBoolean.write(value.`enablePollQueue`, buf)
+            FfiConverterOptionalBoolean.write(value.`mlsSamplingBypass`, buf)
     }
 }
 

--- a/bindings/react-native/ios/Generated/offline_protocol.swift
+++ b/bindings/react-native/ios/Generated/offline_protocol.swift
@@ -4855,15 +4855,17 @@ public struct TelemetryConfig: Equatable, Hashable {
     public var metricsCadenceMs: UInt64?
     public var routingDiagnostic: Bool?
     public var enablePollQueue: Bool?
+    public var mlsSamplingBypass: Bool?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(scrubIds: Bool?, mlsVerbosity: MlsVerbosity?, metricsCadenceMs: UInt64?, routingDiagnostic: Bool?, enablePollQueue: Bool?) {
+    public init(scrubIds: Bool?, mlsVerbosity: MlsVerbosity?, metricsCadenceMs: UInt64?, routingDiagnostic: Bool?, enablePollQueue: Bool?, mlsSamplingBypass: Bool?) {
         self.scrubIds = scrubIds
         self.mlsVerbosity = mlsVerbosity
         self.metricsCadenceMs = metricsCadenceMs
         self.routingDiagnostic = routingDiagnostic
         self.enablePollQueue = enablePollQueue
+        self.mlsSamplingBypass = mlsSamplingBypass
     }
 
     
@@ -4884,7 +4886,8 @@ public struct FfiConverterTypeTelemetryConfig: FfiConverterRustBuffer {
                 mlsVerbosity: FfiConverterOptionTypeMlsVerbosity.read(from: &buf), 
                 metricsCadenceMs: FfiConverterOptionUInt64.read(from: &buf), 
                 routingDiagnostic: FfiConverterOptionBool.read(from: &buf), 
-                enablePollQueue: FfiConverterOptionBool.read(from: &buf)
+                enablePollQueue: FfiConverterOptionBool.read(from: &buf), 
+                mlsSamplingBypass: FfiConverterOptionBool.read(from: &buf)
         )
     }
 
@@ -4894,6 +4897,7 @@ public struct FfiConverterTypeTelemetryConfig: FfiConverterRustBuffer {
         FfiConverterOptionUInt64.write(value.metricsCadenceMs, into: &buf)
         FfiConverterOptionBool.write(value.routingDiagnostic, into: &buf)
         FfiConverterOptionBool.write(value.enablePollQueue, into: &buf)
+        FfiConverterOptionBool.write(value.mlsSamplingBypass, into: &buf)
     }
 }
 

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -3834,7 +3834,7 @@ extension OfflineProtocolModule {
             return TelemetryConfig(
                 scrubIds: nil, mlsVerbosity: nil,
                 metricsCadenceMs: nil, routingDiagnostic: nil,
-                enablePollQueue: nil
+                enablePollQueue: nil, mlsSamplingBypass: nil
             )
         }
         let verbosity: MlsVerbosity?
@@ -3857,12 +3857,14 @@ extension OfflineProtocolModule {
         let cadence = (dict["metricsCadenceMs"] as? NSNumber)?.uint64Value
         let routingDiag = dict["routingDiagnostic"] as? Bool
         let enablePollQueue = dict["enablePollQueue"] as? Bool
+        let mlsSamplingBypass = dict["mlsSamplingBypass"] as? Bool
         return TelemetryConfig(
             scrubIds: scrubIds,
             mlsVerbosity: verbosity,
             metricsCadenceMs: cadence,
             routingDiagnostic: routingDiag,
-            enablePollQueue: enablePollQueue
+            enablePollQueue: enablePollQueue,
+            mlsSamplingBypass: mlsSamplingBypass
         )
     }
 }

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -1548,6 +1548,12 @@ export type RoutingReasonCode =
  * routing hot path. With `false`, `pollTelemetry()` returns `null` for
  * records emitted under that config (previously enqueued records remain
  * readable until drained).
+ *
+ * `mlsSamplingBypass` (default false) opts a telemetry-grade sink out of the
+ * fixed-window rate limiter on high-volume MLS lifecycle events
+ * (`mls.decryption_failed`, `mls.session_missing`) so aggregate counts are not
+ * clipped to the per-window ceiling. Only enable it for sinks that apply their
+ * own backpressure (e.g. enqueue-and-drain on a background task).
  */
 export interface TelemetryConfig {
   scrubIds?: boolean;
@@ -1555,6 +1561,7 @@ export interface TelemetryConfig {
   metricsCadenceMs?: number;
   routingDiagnostic?: boolean;
   enablePollQueue?: boolean;
+  mlsSamplingBypass?: boolean;
 }
 
 /**

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -642,6 +642,7 @@ pub struct TelemetryConfig {
     pub metrics_cadence_ms: Option<u64>,
     pub routing_diagnostic: Option<bool>,
     pub enable_poll_queue: Option<bool>,
+    pub mls_sampling_bypass: Option<bool>,
 }
 
 // ---- Conversions: core telemetry types → FFI dicts ----
@@ -909,6 +910,9 @@ fn telemetry_config_into_core(cfg: TelemetryConfig) -> CoreTelemetryConfig {
     }
     if let Some(v) = cfg.routing_diagnostic {
         core = core.with_routing_diagnostic(v);
+    }
+    if let Some(v) = cfg.mls_sampling_bypass {
+        core = core.with_mls_sampling_bypass(v);
     }
     core
 }

--- a/crates/offline-protocol-uniffi/src/offline_protocol.udl
+++ b/crates/offline-protocol-uniffi/src/offline_protocol.udl
@@ -551,12 +551,18 @@ dictionary DeviceCapabilitySnapshot {
 // typed push callbacks still fire, but `poll_telemetry_frame` will always
 // return null for records emitted under that config. Flip back to true
 // (re-install the sink) to resume polling.
+//
+// `mls_sampling_bypass` (default false) opts a telemetry-grade sink out of the
+// fixed-window limiter on high-volume MLS lifecycle events (mls.decryption_failed,
+// mls.session_missing) so aggregate counts are not clipped to the per-window
+// ceiling. Only enable it for sinks that apply their own backpressure.
 dictionary TelemetryConfig {
     boolean? scrub_ids;
     MlsVerbosity? mls_verbosity;
     u64? metrics_cadence_ms;
     boolean? routing_diagnostic;
     boolean? enable_poll_queue;
+    boolean? mls_sampling_bypass;
 };
 
 // Unified telemetry sink. Apps implement this to receive every typed

--- a/crates/offline-protocol/src/protocol/observability.rs
+++ b/crates/offline-protocol/src/protocol/observability.rs
@@ -55,6 +55,19 @@ impl OfflineProtocol {
             .unwrap_or(MlsVerbosity::Lifecycle)
     }
 
+    /// Returns whether the installed sink opted out of MLS event rate
+    /// limiting.
+    ///
+    /// Defaults to `false` (rate limiting active) when no telemetry sink has
+    /// been installed, preserving the always-limited behavior the legacy
+    /// emitter path has always had.
+    fn mls_sampling_bypass(&self) -> bool {
+        self.telemetry
+            .as_ref()
+            .map(|ctx| ctx.config.mls_sampling_bypass())
+            .unwrap_or(false)
+    }
+
     /// Derives the opaque session identifier used to correlate MLS lifecycle
     /// events. The raw seed (`peer=<peer_id>|group=<group_id>`) couples two
     /// identifiers, so it is hashed unconditionally via
@@ -84,7 +97,11 @@ impl OfflineProtocol {
         if matches!(self.mls_verbosity(), MlsVerbosity::Off) {
             return;
         }
-        if !self.mls_event_rate_limiter.should_emit(&event) {
+        // Telemetry-grade sinks can opt out of the fixed-window limiter so
+        // aggregate counts are not clipped to the per-window ceiling. When
+        // bypass is on we skip `should_emit` entirely — its window counter is
+        // left untouched, so toggling bypass off later resumes clean limiting.
+        if !self.mls_sampling_bypass() && !self.mls_event_rate_limiter.should_emit(&event) {
             return;
         }
         // Legacy emitter consumes a value-typed event (its existing

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -766,6 +766,72 @@ fn test_mls_verbosity_off_suppresses_both_sink_and_legacy_emitter() {
     );
 }
 
+/// Counts the `mls.decryption_failed` records observed by the sink.
+fn count_decryption_failed(records: &[TelemetryRecord]) -> usize {
+    records
+        .iter()
+        .filter(|r| {
+            matches!(
+                r,
+                TelemetryRecord::Mls(MlsLifecycleEvent::DecryptionFailed { .. })
+            )
+        })
+        .count()
+}
+
+#[test]
+fn test_mls_sampling_default_caps_decryption_failed_flood() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(Arc::new(sink.clone()), TelemetryConfig::default())
+        .unwrap();
+
+    // 25 failures for the same sender+kind within one window. The default
+    // fixed-window limiter caps emission at 10 per peer+kind.
+    for _ in 0..25 {
+        protocol.emit_mls_decryption_failed(
+            "sender-a",
+            None,
+            DecryptionFailureKind::InvalidCiphertext,
+            MlsOperationContext::Receive,
+        );
+    }
+
+    let count = count_decryption_failed(&sink.take());
+    assert_eq!(
+        count, 10,
+        "default config must cap decryption_failed at the per-window ceiling, got {count}",
+    );
+}
+
+#[test]
+fn test_mls_sampling_bypass_delivers_unsampled_decryption_failed() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let sink = RecordingTelemetrySink::default();
+    protocol
+        .install_telemetry_sink(
+            Arc::new(sink.clone()),
+            TelemetryConfig::default().with_mls_sampling_bypass(true),
+        )
+        .unwrap();
+
+    for _ in 0..25 {
+        protocol.emit_mls_decryption_failed(
+            "sender-a",
+            None,
+            DecryptionFailureKind::InvalidCiphertext,
+            MlsOperationContext::Receive,
+        );
+    }
+
+    let count = count_decryption_failed(&sink.take());
+    assert_eq!(
+        count, 25,
+        "mls_sampling_bypass must deliver every decryption_failed event un-sampled, got {count}",
+    );
+}
+
 #[test]
 fn test_scrub_ids_false_passes_raw_peer_id_to_sink() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();

--- a/crates/offline-protocol/src/telemetry/config.rs
+++ b/crates/offline-protocol/src/telemetry/config.rs
@@ -59,6 +59,7 @@ pub struct TelemetryConfig {
     pub(crate) metrics_cadence: Option<Duration>,
     pub(crate) scrub_secret: Option<[u8; 16]>,
     pub(crate) routing_diagnostic: bool,
+    pub(crate) mls_sampling_bypass: bool,
 }
 
 impl fmt::Debug for TelemetryConfig {
@@ -72,6 +73,7 @@ impl fmt::Debug for TelemetryConfig {
                 &self.scrub_secret.as_ref().map(|_| "<redacted>"),
             )
             .field("routing_diagnostic", &self.routing_diagnostic)
+            .field("mls_sampling_bypass", &self.mls_sampling_bypass)
             .finish()
     }
 }
@@ -84,6 +86,7 @@ impl Default for TelemetryConfig {
             metrics_cadence: Some(Duration::from_secs(5)),
             scrub_secret: None,
             routing_diagnostic: false,
+            mls_sampling_bypass: false,
         }
     }
 }
@@ -180,6 +183,37 @@ impl TelemetryConfig {
         self.routing_diagnostic
     }
 
+    /// Opts the installed sink out of MLS lifecycle event rate limiting.
+    ///
+    /// By default (`false`), high-volume MLS lifecycle events
+    /// (`mls.decryption_failed`, `mls.session_missing`) pass through a
+    /// best-effort fixed-window limiter that caps emission per peer+kind. The
+    /// cap protects naïve sinks from event floods, but it also clips genuine
+    /// failure spikes to the per-window ceiling — an aggregating backend
+    /// cannot tell a real burst of N failures apart from the cap.
+    ///
+    /// Setting this to `true` disables that limiter so a **telemetry-grade**
+    /// sink receives every MLS lifecycle event un-sampled, and aggregate
+    /// counts reflect reality. Only enable it for sinks that apply their own
+    /// backpressure (for example, pushing onto a bounded channel and draining
+    /// on a background task per the [`TelemetrySink`] contract) — an
+    /// unbuffered sink that does real work inline can be overwhelmed by an
+    /// un-capped failure spike.
+    ///
+    /// This knob only affects MLS-event rate limiting; it does not change
+    /// identifier scrubbing, verbosity, or any other field.
+    ///
+    /// [`TelemetrySink`]: crate::telemetry::TelemetrySink
+    pub fn with_mls_sampling_bypass(mut self, mls_sampling_bypass: bool) -> Self {
+        self.mls_sampling_bypass = mls_sampling_bypass;
+        self
+    }
+
+    /// Returns whether MLS lifecycle event rate limiting is bypassed.
+    pub fn mls_sampling_bypass(&self) -> bool {
+        self.mls_sampling_bypass
+    }
+
     /// Returns the configured opaque-identifier hashing secret, if any.
     ///
     /// Crate-private: the secret feeds `Scrubber` construction and is not
@@ -206,6 +240,7 @@ mod tests {
         assert_eq!(cfg.metrics_cadence(), Some(Duration::from_secs(5)));
         assert!(cfg.scrub_secret().is_none());
         assert!(!cfg.routing_diagnostic());
+        assert!(!cfg.mls_sampling_bypass());
     }
 
     #[test]
@@ -215,12 +250,14 @@ mod tests {
             .with_mls_verbosity(MlsVerbosity::Off)
             .with_metrics_cadence(None)
             .with_scrub_secret(Some([7; 16]))
-            .with_routing_diagnostic(true);
+            .with_routing_diagnostic(true)
+            .with_mls_sampling_bypass(true);
         assert!(!cfg.scrub_ids());
         assert_eq!(cfg.mls_verbosity(), MlsVerbosity::Off);
         assert!(cfg.metrics_cadence().is_none());
         assert_eq!(cfg.scrub_secret(), Some([7; 16]));
         assert!(cfg.routing_diagnostic());
+        assert!(cfg.mls_sampling_bypass());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds an opt-in `mls_sampling_bypass` flag to `TelemetryConfig` that lets a telemetry-grade sink receive un-sampled MLS lifecycle events, so aggregate `mls.decryption_failed` counts reflect reality instead of being clipped at the fixed-window rate limiter's 10/window ceiling.

Closes the SDK side of **OQ #13** from the mesh-analytics v1 plan.

## Why

`MlsEventRateLimiter` (wrapping `CategorySampler`, default 10 events per peer+kind per window) caps every MLS lifecycle emission. For a failure spike that means `mls.decryption_failed` flattens to a ceiling of 10/window — an aggregating backend can't distinguish a genuine burst of 10 from a burst of 10,000. The under-count is indistinguishable from the cap, which for an analytics pipeline is data loss dressed up as a number.

## How

- **Core**: new `TelemetryConfig::with_mls_sampling_bypass()` builder + `mls_sampling_bypass()` accessor. `emit_mls_lifecycle_event` short-circuits the limiter when set — the window counter is left untouched, so toggling bypass off later resumes clean limiting. Default stays `false`, preserving existing flood protection.
- **FFI**: flag threaded through the UniFFI `TelemetryConfig` dict, the FFI adapter struct, and `telemetry_config_into_core`.
- **Bindings**: regenerated Swift/Kotlin/Python from the UDL (clean additive diffs) and updated the hand-written RN bridge construction sites + TS interface.

## Safety / scope

This is strictly for sinks that apply their own backpressure (enqueue-and-drain on a background task, per the `TelemetrySink` contract). An unbuffered sink doing inline work can be overwhelmed by an un-capped failure spike — documented on the builder. The knob only affects MLS-event rate limiting; scrubbing, verbosity, and every other field are untouched.

## Tests

- Default config caps `decryption_failed` at 10 per window.
- `mls_sampling_bypass(true)` delivers all 25 emitted events un-sampled.

Full suite: 644 + 54 Rust tests pass, `clippy --workspace -D warnings` clean, `fmt --check` clean, Python compiles.

---
From the mesh-analytics v1 SDK ticket list (item 4 of 4), filed against OQ #13.