### PR TITLE
fix(bindings): ship Android consumer ProGuard rules for the FFI

### DIFF
--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -13,6 +13,11 @@ android {
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"
+
+        // Ship FFI keep rules to consumers so R8/ProGuard in their release
+        // builds does not obfuscate the JNA/uniffi bindings and kill the
+        // mesh transport. See consumer-rules.pro for the rationale.
+        consumerProguardFiles 'consumer-rules.pro'
         
         ndk {
             abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'

--- a/bindings/react-native/android/consumer-rules.pro
+++ b/bindings/react-native/android/consumer-rules.pro
@@ -1,0 +1,34 @@
+# Consumer ProGuard rules for @offline-protocol/mesh-sdk.
+# Applied automatically to any app that consumes this library and minifies
+# (R8 / ProGuard). Without these, release builds (TestFlight / Play Store)
+# silently lose the BLE mesh transport while debug/Metro builds work.
+#
+# The Rust core is reached from Kotlin via JNA, and the uniffi-generated
+# bindings map Kotlin <-> native ENTIRELY BY REFLECTION over class / field /
+# method names: Native.register direct mapping, @Structure.FieldOrder
+# vtables, and com.sun.jna.Callback interfaces for the Rust -> Kotlin
+# callbacks (onFragmentsAvailable, blePeerDiscovered, ...). R8 obfuscation
+# renames them and the FFI dies at runtime.
+
+# SDK Kotlin (RN module, BleManager, TransportManager, MlsSecureStorage).
+-keep class com.offlineprotocol.** { *; }
+
+# uniffi-generated FFI bindings (separate package from com.offlineprotocol).
+-keep class uniffi.** { *; }
+-keepclassmembers class uniffi.** { *; }
+-keep interface uniffi.** { *; }
+
+# JNA — resolves native symbols, Structure fields, and Callback methods by
+# name at runtime; obfuscating them breaks the FFI.
+-keep class com.sun.jna.** { *; }
+-keepclassmembers class com.sun.jna.** { *; }
+-keepclassmembers class * extends com.sun.jna.Structure { <fields>; }
+-keep class * implements com.sun.jna.Callback { *; }
+
+# JNA reads @Structure.FieldOrder and resolves nested Structure.ByValue /
+# ByReference types at runtime (no getFieldOrder() fallback), so the
+# annotation + inner-class metadata must survive R8 (incl. full mode).
+-keepattributes *Annotation*, Signature, InnerClasses, EnclosingMethod
+
+# JNA references java.awt, which does not exist on Android.
+-dontwarn java.awt.**

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -14,6 +14,7 @@
     "ios/*.m",
     "ios/*.podspec",
     "android/build.gradle",
+    "android/consumer-rules.pro",
     "android/src/main/",
     "src/",
     "scripts/",


### PR DESCRIPTION
## What

Ship the Android consumer ProGuard/R8 keep rules from the SDK itself, so consuming apps no longer have to patch them in.

## Why

Any app that consumes `@offline-protocol/mesh-sdk` and minifies its release build (R8/ProGuard — i.e. every TestFlight / Play Store build) silently loses the BLE mesh transport. Debug and Metro builds aren't minified, so it only breaks once you actually ship.

Root cause: the Rust core is reached from Kotlin through JNA + the uniffi-generated bindings, which map Kotlin ↔ native **entirely by reflection over class / field / method names** (`Native.register`, `@Structure.FieldOrder` vtables, `com.sun.jna.Callback` for the Rust→Kotlin callbacks). R8 renames `com.offlineprotocol.**`, `uniffi.**`, and `com.sun.jna.**`, and the FFI dies at runtime.

`fernweh_v2` was carrying a `patch-package` patch (`patches/@offline-protocol+mesh-sdk+0.10.0.patch`) to inject these rules into `node_modules`. This moves the fix into the SDK so no app needs that patch.

## Changes

- **`android/build.gradle`** — add `consumerProguardFiles 'consumer-rules.pro'` so the keep rules attach to the library and propagate into each consuming app's R8 run (RN autolinks `android/` as a Gradle subproject, so no prebuilt AAR is needed).
- **`android/consumer-rules.pro`** — the keep rules: `com.offlineprotocol.**`, `uniffi.**`, `com.sun.jna.**`, JNA `Structure`/`Callback`, the `Annotation`/`Signature`/`InnerClasses`/`EnclosingMethod` attributes, and `-dontwarn java.awt.**`.
- **`package.json`** — add `android/consumer-rules.pro` to `files[]` so the rules actually ship in the npm tarball. Without this the gradle directive points at a file that isn't in the published package.

## Testing

The rules are byte-identical to the patch `fernweh_v2` has been carrying — same behavior, just shipped from the right place. Nothing changes for debug/Metro builds.

## Follow-ups (not in this PR)

- Bump the package version (`0.11.1` reads right for a packaging fix) and publish.
- In `fernweh_v2`: bump the dep off `^0.10.0` and delete `patches/@offline-protocol+mesh-sdk+0.10.0.patch`.
