### PR TITLE
docs: correct stale API and transport-priority references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ build/
 target
 .cursor/
 .claude/
+.claude/todos/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.2.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/bindings/react-native/DORS.md
+++ b/bindings/react-native/DORS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-DORS is the intelligent transport selection engine at the heart of the Offline Protocol SDK. It automatically evaluates, selects, and switches between available transport layers — Internet, BLE Mesh, Wi-Fi Direct, and Reticulum — based on real-time network conditions. The goal is to ensure optimal message delivery while balancing performance, reliability, and energy consumption.
+DORS is the intelligent transport selection engine at the heart of the Offline Protocol SDK. It automatically evaluates, selects, and switches between available transport layers — Internet, BLE Mesh, Wi-Fi Direct, Reticulum, and Nostr relays — based on real-time network conditions. The goal is to ensure optimal message delivery while balancing performance, reliability, and energy consumption.
 
 ## How DORS Works
 
@@ -138,7 +138,7 @@ Optimized for resilience and long-range delivery via LoRa and other Reticulum me
 | Signal | 5% |
 | Bandwidth | 5% |
 
-Reticulum has no base score bonus and the lowest tie-break priority (Internet > WiFi Direct > BLE > Reticulum). It acts as a resilience fallback when other transports are unavailable or degraded.
+Reticulum has no base score bonus and a low tie-break priority. The full order is Internet > WiFi Direct > BLE > Reticulum > Nostr, so Nostr (not Reticulum) is the lowest-priority transport. Reticulum acts as a resilience fallback when other transports are unavailable or degraded.
 
 ## Switching Safeguards
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -44,10 +44,16 @@ pub struct Message {
     pub priority: MessagePriority,  // Message priority
     pub ttl: TTL,                   // Time-to-live (hops remaining)
     pub hop_count: HopCount,        // Hops traversed
-    pub timestamp: Timestamp,       // When message was created
+    pub timestamp: Timestamp,       // When message was created (wall-clock, display only)
+    pub lamport_clock: LamportClock, // Logical clock for causal ordering across devices
+    pub content_type: ContentType,  // Type of content carried (text, file chunk, etc.)
     pub content: String,            // Message content
+    pub binary_content: Option<Vec<u8>>,    // Raw payload for file-chunk data
+    pub media_metadata: Option<MediaMetadata>, // Media details for non-text content
     pub metadata: HashMap<String, String>,  // App-specific data
     pub requires_ack: bool,         // Whether ACK is required
+    pub reply_to_msg: Option<MessageId>,    // Message this is replying to (threading)
+    pub forwarded_from: Option<ForwardInfo>, // Forwarding attribution, if forwarded
 }
 ```
 
@@ -62,12 +68,14 @@ pub struct ProtocolConfig {
     pub app_id: String,             // Application ID (required)
     pub user_id: String,            // User ID (required)
     pub transport: TransportConfig, // Transport settings
-    pub encryption: EncryptionConfig, // Encryption settings (NEW!)
     pub dors: DorsConfig,          // DORS settings
     pub relay: RelayConfig,        // Relay settings
     pub path: PathConfig,          // Path selection settings
     pub reliability: ReliabilityConfig, // Reliability settings
+    pub encryption: EncryptionConfig, // Auto-encryption (MLS) settings
     pub initial_ttl: u8,           // Initial TTL (default: 8)
+    pub group: GroupConfig,        // Mesh group messaging settings
+    pub security: SecurityConfig,  // Transport & control-message hardening
 }
 ```
 

--- a/docs/dors.md
+++ b/docs/dors.md
@@ -130,7 +130,7 @@ Optimized for resilience and long-range delivery via LoRa and other Reticulum me
 | Signal | 5% |
 | Bandwidth | 5% |
 
-Reticulum has no base score bonus and receives the third-lowest tie-break priority (Internet > WiFi Direct > BLE > Reticulum > Nostr). It is selected only when it genuinely outscores other transports or when they are unavailable. The low bandwidth weight reflects that Reticulum's LoRa medium is inherently low-throughput (~0.7 KB/s typical, ~2.7 KB/s peak at SF7/BW500kHz).
+Reticulum has no base score bonus and receives the second-lowest tie-break priority (Internet > WiFi Direct > BLE > Reticulum > Nostr). It is selected only when it genuinely outscores other transports or when they are unavailable. The low bandwidth weight reflects that Reticulum's LoRa medium is inherently low-throughput (~0.7 KB/s typical, ~2.7 KB/s peak at SF7/BW500kHz).
 
 ### Nostr Relay Transport
 Optimized for censorship resistance and last-resort routing through public WebSocket relays. Acts as a fallback when other transports are unreachable or actively blocked.

--- a/docs/react-native-integration.md
+++ b/docs/react-native-integration.md
@@ -144,62 +144,59 @@ See `docs/dors-configuration.md` and `docs/configuration.md` for full parameters
 
 ---
 
-## 7. Group SDK (Relay-Based Groups)
+## 7. Group Messaging (MLS-Encrypted Mesh Groups)
 
-Group features (create groups, send messages, manage members) are provided by **SDK group methods**. Each method returns a JSON string that must be sent to your relay server; the SDK does not open or manage the connection. Your app is responsible for relay connection, authentication, and sending the SDK payloads—or for using a provider that does this (e.g. the example app’s **ProtocolProvider**).
+Group features (create groups, send messages, manage members) are provided directly by the SDK's **mesh group methods**. The SDK handles MLS end-to-end encryption and mesh fan-out automatically — there is **no relay server** to run or connect to. Each method runs against your `OfflineProtocol` instance and delivers over whatever transports DORS has selected.
 
 ### 7.1 Prerequisites
 
-- A relay server that implements the group WebSocket API.
-- User identity (e.g. token) for authenticating with the relay.
+- MLS must be initialised first (see §11.12), e.g. `await protocol.initializeMlsWithSecureStorage(...)`.
+- The creator becomes the group admin; admins manage membership.
 
-### 7.2 Using Group Methods (SDK Only)
-
-Call the group methods on your `OfflineProtocol` instance. Each returns a **Promise&lt;string&gt;** (a JSON string). Your app (or your provider) must send that string to the relay; the SDK does not perform the send.
+### 7.2 Creating and Using Groups
 
 ```ts
-// After your app has established an authenticated relay connection,
-// call SDK group methods and send the returned JSON to the relay.
+// Create a group — the creator is the admin. Returns MlsGroupInfo.
+const group = await protocol.meshCreateGroup('My Group');
 
-const createPayload = await protocol.groupCreate('My Group');
-// Send createPayload to relay (e.g. via your provider’s send() or equivalent).
+// Invite a member by user ID (admin only). Sends MLS Welcome + Commit.
+await protocol.meshInviteToGroup(group.groupId, 'user456');
 
-const listPayload = await protocol.groupGetUserGroups();
-// Send listPayload to relay.
+// Send an encrypted message to all members.
+// Signature: meshSendGroupMessage(groupId, content, priority?, replyToMsg?)
+await protocol.meshSendGroupMessage(group.groupId, 'Hello group!');
 
-const msgPayload = await protocol.groupSendMessage(groupId, content, replyToMsgId ?? null);
-// Send msgPayload to relay.
+// List groups and fetch info.
+const groupIds = await protocol.meshListGroups();
+const info = await protocol.meshGetGroupInfo(group.groupId);
 ```
 
-In the **example React Native app**, **ProtocolProvider** owns the relay connection and exposes group actions (`createGroup`, `sendGroupMessage`, `addGroupMember`, etc.) that call these SDK methods and send the resulting JSON over the relay. Screens use `useProtocol()` and call those context methods only—no direct WebSocket creation. See `examples/react-native-app` and `ProtocolProvider.tsx` for the full pattern.
+In the **example React Native app**, **ProtocolProvider** wraps these in context actions (`createGroup` → `meshCreateGroup`, `sendGroupMessage` → `meshSendGroupMessage`, `addGroupMember` → `meshInviteToGroup`, etc.). Screens use `useProtocol()` and call those context methods only. See `examples/react-native-app` and `ProtocolProvider.tsx` for the full pattern.
 
 ### 7.3 Group Methods Summary
 
 | Method | Description |
 |--------|-------------|
-| `groupCreate(name)` | Create group; creator is admin. |
-| `groupSendMessage(groupId, content, replyToMsg?)` | Send message; optional reply-to message ID. |
-| `groupAddMember(groupId, username)` | Add member (admin). |
-| `groupRemoveMember(groupId, username)` | Remove member (admin or self). |
-| `groupSetAdmin(groupId, username)` | Grant admin (admin). |
-| `groupRemoveAdmin(groupId, username)` | Revoke admin (admin). |
-| `groupLeave(groupId)` | Current user leaves. |
-| `groupDelete(groupId)` | Delete group (admin). |
-| `groupGetInfo(groupId)` | Get group metadata. |
-| `groupGetUserGroups()` | Get all groups for current user. |
+| `meshCreateGroup(name)` | Create group; creator is admin. Returns `MlsGroupInfo`. |
+| `meshSendGroupMessage(groupId, content, priority?, replyToMsg?)` | Send encrypted message to all members. |
+| `meshInviteToGroup(groupId, inviteeUserId)` | Invite member (admin); sends Welcome + Commit. |
+| `meshRemoveFromGroup(groupId, memberId)` | Remove member (admin). |
+| `meshLeaveGroup(groupId)` | Current user leaves the group. |
+| `meshListGroups()` | List all group IDs. |
+| `meshGetGroupInfo(groupId)` | Get group metadata (members, epoch). |
+| `meshRenameGroup(groupId, newName)` | Rename group (admin); broadcasts to members. |
 
-Relay responses (e.g. `UserGroups`, `GroupCreated`, `GroupMessage`, `GroupInfo`, `Error`) are received asynchronously from your relay; see your relay API docs for exact shapes. In the example app, ProtocolProvider tracks these and updates `groups`, `groupDetails`, and `groupMessages` in context.
+Member roles (admin/member) are managed with `meshSetMemberRole` / `meshGetMemberRole` / `meshGetGroupRoles`. See §11.13–§11.14 for the complete reference.
 
 ### 7.4 Reply-to (Threaded Messages)
 
-Store the message ID when the user taps “reply”, then pass it as the third argument:
+Store the message ID when the user taps "reply", then pass it as the `replyToMsg` argument:
 
 ```ts
-const payload = await protocol.groupSendMessage(groupId, content, replyToMessageId);
-// Send payload to relay (or use your provider's sendGroupMessage(groupId, content, replyToMessageId)).
+await protocol.meshSendGroupMessage(groupId, content, null, replyToMessageId);
 ```
 
-Render replies in the UI by resolving `reply_to` / `replyToMsg` to the original message.
+Render replies in the UI by resolving `replyToMsg` to the original message.
 
 ---
 
@@ -219,7 +216,7 @@ Subscribe to `transport_switched`, `relay_promoted`, `network_metrics` for DORS 
 1. BLE/Wi‑Fi Direct permissions granted before start.
 2. `cargo test -p offline-protocol-router` and `cargo test -p offline-protocol` for core logic.
 3. Example app (`examples/react-native-app`) for device scenarios and Control Center.
-4. For groups: relay connection and auth (e.g. via ProtocolProvider), then `groupGetUserGroups` / create / send / reply-to work; add/remove member, leave, delete (admin).
+4. For groups: MLS initialised, then `meshCreateGroup` / `meshSendGroupMessage` / reply-to work; invite, remove member, leave, rename (admin).
 
 ---
 
@@ -468,25 +465,6 @@ High-level group methods that handle MLS encryption and mesh fan-out automatical
 | **forwardMessage** | `forwardMessage(params: ForwardMessageParams): Promise<string>` | Forwards a message to a 1:1 recipient with attribution. |
 
 For group forwarding, see `meshForwardMessageToGroup` in [§11.13](#1113-mesh-group-messaging-mls-encrypted).
-
----
-
-### 11.18 Group Management (Relay Server API)
-
-Each method returns a **JSON string** that your app (or provider) sends to the relay. The SDK does not open or manage the connection. In the example app, ProtocolProvider owns the relay and exposes group actions that call these methods and send the JSON for you.
-
-| Method | Signature | Description |
-|--------|-----------|-------------|
-| **groupCreate** | `groupCreate(name: string): Promise<string>` | Create group; creator is admin. |
-| **groupSendMessage** | `groupSendMessage(groupId, content, replyToMsg?: string \| null): Promise<string>` | Send message to group; optional reply-to message ID. |
-| **groupAddMember** | `groupAddMember(groupId, username): Promise<string>` | Add member (admin). |
-| **groupRemoveMember** | `groupRemoveMember(groupId, username): Promise<string>` | Remove member (admin or self). |
-| **groupSetAdmin** | `groupSetAdmin(groupId, username): Promise<string>` | Set member as admin (admin). |
-| **groupRemoveAdmin** | `groupRemoveAdmin(groupId, username): Promise<string>` | Remove admin role (admin). |
-| **groupLeave** | `groupLeave(groupId): Promise<string>` | Leave group. |
-| **groupDelete** | `groupDelete(groupId): Promise<string>` | Delete group (admin). |
-| **groupGetInfo** | `groupGetInfo(groupId): Promise<string>` | Get group info. |
-| **groupGetUserGroups** | `groupGetUserGroups(): Promise<string>` | Get all groups for current user. |
 
 ---
 

--- a/docs/reticulum.md
+++ b/docs/reticulum.md
@@ -288,7 +288,7 @@ DORS evaluates Reticulum alongside all other transports using the same multi-fac
 | Bandwidth default | 20 | Conservative default score when no measurement available |
 | Energy baseline | 75 | Between BLE (90) and Internet (60) |
 | High-power | No | Not penalized during low battery |
-| Tie-break priority | 3 (lowest) | Internet (0) > WiFi Direct (1) > BLE (2) > Reticulum (3) |
+| Tie-break priority | 3 (second-lowest) | Internet (0) > WiFi Direct (1) > BLE (2) > Reticulum (3) > Nostr (4) |
 
 ### LoRa Throughput Reference
 
@@ -313,7 +313,7 @@ Reticulum will be selected when:
 Reticulum will **not** be selected when:
 - Higher-bandwidth transports are available with comparable reliability
 - The message requests Internet preference (media/file transfers)
-- Scores are tied (tie-break favors Internet > WiFi > BLE > Reticulum)
+- Scores are tied (tie-break favors Internet > WiFi > BLE > Reticulum > Nostr)
 
 ## File Transfer Behavior
 
@@ -478,7 +478,7 @@ On disconnection:
 
 1. Verify `reticulumEnabled: true` in config
 2. Verify `reticulumStatusChanged(true)` was called after the Reticulum stack is ready
-3. Check DORS scores — Reticulum has lowest tie-break priority, so it needs to outscore alternatives
+3. Check DORS scores — Reticulum has a low tie-break priority (only Nostr is lower), so it needs to outscore alternatives
 4. Reticulum is excluded from media transfers by design
 
 ## Further Reading

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -162,6 +162,7 @@ Implementations must be thread-safe and non-blocking. See `bindings/react-native
 | `routingDiagnostic` | boolean | `false` | When `true`, `RoutingDecision.scores` carries per-factor breakdowns (signal, proximity, bandwidth, congestion, energy, reliability, load). Off by default to avoid per-emit allocation on the DORS hot path. |
 | `scrubIds` | boolean | `true` | Hash long-lived identifiers (`peer_id`, `user_id`, `group_id`, actor fields) with SHA-256 before emission. |
 | `enablePollQueue` | boolean | `true` | When `false`, the Rust adapter skips the per-emit JSON envelope used by `pollTelemetry()`. Push listeners still fire. Leave `true` if any consumer calls `pollTelemetry()`. |
+| `mlsSamplingBypass` | boolean | `false` | When `true`, a telemetry-grade sink opts out of MLS event sampling so every MLS lifecycle record is emitted (not rate-limited). Leave `false` for normal dashboards. |
 
 Rust also exposes `with_scrub_secret([u8; 16])` for a deterministic hashing key — without it, the SDK generates a random per-instance fallback so scrubbed IDs are stable for the lifetime of one protocol instance but not across restarts.
 

--- a/docs/transport-architecture.md
+++ b/docs/transport-architecture.md
@@ -182,7 +182,7 @@ Device ←→ Platform Bridge ←→ Reticulum Stack ←→ LoRa/TCP/UDP/I2P ←
 **Key characteristics**:
 - Disabled by default (`reticulumEnabled: false`) — requires external infrastructure
 - Low bandwidth (~0.7 KB/s typical, ~2.7 KB/s peak on LoRa), so excluded from media transfer
-- DORS gives it lowest tie-break priority (resilience fallback)
+- DORS gives it a low tie-break priority (3) — second only to Nostr (resilience fallback)
 - Connection timeout: 60 seconds (vs 30s for Internet)
 
 See the [Reticulum Transport Guide](reticulum.md) for full setup and integration details.

--- a/examples/demo-app/ios/Podfile.lock
+++ b/examples/demo-app/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - MeshSdk (0.9.4):
+  - MeshSdk (0.10.0):
     - React-Core
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -2657,7 +2657,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  MeshSdk: 31e6e2caa9d18ebd49f4b655e038d3fa101419d6
+  MeshSdk: 11fc68ea0b66fd6e0c76397177108a4f648f917c
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a
   RCTRequired: e2c574c1b45231f7efb0834936bd609d75072b63

--- a/examples/demo-app/package-lock.json
+++ b/examples/demo-app/package-lock.json
@@ -37,7 +37,7 @@
     },
     "../../bindings/react-native": {
       "name": "@offline-protocol/mesh-sdk",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "license": "ISC",
       "devDependencies": {
         "@types/react-native": "^0.72.8",

--- a/examples/react-native-app/INTEGRATION_GUIDE.md
+++ b/examples/react-native-app/INTEGRATION_GUIDE.md
@@ -301,9 +301,9 @@ export default function App() {
   const { isStarted, start, stop, sendMessage } = useOfflineProtocol({
     appId: 'my-app',
     userId: 'user123',
-    transport: {
-      bleEnabled: true,
-      internetEnabled: true,
+    transports: {
+      ble: { enabled: true },
+      internet: { enabled: true },
     },
   });
 
@@ -376,10 +376,10 @@ const config: ProtocolConfig = {
   userId: 'current-user-id',
 
   // Transport configuration
-  transport: {
-    bleEnabled: true,          // Enable Bluetooth Low Energy
-    wifiDirectEnabled: true,   // Enable Wi-Fi Direct (Android)
-    internetEnabled: true,     // Enable Internet connectivity
+  transports: {
+    ble: { enabled: true },          // Enable Bluetooth Low Energy
+    wifiDirect: { enabled: true },   // Enable Wi-Fi Direct (Android)
+    internet: { enabled: true },     // Enable Internet connectivity
   },
 
   // DORS (Dynamic Offline Routing Strategy) configuration


### PR DESCRIPTION
## What

A documentation accuracy pass. No code changes — just bringing the docs back in line with what the code actually does. Each fix was verified against source before editing.

## Why

The docs had drifted in several spots that would actively mislead anyone integrating against them:

- **`react-native-integration.md` documented a phantom group API.** §7 ("Relay-Based Groups") and §11.18 ("Relay Server API") described `groupCreate` / `groupSendMessage` / `groupAddMember` etc. — methods that exist **nowhere** in the bindings. The real, shipped API is MLS mesh groups (`meshCreateGroup` / `meshSendGroupMessage` / `meshInviteToGroup`), which is exactly what the example app's `ProtocolProvider` calls. Rewrote §7 around the real API; removed the duplicate §11.18 (already covered by §11.13); fixed the testing checklist.
- **Nostr broke the "Reticulum is lowest priority" claim.** DORS now has 5 transports (Internet > WiFi Direct > BLE > Reticulum > **Nostr**). Nostr is the lowest tie-break priority; Reticulum is second-lowest. Corrected in `DORS.md`, `reticulum.md`, `dors.md`, and `transport-architecture.md`.
- **`api-reference.md` was incomplete.** `Message` was missing 6 real fields (`lamport_clock`, `content_type`, `binary_content`, `media_metadata`, `reply_to_msg`, `forwarded_from`); `ProtocolConfig` was missing `group` and `security`.
- **`telemetry.md`** never documented the `mlsSamplingBypass` config knob (#113).
- **`SECURITY.md`** still listed `0.1.x` as supported; workspace is on `0.2.0`.
- **`examples/react-native-app/INTEGRATION_GUIDE.md`** used a flat `transport: { bleEnabled }` shape; the JS public API is nested `transports: { ble: { enabled } }`.

## Deliberately left alone

The Kotlin/Swift config examples in `reticulum.md` / `nostr.md` use **flat** fields (`bleEnabled`, `reticulumEnabled`) — and that's correct, because the UniFFI `ProtocolConfig` dictionary really is flat. Only the JS layer is nested.

## Not in scope (flagged for follow-up)

- Stale rustdoc comments in `crates/offline-protocol-router/src/dors.rs` that omit Nostr from the tie-break order (source comments, not docs).
- `examples/demo-app/` and `examples/mesh-wiki/` have no README (missing docs, not stale docs).