### PR TITLE
chore: add community-health files (CoC, templates, CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# CODEOWNERS — auto-requests review from the listed owners when matching
+# paths change. See https://docs.github.com/articles/about-code-owners
+#
+# Ownership is assigned to the @Offline-Protocol/maintainers team. The team
+# must exist in the org AND have write access to this repo, otherwise these
+# entries are silently ignored. Manage who is a maintainer here:
+#   https://github.com/orgs/Offline-Protocol/teams/maintainers
+
+# Default owner for everything in the repo
+*                                   @Offline-Protocol/maintainers
+
+# Security-sensitive areas — encryption core and the FFI boundary.
+# Pinned explicitly so they stay with the maintainers team even if the
+# default owner above is ever delegated to a wider group.
+/crates/offline-protocol-mls/       @Offline-Protocol/maintainers
+/crates/offline-protocol-uniffi/    @Offline-Protocol/maintainers
+/SECURITY.md                        @Offline-Protocol/maintainers
+/CLA.md                             @Offline-Protocol/maintainers
+
+# Repo/CI configuration
+/.github/                           @Offline-Protocol/maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,115 @@
+name: 🐛 Bug Report
+description: Report a defect in the Offline Protocol SDK
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+
+        ⚠️ **Do not report security vulnerabilities here.** Please follow our
+        [Security Policy](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/SECURITY.md)
+        to report them privately.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and this has not already been reported.
+          required: true
+        - label: This is not a security vulnerability (those go through the Security Policy).
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: SDK version
+      description: Which version of the SDK are you using? (e.g. crate version, npm package version, or git commit)
+      placeholder: "0.2.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected crate / area
+      description: Which part of the SDK does this affect? (maps to our Conventional Commit scopes)
+      options:
+        - core (offline-protocol-core)
+        - transport (offline-protocol-transport)
+        - router / DORS (offline-protocol-router)
+        - reliability (offline-protocol-reliability)
+        - mls / encryption (offline-protocol-mls)
+        - services (offline-protocol-services)
+        - protocol / main API (offline-protocol)
+        - uniffi (offline-protocol-uniffi)
+        - bindings (React Native / Python / other)
+        - docs
+        - examples
+        - CI / build / tooling
+        - "Not sure / other"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Where does the bug occur?
+      options:
+        - Rust (desktop / server)
+        - iOS (Swift)
+        - Android (Kotlin)
+        - React Native
+        - Python
+        - Embedded (C FFI / ESP32)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps (ideally a code snippet or repo) that reproduce the problem.
+      placeholder: |
+        1. Configure the protocol with '...'
+        2. Call '...'
+        3. Observe '...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / backtrace
+      description: |
+        Relevant logs or panic output. Run with `RUST_BACKTRACE=1` for backtraces.
+        This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help — environment, transport in use, related issues, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Disable the "open a blank issue" escape hatch so reports go through a template
+# (and so security reports get redirected privately rather than filed publicly).
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/SECURITY.md
+    about: Do NOT open a public issue for vulnerabilities. Follow our Security Policy to report privately.
+  - name: 💬 Questions & discussion
+    url: https://github.com/Offline-Protocol/offline-protocol-sdk/discussions
+    about: Ask usage questions or propose ideas in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement for the SDK
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the Offline Protocol SDK! Please describe the
+        problem you're trying to solve before jumping to a proposed solution.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and discussions and this has not already been proposed.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What's the use case? ("I'm trying to ... but ...")
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected crate / area
+      description: Which part of the SDK would this touch? (maps to our Conventional Commit scopes)
+      options:
+        - core (offline-protocol-core)
+        - transport (offline-protocol-transport)
+        - router / DORS (offline-protocol-router)
+        - reliability (offline-protocol-reliability)
+        - mls / encryption (offline-protocol-mls)
+        - services (offline-protocol-services)
+        - protocol / main API (offline-protocol)
+        - uniffi (offline-protocol-uniffi)
+        - bindings (React Native / Python / other)
+        - docs
+        - examples
+        - CI / build / tooling
+        - "Not sure / other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've thought about.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I would be willing to submit a PR for this feature.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,60 @@
+<!--
+Thanks for contributing to the Offline Protocol SDK!
+Please fill out the sections below. Delete anything that doesn't apply.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issues
+
+<!-- e.g. "Closes #123" / "Refs #456". Use "Closes" to auto-close on merge. -->
+
+Closes #
+
+## Type of change
+
+<!-- Mark with an [x] all that apply. Matches our Conventional Commit types. -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
+- [ ] `perf` — performance improvement
+- [ ] `test` — adding or correcting tests
+- [ ] `chore` — build, tooling, or dependency changes
+
+## Checklist
+
+<!-- These mirror the CI gates — PRs that fail them will be blocked. -->
+
+- [ ] `cargo fmt --workspace -- --check` passes
+- [ ] `cargo clippy --workspace -- -D warnings` passes
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo-deny` is satisfied (no new license/advisory violations)
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <subject>`)
+- [ ] Docs / `CHANGELOG.md` updated where relevant
+- [ ] No new `unsafe` in core crates (only the `offline-protocol-uniffi` FFI boundary may use it, with SAFETY comments)
+- [ ] If the UniFFI UDL changed, bindings were regenerated (`npm run generate:bindings` and/or the Python build) and committed
+
+## Breaking changes
+
+<!-- Describe any breaking API/wire/config changes and the migration path, or "None". -->
+
+None
+
+## Notes for reviewers
+
+<!-- Anything that helps review: design decisions, areas needing extra scrutiny, follow-ups. -->
+
+---
+
+<!--
+First-time contributor? Our CLA bot will comment on this PR with a link to
+CLA.md. To sign, comment exactly:
+
+  I have read the CLA Document and I hereby sign the CLA
+
+You only sign once. PRs cannot be merged until the CLA check is green.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at gm@offlineprotocol.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
## Summary

Adds the standard GitHub community-health files the repo was missing. These are the files GitHub looks for to populate the **Community Standards** page — the hard parts (CLA bot, SECURITY.md, CONTRIBUTING.md, dual licensing) were already done; this fills the gaps.

| File | What it does |
|---|---|
| `CODE_OF_CONDUCT.md` | Contributor Covenant **2.1** verbatim; enforcement contact → `gm@offlineprotocol.com` |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | YAML issue form: version, affected-crate dropdown (mapped to commit scopes), platform, repro/expected/actual, logs |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | YAML issue form: problem, proposal, area, alternatives |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues; redirects security → `SECURITY.md`, questions → Discussions |
| `.github/PULL_REQUEST_TEMPLATE.md` | Checklist mirroring the real CI gates (fmt/clippy/test/cargo-deny/bindings) + CLA reminder |
| `.github/CODEOWNERS` | Owned by the `@Offline-Protocol/maintainers` team (all paths + explicit security-sensitive paths) |

YAML issue forms were chosen over classic Markdown templates so reports carry structured fields instead of free text. The dropdowns reuse the project's Conventional-Commit scopes.


## Verification

- All three issue-form YAML files parse cleanly.
- No code/test/build changes — CI behavior is unaffected.