### PR TITLE
fix(ble,mls,protocol): restore offline 1:1 MLS convergence over BLE mesh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,33 @@ jobs:
       - name: Run pytest
         run: pytest bindings/python/tests/ -v
 
+  android-unit-tests:
+    name: Android Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      # ubuntu-latest ships an Android SDK, but provision it explicitly so the
+      # toolchain (and license acceptance) doesn't drift out from under us.
+      - uses: android-actions/setup-android@v3
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.9"
+
+      # Runs the RN Android module's JVM unit tests (InboundFragmentBuffer,
+      # OutboundFragmentQueue, the GATT CCCD/long-read helpers, MeshController,
+      # ...) via a standalone harness, since the module can't build on its own.
+      # See bindings/react-native/android-ci-harness/README.md.
+      - name: Android unit tests
+        working-directory: bindings/react-native/android-ci-harness
+        run: gradle :offlineprotocol:testDebugUnitTest --no-daemon --stacktrace
+
   coverage:
     name: Code Coverage
     if: github.event_name == 'push'

--- a/bindings/react-native/android-ci-harness/README.md
+++ b/bindings/react-native/android-ci-harness/README.md
@@ -1,0 +1,40 @@
+# Android CI harness
+
+A minimal standalone Gradle project whose only purpose is to run the Android
+library module's **JVM unit tests** (`../android/src/test`) in CI and locally,
+without a full React Native app.
+
+## Why this exists
+
+`../android` is a React Native library module. It uses legacy
+`apply plugin: 'com.android.library'` and has no `settings.gradle` or Gradle
+wrapper of its own, because it is meant to be configured by a *host app's*
+build. That makes it impossible to run `./gradlew test` against it directly.
+
+This harness:
+
+- supplies the Android Gradle Plugin + Kotlin plugin on the buildscript
+  classpath (`build.gradle`),
+- includes `../android` as the `:offlineprotocol` subproject **without editing
+  that module's `build.gradle`**, so real RN-app consumption is unaffected.
+
+In CI there is no `node_modules`, so the module's `reactNativeExists` check is
+false and it takes its built-in "standalone build or testing" path
+(`compileOnly` react-android) — the path this harness exercises.
+
+## Run it
+
+```bash
+# Gradle 8.7+ and JDK 17 required (Android SDK auto-provisioned by AGP).
+cd bindings/react-native/android-ci-harness
+gradle :offlineprotocol:testDebugUnitTest
+```
+
+The same task runs in the `Android Unit Tests` job in `.github/workflows/ci.yml`.
+
+## Version notes
+
+Kotlin is pinned to **1.9.24** to match the module's current source. Moving to
+Kotlin 2.x requires the `optString`/nullability fixes tracked in `todo.md`
+first, or the module will not compile under strict 2.x platform-type rules.
+AGP 8.5.2 / Gradle 8.9 / `compileSdk 34` / JDK 17 form the validated matrix.

--- a/bindings/react-native/android-ci-harness/build.gradle
+++ b/bindings/react-native/android-ci-harness/build.gradle
@@ -1,0 +1,21 @@
+// Root project of the CI harness. Its ONLY job is to put the Android Gradle
+// Plugin and the Kotlin Gradle plugin on the buildscript classpath so the
+// included `:offlineprotocol` module's legacy
+// `apply plugin: 'com.android.library'` / `'kotlin-android'` resolve. Subproject
+// `apply plugin` calls inherit this buildscript classpath, which is exactly the
+// classpath a host RN app would otherwise provide.
+//
+// Kotlin is pinned to 1.9.x to match the module's current (pre-Kotlin-2)
+// source. Bumping to 2.x first requires the `optString`/nullability fixes
+// tracked in todo.md, or the module will not compile under the strict 2.x
+// platform-type rules.
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:8.5.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24"
+    }
+}

--- a/bindings/react-native/android-ci-harness/gradle.properties
+++ b/bindings/react-native/android-ci-harness/gradle.properties
@@ -1,0 +1,4 @@
+# The module depends on androidx.security:security-crypto, so AndroidX must be on.
+android.useAndroidX=true
+# Bound the JVM so unit-test runs stay within CI memory limits.
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8

--- a/bindings/react-native/android-ci-harness/settings.gradle
+++ b/bindings/react-native/android-ci-harness/settings.gradle
@@ -1,0 +1,31 @@
+// Standalone Gradle harness for running the Android library module's JVM unit
+// tests (../android/src/test) in CI.
+//
+// The module itself (../android) is a React Native library: it uses the legacy
+// `apply plugin: 'com.android.library'` style and relies on a *host app's*
+// buildscript classpath to supply the Android Gradle Plugin + Kotlin plugin, so
+// it cannot be configured on its own. This harness supplies that classpath (see
+// build.gradle) and includes the module as a subproject WITHOUT modifying its
+// build.gradle, so the way real RN apps consume `../android` is untouched.
+//
+// In CI no `node_modules` is installed, so the module's `reactNativeExists`
+// check is false and it takes its built-in "standalone build or testing" path
+// (compileOnly react-android) — exactly what this harness exercises.
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+// NB: deliberately NO `dependencyResolutionManagement { repositoriesMode = ... }`
+// here — the included module declares its own `repositories {}` block, and the
+// default PREFER_PROJECT mode lets that stand. A FAIL_ON_PROJECT_REPOS policy
+// would break the module's build.gradle.
+
+rootProject.name = "offline-protocol-android-ci"
+
+include(":offlineprotocol")
+project(":offlineprotocol").projectDir = file("../android")

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -18,7 +18,7 @@ android {
         // builds does not obfuscate the JNA/uniffi bindings and kill the
         // mesh transport. See consumer-rules.pro for the rationale.
         consumerProguardFiles 'consumer-rules.pro'
-        
+
         ndk {
             abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
         }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -366,9 +366,17 @@ class BleTransportFacade(
                     // `on_peer_lost`. All that remains is the facade-side
                     // staged entry keyed by BLE address (non-empty in the
                     // edge case where `onPeerMtuNegotiated` landed but
-                    // the device-id read never completed).
+                    // the device-id read never completed) plus the
+                    // per-device MTU slots, both cleared below.
+                    //
+                    // Asymmetry (by design): this drops the peer's MTU state
+                    // wholesale even if a peripheral/notify link to the same
+                    // peer is still alive — whether a central give-up should
+                    // imply peer loss is a protocol-level question left out of
+                    // scope here. A surviving link self-heals: its next inbound
+                    // fragment re-stages the MTU via onPeripheralMtuNegotiated.
                     if (shuttingDown) return
-                    dropStagedPeerMtu(address)
+                    dropStagedPeerMtu(address, peerId)
                 }
             },
             diagnosticEmitter = { level, message, ctx -> emitDiagnostic(level, message, ctx) },
@@ -426,6 +434,18 @@ class BleTransportFacade(
     // (in [handleCentralDisconnectedOnMain]) so the central MTU is restored.
     // Main-thread only.
     private val peripheralMaxPayloads = HashMap<String, Int>()
+    // Per-DEVICE-ID negotiated ATT payloads, one slot per direction. A peer can
+    // be reachable over two links with DIFFERENT BLE addresses (iOS uses distinct
+    // connection handles per direction), so the central and peripheral payloads
+    // must be combined by device identity, not by a single address — otherwise a
+    // late renegotiation on one link would flush an MTU unbounded by the other and
+    // the notify egress overflows it (the offline 1:1 Welcome stall this fix
+    // targets). The per-address maps above are the deferral buffer for a payload
+    // negotiated before the device id resolves; [flushPeerMtu] promotes them into
+    // these per-device slots and mins across THESE. Cleared per-direction on that
+    // link's teardown. Main-thread only.
+    private val centralPayloadByDevice = HashMap<String, Int>()
+    private val peripheralPayloadByDevice = HashMap<String, Int>()
     private val discoveryLogTimestamps = ConcurrentHashMap<String, Long>()
     @Volatile private var lastDiscoveryAt: Long = 0L
 
@@ -945,6 +965,14 @@ class BleTransportFacade(
         // handshake stages its own MTU.
         peerMaxPayloads.clear()
         peripheralMaxPayloads.clear()
+        centralPayloadByDevice.clear()
+        peripheralPayloadByDevice.clear()
+        // The per-peer write gate is otherwise self-healing across a restart
+        // (watchdogs fire within the gate window and the stale-check covers a
+        // fast restart since elapsedRealtime is monotonic), but clear it here to
+        // match the documented "drop prior-session state" intent and remove the
+        // cross-session reasoning burden.
+        writeInFlight.clear()
         centralClient.clearAll()
         lastSeenMeshAdvertisements.clear()
         verifiedNonMeshDevices.clear()
@@ -1990,28 +2018,69 @@ class BleTransportFacade(
      * central link but egressed as a notify overflows the peripheral link and
      * is truncated/dropped on air — the offline 1:1 Welcome-delivery stall.
      *
+     * The two links can use DIFFERENT BLE addresses for the same peer (iOS uses
+     * distinct connection handles per direction) and Rust is keyed by device id,
+     * so the min MUST be taken per DEVICE, not per address: a single call sees
+     * only one link's [address], so it promotes that address's staged value into
+     * the matching per-device direction slot ([centralPayloadByDevice] /
+     * [peripheralPayloadByDevice]) and mins across those. This accumulates both
+     * directions across the two links' separate flushes, so a late renegotiation
+     * on one link can no longer drop the bound the other imposed.
+     *
      * Called whenever either link's MTU is (re)negotiated, when the device id
      * resolves ([CentralGattClient.Host.onDeviceIdResolved]), and when a link
-     * tears down (to restore the surviving link's MTU). If neither link has a
-     * value the Rust entry is cleared so the fragmenter reverts to its
+     * tears down (to restore the surviving link's MTU). If neither direction has
+     * a value the Rust entry is cleared so the fragmenter reverts to its
      * 185-byte floor rather than retaining a dead link's value. Idempotent and
-     * main-thread only. The staged values are NOT removed on flush (they are
-     * inputs to the min); link-teardown paths clear them explicitly.
+     * main-thread only. The per-address staged values are NOT removed on flush
+     * (they are inputs to the min); link-teardown paths clear the dropped
+     * direction's per-device slot explicitly.
      */
     private fun flushPeerMtu(address: String, deviceId: String) {
         assertMainThread("flushPeerMtu")
-        val central = peerMaxPayloads[address]
-        val peripheral = peripheralMaxPayloads[address]
+        // Promote this link's staged (per-address) payload into the per-DEVICE
+        // direction slot. On asymmetric-address peers each flush sees only its own
+        // link's address, so both directions accumulate across the two links'
+        // separate flushes; on a symmetric (single-address) peer both promote
+        // together. Promotion only sets — never clears — so a flush via one link
+        // cannot wipe the bound the other imposed.
+        peerMaxPayloads[address]?.let { centralPayloadByDevice[deviceId] = it }
+        peripheralMaxPayloads[address]?.let { peripheralPayloadByDevice[deviceId] = it }
+
+        val central = centralPayloadByDevice[deviceId]
+        val peripheral = peripheralPayloadByDevice[deviceId]
         val effective = listOfNotNull(central, peripheral).minOrNull()
         if (effective == null) {
-            // Both links gone — drop the Rust entry so the fragmenter falls
-            // back to the floor instead of keeping a stale per-peer size.
+            // Both directions gone — drop the Rust entry so the fragmenter falls
+            // back to the floor instead of keeping a stale per-peer size, and the
+            // now-empty per-device slots.
+            centralPayloadByDevice.remove(deviceId)
+            peripheralPayloadByDevice.remove(deviceId)
             try {
                 protocol.bleClearPeerMtu(deviceId)
             } catch (e: Exception) {
                 Log.w(TAG, "bleClearPeerMtu failed for $deviceId", e)
             }
             return
+        }
+        // A link that negotiated BELOW the fragment floor is a real offline-
+        // failure case: Rust rejects a sub-floor MTU and reverts to the 185-byte
+        // floor (see `set_peer_mtu`), which is LARGER than this link can carry, so
+        // a multi-fragment notify can still overflow. Rare on modern stacks (both
+        // platforms request the BLE-5 max) but it is exactly the legacy/quirky-peer
+        // population, so surface it to Metro instead of failing silently. (Honoring
+        // a sub-floor notify fragment size is a deeper fragmenter change tracked
+        // separately.)
+        if (effective < MAX_FRAGMENT_SIZE) {
+            emitDiagnostic(
+                "warning",
+                "BLE link negotiated below fragment floor; notify may overflow",
+                mapOf(
+                    "deviceId" to deviceId,
+                    "effectivePayload" to effective,
+                    "floor" to MAX_FRAGMENT_SIZE,
+                ),
+            )
         }
         try {
             protocol.bleSetPeerMtu(deviceId, effective.toUInt())
@@ -2053,14 +2122,23 @@ class BleTransportFacade(
      * [handleCentralDisconnectedOnMain] for the bug this invariant
      * exists to prevent.
      *
-     * [address] may be null on paths where we only know the device
-     * id, in which case this is a no-op. Main-thread only.
+     * [address] may be null on paths where we only know the device id; the
+     * per-device direction slots keyed by [deviceId] are still cleared.
+     * Main-thread only.
      */
-    private fun dropStagedPeerMtu(address: String?) {
+    private fun dropStagedPeerMtu(address: String?, deviceId: String?) {
         assertMainThread("dropStagedPeerMtu")
         if (address != null) {
             peerMaxPayloads.remove(address)
             peripheralMaxPayloads.remove(address)
+        }
+        // Also clear the per-device direction slots [flushPeerMtu] promotes into,
+        // or a stale value would survive this address's teardown and skew the min
+        // on the peer's next link. Callers that drop the whole peer (blePeerLost)
+        // pass the device id so both directions are cleared.
+        if (deviceId != null) {
+            centralPayloadByDevice.remove(deviceId)
+            peripheralPayloadByDevice.remove(deviceId)
         }
     }
 
@@ -2154,7 +2232,7 @@ class BleTransportFacade(
             outboundQueue.removeAll(peerId)
             // Facade-only staged drop; the Rust-side MTU entry is cleared
             // by `protocol.blePeerLost` below via `on_peer_lost`.
-            dropStagedPeerMtu(address)
+            dropStagedPeerMtu(address, peerId)
             meshController.registerDisconnection(peerId)
             refreshSelfMetrics()
 
@@ -2318,6 +2396,13 @@ class BleTransportFacade(
      */
     fun onWriteCompleted(address: String) {
         assertMainThread("onWriteCompleted")
+        // Address-keyed, not per-write: a stale onCharacteristicWrite for an
+        // earlier write that fires after the watchdog/stale-check already advanced
+        // the gate to a newer write on the same address will clear the NEWER
+        // write's gate. Android's write callback carries no per-op token, so
+        // completion cannot be correlated to a specific write. The worst case is a
+        // single ERROR_GATT_WRITE_REQUEST_BUSY (201) on that newer write, which
+        // self-heals via the caller's re-enqueue + BACKPRESSURE_RETRY — no data loss.
         writeInFlight.remove(address)
         if (state == TransportState.RUNNING) {
             // Pace the next completion-driven send by one BLE connection
@@ -3285,6 +3370,11 @@ class BleTransportFacade(
         // peer_mtus wholesale) + dropStagedPeerMtu, so we defer to that path.
         if (isCleanDisconnect && peripheralMaxPayloads.remove(address) != null) {
             connections.deviceIdForAddress(address)?.let { peerId ->
+                // Drop the per-device peripheral slot too, or the recompute would
+                // re-min against the dead notify link's (smaller) bound. With it
+                // gone, flushPeerMtu restores the per-peer MTU from the surviving
+                // central link's per-device slot.
+                peripheralPayloadByDevice.remove(peerId)
                 flushPeerMtu(address, peerId)
             }
         }
@@ -3301,7 +3391,7 @@ class BleTransportFacade(
                 // `blePeerLost` above already dropped the Rust-side MTU
                 // entry via `on_peer_lost`; only the facade-side staged
                 // slot (keyed by BLE address) still needs clearing here.
-                dropStagedPeerMtu(address)
+                dropStagedPeerMtu(address, peerId)
                 meshController.registerDisconnection(peerId)
                 refreshSelfMetrics()
                 connections.removeIdentifiersForAddress(address)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -147,6 +147,25 @@ class BleTransportFacade(
          *  write doesn't out-run it into ERROR_GATT_WRITE_REQUEST_BUSY (201).
          *  An occasional 201 here still self-heals via the backpressure retry. */
         private const val WRITE_GATE_WATCHDOG_MS = 30L
+        /** Per-peer gate hold for the peripheral INDICATE (notify) egress: the
+         *  safety-net timeout before the next indication is allowed absent a
+         *  completion callback.
+         *
+         *  Unlike the central WRITE_TYPE_NO_RESPONSE path, the notify path has a
+         *  RELIABLE completion signal — the message characteristic is an
+         *  INDICATION (ATT-confirmed), so onNotificationSent fires on the
+         *  central's confirmation (real delivery) and that is the fast path that
+         *  releases the gate. This watchdog is therefore a true fallback, not the
+         *  steady-state pace, so it is deliberately LONGER than
+         *  [WRITE_GATE_WATCHDOG_MS]: an indication confirmation needs at least one
+         *  connection interval plus the central's processing (commonly 30–50ms+),
+         *  and a 30ms watchdog would routinely pre-empt the confirmation, re-drive
+         *  into a stack that rejects a second outstanding indication, and churn
+         *  re-enqueues — partly defeating the per-fragment flow control INDICATE
+         *  exists to provide. A genuinely lost confirmation costs at most this
+         *  long per fragment (≈15 fragments stays well under the reassembly TTL
+         *  and the mesh welcome-confirm timeout). */
+        private const val NOTIFY_GATE_WATCHDOG_MS = 250L
         /** Minimum spacing between two completion-driven fragment sends to the
          *  same link.
          *
@@ -2507,21 +2526,25 @@ class BleTransportFacade(
      * by notifying the message characteristic over the connection it opened and
      * subscribed to — the reliable egress for asymmetric mesh links, used in
      * preference to a reverse central writeCharacteristic that may vanish on a
-     * half-open link. Shares the per-peer [writeInFlight] gate + self-paced
-     * watchdog with the central write path so notifications stay serialised (one
-     * outstanding per peer) and multi-fragment replies self-pace identically.
+     * half-open link. Shares the per-peer [writeInFlight] gate with the central
+     * write path so notifications stay serialised (one outstanding per peer), but
+     * paces on the INDICATE-aware [NOTIFY_GATE_WATCHDOG_MS] fallback — the fast
+     * path is onNotificationSent firing on the indication confirmation.
      * Main-thread only.
      */
     private fun sendViaNotify(recipientId: String, address: String, data: ByteArray): Boolean {
         assertMainThread("sendViaNotify")
         val server = peripheralGattServer ?: return false
 
-        // Serialise to one outstanding notify per peer (same gate as the central
-        // write path) so we don't out-run the stack's one-op-at-a-time limit.
+        // Serialise to one outstanding indication per peer (same gate as the
+        // central write path) so we don't out-run the stack's one-op-at-a-time
+        // limit. The stale threshold is the INDICATE-aware watchdog: a deferred
+        // fragment keeps waiting until onNotificationSent releases the gate or
+        // the (longer) fallback elapses, rather than racing the confirmation.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val inFlightSince = writeInFlight[address]
             if (inFlightSince != null) {
-                if (android.os.SystemClock.elapsedRealtime() - inFlightSince < WRITE_GATE_WATCHDOG_MS) {
+                if (android.os.SystemClock.elapsedRealtime() - inFlightSince < NOTIFY_GATE_WATCHDOG_MS) {
                     if (logThrottler.shouldLog("notify_gated_$recipientId", intervalMs = 5000)) {
                         Log.d(TAG, "Deferring notify to $recipientId: prior notify still in flight")
                     }
@@ -2551,10 +2574,12 @@ class BleTransportFacade(
         meshController.markPeerActive(recipientId)
         meshController.markPeerActive(deviceId)
 
-        // Hold + self-pace the gate exactly like the central write path. The
-        // peripheral onNotificationSent callback is not wired through, so the
-        // 30ms watchdog re-drives the next fragment, making multi-fragment
-        // replies complete without depending on a completion callback.
+        // Hold the per-peer gate. The fast path is onNotificationSent firing on
+        // the INDICATE confirmation (real delivery) -> onWriteCompleted, which
+        // releases the gate and paces the next fragment by one connection
+        // interval. This watchdog only re-drives if that callback is lost; it is
+        // longer than the central path's (see [NOTIFY_GATE_WATCHDOG_MS]) so it
+        // does not pre-empt the confirmation round-trip and churn busy-rejects.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val stamp = android.os.SystemClock.elapsedRealtime()
             writeInFlight[address] = stamp
@@ -2565,7 +2590,7 @@ class BleTransportFacade(
                         drainAndSendFragments()
                     }
                 }
-            }, WRITE_GATE_WATCHDOG_MS)
+            }, NOTIFY_GATE_WATCHDOG_MS)
         }
         return true
     }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -133,6 +133,20 @@ class BleTransportFacade(
          */
         private const val MAX_DRAIN_ITERATIONS_PER_CALL = 32
         private const val BACKPRESSURE_RETRY_MS = 50L
+        /** Max time the per-peer write gate ([writeInFlight]) stays closed
+         *  before the next send is allowed regardless of completion callback.
+         *
+         *  The fast path is onCharacteristicWrite releasing the gate the
+         *  instant the stack accepts the next write. But for
+         *  WRITE_TYPE_NO_RESPONSE that callback is stack-dependent and on many
+         *  devices never fires — observed on-device as the gate clearing only
+         *  via this timeout. So this is NOT a rare-glitch watchdog; it is the
+         *  steady-state inter-write pace whenever the callback is absent. Keep
+         *  it small so a missing callback doesn't throttle throughput, but
+         *  above the few ms a write actually occupies the stack so the next
+         *  write doesn't out-run it into ERROR_GATT_WRITE_REQUEST_BUSY (201).
+         *  An occasional 201 here still self-heals via the backpressure retry. */
+        private const val WRITE_GATE_WATCHDOG_MS = 30L
         private const val CONNECTION_TIMEOUT_MS = 10000L
         private const val SCAN_WATCHDOG_INTERVAL_MS = 30000L // Match iOS timing
         private const val SCAN_WATCHDOG_HEARTBEAT_MS = 10000L
@@ -278,6 +292,8 @@ class BleTransportFacade(
                 ) = this@BleTransportFacade.learnRouteFromMessage(messageJson, neighborId, neighborAddress)
                 override fun drainAndSendFragments() =
                     this@BleTransportFacade.drainAndSendFragments()
+                override fun onWriteCompleted(address: String) =
+                    this@BleTransportFacade.onWriteCompleted(address)
                 override fun handleInboundFragment(address: String, data: ByteArray) =
                     this@BleTransportFacade.handleReceivedData(data, address)
                 override fun connectToDevice(device: BluetoothDevice) =
@@ -683,7 +699,19 @@ class BleTransportFacade(
     private var bytesReceived: Long = 0
     private var fragmentsSent: Long = 0
     private var fragmentsReceived: Long = 0
-    
+
+    // Per-peer BLE write gate. Android 13+ (API 33) rejects a second
+    // writeCharacteristic on the same connection with
+    // ERROR_GATT_WRITE_REQUEST_BUSY (201) while one write is still
+    // outstanding — even for WRITE_TYPE_NO_RESPONSE — so the drain loop's
+    // back-to-back writes used to self-collide and silently drop a
+    // multi-fragment message. We allow at most one outstanding write per BLE
+    // address and release it from [onWriteCompleted] (the onCharacteristicWrite
+    // callback). The value is the elapsedRealtime() the write was issued, used
+    // as a watchdog so a lost completion callback cannot wedge a peer forever.
+    // Main-thread only (every accessor runs under assertMainThread).
+    private val writeInFlight = HashMap<String, Long>()
+
     // MARK: - TransportManager Implementation
     
     private fun emitDiagnostic(level: String, message: String, context: Map<String, Any?> = emptyMap()) {
@@ -2193,6 +2221,22 @@ class BleTransportFacade(
                 // Maintain FIFO ordering: if this recipient already has
                 // fragments waiting, enqueue instead of sending directly.
                 if (outboundQueue.enqueueIfBlocked(recipientId, data)) {
+                    // Backpressure against the write gate: once this peer's
+                    // queue is backed up, stop pulling more fragments out of
+                    // the Rust core (bleGetNextFragment is a destructive pop)
+                    // into the bounded per-peer queue. The write gate paces
+                    // sends to ~1 fragment / WRITE_GATE_WATCHDOG_MS when the
+                    // completion callback is absent, which is far slower than
+                    // this loop can pull; without this stop the loop spins the
+                    // whole backlog into the queue, overflows maxPerPeer, and
+                    // OutboundFragmentQueue.enqueue discards the in-flight
+                    // message. Leaving the backlog in Rust keeps delivery
+                    // lossless — the scheduled re-drain below resumes once
+                    // flush() has drained the queue back down.
+                    if (outboundQueue.isBackedUp(recipientId)) {
+                        hitBackpressure = true
+                        break
+                    }
                     continue
                 }
 
@@ -2214,6 +2258,24 @@ class BleTransportFacade(
             mainHandler.post { drainAndSendFragments() }
         } else if (hitBackpressure && outboundQueue.totalCount() > 0) {
             mainHandler.postDelayed({ drainAndSendFragments() }, BACKPRESSURE_RETRY_MS)
+        }
+    }
+
+    /**
+     * Fast-path release of the per-peer BLE write gate when the stack actually
+     * fires onCharacteristicWrite for the outstanding write, draining the next
+     * fragment immediately. This callback is unreliable for
+     * WRITE_TYPE_NO_RESPONSE (often never fires), so it is only the fast path —
+     * the gate is also released by the self-paced fallback scheduled in
+     * sendFragmentData. Without the gate the drain loop issues writeCharacteristic
+     * calls back-to-back and Android 13+ rejects the concurrent ones with
+     * ERROR_GATT_WRITE_REQUEST_BUSY (201), silently dropping fragments.
+     */
+    fun onWriteCompleted(address: String) {
+        assertMainThread("onWriteCompleted")
+        writeInFlight.remove(address)
+        if (state == TransportState.RUNNING) {
+            drainAndSendFragments()
         }
     }
 
@@ -2298,6 +2360,74 @@ class BleTransportFacade(
         return null
     }
 
+    /**
+     * Reply to a peer that connected to OUR GATT server (we are its peripheral)
+     * by notifying the message characteristic over the connection it opened and
+     * subscribed to — the reliable egress for asymmetric mesh links, used in
+     * preference to a reverse central writeCharacteristic that may vanish on a
+     * half-open link. Shares the per-peer [writeInFlight] gate + self-paced
+     * watchdog with the central write path so notifications stay serialised (one
+     * outstanding per peer) and multi-fragment replies self-pace identically.
+     * Main-thread only.
+     */
+    private fun sendViaNotify(recipientId: String, address: String, data: ByteArray): Boolean {
+        assertMainThread("sendViaNotify")
+        val server = peripheralGattServer ?: return false
+
+        // Serialise to one outstanding notify per peer (same gate as the central
+        // write path) so we don't out-run the stack's one-op-at-a-time limit.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val inFlightSince = writeInFlight[address]
+            if (inFlightSince != null) {
+                if (android.os.SystemClock.elapsedRealtime() - inFlightSince < WRITE_GATE_WATCHDOG_MS) {
+                    if (logThrottler.shouldLog("notify_gated_$recipientId", intervalMs = 5000)) {
+                        Log.d(TAG, "Deferring notify to $recipientId: prior notify still in flight")
+                    }
+                    return false
+                }
+                writeInFlight.remove(address)
+            }
+        }
+
+        val device = try {
+            bluetoothAdapter?.getRemoteDevice(address)
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Cannot resolve device for notify to $recipientId ($address)", e)
+            null
+        } ?: return false
+
+        if (!server.notifyFragment(device, data)) {
+            if (logThrottler.shouldLog("notify_failed_$recipientId", intervalMs = 2000)) {
+                Log.w(TAG, "Failed to notify BLE fragment for $recipientId")
+                emitDiagnostic("warning", "Failed to notify BLE fragment", mapOf("recipientId" to recipientId))
+            }
+            return false
+        }
+
+        bytesSent += data.size
+        fragmentsSent++
+        meshController.markPeerActive(recipientId)
+        meshController.markPeerActive(deviceId)
+
+        // Hold + self-pace the gate exactly like the central write path. The
+        // peripheral onNotificationSent callback is not wired through, so the
+        // 30ms watchdog re-drives the next fragment, making multi-fragment
+        // replies complete without depending on a completion callback.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val stamp = android.os.SystemClock.elapsedRealtime()
+            writeInFlight[address] = stamp
+            mainHandler.postDelayed({
+                if (writeInFlight[address] == stamp) {
+                    writeInFlight.remove(address)
+                    if (state == TransportState.RUNNING) {
+                        drainAndSendFragments()
+                    }
+                }
+            }, WRITE_GATE_WATCHDOG_MS)
+        }
+        return true
+    }
+
     private fun sendFragmentData(recipientId: String, data: ByteArray): Boolean {
         // Every call site (drainAndSendFragments, pollAndSendFragments, the
         // OutboundFragmentQueue.flush callback) runs on main already, but
@@ -2312,7 +2442,23 @@ class BleTransportFacade(
         // Find GATT client for recipient
         val address = resolveTargetAddress(recipientId)
         val gatt = address?.let { connections.getGatt(it) }
-        
+
+        // Asymmetric-link reply: if this peer reached US as a central on our GATT
+        // server and subscribed to the message characteristic, reply over THAT
+        // connection (the one it opened and is actively waiting on) via a
+        // peripheral notify, instead of a reverse central writeCharacteristic.
+        // A central NO_RESPONSE write returns SUCCESS into a reverse link that may
+        // be absent or half-open, and the bytes are silently dropped on air (no
+        // status 201, no error) — so the central path "succeeds" forever while the
+        // peer, never getting our reply, retransmits and eventually gives up. This
+        // is the dominant offline failure for a peer that connected to us.
+        if (address != null && peripheralGattServer?.isSubscribed(address) == true) {
+            if (logThrottler.shouldLog("reply_via_notify_$recipientId", intervalMs = 5000)) {
+                Log.i(TAG, "Replying to $recipientId via peripheral notify (asymmetric link)")
+            }
+            return sendViaNotify(recipientId, address, data)
+        }
+
         // Until the remote has ack'd our CCCD write, the return path is not
         // verified and the BLE stack may still be executing the setup ops
         // (deviceId read → identity read → writeDescriptor). Issuing a write
@@ -2352,7 +2498,28 @@ class BleTransportFacade(
             }
             return false
         }
-        
+
+        // Serialise to a single outstanding write per peer (see [writeInFlight]).
+        // On API 33+ a concurrent writeCharacteristic returns
+        // ERROR_GATT_WRITE_REQUEST_BUSY (201) and the fragment is lost, so
+        // defer (return false → drainAndSendFragments re-enqueues) until the
+        // prior write's onCharacteristicWrite releases the gate. A gate older
+        // than the watchdog is cleared so a lost callback cannot wedge us.
+        // `address` is non-null here: `gatt` is `address?.let { ... }` and we
+        // returned above when `gatt == null`, so Kotlin smart-casts it.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val inFlightSince = writeInFlight[address]
+            if (inFlightSince != null) {
+                if (android.os.SystemClock.elapsedRealtime() - inFlightSince < WRITE_GATE_WATCHDOG_MS) {
+                    if (logThrottler.shouldLog("write_gated_$recipientId", intervalMs = 5000)) {
+                        Log.d(TAG, "Deferring write to $recipientId: prior write still in flight")
+                    }
+                    return false
+                }
+                writeInFlight.remove(address)
+            }
+        }
+
         //  Validate connection state before attempting to send
         if (gatt.device.bondState == BluetoothDevice.BOND_NONE) {
             // Device is not bonded - this might be okay for BLE, but log it
@@ -2430,6 +2597,35 @@ class BleTransportFacade(
         fragmentsSent++
         meshController.markPeerActive(recipientId)
         meshController.markPeerActive(deviceId)
+
+        // Hold the per-peer write gate. onCharacteristicWrite releases it when
+        // it fires — but for WRITE_TYPE_NO_RESPONSE that completion callback is
+        // stack-dependent and on many devices never fires at all. Without a
+        // fallback that strands every fragment after the first: the gate set
+        // here would only ever clear on the next *attempted* send, and nothing
+        // reliably re-attempts, so a multi-fragment message delivers fragment 1
+        // and then stalls. So self-pace — schedule a re-drain after the
+        // watchdog window that releases the gate and pumps the next fragment,
+        // making delivery independent of the callback. Gated on API 33+ to
+        // match the serialise check above; older stacks queue writes fine.
+        // `address` is non-null here: `gatt` is `address?.let { ... }` and we
+        // returned above when `gatt == null`, so Kotlin smart-casts it.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val stamp = android.os.SystemClock.elapsedRealtime()
+            writeInFlight[address] = stamp
+            mainHandler.postDelayed({
+                // Only act if THIS write is still the outstanding one.
+                // onCharacteristicWrite or a newer write may have already moved
+                // the gate on; clearing it then would let the next write race an
+                // in-flight one into status 201.
+                if (writeInFlight[address] == stamp) {
+                    writeInFlight.remove(address)
+                    if (state == TransportState.RUNNING) {
+                        drainAndSendFragments()
+                    }
+                }
+            }, WRITE_GATE_WATCHDOG_MS)
+        }
         return true
     }
     
@@ -2863,6 +3059,24 @@ class BleTransportFacade(
             mainHandler.post {
                 if (shuttingDown) return@post
                 handleReceivedData(bytes, address)
+            }
+        }
+
+        override fun onNotificationSent(device: BluetoothDevice, status: Int) {
+            if (shuttingDown) return
+            // Our peripheral notify to this central completed — release the
+            // per-peer write gate and pump the next fragment, exactly like
+            // onCharacteristicWrite does for the central write path. Makes
+            // multi-fragment notify replies event-paced (fast) instead of
+            // waiting on the 30ms watchdog for every fragment.
+            val address = device.address
+            // Diagnostic: proves the stack actually transmitted the notification
+            // (status 0 = GATT_SUCCESS). If "Replying via notify" appears but this
+            // never does, the notify is stuck in the stack queue / not going OTA.
+            Log.i(TAG, "Notification flushed to $address status=$status")
+            mainHandler.post {
+                if (shuttingDown) return@post
+                onWriteCompleted(address)
             }
         }
 

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -2833,11 +2833,13 @@ class BleTransportFacade(
             // single-threaded decision is race-free — no lock is required.
             val resolvedSender = connections.deviceIdForAddress(address)
             val hasPendingForAddress = pendingInbound.hasPending(address)
-            val queued = resolvedSender == null || hasPendingForAddress
-            if (queued) {
+            // Inline the queue-vs-direct condition (rather than a `val queued`)
+            // so Kotlin can smart-cast `resolvedSender` to non-null after this
+            // guard returns: smart-casting tracks the inline `== null` disjunct
+            // here, but NOT a null check stored in a separate Boolean `val`.
+            if (resolvedSender == null || hasPendingForAddress) {
                 pendingInbound.enqueue(address, data)
-                val senderId: String? = resolvedSender
-                if (senderId == null) {
+                if (resolvedSender == null) {
                     if (logThrottler.shouldLog("queue_pending_$address")) {
                         Log.d(TAG, "Queued fragment while awaiting device ID for $address")
                         emitDiagnostic(
@@ -2894,7 +2896,8 @@ class BleTransportFacade(
 
             // Device ID is already resolved and no earlier bytes are waiting
             // — process directly. Kotlin smart-casts `resolvedSender` to
-            // non-null here because the `queued` branch above returns.
+            // non-null here: the `resolvedSender == null` disjunct in the guard
+            // above returns, so reaching this point proves it is non-null.
             val resolvedSenderId: String = resolvedSender
 
             lastSeenRssi[address]?.toInt()?.let { observedRssi ->

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -2452,11 +2452,34 @@ class BleTransportFacade(
         // status 201, no error) — so the central path "succeeds" forever while the
         // peer, never getting our reply, retransmits and eventually gives up. This
         // is the dominant offline failure for a peer that connected to us.
-        if (address != null && peripheralGattServer?.isSubscribed(address) == true) {
-            if (logThrottler.shouldLog("reply_via_notify_$recipientId", intervalMs = 5000)) {
-                Log.i(TAG, "Replying to $recipientId via peripheral notify (asymmetric link)")
+        //
+        // Resolve the notify egress by PEER IDENTITY, not just `address`: the
+        // address we hold for the peer (the central link WE opened to it,
+        // addressForDevice) can differ from the address it subscribed under (the
+        // link IT opened to our GATT server) — iOS uses distinct handles per
+        // direction. So if the resolved address isn't the subscribed one, fall back
+        // to any subscribed central that maps back to this recipient. Without this
+        // the notify path silently never engages for the very peers it exists for.
+        val notifyAddress = peripheralGattServer?.let { server ->
+            if (address != null && server.isSubscribed(address)) {
+                address
+            } else {
+                server.subscribedAddresses().firstOrNull { subscribed ->
+                    connections.deviceIdForAddress(subscribed) == recipientId
+                }
             }
-            return sendViaNotify(recipientId, address, data)
+        }
+        if (notifyAddress != null) {
+            if (logThrottler.shouldLog("reply_via_notify_$recipientId", intervalMs = 5000)) {
+                Log.i(TAG, "Replying to $recipientId via peripheral notify (asymmetric link) addr=$notifyAddress")
+                emitDiagnostic("info", "BLE reply via peripheral notify", mapOf(
+                    "recipientId" to recipientId,
+                    "notifyAddress" to notifyAddress,
+                    "resolvedAddress" to (address ?: "null"),
+                    "matchedByIdentity" to (notifyAddress != address).toString(),
+                ))
+            }
+            return sendViaNotify(recipientId, notifyAddress, data)
         }
 
         // Until the remote has ack'd our CCCD write, the return path is not

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -147,6 +147,23 @@ class BleTransportFacade(
          *  write doesn't out-run it into ERROR_GATT_WRITE_REQUEST_BUSY (201).
          *  An occasional 201 here still self-heals via the backpressure retry. */
         private const val WRITE_GATE_WATCHDOG_MS = 30L
+        /** Minimum spacing between two completion-driven fragment sends to the
+         *  same link.
+         *
+         *  The write gate's fast path ([onWriteCompleted]) drains the next
+         *  fragment the instant the local stack signals completion
+         *  (onCharacteristicWrite / onNotificationSent). But for a peripheral
+         *  NOTIFY that completion fires when the notification leaves OUR
+         *  controller, NOT when the central (e.g. an iOS device) has drained it
+         *  from its receive buffer — so back-to-back notifies out-run a slower
+         *  central and it silently drops fragments mid-burst. A small multi-
+         *  fragment message (a few fragments) survives; a large one (an MLS
+         *  Welcome, ~15 fragments) deterministically loses a fragment every
+         *  pass and never reassembles. Spacing completion-driven sends by ~one
+         *  BLE connection interval lets the peer drain between notifications.
+         *  Tiny relative to a message's lifetime (15 fragments ≈ 0.3s) and
+         *  well under the reassembly TTL. */
+        private const val INTER_FRAGMENT_PACING_MS = 20L
         private const val CONNECTION_TIMEOUT_MS = 10000L
         private const val SCAN_WATCHDOG_INTERVAL_MS = 30000L // Match iOS timing
         private const val SCAN_WATCHDOG_HEARTBEAT_MS = 10000L
@@ -388,20 +405,27 @@ class BleTransportFacade(
     private val connections = MeshConnectionRegistry()
     private val lastSeenRssi = ConcurrentHashMap<String, Short>()
 
-    // Per-address staging map for negotiated ATT payload sizes. Populated
-    // from [CentralGattClient.Host.onPeerMtuNegotiated] (which reposts to
-    // main before touching this map) and drained in
-    // [CentralGattClient.Host.onDeviceIdResolved] once the reverse GATT
-    // read has mapped the address to a stable device id — at that point
-    // we flush into Rust via `protocol.bleSetPeerMtu` so the fragmenter
-    // can size outbound chunks per peer instead of using the 185-byte
-    // fallback. Entries are removed on successful flush (so a reconnect
-    // cannot observe a stale value) and on disconnect alongside the
-    // matching `bleClearPeerMtu` call. Main-thread only — every access
-    // is guarded by [assertMainThread], and the type is a plain `HashMap`
-    // to make the discipline visible rather than silently tolerate cross-
-    // thread writes.
+    // Per-address negotiated ATT payload for the CENTRAL link — the
+    // connection WE opened to the peer's GATT server. Populated from
+    // [CentralGattClient.Host.onPeerMtuNegotiated] and flushed once
+    // [CentralGattClient.Host.onDeviceIdResolved] maps the address to a stable
+    // device id. The Rust core stores ONE MTU per peer, so the value flushed
+    // is min(this, the peripheral-link payload below) — see [flushPeerMtu].
+    // Entries persist until link teardown (they are inputs to the min, not
+    // one-shot), and are cleared in [dropStagedPeerMtu] / on stop. Main-thread
+    // only — every access is guarded by [assertMainThread], and the type is a
+    // plain `HashMap` to make the discipline visible.
     private val peerMaxPayloads = HashMap<String, Int>()
+    // Per-address negotiated ATT payload for the PERIPHERAL/NOTIFY link — the
+    // connection the peer opened to OUR GATT server, reported by
+    // [PeripheralGattServer.Listener.onPeripheralMtuNegotiated]. A multi-
+    // fragment message (e.g. an MLS Welcome) sized for the central link but
+    // egressed as a peripheral notify would overflow this link and be
+    // truncated/dropped on air; folding this into the per-peer MTU via min()
+    // is the offline-convergence fix. Cleared when the peripheral link drops
+    // (in [handleCentralDisconnectedOnMain]) so the central MTU is restored.
+    // Main-thread only.
+    private val peripheralMaxPayloads = HashMap<String, Int>()
     private val discoveryLogTimestamps = ConcurrentHashMap<String, Long>()
     @Volatile private var lastDiscoveryAt: Long = 0L
 
@@ -920,6 +944,7 @@ class BleTransportFacade(
         // a stale value from the prior session before the new
         // handshake stages its own MTU.
         peerMaxPayloads.clear()
+        peripheralMaxPayloads.clear()
         centralClient.clearAll()
         lastSeenMeshAdvertisements.clear()
         verifiedNonMeshDevices.clear()
@@ -1955,36 +1980,55 @@ class BleTransportFacade(
     private fun currentConnectionCount(): Int = connections.connectionCount()
 
     /**
-     * Flushes a staged negotiated-MTU value into the Rust transport keyed by
-     * [deviceId]. Called from both the MTU-first-then-deviceId path (the
-     * normal handshake order, triggered via
-     * [CentralGattClient.Host.onDeviceIdResolved]) and the
-     * deviceId-first-then-MTU path (triggered from
-     * [CentralGattClient.Host.onPeerMtuNegotiated] when the address already
-     * has a resolved identifier). Idempotent: if no staged value exists the
-     * call is a no-op and the Rust fragmenter falls back to the 185-byte
-     * floor for that peer.
+     * Recomputes and flushes the effective per-peer ATT payload into the Rust
+     * transport keyed by [deviceId]. The core stores ONE MTU per peer but a
+     * peer can be reachable over two links with different MTUs — the central
+     * link WE opened ([peerMaxPayloads]) and the peripheral/NOTIFY link the
+     * peer opened to our GATT server ([peripheralMaxPayloads]). A single
+     * fragment stream must fit BOTH, so we flush the **minimum** of whatever
+     * is currently known. Without this, a message sized for the (larger)
+     * central link but egressed as a notify overflows the peripheral link and
+     * is truncated/dropped on air — the offline 1:1 Welcome-delivery stall.
      *
-     * On successful flush the staged entry is removed so that a reconnect
-     * on the same BLE address cannot observe a stale value before the new
-     * handshake stages its own MTU. If the controller later renegotiates
-     * mid-link (rare), [CentralGattClient.Host.onPeerMtuNegotiated] re-
-     * stages and re-flushes from scratch. Main-thread only.
+     * Called whenever either link's MTU is (re)negotiated, when the device id
+     * resolves ([CentralGattClient.Host.onDeviceIdResolved]), and when a link
+     * tears down (to restore the surviving link's MTU). If neither link has a
+     * value the Rust entry is cleared so the fragmenter reverts to its
+     * 185-byte floor rather than retaining a dead link's value. Idempotent and
+     * main-thread only. The staged values are NOT removed on flush (they are
+     * inputs to the min); link-teardown paths clear them explicitly.
      */
     private fun flushPeerMtu(address: String, deviceId: String) {
         assertMainThread("flushPeerMtu")
-        val staged = peerMaxPayloads[address] ?: return
+        val central = peerMaxPayloads[address]
+        val peripheral = peripheralMaxPayloads[address]
+        val effective = listOfNotNull(central, peripheral).minOrNull()
+        if (effective == null) {
+            // Both links gone — drop the Rust entry so the fragmenter falls
+            // back to the floor instead of keeping a stale per-peer size.
+            try {
+                protocol.bleClearPeerMtu(deviceId)
+            } catch (e: Exception) {
+                Log.w(TAG, "bleClearPeerMtu failed for $deviceId", e)
+            }
+            return
+        }
         try {
-            protocol.bleSetPeerMtu(deviceId, staged.toUInt())
-            peerMaxPayloads.remove(address)
+            protocol.bleSetPeerMtu(deviceId, effective.toUInt())
             emitDiagnostic(
                 "info",
                 "BLE per-peer MTU flushed to Rust",
-                mapOf("address" to address, "deviceId" to deviceId, "maxPayload" to staged),
+                mapOf(
+                    "address" to address,
+                    "deviceId" to deviceId,
+                    "centralPayload" to (central ?: -1),
+                    "peripheralPayload" to (peripheral ?: -1),
+                    "effectivePayload" to effective,
+                ),
             )
         } catch (e: Exception) {
-            // Leave the staged entry in place on failure so the next
-            // flush opportunity (re-entry via onPeerMtuNegotiated or
+            // Leave the staged entries in place on failure so the next
+            // flush opportunity (re-entry via either link's negotiation or
             // onDeviceIdResolved) can retry without losing the value.
             Log.w(TAG, "bleSetPeerMtu failed for $deviceId", e)
             emitDiagnostic(
@@ -2016,6 +2060,7 @@ class BleTransportFacade(
         assertMainThread("dropStagedPeerMtu")
         if (address != null) {
             peerMaxPayloads.remove(address)
+            peripheralMaxPayloads.remove(address)
         }
     }
 
@@ -2275,7 +2320,19 @@ class BleTransportFacade(
         assertMainThread("onWriteCompleted")
         writeInFlight.remove(address)
         if (state == TransportState.RUNNING) {
-            drainAndSendFragments()
+            // Pace the next completion-driven send by one BLE connection
+            // interval instead of draining immediately. onNotificationSent /
+            // onCharacteristicWrite signal that OUR controller accepted the
+            // op, not that the peer has drained it — firing the next notify
+            // instantly out-runs a slower central (iOS) and drops fragments
+            // mid-burst, so a large multi-fragment Welcome never reassembles.
+            // The brief spacing lets the peer keep up; small messages are
+            // unaffected in practice.
+            mainHandler.postDelayed({
+                if (state == TransportState.RUNNING) {
+                    drainAndSendFragments()
+                }
+            }, INTER_FRAGMENT_PACING_MS)
         }
     }
 
@@ -2477,6 +2534,7 @@ class BleTransportFacade(
                     "notifyAddress" to notifyAddress,
                     "resolvedAddress" to (address ?: "null"),
                     "matchedByIdentity" to (notifyAddress != address).toString(),
+                    "fragmentSize" to data.size,
                 ))
             }
             return sendViaNotify(recipientId, notifyAddress, data)
@@ -3067,6 +3125,27 @@ class BleTransportFacade(
             }
         }
 
+        override fun onPeripheralMtuNegotiated(device: BluetoothDevice, maxPayload: Int) {
+            // Fired on the GATT-server binder thread when a central renegotiates
+            // the MTU on the link it opened to us. Repost to main to touch the
+            // staging maps and the connection registry without racing the
+            // handshake state machine, mirroring onPeerMtuNegotiated.
+            if (shuttingDown) return
+            mainHandler.post {
+                if (shuttingDown) return@post
+                assertMainThread("onPeripheralMtuNegotiated.stage")
+                val address = device.address
+                peripheralMaxPayloads[address] = maxPayload
+                // Flush now if the peer's device id is already resolved (via our
+                // central link's device-id read); otherwise onDeviceIdResolved →
+                // flushPeerMtu picks up this staged peripheral payload later.
+                val deviceId = connections.deviceIdForAddress(address)
+                if (deviceId != null) {
+                    flushPeerMtu(address, deviceId)
+                }
+            }
+        }
+
         override fun onInboundFragment(device: BluetoothDevice, bytes: ByteArray) {
             if (shuttingDown) return
             Log.i(TAG, "MESSAGE CHARACTERISTIC WRITE from ${device.address}, processing...")
@@ -3170,9 +3249,13 @@ class BleTransportFacade(
         // RSSI cached to speed up reconnection. Any other status is a real
         // failure and we tear the peer state down.
         //
-        // MTU state invariant: this handler MUST NOT touch the Rust-side
-        // `peer_mtus` entry for the peer, and MUST NOT touch the facade
-        // staging map either. This function runs on a peripheral-role
+        // MTU state invariant: this handler MUST NOT clear or demote the
+        // CENTRAL-owned `peer_mtus` value or its staging slot
+        // (`peerMaxPayloads`). It MAY drop the peripheral/NOTIFY-link slot
+        // (`peripheralMaxPayloads`) — that link IS this connection — and
+        // re-flush the recomputed min, which only ever RAISES the per-peer
+        // MTU back toward the central value (see the clean-disconnect block
+        // below). This function runs on a peripheral-role
         // disconnect (a remote central disconnected from our GATT
         // server). The `peer_mtus[deviceId]` entry is owned by our
         // *central-role* link to the same peer, populated via
@@ -3194,6 +3277,17 @@ class BleTransportFacade(
         // `peer_mtus` via `on_peer_lost`, which is correct for a path
         // that *also* drops the peer from the Rust `peers` map.
         val isCleanDisconnect = status == 0 || status == 19
+        // The peripheral/NOTIFY link to this central is gone. Drop its payload
+        // and, on a clean disconnect (peer likely returns, deviceId mapping
+        // kept), recompute the per-peer MTU from the surviving central link —
+        // restoring it from any min() demotion the notify link imposed. On a
+        // non-clean disconnect the teardown below calls blePeerLost (drops
+        // peer_mtus wholesale) + dropStagedPeerMtu, so we defer to that path.
+        if (isCleanDisconnect && peripheralMaxPayloads.remove(address) != null) {
+            connections.deviceIdForAddress(address)?.let { peerId ->
+                flushPeerMtu(address, peerId)
+            }
+        }
         if (!isCleanDisconnect) {
             lastSeenRssi.remove(address)
             connections.deviceIdForAddress(address)?.let { peerId ->

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/CentralGattClient.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/CentralGattClient.kt
@@ -99,6 +99,16 @@ internal class CentralGattClient(
         fun learnRouteFromMessage(messageJson: String, neighborId: String, neighborAddress: String?)
         fun drainAndSendFragments()
 
+        /** Release the per-peer write gate after a GATT characteristic write
+         *  to [address] completes (the stack flushed the op and will accept
+         *  the next write). On API 33+ the value-overload of
+         *  writeCharacteristic rejects a concurrent write with
+         *  ERROR_GATT_WRITE_REQUEST_BUSY (201) while one is still outstanding,
+         *  even for WRITE_TYPE_NO_RESPONSE, so the facade serialises one
+         *  outstanding write per peer and uses this signal to drain the next
+         *  fragment. Called on the main thread. */
+        fun onWriteCompleted(address: String)
+
         /** Hand a received fragment to the facade (either via client
          *  notify or via central-side write). Called on the main thread. */
         fun handleInboundFragment(address: String, data: ByteArray)
@@ -594,12 +604,13 @@ internal class CentralGattClient(
         override fun onCharacteristicWrite(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
             if (host.isShuttingDown()) return
             if (characteristic.uuid != messageCharUuid) return
-            if (status != BluetoothGatt.GATT_SUCCESS) return
+            // Release the per-peer write gate and drive the next fragment. Done
+            // even on a non-success status so a failed write cannot leave the
+            // gate stuck and wedge the peer; the facade re-drives from the queue.
+            val address = gatt.device.address
             mainHandler.post {
                 if (host.isShuttingDown()) return@post
-                if (host.isRunning()) {
-                    host.drainAndSendFragments()
-                }
+                host.onWriteCompleted(address)
             }
         }
 

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/InboundFragmentBuffer.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/InboundFragmentBuffer.kt
@@ -137,11 +137,23 @@ internal class InboundFragmentBuffer(
     }
 
     /**
-     * Walk every peer's buffer, evicting entries older than [timeoutMs] and
-     * pruning buffers that become empty. Returns the total number of
-     * fragments evicted for diagnostics. Called by the transport's routing
-     * cleanup ticker so stale inbound bytes do not pin memory forever when
-     * a peer that was mid-handshake goes silent.
+     * Walk every peer's buffer and evict whole buffers that have gone idle
+     * for [timeoutMs] (no fragment received within the window). Returns the
+     * total number of fragments evicted for diagnostics. Called by the
+     * transport's routing cleanup ticker so stale inbound bytes do not pin
+     * memory forever when a peer that was mid-handshake goes silent.
+     *
+     * Eviction is at WHOLE-BUFFER granularity keyed on the NEWEST entry —
+     * not per-fragment. The previous per-fragment sweep tore a still-arriving
+     * multi-fragment message: while device-id resolution was pending (a
+     * reverse connect throttled to once / [timeoutMs]), the sender keeps
+     * streaming fragments, but the sweep dropped fragment 0 the moment it
+     * aged past the window while fragments 1..n were still in flight, handing
+     * the reassembler a permanent hole and dropping the message. Keying on the
+     * newest fragment means a buffer survives as long as bytes are still
+     * arriving, and is dropped wholesale only once the peer truly goes silent —
+     * matching the whole-message invariant [enqueue]'s overflow policy already
+     * documents.
      */
     fun evictExpired(): Int {
         mainThreadCheck()
@@ -151,21 +163,17 @@ internal class InboundFragmentBuffer(
         while (iter.hasNext()) {
             val entry = iter.next()
             val queue = entry.value
-            var expired = 0
-            val qIter = queue.iterator()
-            while (qIter.hasNext()) {
-                val frag = qIter.next()
-                if (now - frag.timestamp >= timeoutMs) {
-                    qIter.remove()
-                    expired++
-                }
+            // Newest entry = last appended (timestamps are append-monotonic).
+            val newestTs = queue.lastOrNull()?.timestamp
+            if (newestTs == null) {
+                iter.remove()
+                continue
             }
-            if (expired > 0) {
-                total.addAndGet(-expired)
-                onDropped(entry.key, DropReason.EXPIRED, expired)
-                totalEvicted += expired
-            }
-            if (queue.isEmpty()) {
+            if (now - newestTs >= timeoutMs) {
+                val dropped = queue.size
+                total.addAndGet(-dropped)
+                onDropped(entry.key, DropReason.EXPIRED, dropped)
+                totalEvicted += dropped
                 iter.remove()
             }
         }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/OutboundFragmentQueue.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/OutboundFragmentQueue.kt
@@ -153,6 +153,15 @@ internal class OutboundFragmentQueue(
         for (recipientId in queues.keys.toList()) {
             val queue = queues[recipientId] ?: continue
 
+            // Expiry is per-fragment, not per-message. These entries are opaque
+            // fragment bytes from the Rust fragmenter with no message grouping at
+            // this layer, so on a stall longer than timeoutMs the early fragments
+            // of a multi-fragment message can be dropped while later ones survive,
+            // tearing it. Bounded, not silent: the receiver's idle reassembly times
+            // out the partial and the sender's higher layer (Welcome retransmit /
+            // ack-driven retry) re-sends the whole message. True whole-message
+            // expiry would need message ids threaded down from Rust — tracked
+            // separately.
             var expired = 0
             val expiryIter = queue.iterator()
             while (expiryIter.hasNext()) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/OutboundFragmentQueue.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/OutboundFragmentQueue.kt
@@ -64,6 +64,24 @@ internal class OutboundFragmentQueue(
     }
 
     /**
+     * True once [recipientId]'s queue has filled past a high-water mark
+     * (3/4 of [maxPerPeer]). The drain loop uses this as a backpressure
+     * signal to STOP pulling more fragments out of the Rust core — which is
+     * a destructive pop — into this bounded queue. Without it, when the BLE
+     * write gate paces sends slower than the loop can pull, the loop spins
+     * the whole Rust backlog into the queue, overflows [maxPerPeer], and
+     * [enqueue] discards the entire per-peer queue mid-message. Holding the
+     * backlog in Rust (the proper unbounded, ordered buffer) instead keeps
+     * delivery lossless; the scheduled re-drain resumes pulling once
+     * [flush] has drained the queue back below the mark.
+     */
+    fun isBackedUp(recipientId: String): Boolean {
+        mainThreadCheck()
+        val size = queues[recipientId]?.size ?: 0
+        return size >= maxPerPeer * 3 / 4
+    }
+
+    /**
      * Append a fragment to [recipientId]'s queue. If doing so would exceed
      * [maxPerPeer] the entire per-recipient queue is discarded first (see
      * the class-level overflow policy note). [onDropped] is invoked once

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
@@ -301,14 +301,20 @@ class PeripheralGattServer(
         val characteristic = messageCharacteristic ?: return false
         if (!subscribedCentralAddresses.contains(device.address)) return false
         return try {
+            // confirm = true → ATT Handle Value INDICATION (acknowledged) rather
+            // than a fire-and-forget NOTIFICATION. The central must confirm each
+            // one before the stack accepts the next, giving the per-fragment flow
+            // control that keeps a large Welcome from overrunning the receiver.
+            // onNotificationSent then fires on the CONFIRMATION (real delivery),
+            // which releases the per-peer write gate only once the peer has it.
             val accepted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                server.notifyCharacteristicChanged(device, characteristic, false, bytes) ==
+                server.notifyCharacteristicChanged(device, characteristic, true, bytes) ==
                     BluetoothStatusCodes.SUCCESS
             } else {
                 @Suppress("DEPRECATION")
                 characteristic.value = bytes
                 @Suppress("DEPRECATION")
-                server.notifyCharacteristicChanged(device, characteristic, false)
+                server.notifyCharacteristicChanged(device, characteristic, true)
             }
             if (!accepted) {
                 // The stack refused the notification. The dominant cause for a
@@ -468,8 +474,17 @@ class PeripheralGattServer(
     private fun registerNotifyCharacteristic(uuid: UUID): BluetoothGattCharacteristic {
         val char = BluetoothGattCharacteristic(
             uuid,
+            // INDICATE, not NOTIFY: indications are ATT-confirmed, so the stack
+            // will not send the next fragment until the central confirms the
+            // previous one. That per-fragment flow control is what an
+            // unacknowledged NOTIFY lacks — a large multi-fragment message (an
+            // MLS Welcome) out-runs a slower central's receive buffer and loses
+            // a fragment every pass, so it never reassembles. With only
+            // INDICATE advertised, iOS subscribes for indications (it prefers
+            // NOTIFY when both are offered), and the CCCD classifier already
+            // accepts the 0x0002 enable value.
             BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE or
-                BluetoothGattCharacteristic.PROPERTY_NOTIFY,
+                BluetoothGattCharacteristic.PROPERTY_INDICATE,
             BluetoothGattCharacteristic.PERMISSION_WRITE,
         )
         val cccd = BluetoothGattDescriptor(

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
@@ -112,6 +112,13 @@ class PeripheralGattServer(
          *  go. Lets the transport release its per-peer send gate on real
          *  completion instead of relying solely on the watchdog timeout. */
         fun onNotificationSent(device: BluetoothDevice, status: Int)
+        /** The ATT MTU for [device]'s connection to OUR GATT server has been
+         *  (re)negotiated by that central. [maxPayload] is the header-adjusted
+         *  max NOTIFY payload (MTU − 3) we can push to it via [notifyFragment].
+         *  The transport bounds the per-peer fragment size by this so a message
+         *  sized for OUR central link to the peer is not over-sized for this
+         *  notify link — the cause of the offline 1:1 Welcome-delivery stall. */
+        fun onPeripheralMtuNegotiated(device: BluetoothDevice, maxPayload: Int)
         /** Return the current device-ID bytes, or null to fail the read. */
         fun provideDeviceIdBytes(device: BluetoothDevice): ByteArray?
         /** Return the current signed-identity bytes, or null to fail the read. */
@@ -130,6 +137,11 @@ class PeripheralGattServer(
          *  facade's MAX_FRAGMENT_SIZE (185 bytes) to tolerate MTU-negotiation
          *  headroom, but bounded so a hostile central cannot balloon memory. */
         const val MAX_INBOUND_WRITE_BYTES = 4096
+        /** ATT protocol header subtracted from a negotiated ATT MTU to get the
+         *  usable NOTIFY payload (MTU − 3). Matches CentralGattClient's
+         *  ATT_HEADER_BYTES so both link directions report payloads on the
+         *  same basis. */
+        private const val ATT_HEADER_BYTES = 3
         /** Maximum age of a per-central identity long-read snapshot. A
          *  coherent long-read session finishes in well under a second on
          *  real hardware; anything older is either the result of a central
@@ -289,7 +301,7 @@ class PeripheralGattServer(
         val characteristic = messageCharacteristic ?: return false
         if (!subscribedCentralAddresses.contains(device.address)) return false
         return try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val accepted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 server.notifyCharacteristicChanged(device, characteristic, false, bytes) ==
                     BluetoothStatusCodes.SUCCESS
             } else {
@@ -298,6 +310,18 @@ class PeripheralGattServer(
                 @Suppress("DEPRECATION")
                 server.notifyCharacteristicChanged(device, characteristic, false)
             }
+            if (!accepted) {
+                // The stack refused the notification. The dominant cause for a
+                // multi-fragment payload is a fragment larger than this notify
+                // link's ATT_MTU − 3. Surface the size so a stalled Welcome is
+                // attributable to an MTU mismatch rather than silent loss.
+                diagnosticEmitter(
+                    "warning",
+                    "notify rejected by stack",
+                    mapOf("address" to device.address, "fragmentSize" to bytes.size),
+                )
+            }
+            accepted
         } catch (e: Exception) {
             Log.e(TAG, "notifyFragment failed for ${device.address}", e)
             false
@@ -499,6 +523,24 @@ class PeripheralGattServer(
                     listener.onCentralDisconnected(device, status)
                 }
             }
+        }
+
+        override fun onMtuChanged(device: BluetoothDevice, mtu: Int) {
+            // A remote central (re)negotiated the ATT MTU on the connection IT
+            // opened to OUR GATT server. This callback is the ONLY place the
+            // peripheral/NOTIFY link's capacity is observable on the server
+            // side — without it the transport keeps sizing notifications for
+            // our central link to the peer and overflows this one, silently
+            // truncating/dropping the multi-fragment MLS Welcome on air.
+            // Surface the raw value as a diagnostic and the header-adjusted
+            // payload to the transport, which folds it into the per-peer MTU.
+            val maxPayload = (mtu - ATT_HEADER_BYTES).coerceAtLeast(0)
+            diagnosticEmitter(
+                "info",
+                "peripheral_link_mtu",
+                mapOf("address" to device.address, "mtu" to mtu, "maxPayload" to maxPayload),
+            )
+            listener.onPeripheralMtuNegotiated(device, maxPayload)
         }
 
         override fun onCharacteristicReadRequest(

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
@@ -263,6 +263,12 @@ class PeripheralGattServer(
     fun isSubscribed(address: String): Boolean =
         subscribedCentralAddresses.contains(address)
 
+    /** Snapshot of the addresses of centrals currently subscribed via CCCD.
+     *  Used to resolve the notify egress by PEER IDENTITY when the address we
+     *  hold for a peer (the central link we opened to it) differs from the
+     *  address it subscribed under (the link it opened to our server). */
+    fun subscribedAddresses(): Set<String> = subscribedCentralAddresses.toSet()
+
     /**
      * Reply to a central by notifying the message characteristic over the
      * connection IT opened to our GATT server. This is the egress for

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
@@ -9,7 +9,9 @@ import android.bluetooth.BluetoothGattServerCallback
 import android.bluetooth.BluetoothGattService
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
+import android.bluetooth.BluetoothStatusCodes
 import android.content.Context
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -105,6 +107,11 @@ class PeripheralGattServer(
         fun onCentralConnected(device: BluetoothDevice)
         fun onCentralDisconnected(device: BluetoothDevice, status: Int)
         fun onInboundFragment(device: BluetoothDevice, bytes: ByteArray)
+        /** A notification we pushed to [device] (via [notifyFragment]) has been
+         *  flushed by the stack — the next notification to that central may now
+         *  go. Lets the transport release its per-peer send gate on real
+         *  completion instead of relying solely on the watchdog timeout. */
+        fun onNotificationSent(device: BluetoothDevice, status: Int)
         /** Return the current device-ID bytes, or null to fail the read. */
         fun provideDeviceIdBytes(device: BluetoothDevice): ByteArray?
         /** Return the current signed-identity bytes, or null to fail the read. */
@@ -248,6 +255,48 @@ class PeripheralGattServer(
 
     /** Count of centrals currently subscribed via CCCD. Observability only. */
     fun subscribedCentralCount(): Int = subscribedCentralAddresses.size
+
+    /** True if [address] is a central currently subscribed to the message
+     *  characteristic via CCCD — i.e. we can push notifications to it over the
+     *  connection it opened to our GATT server. [subscribedCentralAddresses] is
+     *  a concurrent set so this is safe to read from the main thread. */
+    fun isSubscribed(address: String): Boolean =
+        subscribedCentralAddresses.contains(address)
+
+    /**
+     * Reply to a central by notifying the message characteristic over the
+     * connection IT opened to our GATT server. This is the egress for
+     * asymmetric mesh links where we are only the peripheral for [device] (see
+     * the class note above): the central's reverse link back to us may be
+     * absent or half-open, so a central-role `writeCharacteristic(NO_RESPONSE)`
+     * returns SUCCESS into a dead link and the bytes are silently dropped on air
+     * (no status 201, no error) — the peer never gets the reply and retransmits
+     * forever. Notifying over the live, subscribed connection is reliable.
+     *
+     * Returns true if the stack accepted the notification. No-op (false) if the
+     * server/characteristic is gone or [device] is not subscribed. Notifications
+     * are serialised one-outstanding-per-connection by the stack, just like
+     * NO_RESPONSE writes, so the caller paces them via the shared write gate.
+     */
+    fun notifyFragment(device: BluetoothDevice, bytes: ByteArray): Boolean {
+        val server = gattServer ?: return false
+        val characteristic = messageCharacteristic ?: return false
+        if (!subscribedCentralAddresses.contains(device.address)) return false
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                server.notifyCharacteristicChanged(device, characteristic, false, bytes) ==
+                    BluetoothStatusCodes.SUCCESS
+            } else {
+                @Suppress("DEPRECATION")
+                characteristic.value = bytes
+                @Suppress("DEPRECATION")
+                server.notifyCharacteristicChanged(device, characteristic, false)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "notifyFragment failed for ${device.address}", e)
+            false
+        }
+    }
 
     /** Cancel an in-flight connection to a central. */
     fun cancelConnection(device: BluetoothDevice) {
@@ -566,6 +615,10 @@ class PeripheralGattServer(
                     iterator.remove()
                 }
             }
+        }
+
+        override fun onNotificationSent(device: BluetoothDevice, status: Int) {
+            listener.onNotificationSent(device, status)
         }
 
         override fun onCharacteristicWriteRequest(

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/InboundFragmentBufferTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/InboundFragmentBufferTest.kt
@@ -20,8 +20,10 @@ import org.junit.Test
  *     This is the exact regression from the previous head-eviction policy.
  *   - Peer cap evicts the peer with the stalest head entry, excluding the
  *     address currently being queued for.
- *   - Expiry during [evictExpired] evicts stale entries and prunes empty
- *     buckets while keeping the aggregate counter consistent.
+ *   - [evictExpired] evicts a peer's buffer wholesale once it has gone idle
+ *     (its NEWEST fragment aged past the window) and prunes empty buckets, but
+ *     never tears a buffer whose fragments are still arriving — all while
+ *     keeping the aggregate counter consistent.
  *   - `removeAll` / `clear` bring the total counter back to zero.
  *   - `totalCount` is readable without tripping the main-thread guard, so
  *     callback-thread diagnostic paths stay safe.
@@ -186,29 +188,59 @@ class InboundFragmentBufferTest {
     }
 
     @Test
-    fun `evictExpired drops old entries and prunes empty buckets`() {
+    fun `evictExpired evicts a whole idle buffer but never a still-arriving one`() {
+        // Regression for the per-fragment sweep that tore an in-flight message:
+        // while device-id resolution was pending the sender keeps streaming
+        // fragments, and the old sweep dropped fragment 0 the moment it aged past
+        // the window while fragments 1..n were still in flight — handing the
+        // reassembler a permanent hole. Eviction now keys on the NEWEST fragment,
+        // so a buffer survives as long as bytes keep arriving and is dropped only
+        // once the peer truly goes silent.
+        val h = Harness(timeoutMs = 1_000L)
+        h.buffer.enqueue("aa:00", byteArrayOf(1)) // ts = 0
+        h.buffer.enqueue("aa:00", byteArrayOf(2)) // ts = 0
+        h.buffer.enqueue("bb:11", byteArrayOf(10)) // ts = 0, then goes silent
+        h.clock.advance(1_500L)
+        h.buffer.enqueue("aa:00", byteArrayOf(3)) // ts = 1500 -> aa:00 still arriving
+
+        val expired = h.buffer.evictExpired()
+        // aa:00's newest fragment is fresh, so the WHOLE buffer is kept (its old
+        // head is NOT torn out). bb:11 has been idle since ts=0 (age >= timeout),
+        // so it is evicted wholesale.
+        assertEquals(1, expired)
+        assertEquals(3, h.buffer.totalCount())
+        assertTrue(h.buffer.hasPending("aa:00"))
+        assertFalse(h.buffer.hasPending("bb:11"))
+
+        // The aa:00 buffer survived intact and in order, including its old head.
+        val aaDrain = h.buffer.drain("aa:00")
+        assertEquals(3, aaDrain.size)
+        assertArrayEquals(byteArrayOf(1), aaDrain[0])
+        assertArrayEquals(byteArrayOf(2), aaDrain[1])
+        assertArrayEquals(byteArrayOf(3), aaDrain[2])
+
+        val expiryDrops = h.drops.filter { it.reason == InboundFragmentBuffer.DropReason.EXPIRED }
+        assertEquals(
+            setOf("bb:11" to 1),
+            expiryDrops.map { it.address to it.count }.toSet(),
+        )
+    }
+
+    @Test
+    fun `evictExpired drops a fully idle buffer wholesale and prunes it`() {
         val h = Harness(timeoutMs = 1_000L)
         h.buffer.enqueue("aa:00", byteArrayOf(1))
         h.buffer.enqueue("aa:00", byteArrayOf(2))
-        h.buffer.enqueue("bb:11", byteArrayOf(10))
-        h.clock.advance(1_500L)
-        h.buffer.enqueue("aa:00", byteArrayOf(3))
+        h.clock.advance(1_500L) // nothing new arrives -> the whole buffer is idle
 
         val expired = h.buffer.evictExpired()
-        // aa:00: two entries expired, one survived (the post-advance one).
-        // bb:11: one entry expired, bucket now empty and pruned.
-        assertEquals(3, expired)
-        assertEquals(1, h.buffer.totalCount())
-        assertTrue(h.buffer.hasPending("aa:00"))
-        assertFalse(h.buffer.hasPending("bb:11"))
-        val aaDrain = h.buffer.drain("aa:00")
-        assertEquals(1, aaDrain.size)
-        assertArrayEquals(byteArrayOf(3), aaDrain[0])
+        assertEquals(2, expired)
+        assertEquals(0, h.buffer.totalCount())
+        assertFalse(h.buffer.hasPending("aa:00"))
 
         val expiryDrops = h.drops.filter { it.reason == InboundFragmentBuffer.DropReason.EXPIRED }
-        assertEquals(2, expiryDrops.size)
         assertEquals(
-            setOf("aa:00" to 2, "bb:11" to 1),
+            setOf("aa:00" to 2),
             expiryDrops.map { it.address to it.count }.toSet(),
         )
     }

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/mesh/MeshControllerTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/mesh/MeshControllerTest.kt
@@ -7,7 +7,12 @@ class MeshControllerTest {
 
     @Test
     fun `should evict low score peer when candidate better`() {
-        val controller = MeshController("self")
+        // maxConnections = 2 saturates the mesh with the two registered peers so
+        // shouldInitiateOutbound evaluates a swap instead of returning
+        // capacity_available. The default max of 4 leaves free slots for two
+        // peers, so this test — added in 542e547 alongside that default and never
+        // run in CI until now — never actually exercised the eviction path.
+        val controller = MeshController("self", MeshController.MeshConfig(maxConnections = 2))
         controller.updateSelfMetrics(
             MeshController.PeerMetrics(
                 rssi = -55,
@@ -61,7 +66,8 @@ class MeshControllerTest {
 
     @Test
     fun `should bridge when candidate has availability even if score similar`() {
-        val controller = MeshController("self")
+        // maxConnections = 2 so the mesh is saturated and a swap is evaluated.
+        val controller = MeshController("self", MeshController.MeshConfig(maxConnections = 2))
         controller.updateSelfMetrics(
             MeshController.PeerMetrics(
                 rssi = -45,
@@ -72,6 +78,7 @@ class MeshControllerTest {
             )
         )
 
+        // A strong incumbent that must NOT be the eviction target.
         controller.registerConnection("anchor", MeshController.MeshRole.MEMBER)
         controller.updatePeerMetrics(
             "anchor",
@@ -84,30 +91,37 @@ class MeshControllerTest {
             )
         )
 
+        // The genuinely weakest peer — the one a bridge swap should evict. The
+        // original test mislabelled the BEST-metric peer as "weak", so it could
+        // never have evicted it; these metrics make "weak" actually the
+        // lowest-scored active peer.
         controller.registerConnection("weak", MeshController.MeshRole.MEMBER)
         controller.updatePeerMetrics(
             "weak",
             MeshController.PeerMetrics(
-                rssi = -40,
-                batteryPercent = 95,
-                stability = 0.95,
-                loadPercent = 5,
-                uptimeSeconds = 1_800
+                rssi = -80,
+                batteryPercent = 45,
+                stability = 0.45,
+                loadPercent = 55,
+                uptimeSeconds = 500
             )
         )
 
+        // Candidate whose overall score is ~equal to "weak" (so it does NOT win
+        // on score alone — that path is swap_low_score_peer) but which advertises
+        // spare capacity the saturated incumbent lacks, so it wins as a bridge.
         val metadata = MeshAdvertisementData(
-            degree = 1,
-            freeSlotEstimate = 4,
-            nodeScore = 0.45,
+            degree = 2,
+            freeSlotEstimate = 1,
+            nodeScore = 0.30,
             uptimeSeconds = 600,
-            batteryPercent = 80,
-            loadPercent = 25,
-            rssiToYou = -30,
+            batteryPercent = 50,
+            loadPercent = 50,
+            rssiToYou = -65,
             nodeIdHash = 84L
         )
 
-        val decision = controller.shouldInitiateOutbound(metadata, rssi = -55)
+        val decision = controller.shouldInitiateOutbound(metadata, rssi = -70)
 
         assertEquals(MeshController.ConnectionIntent.INTRA_CLUSTER, decision.intent)
         assertEquals("weak", decision.evictPeerId)

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -1480,8 +1480,12 @@ public class BleManager: NSObject, TransportManager {
                 if self.pendingFragments[centralId] == nil {
                     self.pendingFragments[centralId] = []
                 }
+                // Whole-buffer overflow drop (matches Android InboundFragmentBuffer):
+                // fragments are slices of one message, so dropping just the oldest
+                // leaves orphan slices that the reassembler stitches into garbage.
+                // Drop the whole peer buffer at message-boundary granularity instead.
                 if (self.pendingFragments[centralId]?.count ?? 0) >= self.MAX_PENDING_FRAGMENTS_PER_PEER {
-                    self.pendingFragments[centralId]?.removeFirst()
+                    self.pendingFragments[centralId]?.removeAll()
                 }
                 self.pendingFragments[centralId]?.append((data, Date()))
                 
@@ -1510,8 +1514,12 @@ public class BleManager: NSObject, TransportManager {
             // processPendingFragments() will handle them all in FIFO order.
             if let centralId = centralId,
                self.pendingFragments[centralId]?.isEmpty == false {
+                // Whole-buffer overflow drop (matches Android InboundFragmentBuffer):
+                // fragments are slices of one message, so dropping just the oldest
+                // leaves orphan slices that the reassembler stitches into garbage.
+                // Drop the whole peer buffer at message-boundary granularity instead.
                 if (self.pendingFragments[centralId]?.count ?? 0) >= self.MAX_PENDING_FRAGMENTS_PER_PEER {
-                    self.pendingFragments[centralId]?.removeFirst()
+                    self.pendingFragments[centralId]?.removeAll()
                 }
                 self.pendingFragments[centralId, default: []].append((data, Date()))
                 return
@@ -1642,12 +1650,25 @@ public class BleManager: NSObject, TransportManager {
     
     private func cleanupPendingFragments() {
         let now = Date()
-        for (centralId, fragments) in pendingFragments {
-            let validFragments = fragments.filter { now.timeIntervalSince($0.1) < PENDING_FRAGMENT_TIMEOUT }
-            if validFragments.isEmpty {
+        // Idle-window eviction at WHOLE-BUFFER granularity. A buffer is stale
+        // only if NOTHING has arrived for it within PENDING_FRAGMENT_TIMEOUT —
+        // i.e. its newest fragment is older than the window. The previous
+        // per-fragment filter tore a still-arriving multi-fragment message:
+        // while device-id resolution was pending the sender keeps streaming
+        // fragments, but the filter dropped fragment 0 once it aged past the
+        // window while later fragments were still in flight, handing the
+        // reassembler a permanent hole. Key on the newest fragment so a buffer
+        // survives as long as bytes keep arriving, and drop it wholesale only
+        // once the peer goes silent (matching the whole-buffer overflow policy).
+        // Snapshot the keys so we never mutate the dictionary mid-iteration.
+        for centralId in Array(pendingFragments.keys) {
+            guard let fragments = pendingFragments[centralId] else { continue }
+            guard let newest = fragments.map({ $0.1 }).max() else {
                 pendingFragments.removeValue(forKey: centralId)
-            } else {
-                pendingFragments[centralId] = validFragments
+                continue
+            }
+            if now.timeIntervalSince(newest) >= PENDING_FRAGMENT_TIMEOUT {
+                pendingFragments.removeValue(forKey: centralId)
             }
         }
     }
@@ -2643,6 +2664,16 @@ extension BleManager: CBPeripheralDelegate {
                         processPendingFragments(for: centralId, deviceId: deviceId)
                     }
                 }
+
+                // The recipient -> peripheral mapping and MESSAGE characteristic
+                // now exist, so flush any OUTBOUND fragments parked while this
+                // connection was still forming. drainAndSendFragments previously
+                // ran only on connect / onFragmentsAvailable, so the FIRST message
+                // a user sent into a still-connecting peer (already popped out of
+                // the Rust queue and parked in pendingOutboundFragments) had
+                // nothing to re-trigger it and stalled until a later fragment
+                // event or the 30s expiry — the iOS->Android first-message stall.
+                self.drainAndSendFragments()
             }
         } else if characteristic.uuid == MESSAGE_CHAR_UUID {
             // Handle received message fragment

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -705,6 +705,22 @@ export interface SecureSessionFailedEvent extends BaseEvent {
 }
 
 /**
+ * Convergence diagnostic event (1:1 MLS convergence instrumentation).
+ * Pure receiver-side breadcrumb for the Welcome receive / adopt / confirm
+ * path — carries no protocol effect. Surfaces stages the receiver otherwise
+ * emits nothing for (welcome reassembled, branch taken, decrypt landed).
+ */
+export interface ConvergenceDiagEvent extends BaseEvent {
+  type: 'convergence_diag';
+  /** Fixed stage label, e.g. 'welcome_received' | 'welcome_branch' | 'decrypt_success' */
+  stage: string;
+  /** Peer ID this breadcrumb concerns */
+  peer_id: string;
+  /** Free-form key=value context */
+  detail: string;
+}
+
+/**
  * Machine-readable reason codes for welcome delivery failures.
  */
 export type WelcomeReasonCode =
@@ -1141,6 +1157,7 @@ export type ProtocolEvent =
   | DiagnosticEvent
   | SecureSessionEstablishedEvent
   | SecureSessionFailedEvent
+  | ConvergenceDiagEvent
   | WelcomeSendAttemptedEvent
   | WelcomeSendSucceededEvent
   | WelcomeSendFailedEvent

--- a/crates/offline-protocol-mls/src/group.rs
+++ b/crates/offline-protocol-mls/src/group.rs
@@ -234,6 +234,45 @@ impl GroupManager {
         Ok(group)
     }
 
+    /// Joins a group from a Welcome, replacing any existing group at the same
+    /// `group_id` **non-destructively**.
+    ///
+    /// Unlike a naive delete-then-join, this stages the incoming Welcome FIRST.
+    /// Staging (`StagedWelcome::new_from_welcome`) is the step that consumes the
+    /// one-time key package, so it is the natural failure point: if the key
+    /// package is unavailable — e.g. a retransmitted Welcome we already adopted,
+    /// or a first-contact key-package race — staging returns `Err` and the
+    /// existing group is left **completely intact** instead of being bricked.
+    /// Only once staging succeeds do we remove the prior group (1:1 session
+    /// groups share the deterministic MLS group id derived from the session
+    /// string, so `into_group` must write into a cleared slot) and install the
+    /// adopted one. This makes both-create adoption idempotent: a duplicate
+    /// Welcome is a safe no-op rather than a re-brick.
+    pub fn join_group_replacing(&self, welcome: Welcome, group_id: &GroupId) -> Result<MlsGroup> {
+        let group_config = MlsGroupJoinConfig::builder()
+            .use_ratchet_tree_extension(true)
+            .build();
+
+        // Stage first — non-destructive failure point (consumes the key package).
+        let staged = StagedWelcome::new_from_welcome(&self.provider, &group_config, welcome, None)
+            .map_err(|e| MlsError::WelcomeProcessing(format!("Failed to stage welcome: {}", e)))?;
+
+        // Staging succeeded: it is now safe to drop any prior group at this id so
+        // `into_group` writes a clean slot at the shared MLS group id.
+        if self.load_group(group_id)?.is_some() {
+            self.delete_group(group_id)?;
+        }
+
+        let group = staged
+            .into_group(&self.provider)
+            .map_err(|e| MlsError::WelcomeProcessing(format!("Failed to join group: {}", e)))?;
+
+        self.save_group(group_id, &group)?;
+
+        debug!(group_id = %group_id, "Joined/adopted group via Welcome (non-destructive)");
+        Ok(group)
+    }
+
     /// Gets information about a group.
     pub fn get_group_info(&self, group: &MlsGroup, group_id: &GroupId) -> GroupInfo {
         let members: Vec<String> = group

--- a/crates/offline-protocol-mls/src/group.rs
+++ b/crates/offline-protocol-mls/src/group.rs
@@ -110,13 +110,29 @@ impl GroupManager {
     pub fn delete_group(&self, group_id: &GroupId) -> Result<()> {
         let mls_group_id = openmls::group::GroupId::from_slice(group_id.as_str().as_bytes());
 
-        if let Ok(Some(mut group)) = MlsGroup::load(self.provider.storage(), &mls_group_id) {
-            group.delete(self.provider.storage()).map_err(|e| {
-                MlsError::Storage(StorageError::DeleteFailed(format!(
-                    "Failed to delete group from provider storage: {:?}",
-                    e
-                )))
-            })?;
+        match MlsGroup::load(self.provider.storage(), &mls_group_id) {
+            Ok(Some(mut group)) => {
+                group.delete(self.provider.storage()).map_err(|e| {
+                    MlsError::Storage(StorageError::DeleteFailed(format!(
+                        "Failed to delete group from provider storage: {:?}",
+                        e
+                    )))
+                })?;
+            }
+            // No group at this id — nothing to clean up.
+            Ok(None) => {}
+            // We could not load the group to delete its provider-side state
+            // (epoch keypairs, secrets); that state may now leak. Warn rather
+            // than abort and still drop the marker below: callers such as
+            // `join_group_replacing` deliberately rely on `delete_group` not
+            // failing here once the one-time key package is already consumed.
+            Err(e) => {
+                warn!(
+                    group_id = %group_id,
+                    error = ?e,
+                    "delete_group: could not load group to clean provider state; dropping marker only"
+                );
+            }
         }
 
         let key_type = StorageKeyType::GroupState.as_str();
@@ -235,41 +251,61 @@ impl GroupManager {
     }
 
     /// Joins a group from a Welcome, replacing any existing group at the same
-    /// `group_id` **non-destructively**.
+    /// `group_id`. **Non-destructive on the common failure (a duplicate
+    /// Welcome); best-effort — NOT atomic — on the rare storage failure.**
     ///
-    /// Unlike a naive delete-then-join, this stages the incoming Welcome FIRST.
-    /// Staging (`StagedWelcome::new_from_welcome`) is the step that consumes the
-    /// one-time key package, so it is the natural failure point: if the key
-    /// package is unavailable — e.g. a retransmitted Welcome we already adopted,
-    /// or a first-contact key-package race — staging returns `Err` and the
-    /// existing group is left **completely intact** instead of being bricked.
-    /// Only once staging succeeds do we remove the prior group (1:1 session
-    /// groups share the deterministic MLS group id derived from the session
-    /// string, so `into_group` must write into a cleared slot) and install the
-    /// adopted one. This makes both-create adoption idempotent: a duplicate
-    /// Welcome is a safe no-op rather than a re-brick.
+    /// Staging the incoming Welcome (`StagedWelcome::new_from_welcome`) is the
+    /// step that consumes the one-time key package, so it is the natural failure
+    /// point: if the key package is unavailable — e.g. a retransmitted Welcome we
+    /// already adopted, or a first-contact key-package race — staging returns
+    /// `Err` **before** we touch the existing group, which is therefore left
+    /// completely intact. This makes both-create adoption idempotent: a duplicate
+    /// Welcome is a safe no-op rather than a re-brick, the case this method exists
+    /// to handle.
+    ///
+    /// Caveat — once staging succeeds the swap is **not atomic**. We delete the
+    /// prior group (to avoid orphaning its old-leaf epoch encryption keypairs,
+    /// which are keyed by `(group_id, epoch, leaf_index)`; the adopted group
+    /// installs at a different leaf and so would not overwrite them) and then call
+    /// `into_group`, which performs several sequential, non-transactional storage
+    /// writes. If one of those fails (e.g. a Keychain/Keystore write error), the
+    /// old group is already gone and the new one is absent — a lost session. The
+    /// key package is spent by then, so the same Welcome cannot simply be retried;
+    /// recovery is a fresh key-package exchange. The caller distinguishes this
+    /// "lost group" outcome from a benign duplicate by observing `has_session`
+    /// (false here, true for a duplicate) and surfaces it as a session failure.
     pub fn join_group_replacing(&self, welcome: Welcome, group_id: &GroupId) -> Result<MlsGroup> {
         let group_config = MlsGroupJoinConfig::builder()
             .use_ratchet_tree_extension(true)
             .build();
 
         // Stage first — non-destructive failure point (consumes the key package).
+        // A failure here leaves the existing group untouched (benign duplicate).
         let staged = StagedWelcome::new_from_welcome(&self.provider, &group_config, welcome, None)
             .map_err(|e| MlsError::WelcomeProcessing(format!("Failed to stage welcome: {}", e)))?;
 
-        // Staging succeeded: it is now safe to drop any prior group at this id so
-        // `into_group` writes a clean slot at the shared MLS group id.
-        if self.load_group(group_id)?.is_some() {
-            self.delete_group(group_id)?;
-        }
+        // Staging consumed the key package; from here a failure is not
+        // recoverable by retrying the same Welcome. Drop the prior group so its
+        // old-leaf epoch keypairs are not orphaned. `delete_group` already
+        // no-ops on absence and tolerates a corrupt prior group, so call it
+        // unconditionally — a redundant `load_group` here would only add another
+        // fallible storage read that could abort the join with the key package
+        // already spent.
+        self.delete_group(group_id)?;
 
-        let group = staged
-            .into_group(&self.provider)
-            .map_err(|e| MlsError::WelcomeProcessing(format!("Failed to join group: {}", e)))?;
+        let group = staged.into_group(&self.provider).map_err(|e| {
+            // Distinct message from the staging failure above: the prior group is
+            // already deleted and the key package is spent, so this is the
+            // non-atomic "lost group" window, not a benign duplicate.
+            MlsError::WelcomeProcessing(format!(
+                "Failed to install adopted group (prior group removed, key package consumed): {}",
+                e
+            ))
+        })?;
 
         self.save_group(group_id, &group)?;
 
-        debug!(group_id = %group_id, "Joined/adopted group via Welcome (non-destructive)");
+        debug!(group_id = %group_id, "Joined/adopted group via Welcome (non-destructive stage, best-effort swap)");
         Ok(group)
     }
 

--- a/crates/offline-protocol-mls/src/manager.rs
+++ b/crates/offline-protocol-mls/src/manager.rs
@@ -355,7 +355,9 @@ impl MlsManager {
         let key_type = StorageKeyType::ContactKeyPackage.as_str();
         let _ = self.storage.delete(key_type, other_user_id);
 
-        // Join using their Welcome (session.join_session handles deleting our existing session)
+        // Join using their Welcome. `join_session` adopts non-destructively
+        // (stage-then-swap), so a retransmitted Welcome that re-stages is a safe
+        // no-op rather than deleting and re-creating our existing session.
         self.session_manager.join_session(welcome)
     }
 
@@ -1204,6 +1206,9 @@ mod tests {
             .encrypt_for_user("bob", b"still converged after retransmit")
             .unwrap();
         let pt2 = bob.decrypt_from_user(&ct2).unwrap();
-        assert_eq!(pt2.as_deref(), Some(&b"still converged after retransmit"[..]));
+        assert_eq!(
+            pt2.as_deref(),
+            Some(&b"still converged after retransmit"[..])
+        );
     }
 }

--- a/crates/offline-protocol-mls/src/manager.rs
+++ b/crates/offline-protocol-mls/src/manager.rs
@@ -1141,4 +1141,69 @@ mod tests {
         let groups = manager.list_groups().unwrap();
         assert_eq!(groups.len(), 1);
     }
+
+    /// Regression test for the both-create split-brain re-brick.
+    ///
+    /// With auto key exchange, both peers create a `session:a:b` group and the
+    /// higher-id peer adopts the lower-id "owner"'s Welcome. The owner keeps
+    /// retransmitting its Welcome until it sees a group-aware proof, so the
+    /// adopter receives the SAME Welcome again *after* it already adopted. MLS
+    /// key packages are one-time, so re-staging that Welcome must fail — but it
+    /// must fail NON-DESTRUCTIVELY, leaving the converged group intact. The old
+    /// delete-then-stage path deleted the good group first and then could not
+    /// re-stage, permanently bricking a working session.
+    #[test]
+    fn test_both_create_adopt_is_non_destructive_on_welcome_retransmit() {
+        // alice = lexicographically-lower "owner"; bob = higher "adopter".
+        let alice = create_test_manager("alice");
+        let bob = create_test_manager("bob");
+
+        // Exchange key packages both ways (both sides will auto-create).
+        let alice_kp = alice.generate_key_package().unwrap();
+        let bob_kp = bob.generate_key_package().unwrap();
+        alice
+            .import_key_package("bob", &bob_kp.key_package_data)
+            .unwrap();
+        bob.import_key_package("alice", &alice_kp.key_package_data)
+            .unwrap();
+
+        // Both-create race: each peer creates its own session group + Welcome.
+        let alice_welcome = alice.create_session("bob").unwrap(); // owner's Welcome
+        let _bob_welcome = bob.create_session("alice").unwrap(); // adopter's own group
+        assert!(bob.has_session("alice").unwrap());
+
+        // Adopter adopts the owner's Welcome (first delivery): replaces its own
+        // group with alice's, consuming bob's one-time key package.
+        bob.join_session(&alice_welcome).unwrap();
+        assert!(bob.has_session("alice").unwrap());
+
+        // Convergence: alice encrypts and bob decrypts on the shared group.
+        let ct = alice
+            .encrypt_for_user("bob", b"hello over the converged group")
+            .unwrap();
+        let pt = bob.decrypt_from_user(&ct).unwrap();
+        assert_eq!(pt.as_deref(), Some(&b"hello over the converged group"[..]));
+
+        // Owner retransmits the SAME Welcome (its periodic retry). Re-staging
+        // MUST fail (bob's key package is consumed) but MUST be non-destructive.
+        let retransmit = bob.join_session(&alice_welcome);
+        assert!(
+            retransmit.is_err(),
+            "re-staging a consumed key package should fail"
+        );
+
+        // The converged group MUST survive the failed retransmit. This is the
+        // regression: the old delete-then-stage path left bob with no session.
+        assert!(
+            bob.has_session("alice").unwrap(),
+            "duplicate Welcome must not brick the converged session"
+        );
+
+        // ...and it must still be functional after the failed retransmit.
+        let ct2 = alice
+            .encrypt_for_user("bob", b"still converged after retransmit")
+            .unwrap();
+        let pt2 = bob.decrypt_from_user(&ct2).unwrap();
+        assert_eq!(pt2.as_deref(), Some(&b"still converged after retransmit"[..]));
+    }
 }

--- a/crates/offline-protocol-mls/src/session.rs
+++ b/crates/offline-protocol-mls/src/session.rs
@@ -99,23 +99,14 @@ impl SessionManager {
 
     /// Joins a session using a Welcome message.
     ///
-    /// Implements "welcome-wins" strategy: if we already created a session for this peer
-    /// (race condition), we delete our session and adopt the incoming Welcome instead.
-    /// This ensures both peers end up with the same cryptographic state.
+    /// Implements a **non-destructive** "welcome-wins" strategy: if we already
+    /// created a session for this peer (both-create race), the incoming Welcome
+    /// is staged first and only replaces our group once staging succeeds (see
+    /// [`crate::group::GroupManager::join_group_replacing`]). A retransmitted
+    /// Welcome we already adopted, or a first-contact key-package race, fails to
+    /// stage and leaves the existing converged group intact — so adoption is
+    /// idempotent and never bricks a working session.
     pub fn join_session(&self, welcome_msg: &WelcomeMessage) -> Result<GroupInfo> {
-        let session_id = GroupId::from(welcome_msg.group_id.as_str());
-
-        // Welcome-wins: If we already created a session for this peer,
-        // delete it and use the incoming Welcome instead
-        if self.group_manager.load_group(&session_id)?.is_some() {
-            info!(
-                session_id = %session_id,
-                inviter = %welcome_msg.inviter_id,
-                "Welcome-wins: replacing existing session with incoming Welcome"
-            );
-            self.group_manager.delete_group(&session_id)?;
-        }
-
         // Deserialize the Welcome from the MlsMessageOut bytes
         let mls_msg = MlsMessageIn::tls_deserialize_exact(&welcome_msg.welcome_data)
             .map_err(|e| MlsError::Deserialization(e.to_string()))?;
@@ -130,9 +121,11 @@ impl SessionManager {
             }
         };
 
+        // Stage-then-swap: replaces any existing group only after the incoming
+        // Welcome stages successfully, so a failed stage is a safe no-op.
         let group = self
             .group_manager
-            .join_group(welcome, &welcome_msg.group_id)?;
+            .join_group_replacing(welcome, &welcome_msg.group_id)?;
         let info = self
             .group_manager
             .get_group_info(&group, &welcome_msg.group_id);
@@ -140,7 +133,7 @@ impl SessionManager {
         info!(
             session_id = %welcome_msg.group_id,
             inviter = %welcome_msg.inviter_id,
-            "Joined 1:1 session"
+            "Joined/adopted 1:1 session (non-destructive)"
         );
 
         Ok(info)

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -604,6 +604,15 @@ impl TransportSelector {
             }
 
             let score = self.calculate_transport_score(message, *transport_type, metrics);
+            // INVARIANT: `score.total` recorded here may be the *negative*
+            // fallback-demotion sentinel for a demoted Internet transport
+            // (prefer_online=false), not a real 0–125 quality score. The
+            // stability-window consumers (`is_stable_better` / `get_scores_in_window`)
+            // tolerate this by sign today (it makes "leave Internet for mesh"
+            // trivially allowed, which matches intent). Any FUTURE consumer that
+            // *aggregates* this history across transports (e.g. a global average)
+            // must first map entries through `display_routing_score`, or the
+            // sentinel will skew the result.
             self.record_score(*transport_type, score.total);
             scored_transports.push((*transport_type, score));
         }
@@ -648,6 +657,11 @@ impl TransportSelector {
         // Log all scored transports for observability.
         // Guard allocation behind level check to avoid Vec<String> on every call.
         if tracing::enabled!(tracing::Level::DEBUG) {
+            // These are the RAW totals, intentionally NOT passed through
+            // `display_routing_score`: a negative Internet total here is the
+            // fallback-demotion rank (prefer_online=false), and showing it raw is
+            // exactly what explains why a lower-quality mesh transport outranks it.
+            // Sanitizing here would hide the demotion and make selection look wrong.
             let scores_summary: Vec<_> = scored_transports
                 .iter()
                 .map(|(t, s)| format!("{:?}={:.1}", t, s.total))
@@ -898,11 +912,24 @@ impl TransportSelector {
             return false;
         }
 
-        // Emergency bypass: if current transport has critical degradation, switch immediately.
-        // `candidate_score` is the best (argmax) score, so it is always a non-negative mesh
-        // score whenever Internet is fallback-demoted (the negative sentinel can only be the
-        // *best* when Internet is the sole transport, and then `should_switch` is not reached).
-        // So the `> 10.0` "reasonable candidate" floor never sees the demotion sentinel.
+        // Emergency bypass: if current transport has critical degradation, switch
+        // immediately to any reasonably scored candidate. `candidate_score` is the
+        // argmax score, so whenever Internet is fallback-demoted it is a
+        // non-negative mesh score (the negative sentinel can only be the argmax
+        // when Internet is the sole transport, and then `should_switch` is not
+        // reached), so the `> 10.0` floor never sees the sentinel.
+        //
+        // IMPORTANT behavioral note for prefer_online=false: when the ONLY
+        // alternative to a critically degraded mesh link is the demoted Internet,
+        // `best_transport` is still that mesh link (demoted Internet ranks below
+        // it), so `select_transport` returns early on `current == best_transport`
+        // BEFORE reaching this emergency check. Proactive mesh→Internet escalation
+        // is therefore intentionally delegated to the `send()` fallback loop (which
+        // escalates only when a mesh send returns a hard error), NOT driven from
+        // here. Consequence: a mesh link that is degraded yet still returns Ok from
+        // send() is not proactively abandoned for Internet — by design, to keep the
+        // offline-first preference. Do not read this bypass as a general mesh→
+        // Internet safety net under the default config.
         if self.is_emergency_switch_needed(current_transport) {
             return candidate_score > 10.0; // Any reasonably scored candidate is acceptable
         }
@@ -1818,7 +1845,10 @@ mod tests {
     fn test_display_routing_score_reverses_fallback_demotion() {
         // A demoted Internet total (real score 42 minus the demotion) recovers to 42.
         let demoted = 42.0 - INTERNET_FALLBACK_DEMOTION;
-        assert!(demoted < 0.0, "precondition: demotion makes the total negative");
+        assert!(
+            demoted < 0.0,
+            "precondition: demotion makes the total negative"
+        );
         assert!((display_routing_score(demoted) - 42.0).abs() < 1e-3);
 
         // Normal mesh scores pass through untouched.
@@ -1838,7 +1868,10 @@ mod tests {
         let raw = selector
             .calculate_transport_score(&message, TransportType::Internet, &metrics)
             .total;
-        assert!(raw < 0.0, "Internet is demoted negative under default config");
+        assert!(
+            raw < 0.0,
+            "Internet is demoted negative under default config"
+        );
         assert!(display_routing_score(raw) >= 0.0);
     }
 

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -102,6 +102,14 @@ const TIE_EPSILON: f32 = 0.01;
 /// "we don't know the signal yet").
 const SIGNAL_SCORE_NO_DATA: f32 = 50.0;
 
+/// Demotion subtracted from the Internet transport's score to make it a strict
+/// *fallback* (only chosen when no mesh transport can reach the peer). Applied
+/// only when `prefer_online == false` and the message is not internet-preferred.
+/// Large enough to push Internet below every possible mesh score (max ≈ 125),
+/// so it ranks last while remaining the sole candidate for genuinely remote
+/// peers where no mesh transport is available. See `calculate_transport_score`.
+const INTERNET_FALLBACK_DEMOTION: f32 = 10_000.0;
+
 /// Tie-break priority for transport selection when scores are equal or within TIE_EPSILON.
 /// Lower value = preferred. Order: Internet, WiFiDirect, BLE, Reticulum.
 ///
@@ -813,7 +821,7 @@ impl TransportSelector {
         };
 
         let w = &profile.weights;
-        let total = (profile.base_score
+        let mut total = (profile.base_score
             + media_adjust
             + (signal_score * w.signal)
             + (proximity_score * w.proximity)
@@ -823,6 +831,25 @@ impl TransportSelector {
             + (reliability_score * w.reliability)
             + (load_score * w.load))
             .max(0.0);
+
+        // Internet-as-fallback. When the caller is not preferring online and the
+        // message is not internet-preferred (media/file chunks), demote Internet
+        // far below every mesh transport so DORS only escalates to it when a mesh
+        // send reports the peer unreachable (the fallback loop in
+        // TransportManager::send). This keeps a nearby peer on BLE/Wi-Fi-Direct —
+        // which an app-level relay bridge cannot reach when that peer is off the
+        // relay — while still leaving Internet as the sole candidate for a
+        // genuinely remote peer (no mesh transport available at all). The score
+        // goes negative here on purpose; selection only cares about relative
+        // order, and Internet must rank below mesh's 0–100 band. With
+        // `prefer_online == true` the historical internet-first behaviour is
+        // unchanged.
+        if transport_type == TransportType::Internet
+            && !self.config.prefer_online
+            && !prefers_internet
+        {
+            total -= INTERNET_FALLBACK_DEMOTION;
+        }
 
         TransportScore {
             signal: signal_score,
@@ -1702,6 +1729,61 @@ mod tests {
         assert_eq!(selected, TransportType::Internet);
     }
 
+    /// Internet is a *fallback* transport when prefer_online is false: a mesh
+    /// transport wins when available, Internet is only chosen when no mesh
+    /// transport is available (a genuinely remote peer), and an internet-
+    /// preferred (media) message keeps Internet on top.
+    #[test]
+    fn test_internet_is_fallback_when_not_prefer_online() {
+        // Default config => prefer_online = false.
+        let message = create_test_message();
+
+        let mut both = HashMap::new();
+        both.insert(TransportType::Internet, create_test_metrics(None, 0.0, 0));
+        both.insert(TransportType::BLE, create_test_metrics(Some(-60), 0.1, 5));
+
+        // score_and_rank (drives the fallback order): BLE first, Internet last
+        // but still present as a fallback candidate.
+        let mut selector = TransportSelector::new();
+        let ranked = selector.score_and_rank(&message, &both);
+        assert_eq!(
+            ranked[0].0,
+            TransportType::BLE,
+            "mesh must outrank Internet when prefer_online = false (ranked: {ranked:?})",
+        );
+        assert!(
+            ranked.iter().any(|(t, _)| *t == TransportType::Internet),
+            "Internet must remain a candidate for fallback, just ranked last",
+        );
+        assert_eq!(
+            selector.select_transport(&message, &both),
+            Some(TransportType::BLE),
+            "primary selection must be mesh, not Internet",
+        );
+
+        // Only Internet available (remote peer): Internet must still be selected.
+        let mut internet_only = HashMap::new();
+        internet_only.insert(TransportType::Internet, create_test_metrics(None, 0.0, 0));
+        let mut remote_selector = TransportSelector::new();
+        assert_eq!(
+            remote_selector.select_transport(&message, &internet_only),
+            Some(TransportType::Internet),
+            "Internet must be selected when it is the only available transport",
+        );
+
+        // Media message (transport_preference = internet): Internet not demoted.
+        let mut media = create_test_message();
+        media
+            .metadata
+            .insert("transport_preference".to_string(), "internet".to_string());
+        let mut media_selector = TransportSelector::new();
+        assert_eq!(
+            media_selector.select_transport(&media, &both),
+            Some(TransportType::Internet),
+            "an internet-preferred (media) message must keep Internet on top",
+        );
+    }
+
     #[test]
     fn test_hysteresis_prevents_switching() {
         let mut selector = TransportSelector::new();
@@ -2107,7 +2189,11 @@ mod tests {
         );
         for (tt, score) in &ranked {
             assert!(score.is_finite(), "Score for {:?} must be finite", tt);
-            assert!(*score >= 0.0, "Score for {:?} must be non-negative", tt);
+            // Internet is demoted to a negative fallback sentinel under the
+            // default (prefer_online = false) config; mesh transports stay >= 0.
+            if *tt != TransportType::Internet {
+                assert!(*score >= 0.0, "Score for {:?} must be non-negative", tt);
+            }
         }
         let scores: Vec<f32> = ranked.iter().map(|(_, s)| *s).collect();
         let sorted: Vec<f32> = {
@@ -2179,11 +2265,15 @@ mod tests {
                 "Missing metrics must not produce NaN for {:?}",
                 tt
             );
-            assert!(
-                !score.is_nan() && *score >= 0.0,
-                "Missing metrics must yield safe default score for {:?}",
-                tt
-            );
+            // Internet is demoted to a negative fallback sentinel under the
+            // default config; mesh transports stay >= 0.
+            if *tt != TransportType::Internet {
+                assert!(
+                    !score.is_nan() && *score >= 0.0,
+                    "Missing metrics must yield safe default score for {:?}",
+                    tt
+                );
+            }
         }
     }
 
@@ -2416,7 +2506,10 @@ mod tests {
         let mut metrics = create_test_metrics(None, 0.0, 0);
         metrics.bandwidth_bps = Some(5_000_000); // 5 Mbps
         let score = selector.calculate_transport_score(&message, TransportType::Internet, &metrics);
-        assert!(score.total.is_finite() && score.total >= 0.0);
+        // total is finite; under the default (prefer_online = false) config the
+        // Internet total is demoted negative (fallback), so we assert finiteness
+        // only. The sub-scores below are unaffected by the demotion.
+        assert!(score.total.is_finite());
         assert!(score.bandwidth >= 0.0 && score.bandwidth <= 100.0);
         assert!(score.reliability >= 0.0 && score.reliability <= 100.0);
     }
@@ -2511,11 +2604,15 @@ mod tests {
                 "total must be finite for {:?}",
                 transport_type
             );
-            assert!(
-                score.total >= 0.0,
-                "total must be non-negative for {:?}",
-                transport_type
-            );
+            // Internet is demoted to a negative fallback sentinel under the
+            // default config; mesh transports stay >= 0.
+            if transport_type != TransportType::Internet {
+                assert!(
+                    score.total >= 0.0,
+                    "total must be non-negative for {:?}",
+                    transport_type
+                );
+            }
             assert!(score.bandwidth >= 0.0 && score.bandwidth <= 100.0);
             assert!(score.congestion >= 0.0 && score.congestion <= 100.0);
         }
@@ -2867,10 +2964,19 @@ mod tests {
         // Verify all scores are finite and non-negative.
         for (label, score) in [("BLE", &ble), ("WiFiDirect", &wifi), ("Internet", &inet)] {
             assert!(
-                score.total.is_finite() && score.total >= 0.0,
-                "{label} score must be finite and non-negative, got {}",
+                score.total.is_finite(),
+                "{label} score must be finite, got {}",
                 score.total,
             );
+            // Internet is demoted to a negative fallback sentinel under the
+            // default config; mesh transports stay >= 0.
+            if label != "Internet" {
+                assert!(
+                    score.total >= 0.0,
+                    "{label} score must be non-negative, got {}",
+                    score.total,
+                );
+            }
         }
 
         // With good RSSI (-60) and 75% battery, BLE's energy-efficiency weighting

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -110,6 +110,29 @@ const SIGNAL_SCORE_NO_DATA: f32 = 50.0;
 /// peers where no mesh transport is available. See `calculate_transport_score`.
 const INTERNET_FALLBACK_DEMOTION: f32 = 10_000.0;
 
+/// Recovers the real 0–125 quality score from a (possibly demoted) routing
+/// `total` for telemetry / display.
+///
+/// [`INTERNET_FALLBACK_DEMOTION`] is a pure *ranking* device: it pushes the
+/// Internet transport below every mesh score so selection only escalates to it
+/// as a last resort. That sentinel must never leak to app-facing telemetry
+/// (events, routing decisions, the UniFFI boundary) — a dashboard reading a
+/// "score" of ≈ -9900 for a remote peer is nonsense. Selection keeps the raw
+/// (negative) total internally; consumers that *display* a score call this.
+///
+/// The demotion is detectable by sign: a non-demoted total is always `>= 0`
+/// (it is `.max(0.0)`'d in `calculate_transport_score`), and a demoted Internet
+/// total is `real - INTERNET_FALLBACK_DEMOTION` with `real ∈ [0, ~125]`, so
+/// adding the demotion back recovers the real score exactly. Idempotent — safe
+/// to apply to an already-sanitized (non-negative) value.
+pub fn display_routing_score(raw_total: f32) -> f32 {
+    if raw_total < 0.0 {
+        (raw_total + INTERNET_FALLBACK_DEMOTION).max(0.0)
+    } else {
+        raw_total
+    }
+}
+
 /// Tie-break priority for transport selection when scores are equal or within TIE_EPSILON.
 /// Lower value = preferred. Order: Internet, WiFiDirect, BLE, Reticulum.
 ///
@@ -875,7 +898,11 @@ impl TransportSelector {
             return false;
         }
 
-        // Emergency bypass: if current transport has critical degradation, switch immediately
+        // Emergency bypass: if current transport has critical degradation, switch immediately.
+        // `candidate_score` is the best (argmax) score, so it is always a non-negative mesh
+        // score whenever Internet is fallback-demoted (the negative sentinel can only be the
+        // *best* when Internet is the sole transport, and then `should_switch` is not reached).
+        // So the `> 10.0` "reasonable candidate" floor never sees the demotion sentinel.
         if self.is_emergency_switch_needed(current_transport) {
             return candidate_score > 10.0; // Any reasonably scored candidate is acceptable
         }
@@ -1782,6 +1809,37 @@ mod tests {
             Some(TransportType::Internet),
             "an internet-preferred (media) message must keep Internet on top",
         );
+    }
+
+    /// `display_routing_score` must recover the real 0–125 quality score from the
+    /// negative fallback-demotion sentinel (so telemetry never leaks ≈ -9900),
+    /// be the identity for normal mesh scores, and be idempotent.
+    #[test]
+    fn test_display_routing_score_reverses_fallback_demotion() {
+        // A demoted Internet total (real score 42 minus the demotion) recovers to 42.
+        let demoted = 42.0 - INTERNET_FALLBACK_DEMOTION;
+        assert!(demoted < 0.0, "precondition: demotion makes the total negative");
+        assert!((display_routing_score(demoted) - 42.0).abs() < 1e-3);
+
+        // Normal mesh scores pass through untouched.
+        assert_eq!(display_routing_score(0.0), 0.0);
+        assert_eq!(display_routing_score(73.5), 73.5);
+        assert_eq!(display_routing_score(125.0), 125.0);
+
+        // Idempotent: applying it to an already-sanitized value is a no-op.
+        let once = display_routing_score(demoted);
+        assert_eq!(display_routing_score(once), once);
+
+        // And the live demotion path: an Internet-only selection still scores
+        // negative INTERNALLY, but display_routing_score sanitizes it to >= 0.
+        let selector = TransportSelector::new();
+        let message = create_test_message();
+        let metrics = create_test_metrics(None, 0.0, 0);
+        let raw = selector
+            .calculate_transport_score(&message, TransportType::Internet, &metrics)
+            .total;
+        assert!(raw < 0.0, "Internet is demoted negative under default config");
+        assert!(display_routing_score(raw) >= 0.0);
     }
 
     #[test]

--- a/crates/offline-protocol-router/src/lib.rs
+++ b/crates/offline-protocol-router/src/lib.rs
@@ -18,7 +18,8 @@ pub mod ttl;
 
 pub use congestion::{CongestionConfig, CongestionController, DeliveryOutcome, SendDecision};
 pub use dors::{
-    DorsConfig, EscalationTriggerReason, TransportScore, TransportScoreFactors, TransportSelector,
+    display_routing_score, DorsConfig, EscalationTriggerReason, TransportScore,
+    TransportScoreFactors, TransportSelector,
 };
 pub use error::{Error, Result};
 pub use relay::{RelayConfig, RelayDemotionReason, RelayManager, RelayRole, RelayTransition};

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -63,8 +63,16 @@ struct FragmentAssembly {
     total_fragments: u16,
     /// Received fragments (index -> data)
     fragments: HashMap<u16, Vec<u8>>,
-    /// First fragment received time
+    /// First fragment received time. Anchors the assembly-latency metric and
+    /// the eviction-priority age penalty — NOT the idle timeout.
     started_at: SystemTime,
+    /// Time the most recent fragment was inserted. The idle timeout in
+    /// [`Self::cleanup_fragment_buffers`] is measured from this, not
+    /// [`started_at`], so a large/slow multi-fragment message that is still
+    /// arriving is not evicted mid-flight just because its first fragment is
+    /// old (e.g. a backgrounded receiver, a 100-200ms connection interval, or
+    /// an iOS->Android sender with no per-write pacing).
+    last_seen: SystemTime,
 }
 
 impl FragmentAssembly {
@@ -490,8 +498,11 @@ impl BleTransport {
         let mut expired = Vec::new();
 
         for (message_id, assembly) in buffers.iter() {
+            // Idle timeout: evict only buffers with no fragment received within
+            // the window (measured from last_seen, not started_at), so a slow
+            // but still-arriving message is never torn mid-assembly.
             if now
-                .duration_since(assembly.started_at)
+                .duration_since(assembly.last_seen)
                 .unwrap_or_else(|_| StdDuration::from_secs(0))
                 > StdDuration::from_secs(BLE_FRAGMENT_TIMEOUT_SECS)
             {
@@ -769,6 +780,7 @@ impl BleTransport {
                     total_fragments: fragment.total_fragments,
                     fragments: HashMap::new(),
                     started_at: now,
+                    last_seen: now,
                 });
 
             // Validate fragment
@@ -782,6 +794,10 @@ impl BleTransport {
             assembly
                 .fragments
                 .insert(fragment.fragment_index, fragment.data);
+            // Idle-timeout anchor: refresh on every fragment so an actively
+            // arriving multi-fragment message keeps its buffer alive past the
+            // BLE_FRAGMENT_TIMEOUT_SECS window measured from the first fragment.
+            assembly.last_seen = now;
 
             // Check if complete
             if assembly.fragments.len() == assembly.total_fragments as usize {
@@ -1243,6 +1259,7 @@ mod tests {
                 total_fragments: 2,
                 fragments: HashMap::new(),
                 started_at: SystemTime::now(),
+                last_seen: SystemTime::now(),
             },
         );
 

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -797,6 +797,12 @@ impl BleTransport {
             // Idle-timeout anchor: refresh on every fragment so an actively
             // arriving multi-fragment message keeps its buffer alive past the
             // BLE_FRAGMENT_TIMEOUT_SECS window measured from the first fragment.
+            // Security note: a peer dribbling one fragment per sub-timeout interval
+            // can therefore hold a partial assembly open indefinitely (vs. a hard
+            // first-fragment deadline). The exposure is bounded by the
+            // BLE_MAX_FRAGMENT_ASSEMBLIES cap + low-progress priority eviction, and
+            // is the deliberate tradeoff for not tearing a slow-but-legitimate
+            // multi-fragment message mid-flight.
             assembly.last_seen = now;
 
             // Check if complete

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -430,6 +430,19 @@ pub enum Event {
         reason: String,
     },
 
+    /// Diagnostic breadcrumb for the 1:1 MLS convergence (Welcome receive /
+    /// adopt / confirm) path. Emitted so the receiver side — which otherwise
+    /// produces no event until it fully establishes or loudly fails — is
+    /// observable in Metro. Pure instrumentation; carries no protocol effect.
+    ConvergenceDiag {
+        /// Fixed stage label, e.g. "welcome_received" or "welcome_branch".
+        stage: String,
+        /// Peer ID this breadcrumb concerns.
+        peer_id: String,
+        /// Free-form `key=value` context (counts, branch taken, errors).
+        detail: String,
+    },
+
     /// Welcome send lifecycle entered attempted state.
     WelcomeSendAttempted {
         /// Peer identifier for this welcome lifecycle.
@@ -1100,6 +1113,15 @@ impl Event {
         Self::SecureSessionFailed { peer_id, reason }
     }
 
+    /// Creates a ConvergenceDiag event (1:1 MLS convergence instrumentation).
+    pub fn convergence_diag(stage: String, peer_id: String, detail: String) -> Self {
+        Self::ConvergenceDiag {
+            stage,
+            peer_id,
+            detail,
+        }
+    }
+
     /// Creates a WelcomeSendAttempted event.
     pub fn welcome_send_attempted(
         peer_id: String,
@@ -1576,6 +1598,7 @@ impl Event {
             Self::RelayDemotedBattery { .. } => "protocol.relay.demoted_battery",
             Self::SecureSessionEstablished { .. } => "protocol.secure_session.established",
             Self::SecureSessionFailed { .. } => "protocol.secure_session.failed",
+            Self::ConvergenceDiag { .. } => "protocol.convergence.diag",
             Self::WelcomeSendAttempted { .. } => "protocol.welcome.send_attempted",
             Self::WelcomeSendSucceeded { .. } => "protocol.welcome.send_succeeded",
             Self::WelcomeSendFailed { .. } => "protocol.welcome.send_failed",
@@ -1891,6 +1914,16 @@ impl fmt::Debug for Event {
                 .debug_struct("SecureSessionFailed")
                 .field("peer_id", &"[REDACTED]")
                 .field("reason", reason)
+                .finish(),
+            Self::ConvergenceDiag {
+                stage,
+                peer_id: _,
+                detail,
+            } => f
+                .debug_struct("ConvergenceDiag")
+                .field("stage", stage)
+                .field("peer_id", &"[REDACTED]")
+                .field("detail", detail)
                 .finish(),
             Self::WelcomeSendAttempted {
                 peer_id: _,

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -248,20 +248,37 @@ impl OfflineProtocol {
                                     }
                                 }
                             }
-                        } else {
+                        } else if self.welcome_lifecycles.contains_key(sender) {
                             info!(
                                 sender = %sender,
                                 local_id = %local_id,
                                 "Welcome-wins tiebreaker: keeping local session (local < remote); \
                                  awaiting group-aware decrypt before confirming our Welcome"
                             );
-                            // Owner side of a both-create race: keep our own group, but do NOT
-                            // confirm our outbound Welcome merely because we received the peer's.
-                            // Receiving their Welcome is no proof they received ours, so confirming
-                            // here would mark our Welcome Sent and stop retransmission — the
-                            // convergence bug. Keep retransmitting until a decrypt proves they
-                            // adopted our group.
+                            // Genuine both-create owner: we created our OWN group for this
+                            // peer AND sent a Welcome (hence an outbound welcome lifecycle
+                            // exists). Keep our group, but do NOT confirm our outbound
+                            // Welcome merely because we received the peer's — that is no
+                            // proof they adopted ours. Keep retransmitting until a decrypt
+                            // proves they adopted our group.
                             owner_keep = true;
+                        } else {
+                            // NOT a both-create owner: we have no outbound welcome
+                            // lifecycle for this peer, so we never created our own group —
+                            // we joined THEIR group via an earlier Welcome. This is the
+                            // owner re-sending its Welcome because it has not yet observed
+                            // our confirm. Re-send the encrypted confirm so a lost first
+                            // confirm self-heals in lockstep with the owner's
+                            // retransmission. Critically, do NOT enter owner_keep: we are
+                            // the adopter, and gating on decrypt here (plus poisoning
+                            // both_create_awaiting_decrypt) would suppress our confirm and
+                            // strand the owner in Pending forever — the convergence bug.
+                            debug!(
+                                sender = %sender,
+                                local_id = %local_id,
+                                "Welcome retransmit for an already-adopted session; re-sending encrypted confirm"
+                            );
+                            resend_confirm_on_retransmit = true;
                         }
                     } else {
                         match manager.join_session(&welcome) {

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -193,6 +193,9 @@ impl OfflineProtocol {
 
             // Track if we need to flush pending messages and process pending decryption
             let mut should_flush = false;
+            // Owner side of a both-create race kept its own group; it must await a
+            // group-aware decrypt before confirming (see below).
+            let mut owner_keep = false;
             let sender_owned = sender.to_string();
             let group_id = welcome.group_id.as_str().to_string();
             let is_session = group_id.starts_with("session:");
@@ -222,17 +225,36 @@ impl OfflineProtocol {
                                     should_flush = true;
                                 }
                                 Err(e) => {
-                                    warn!(error = %e, sender = %sender, "Failed to replace session");
-                                    error_reason = Some(e.to_string());
+                                    // Non-destructive adopt: if our session survived, the
+                                    // staging failure is a retransmitted Welcome we already
+                                    // adopted (the one-time key package is consumed). It is a
+                                    // harmless duplicate — drop it instead of erroring/bricking.
+                                    if manager.has_session(sender).unwrap_or(false) {
+                                        debug!(
+                                            error = %e,
+                                            sender = %sender,
+                                            "Duplicate Welcome after adopt; already converged, ignoring"
+                                        );
+                                    } else {
+                                        warn!(error = %e, sender = %sender, "Failed to replace session");
+                                        error_reason = Some(e.to_string());
+                                    }
                                 }
                             }
                         } else {
                             info!(
                                 sender = %sender,
                                 local_id = %local_id,
-                                "Welcome-wins tiebreaker: keeping local session (local < remote)"
+                                "Welcome-wins tiebreaker: keeping local session (local < remote); \
+                                 awaiting group-aware decrypt before confirming our Welcome"
                             );
-                            should_flush = true;
+                            // Owner side of a both-create race: keep our own group, but do NOT
+                            // confirm our outbound Welcome merely because we received the peer's.
+                            // Receiving their Welcome is no proof they received ours, so confirming
+                            // here would mark our Welcome Sent and stop retransmission — the
+                            // convergence bug. Keep retransmitting until a decrypt proves they
+                            // adopted our group.
+                            owner_keep = true;
                         }
                     } else {
                         match manager.join_session(&welcome) {
@@ -247,6 +269,13 @@ impl OfflineProtocol {
                         }
                     }
                 }
+            }
+
+            // Owner side of a both-create race: record that this peer must prove
+            // it adopted our group via a group-aware decrypt before we confirm
+            // (and stop retransmitting). A plaintext probe/ack is not sufficient.
+            if owner_keep {
+                self.both_create_awaiting_decrypt.insert(sender_owned.clone());
             }
 
             // Confirm session and process queued items after releasing the MLS lock

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -204,10 +204,22 @@ impl OfflineProtocol {
             let group_id = welcome.group_id.as_str().to_string();
             let is_session = group_id.starts_with("session:");
             let mut error_reason: Option<String> = None;
+            // Receiver-side convergence instrumentation: prove the Welcome
+            // actually reassembled and reached MLS handling on THIS device.
+            // (Absent in logs => the Welcome never fully arrived — a transport
+            // problem; present => the problem is in adoption/confirm, not
+            // transport.) Emitted before taking the MLS lock.
+            let mut had_existing = false;
+            self.emit_event(Event::convergence_diag(
+                "welcome_received".to_string(),
+                sender_owned.clone(),
+                format!("group_id={} is_session={}", group_id, is_session),
+            ));
 
             if let Some(mls) = self.mls_manager.clone() {
                 if let Ok(manager) = mls.read() {
                     let has_existing = manager.has_session(sender).unwrap_or(false);
+                    had_existing = has_existing;
 
                     if has_existing {
                         // Both sides created a session and exchanged Welcomes.
@@ -300,6 +312,32 @@ impl OfflineProtocol {
             // (and stop retransmitting). A plaintext probe/ack is not sufficient.
             if owner_keep {
                 self.mark_both_create_awaiting_decrypt(&sender_owned);
+            }
+
+            // Receiver-side convergence instrumentation: which branch did this
+            // device take, and did adoption succeed? Decisive for the owner
+            // (iOS) side, which otherwise emits NOTHING on the owner_keep /
+            // resend_confirm / no-mls paths. Emitted after the MLS lock release.
+            {
+                let branch = if should_flush {
+                    "adopted"
+                } else if owner_keep {
+                    "owner_keep"
+                } else if resend_confirm_on_retransmit {
+                    "resend_confirm"
+                } else if error_reason.is_some() {
+                    "join_failed"
+                } else {
+                    "no_mls"
+                };
+                self.emit_event(Event::convergence_diag(
+                    "welcome_branch".to_string(),
+                    sender_owned.clone(),
+                    format!(
+                        "had_existing={} branch={} err={:?}",
+                        had_existing, branch, error_reason
+                    ),
+                ));
             }
 
             // Confirm session and process queued items after releasing the MLS lock
@@ -485,6 +523,15 @@ impl OfflineProtocol {
                     // Confirm as normal below, then consume it so it never surfaces as
                     // a chat message.
                     let is_session_confirm = text == internal_prefixes::SESSION_CONFIRM_ENCRYPTED;
+                    // Convergence instrumentation: a group-aware decrypt landed.
+                    // This is exactly what the both-create owner waits on to
+                    // confirm its own Welcome — seeing it (with is_confirm=true)
+                    // means the adopter's proof arrived and decrypted.
+                    self.emit_event(Event::convergence_diag(
+                        "decrypt_success".to_string(),
+                        sender_owned.clone(),
+                        format!("is_confirm={} group_id={}", is_session_confirm, group_id),
+                    ));
                     let surfaced = if is_session_confirm {
                         Some(InternalMessageResult::Consumed)
                     } else {

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -299,7 +299,7 @@ impl OfflineProtocol {
             // it adopted our group via a group-aware decrypt before we confirm
             // (and stop retransmitting). A plaintext probe/ack is not sufficient.
             if owner_keep {
-                self.both_create_awaiting_decrypt.insert(sender_owned.clone());
+                self.mark_both_create_awaiting_decrypt(&sender_owned);
             }
 
             // Confirm session and process queued items after releasing the MLS lock

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -210,10 +210,15 @@ impl OfflineProtocol {
             // problem; present => the problem is in adoption/confirm, not
             // transport.) Emitted before taking the MLS lock.
             let mut had_existing = false;
+            // NB: keep `detail` free of raw identifiers — the telemetry scrubber
+            // only hashes the named `peer_id` field, so anything embedded here
+            // ships in cleartext. `group_id` is `session:<localId>:<peerId>`, so
+            // it is deliberately omitted; the (hashed) peer_id already identifies
+            // the pair and `is_session` is the only non-identifying bit of value.
             self.emit_event(Event::convergence_diag(
                 "welcome_received".to_string(),
                 sender_owned.clone(),
-                format!("group_id={} is_session={}", group_id, is_session),
+                format!("is_session={}", is_session),
             ));
 
             if let Some(mls) = self.mls_manager.clone() {
@@ -330,12 +335,18 @@ impl OfflineProtocol {
                 } else {
                     "no_mls"
                 };
+                // `err_present` is a bool, not the raw error string: MLS error
+                // text can carry group/peer identifiers and `detail` is not
+                // scrubbed. The `join_failed` branch already flags the failure,
+                // and the scrubbed `SecureSessionFailed` event carries the reason.
                 self.emit_event(Event::convergence_diag(
                     "welcome_branch".to_string(),
                     sender_owned.clone(),
                     format!(
-                        "had_existing={} branch={} err={:?}",
-                        had_existing, branch, error_reason
+                        "had_existing={} branch={} err_present={}",
+                        had_existing,
+                        branch,
+                        error_reason.is_some()
                     ),
                 ));
             }
@@ -527,10 +538,13 @@ impl OfflineProtocol {
                     // This is exactly what the both-create owner waits on to
                     // confirm its own Welcome — seeing it (with is_confirm=true)
                     // means the adopter's proof arrived and decrypted.
+                    // `group_id` (= `session:<localId>:<peerId>`) is omitted: it
+                    // would leak both ids in cleartext through the unscrubbed
+                    // `detail`. The hashed `peer_id` already identifies the pair.
                     self.emit_event(Event::convergence_diag(
                         "decrypt_success".to_string(),
                         sender_owned.clone(),
-                        format!("is_confirm={} group_id={}", is_session_confirm, group_id),
+                        format!("is_confirm={}", is_session_confirm),
                     ));
                     let surfaced = if is_session_confirm {
                         Some(InternalMessageResult::Consumed)

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -196,6 +196,10 @@ impl OfflineProtocol {
             // Owner side of a both-create race kept its own group; it must await a
             // group-aware decrypt before confirming (see below).
             let mut owner_keep = false;
+            // Adopter side: on a Welcome RETRANSMIT for a group we already adopted,
+            // re-send the encrypted confirm so a lost first confirm is retried in
+            // lockstep with the owner's retransmission until it converges.
+            let mut resend_confirm_on_retransmit = false;
             let sender_owned = sender.to_string();
             let group_id = welcome.group_id.as_str().to_string();
             let is_session = group_id.starts_with("session:");
@@ -235,6 +239,9 @@ impl OfflineProtocol {
                                             sender = %sender,
                                             "Duplicate Welcome after adopt; already converged, ignoring"
                                         );
+                                        // Owner is still retransmitting → it hasn't
+                                        // decrypted our adoption proof yet. Re-send it.
+                                        resend_confirm_on_retransmit = true;
                                     } else {
                                         warn!(error = %e, sender = %sender, "Failed to replace session");
                                         error_reason = Some(e.to_string());
@@ -301,10 +308,22 @@ impl OfflineProtocol {
                             let _ = self.send_key_package_to(&sender_owned, false);
                         }
 
+                        // Proactively prove to the peer that we adopted ITS group.
+                        // The peer may be the both-create "owner", which confirms ONLY
+                        // on a group-aware decrypt from us (a plaintext probe/ack is
+                        // rejected by `can_confirm_from_source`); our session is
+                        // confirmed locally just above, so we can encrypt now. Without
+                        // this, a passive owner with no traffic to send never decrypts
+                        // anything from us, stays Pending, and the 1:1 connection never
+                        // completes. The marker is consumed on receipt (never shown).
+                        if is_session && self.config.encryption.enabled {
+                            self.send_session_confirm_encrypted(&sender_owned);
+                        }
+
                         // Emit secure session established event
                         if let Ok(state) = lock_shared_state(&self.shared_state) {
                             state.emit_event(Event::secure_session_established(
-                                sender_owned,
+                                sender_owned.clone(),
                                 group_id,
                                 is_session,
                                 false, // initiated_by_local is false - we received the Welcome
@@ -314,7 +333,7 @@ impl OfflineProtocol {
                     Err(e) => {
                         if let Ok(state) = lock_shared_state(&self.shared_state) {
                             state.emit_event(Event::secure_session_failed(
-                                sender_owned,
+                                sender_owned.clone(),
                                 format!("Failed to persist confirmation: {}", e),
                             ));
                         }
@@ -323,8 +342,18 @@ impl OfflineProtocol {
             } else if let Some(reason) = error_reason {
                 // Emit secure session failed event
                 if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::secure_session_failed(sender_owned, reason));
+                    state.emit_event(Event::secure_session_failed(sender_owned.clone(), reason));
                 }
+            }
+
+            // Retransmit case: we already adopted the owner's group (session
+            // confirmed earlier), but it is still retransmitting its Welcome
+            // because it has not decrypted our adoption proof. Re-send the
+            // encrypted confirm in lockstep so a lost confirm self-heals. (The
+            // owner stops retransmitting — and we stop re-sending — once it
+            // confirms via decrypt.)
+            if resend_confirm_on_retransmit && is_session && self.config.encryption.enabled {
+                self.send_session_confirm_encrypted(&sender_owned);
             }
         }
     }
@@ -434,12 +463,22 @@ impl OfflineProtocol {
                     sender: sender_owned,
                     group_id,
                 } => {
+                    // A proactive adopter confirm carries no user payload — its only
+                    // job is to BE a group-aware decrypt so we (the owner) can confirm.
+                    // Confirm as normal below, then consume it so it never surfaces as
+                    // a chat message.
+                    let is_session_confirm = text == internal_prefixes::SESSION_CONFIRM_ENCRYPTED;
+                    let surfaced = if is_session_confirm {
+                        Some(InternalMessageResult::Consumed)
+                    } else {
+                        Some(InternalMessageResult::Decrypted(text))
+                    };
                     if !self.can_confirm_from_source(&sender_owned, "decrypt_success") {
                         debug!(
                             sender = %sender_owned,
                             "Skipping decrypt-based confirmation until welcome send is at least attempted"
                         );
-                        Some(InternalMessageResult::Decrypted(text))
+                        surfaced
                     } else {
                         match self.confirm_session_state(&sender_owned, "decrypt_success") {
                             Ok(true) => {
@@ -460,7 +499,7 @@ impl OfflineProtocol {
                                 );
                             }
                         }
-                        Some(InternalMessageResult::Decrypted(text))
+                        surfaced
                     }
                 }
                 DecryptResult::Empty => {

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -1073,6 +1073,12 @@ impl OfflineProtocol {
         self.confirmed_sessions.remove(peer_id);
         self.clear_confirmation_recovery_tracking(peer_id);
         self.welcome_lifecycles.remove(peer_id);
+        // Drop the both-create owner gate too (memory + storage). A leaked gate
+        // entry would make `can_confirm_from_source` reject every non-decrypt
+        // confirmation source — including `welcome_received` — on the NEXT
+        // session with this peer, re-stranding it in Pending (and surviving
+        // restart via `restore_both_create_awaiting_decrypt`).
+        self.clear_both_create_awaiting_decrypt(peer_id);
         self.clear_session_state_entry(peer_id)?;
         self.clear_welcome_lifecycle_entry(peer_id)?;
         Ok(())

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -727,6 +727,11 @@ impl OfflineProtocol {
         // Flush any pending outbox messages destined for this peer
         self.flush_outbox_for_peer(peer_id);
 
+        // A Welcome that stalled or expired while this peer was unreachable now
+        // has a fresh delivery opportunity over the carrier that surfaced this
+        // peer — re-arm it. No-op when there is no pending Welcome for the peer.
+        self.rearm_welcome_for_peer(peer_id, "peer_rediscovered");
+
         // Only send key package if encryption is enabled and auto key exchange is on
         if !self.config.encryption.enabled || !self.config.encryption.auto_key_exchange {
             return;

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -127,8 +127,11 @@ pub struct OfflineProtocol {
     /// confirmation probe/ack is NOT group-aware (it only proves the peer holds
     /// *some* session, possibly its own pre-adoption group) and must not be
     /// allowed to stop our Welcome retransmission, or the peer could be left
-    /// stranded on a divergent group. In-memory only: rebuilt on the next
-    /// received Welcome after a restart.
+    /// stranded on a divergent group. Persisted (see
+    /// `restore_both_create_awaiting_decrypt`) so an owner restart mid-convergence
+    /// keeps the gate, rather than letting a stale plaintext probe/ack confirm
+    /// prematurely. Mutate only via `mark_both_create_awaiting_decrypt` /
+    /// `clear_both_create_awaiting_decrypt` to keep memory and storage in sync.
     both_create_awaiting_decrypt: std::collections::HashSet<String>,
 
     /// Sink for MLS lifecycle telemetry.
@@ -386,6 +389,7 @@ impl OfflineProtocol {
             self.restore_session_states_from_manager(manager.clone())?;
             self.restore_peer_key_packages(&manager)?;
             self.restore_welcome_lifecycles()?;
+            self.restore_both_create_awaiting_decrypt();
             Ok(())
         })();
 

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -120,6 +120,17 @@ pub struct OfflineProtocol {
     /// Outbound welcome lifecycle records keyed by peer id.
     welcome_lifecycles: HashMap<String, WelcomeLifecycleRecord>,
 
+    /// Peers for which we are the both-create "owner" (kept our own session
+    /// group on the lexicographic tiebreak) and are still awaiting a
+    /// *group-aware* proof that the peer adopted our group. While a peer is in
+    /// this set, only `decrypt_success` may confirm the session — a plaintext
+    /// confirmation probe/ack is NOT group-aware (it only proves the peer holds
+    /// *some* session, possibly its own pre-adoption group) and must not be
+    /// allowed to stop our Welcome retransmission, or the peer could be left
+    /// stranded on a divergent group. In-memory only: rebuilt on the next
+    /// received Welcome after a restart.
+    both_create_awaiting_decrypt: std::collections::HashSet<String>,
+
     /// Sink for MLS lifecycle telemetry.
     mls_event_emitter: Arc<dyn MlsEventEmitter>,
 
@@ -286,6 +297,7 @@ impl OfflineProtocol {
             confirmation_retry_due_at: HashMap::new(),
             confirmation_probe_due_at: HashMap::new(),
             welcome_lifecycles: HashMap::new(),
+            both_create_awaiting_decrypt: std::collections::HashSet::new(),
             mls_event_emitter: Arc::new(NoopMlsEventEmitter),
             mls_event_rate_limiter: MlsEventRateLimiter::default(),
             // The pre-install scrubber uses `TelemetryConfig::default()` —

--- a/crates/offline-protocol/src/protocol/prefixes.rs
+++ b/crates/offline-protocol/src/protocol/prefixes.rs
@@ -63,6 +63,12 @@ define_internal_prefixes! {
     SESSION_CONFIRM_PROBE = "__MLS_CONFIRM_PROBE__",
     /// Prefix for session confirmation acknowledgement messages.
     SESSION_CONFIRM_ACK = "__MLS_CONFIRM_ACK__",
+    /// Prefix for the MLS-encrypted session-confirm an adopter sends on adopting
+    /// the peer's Welcome. Only ever travels INSIDE an `ENCRYPTED` envelope, never
+    /// as a raw control message on the wire; its sole purpose is to be a
+    /// group-aware decrypt so the both-create "owner" (which confirms only on
+    /// `decrypt_success`) converges. Consumed on receipt — never surfaced to the app.
+    SESSION_CONFIRM_ENCRYPTED = "__MLS_ENC_CONFIRM__",
     /// Prefix for connection request messages.
     CONN_REQUEST = "__CONN_REQ__",
     /// Prefix for connection accepted messages.

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -379,8 +379,8 @@ impl OfflineProtocol {
             }
             Err(err) => {
                 let current_transport = self.transport_manager.current_transport();
-                let _ = self
-                    .handle_send_failure(&message, current_transport.or(previous_transport));
+                let _ =
+                    self.handle_send_failure(&message, current_transport.or(previous_transport));
                 debug!(
                     peer = %peer_id,
                     error = %err,

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -1574,8 +1574,17 @@ impl OfflineProtocol {
             return Ok(());
         };
         let reason = crate::events::WelcomeReasonCode::TransportUnavailable;
-        let _ =
-            self.apply_welcome_send_failure(&peer_id, reason, transport_error, "transport_failed")?;
+        // No raw error is available on this async path, so infer no-carrier from
+        // live connectivity: with no transport currently available the peer is
+        // simply unreachable and the Welcome must be kept alive, not aged.
+        let no_carrier = self.transport_manager.get_available_transports().is_empty();
+        let _ = self.apply_welcome_send_failure(
+            &peer_id,
+            reason,
+            transport_error,
+            no_carrier,
+            "transport_failed",
+        )?;
         Ok(())
     }
 

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -326,6 +326,70 @@ impl OfflineProtocol {
         Ok(message_id)
     }
 
+    /// Sends one MLS-encrypted session-confirm marker to `peer_id`.
+    ///
+    /// Used by the Welcome-adopt path: after we adopt the peer's `session:` group
+    /// (and confirm our own side), the peer may be the both-create "owner" that
+    /// kept its own group and confirms ONLY on a group-aware decrypt from us. A
+    /// plaintext probe/ack does not count, and we may have no user traffic to
+    /// send — so without this the owner stays Pending forever and the 1:1
+    /// connection never completes. The marker is `SESSION_CONFIRM_ENCRYPTED`
+    /// wrapped in the normal `ENCRYPTED` envelope; the peer consumes it on decrypt
+    /// (never surfaced). Mirrors [`Self::send_internal_message`] but encrypts
+    /// (data-plane, so NOT signed) and never propagates errors — it is re-sent on
+    /// every received Welcome while still adopting, so a lost confirm is retried
+    /// in lockstep with the owner's Welcome retransmission.
+    pub(super) fn send_session_confirm_encrypted(&mut self, peer_id: &str) {
+        let encrypted = match self.encrypt_content_for_recipient(
+            peer_id,
+            internal_prefixes::SESSION_CONFIRM_ENCRYPTED,
+            MessagePriority::High,
+        ) {
+            Ok(content) => content,
+            Err(err) => {
+                debug!(
+                    peer = %peer_id,
+                    error = %err,
+                    "Skipped proactive session-confirm (encryption not ready); welcome retry remains"
+                );
+                return;
+            }
+        };
+
+        let message =
+            match self.create_message(peer_id, encrypted, Some(MessagePriority::High), None) {
+                Ok(message) => message,
+                Err(err) => {
+                    warn!(peer = %peer_id, error = %err, "Failed to build session-confirm message");
+                    return;
+                }
+            };
+
+        if self.deduplicator.is_duplicate(&message.id) {
+            return;
+        }
+        self.deduplicator.mark_seen(message.id.clone());
+
+        let previous_transport = self.transport_manager.current_transport();
+        match self.transport_manager.send(&message) {
+            Ok(()) => {
+                let current_transport = self.transport_manager.current_transport();
+                let _ = self.handle_send_success(&message, current_transport);
+                info!(peer = %peer_id, "Sent proactive encrypted session-confirm to owner");
+            }
+            Err(err) => {
+                let current_transport = self.transport_manager.current_transport();
+                let _ = self
+                    .handle_send_failure(&message, current_transport.or(previous_transport));
+                debug!(
+                    peer = %peer_id,
+                    error = %err,
+                    "Proactive session-confirm deferred (will retry with welcome)"
+                );
+            }
+        }
+    }
+
     /// Sends a message via a specific transport type.
     pub fn send_message_via_transport(
         &mut self,

--- a/crates/offline-protocol/src/protocol/session.rs
+++ b/crates/offline-protocol/src/protocol/session.rs
@@ -4,7 +4,7 @@ use super::{
     internal_prefixes, lock_shared_state, OfflineProtocol, SessionState, WelcomeDeliveryState,
     WelcomeLifecycleRecord, CONFIRMATION_PROBE_INTERVAL_SECS, CONFIRMATION_RETRY_INTERVAL_SECS,
     RECONCILIATION_THROTTLE_MS, WELCOME_INTERNET_CONFIRM_TIMEOUT_SECS, WELCOME_LIFECYCLE_TTL_SECS,
-    WELCOME_RETRY_BATCH_SIZE, WELCOME_RETRY_JITTER_RATIO,
+    WELCOME_MESH_CONFIRM_TIMEOUT_SECS, WELCOME_RETRY_BATCH_SIZE, WELCOME_RETRY_JITTER_RATIO,
 };
 use crate::mls_observability::MlsOperationContext;
 use crate::{Error, EstablishmentState, Event, Result, SessionStateError};
@@ -138,6 +138,7 @@ impl OfflineProtocol {
         if matches!(previous, SessionState::Confirmed) {
             self.confirmed_sessions.insert(peer_id.to_string());
             self.clear_confirmation_recovery_tracking(peer_id);
+            self.both_create_awaiting_decrypt.remove(peer_id);
             info!(
                 event = "session_state_transition",
                 session_or_group_id = %peer_id,
@@ -158,6 +159,15 @@ impl OfflineProtocol {
 
         self.confirmed_sessions.insert(peer_id.to_string());
         self.clear_confirmation_recovery_tracking(peer_id);
+        // Group-aware proof has arrived (decrypt), so we no longer need to gate
+        // confirmation on decrypt for this both-create peer.
+        self.both_create_awaiting_decrypt.remove(peer_id);
+        // The peer has proved the session, so the outbound Welcome — kept
+        // non-terminal so a lost fragment keeps being retried — is delivered.
+        // Mark it Sent so process_welcome_retry_queue stops re-sending it. Mesh
+        // has no transport-level delivery ack, so this session proof is the mesh
+        // equivalent of on_transport_send_confirmed.
+        self.mark_welcome_confirmed(peer_id, source_event);
         if source_event != "welcome_received" && source_event != "decrypt_success" {
             self.maybe_emit_local_session_established(
                 peer_id,
@@ -173,6 +183,43 @@ impl OfflineProtocol {
             "session_state_transition"
         );
         Ok(true)
+    }
+
+    /// Marks a non-terminal outbound welcome lifecycle as `Sent` once the peer
+    /// has proved the session (probe / ack / welcome / decrypt). The mesh
+    /// equivalent of [`Self::on_transport_send_confirmed`], which only fires for
+    /// Internet. No-op when there is no welcome lifecycle for `peer_id` (e.g. a
+    /// confirmation keyed by a group id rather than a 1:1 peer) or it is already
+    /// terminal, so it is safe to call from every confirmation path.
+    fn mark_welcome_confirmed(&mut self, peer_id: &str, source_event: &str) {
+        if !matches!(
+            self.welcome_lifecycles.get(peer_id).map(|r| r.state),
+            Some(WelcomeDeliveryState::SendAttempted) | Some(WelcomeDeliveryState::Failed)
+        ) {
+            return;
+        }
+        if let Some(record) = self.welcome_lifecycles.get_mut(peer_id) {
+            record.next_retry_at = None;
+            record.last_reason_code = None;
+            record.last_transport_error = None;
+        }
+        // transition_welcome_state persists the record and logs the transition.
+        if self
+            .transition_welcome_state(peer_id, WelcomeDeliveryState::Sent, source_event)
+            .is_err()
+        {
+            return;
+        }
+        if let Some(snapshot) = self.welcome_lifecycles.get(peer_id).cloned() {
+            if let Ok(state) = lock_shared_state(&self.shared_state) {
+                state.emit_event(Event::welcome_send_succeeded(
+                    peer_id.to_string(),
+                    snapshot.welcome_message.id.as_str().to_string(),
+                    snapshot.group_id,
+                    snapshot.attempt,
+                ));
+            }
+        }
     }
 
     /// Ensures a session has an explicit persisted state entry.
@@ -456,6 +503,15 @@ impl OfflineProtocol {
     }
 
     pub(super) fn can_confirm_from_source(&self, peer_id: &str, source_event: &str) -> bool {
+        // Both-create owner: we kept our own group and are waiting for the peer to
+        // prove it adopted *our* group. Only a successful decrypt is group-aware
+        // proof of that; a plaintext probe/ack proves only that the peer holds
+        // some session (possibly its own, pre-adoption group), so it must not
+        // confirm us or we would stop retransmitting and strand the peer.
+        if self.both_create_awaiting_decrypt.contains(peer_id) && source_event != "decrypt_success" {
+            return false;
+        }
+
         if !matches!(
             source_event,
             "decrypt_success"
@@ -597,36 +653,34 @@ impl OfflineProtocol {
                             Error::Other(format!("Missing welcome lifecycle for {}", peer_id))
                         })?;
 
-                if matches!(transport_used, Some(TransportType::Internet)) {
-                    // Internet send() only enqueues for platform polling. Keep lifecycle
-                    // non-terminal until explicit platform confirmation arrives.
-                    updated.next_retry_at = Some(
-                        Utc::now() + ChronoDuration::seconds(WELCOME_INTERNET_CONFIRM_TIMEOUT_SECS),
-                    );
-                    updated.last_reason_code = None;
-                    updated.last_transport_error = None;
-                    self.welcome_lifecycles
-                        .insert(peer_id.to_string(), updated.clone());
-                    self.persist_welcome_lifecycle_entry(&updated)?;
-                    return Ok(false);
-                }
-
-                updated.next_retry_at = None;
+                // No transport's send() proves the peer reassembled and joined
+                // the group, so keep the lifecycle NON-TERMINAL until an explicit
+                // confirmation arrives and let the retry queue re-send on timeout.
+                //
+                //   - Internet send() only enqueues for platform polling; the
+                //     confirmation is on_transport_send_confirmed.
+                //   - A BLE / WiFi-Direct GATT WRITE_TYPE_NO_RESPONSE returning Ok
+                //     only means the local stack accepted the bytes. A single lost
+                //     fragment of the multi-fragment Welcome would otherwise leave
+                //     the sender believing the session exists while the peer holds
+                //     undecryptable ciphertext, with NO retry — permanently
+                //     bricking the pair. The mesh confirmation is the peer proving
+                //     the session (its probe / ack / welcome / decrypt), which marks
+                //     the welcome Sent via confirm_session_state.
+                let confirm_timeout_secs =
+                    if matches!(transport_used, Some(TransportType::Internet)) {
+                        WELCOME_INTERNET_CONFIRM_TIMEOUT_SECS
+                    } else {
+                        WELCOME_MESH_CONFIRM_TIMEOUT_SECS
+                    };
+                updated.next_retry_at =
+                    Some(Utc::now() + ChronoDuration::seconds(confirm_timeout_secs));
                 updated.last_reason_code = None;
                 updated.last_transport_error = None;
                 self.welcome_lifecycles
                     .insert(peer_id.to_string(), updated.clone());
                 self.persist_welcome_lifecycle_entry(&updated)?;
-                self.transition_welcome_state(peer_id, WelcomeDeliveryState::Sent, source_event)?;
-                if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::welcome_send_succeeded(
-                        peer_id.to_string(),
-                        updated.welcome_message.id.as_str().to_string(),
-                        updated.group_id,
-                        updated.attempt,
-                    ));
-                }
-                Ok(true)
+                Ok(false)
             }
             Err(err) => {
                 let reason = Self::map_welcome_reason_code(&err);
@@ -927,6 +981,13 @@ impl OfflineProtocol {
             .welcome_lifecycles
             .iter()
             .filter_map(|(peer_id, record)| {
+                // Skip peers whose session is already confirmed: the welcome is
+                // delivered, mark_welcome_confirmed should have marked it Sent,
+                // and re-sending would be wasted bandwidth (defensive against any
+                // keying mismatch that left the lifecycle non-terminal).
+                if self.confirmed_sessions.contains(peer_id) {
+                    return None;
+                }
                 if matches!(record.state, WelcomeDeliveryState::SendAttempted)
                     && record.next_retry_at.is_some_and(|retry_at| retry_at <= now)
                 {
@@ -950,6 +1011,9 @@ impl OfflineProtocol {
             .welcome_lifecycles
             .iter()
             .filter_map(|(peer_id, record)| {
+                if self.confirmed_sessions.contains(peer_id) {
+                    return None;
+                }
                 if matches!(record.state, WelcomeDeliveryState::Failed)
                     && record.next_retry_at.is_some_and(|retry_at| retry_at <= now)
                 {

--- a/crates/offline-protocol/src/protocol/session.rs
+++ b/crates/offline-protocol/src/protocol/session.rs
@@ -52,6 +52,10 @@ impl OfflineProtocol {
                 self.confirmed_sessions.remove(peer_id);
                 self.clear_confirmation_recovery_tracking(peer_id);
                 self.welcome_lifecycles.remove(peer_id);
+                // The MLS session is gone, so any both-create owner gate for this
+                // peer is stale; clear it (memory + storage) or it would block
+                // `welcome_received` confirmation on the next re-pairing.
+                self.clear_both_create_awaiting_decrypt(peer_id);
                 if let Err(err) = self.clear_session_state_entry(peer_id) {
                     warn!(
                         peer_id = %peer_id,
@@ -193,11 +197,27 @@ impl OfflineProtocol {
     /// confirmation keyed by a group id rather than a 1:1 peer) or it is already
     /// terminal, so it is safe to call from every confirmation path.
     fn mark_welcome_confirmed(&mut self, peer_id: &str, source_event: &str) {
-        if !matches!(
-            self.welcome_lifecycles.get(peer_id).map(|r| r.state),
-            Some(WelcomeDeliveryState::SendAttempted) | Some(WelcomeDeliveryState::Failed)
-        ) {
-            return;
+        match self.welcome_lifecycles.get(peer_id).map(|r| r.state) {
+            // In flight / retried — fall through and mark Sent below.
+            Some(WelcomeDeliveryState::SendAttempted) | Some(WelcomeDeliveryState::Failed) => {}
+            // Parked, never actually sent (no carrier at send time) for a peer
+            // that converged over some other path. `Created -> Sent` is not a
+            // legal transition and there is nothing in flight to confirm, so drop
+            // the now-moot lifecycle (memory + storage) rather than leaving it to
+            // linger until the session is deleted.
+            Some(WelcomeDeliveryState::Created) => {
+                self.welcome_lifecycles.remove(peer_id);
+                if let Err(err) = self.clear_welcome_lifecycle_entry(peer_id) {
+                    warn!(
+                        peer_id = %peer_id,
+                        error = %err,
+                        "Failed to clear parked welcome lifecycle on confirmation"
+                    );
+                }
+                return;
+            }
+            // Already terminal (Sent / Expired) or no lifecycle — nothing to do.
+            _ => return,
         }
         if let Some(record) = self.welcome_lifecycles.get_mut(peer_id) {
             record.next_retry_at = None;
@@ -508,7 +528,10 @@ impl OfflineProtocol {
     /// an owner restart mid-convergence cannot let a stale plaintext probe/ack
     /// confirm prematurely. Only writes storage on a genuine insert.
     pub(super) fn mark_both_create_awaiting_decrypt(&mut self, peer_id: &str) {
-        if self.both_create_awaiting_decrypt.insert(peer_id.to_string()) {
+        if self
+            .both_create_awaiting_decrypt
+            .insert(peer_id.to_string())
+        {
             self.persist_both_create_awaiting_decrypt(peer_id);
         }
     }
@@ -527,7 +550,8 @@ impl OfflineProtocol {
         // proof of that; a plaintext probe/ack proves only that the peer holds
         // some session (possibly its own, pre-adoption group), so it must not
         // confirm us or we would stop retransmitting and strand the peer.
-        if self.both_create_awaiting_decrypt.contains(peer_id) && source_event != "decrypt_success" {
+        if self.both_create_awaiting_decrypt.contains(peer_id) && source_event != "decrypt_success"
+        {
             return false;
         }
 

--- a/crates/offline-protocol/src/protocol/session.rs
+++ b/crates/offline-protocol/src/protocol/session.rs
@@ -610,7 +610,12 @@ impl OfflineProtocol {
             return Ok(false);
         }
 
-        if record.expires_at <= now {
+        // Only honor the TTL when a carrier actually exists: a Welcome that has
+        // never had a deliverable transport must not age out. With no carrier we
+        // fall through to the send attempt, which fails no-carrier and is kept
+        // alive (non-terminal) by apply_welcome_send_failure.
+        let carrier_available = !self.transport_manager.get_available_transports().is_empty();
+        if carrier_available && record.expires_at <= now {
             self.transition_welcome_state(peer_id, WelcomeDeliveryState::Expired, source_event)?;
             if let Ok(state) = lock_shared_state(&self.shared_state) {
                 state.emit_event(Event::welcome_send_expired(
@@ -683,22 +688,97 @@ impl OfflineProtocol {
                 Ok(false)
             }
             Err(err) => {
+                let no_carrier = Self::is_no_carrier_error(&err);
                 let reason = Self::map_welcome_reason_code(&err);
                 self.apply_welcome_send_failure(
                     peer_id,
                     reason,
                     Some(err.to_string()),
+                    no_carrier,
                     source_event,
                 )
             }
         }
     }
 
+    /// Re-arms a stalled or expired outbound Welcome when a peer becomes
+    /// reachable again, so a session that never converged while the peer was
+    /// offline gets a fresh delivery attempt over the now-available carrier.
+    ///
+    /// No-op when the peer's session is already confirmed, when there is no
+    /// Welcome lifecycle, or when the Welcome is already `Sent` or still
+    /// in-flight (`SendAttempted`). An `Expired` lifecycle is rebuilt from its
+    /// retained Welcome message — the MLS group is not torn down on expiry, so
+    /// the stored Welcome is still valid to re-send — while a `Created`/`Failed`
+    /// lifecycle has its budget and TTL reset and is retried immediately.
+    pub(super) fn rearm_welcome_for_peer(&mut self, peer_id: &str, source_event: &str) {
+        if self.confirmed_sessions.contains(peer_id) {
+            return;
+        }
+        let Some(record) = self.welcome_lifecycles.get(peer_id).cloned() else {
+            return;
+        };
+        match record.state {
+            WelcomeDeliveryState::Sent | WelcomeDeliveryState::SendAttempted => {}
+            WelcomeDeliveryState::Created | WelcomeDeliveryState::Failed => {
+                if let Some(entry) = self.welcome_lifecycles.get_mut(peer_id) {
+                    entry.attempt = 0;
+                    entry.next_retry_at = Some(Utc::now());
+                    entry.last_reason_code = None;
+                    entry.last_transport_error = None;
+                    entry.expires_at =
+                        Utc::now() + ChronoDuration::seconds(WELCOME_LIFECYCLE_TTL_SECS);
+                }
+                if let Err(err) = self.try_send_welcome(peer_id, source_event) {
+                    warn!(
+                        peer_id = %peer_id,
+                        error = %err,
+                        "Failed to re-arm welcome on peer reachability"
+                    );
+                }
+            }
+            WelcomeDeliveryState::Expired => {
+                // Expired is terminal in the lifecycle state machine, so rebuild
+                // from the retained Welcome message (upsert permits overwrite
+                // from Expired) before re-sending.
+                let welcome_message = record.welcome_message.clone();
+                let group_id = record.group_id.clone();
+                if let Err(err) =
+                    self.upsert_welcome_lifecycle(peer_id, &group_id, welcome_message, source_event)
+                {
+                    warn!(
+                        peer_id = %peer_id,
+                        error = %err,
+                        "Failed to rebuild expired welcome on peer reachability"
+                    );
+                    return;
+                }
+                if let Err(err) = self.try_send_welcome(peer_id, source_event) {
+                    warn!(
+                        peer_id = %peer_id,
+                        error = %err,
+                        "Failed to re-arm expired welcome on peer reachability"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Records a Welcome send failure and decides whether to retry or expire.
+    ///
+    /// `no_carrier` is `true` when the failure was simply that no transport
+    /// carrier exists yet (vs. a present carrier that failed mid-send). A
+    /// no-carrier failure must NOT age the Welcome: it neither counts toward
+    /// the retry budget nor lets the TTL expire it, because the peer is merely
+    /// unreachable for now and will be retried once a carrier appears. The
+    /// speculative attempt increment from [`Self::try_send_welcome`] is rolled
+    /// back so a long offline period leaves the real-delivery budget intact.
     pub(super) fn apply_welcome_send_failure(
         &mut self,
         peer_id: &str,
         reason: crate::events::WelcomeReasonCode,
         transport_error: Option<String>,
+        no_carrier: bool,
         source_event: &str,
     ) -> Result<bool> {
         let mut updated = self
@@ -715,7 +795,11 @@ impl OfflineProtocol {
         }
 
         let max_attempts = self.config.reliability.retry.max_retries.max(1);
-        let should_expire = updated.attempt >= max_attempts || updated.expires_at <= Utc::now();
+        // A no-carrier failure never expires the Welcome: neither the retry
+        // budget nor the TTL applies while the peer is simply unreachable. Only
+        // a carrier-backed failure (SendFailed / Timeout) ages it toward expiry.
+        let should_expire =
+            !no_carrier && (updated.attempt >= max_attempts || updated.expires_at <= Utc::now());
         if should_expire {
             let terminal_reason = crate::events::WelcomeReasonCode::RetryExhausted;
             {
@@ -772,6 +856,16 @@ impl OfflineProtocol {
             let record = self.welcome_lifecycles.get_mut(peer_id).ok_or_else(|| {
                 Error::Other(format!("Missing welcome lifecycle for {}", peer_id))
             })?;
+            // Roll back the speculative attempt increment from try_send_welcome
+            // for a no-carrier failure so the retry budget stays reserved for
+            // real delivery attempts over an available carrier, and push the TTL
+            // forward so a never-deliverable Welcome does not age out — the TTL
+            // clock is carrier-relative, not creation-relative.
+            if no_carrier {
+                record.attempt = record.attempt.saturating_sub(1);
+                record.expires_at =
+                    Utc::now() + ChronoDuration::seconds(WELCOME_LIFECYCLE_TTL_SECS);
+            }
             record.last_reason_code = Some(reason);
             record.last_transport_error = transport_error;
             record.next_retry_at = Some(retry_at);
@@ -954,6 +1048,19 @@ impl OfflineProtocol {
         SessionStateError::classify(error).to_welcome_reason_code()
     }
 
+    /// True when a send failed because no transport carrier exists yet, as
+    /// opposed to a present-but-unhealthy carrier (`SendFailed`) or a
+    /// sent-but-unconfirmed timeout. A no-carrier failure means the peer is
+    /// simply unreachable right now, so the Welcome must be kept alive and
+    /// retried rather than counted against its budget — see
+    /// [`Self::apply_welcome_send_failure`].
+    pub(super) fn is_no_carrier_error(error: &Error) -> bool {
+        matches!(
+            error,
+            Error::Transport(offline_protocol_transport::Error::TransportNotAvailable(_))
+        )
+    }
+
     pub(super) fn session_ready_context_for_source(source_event: &str) -> MlsOperationContext {
         match source_event {
             "confirmation_ack_received" | "confirmation_probe_received" | "decrypt_success" => {
@@ -1003,6 +1110,9 @@ impl OfflineProtocol {
                 &peer_id,
                 crate::events::WelcomeReasonCode::Timeout,
                 Some("Welcome send confirmation timed out".to_string()),
+                // A confirm timeout means the Welcome was sent over a carrier;
+                // this is not a no-carrier failure, so it ages normally.
+                false,
                 "welcome_confirm_timeout",
             )?;
         }

--- a/crates/offline-protocol/src/protocol/session.rs
+++ b/crates/offline-protocol/src/protocol/session.rs
@@ -4,7 +4,8 @@ use super::{
     internal_prefixes, lock_shared_state, OfflineProtocol, SessionState, WelcomeDeliveryState,
     WelcomeLifecycleRecord, CONFIRMATION_PROBE_INTERVAL_SECS, CONFIRMATION_RETRY_INTERVAL_SECS,
     RECONCILIATION_THROTTLE_MS, WELCOME_INTERNET_CONFIRM_TIMEOUT_SECS, WELCOME_LIFECYCLE_TTL_SECS,
-    WELCOME_MESH_CONFIRM_TIMEOUT_SECS, WELCOME_RETRY_BATCH_SIZE, WELCOME_RETRY_JITTER_RATIO,
+    WELCOME_MESH_CONFIRM_TIMEOUT_SECS, WELCOME_NO_CARRIER_RETRY_SECS, WELCOME_RETRY_BATCH_SIZE,
+    WELCOME_RETRY_JITTER_RATIO,
 };
 use crate::mls_observability::MlsOperationContext;
 use crate::{Error, EstablishmentState, Event, Result, SessionStateError};
@@ -138,7 +139,7 @@ impl OfflineProtocol {
         if matches!(previous, SessionState::Confirmed) {
             self.confirmed_sessions.insert(peer_id.to_string());
             self.clear_confirmation_recovery_tracking(peer_id);
-            self.both_create_awaiting_decrypt.remove(peer_id);
+            self.clear_both_create_awaiting_decrypt(peer_id);
             info!(
                 event = "session_state_transition",
                 session_or_group_id = %peer_id,
@@ -161,7 +162,7 @@ impl OfflineProtocol {
         self.clear_confirmation_recovery_tracking(peer_id);
         // Group-aware proof has arrived (decrypt), so we no longer need to gate
         // confirmation on decrypt for this both-create peer.
-        self.both_create_awaiting_decrypt.remove(peer_id);
+        self.clear_both_create_awaiting_decrypt(peer_id);
         // The peer has proved the session, so the outbound Welcome — kept
         // non-terminal so a lost fragment keeps being retried — is delivered.
         // Mark it Sent so process_welcome_retry_queue stops re-sending it. Mesh
@@ -502,6 +503,24 @@ impl OfflineProtocol {
         }
     }
 
+    /// Marks `peer_id` as a both-create owner gate — we kept our own group and
+    /// must observe a group-aware decrypt before confirming — and persists it so
+    /// an owner restart mid-convergence cannot let a stale plaintext probe/ack
+    /// confirm prematurely. Only writes storage on a genuine insert.
+    pub(super) fn mark_both_create_awaiting_decrypt(&mut self, peer_id: &str) {
+        if self.both_create_awaiting_decrypt.insert(peer_id.to_string()) {
+            self.persist_both_create_awaiting_decrypt(peer_id);
+        }
+    }
+
+    /// Clears the both-create owner gate for `peer_id` (it has converged) from
+    /// both memory and storage. Only writes storage on a genuine removal.
+    pub(super) fn clear_both_create_awaiting_decrypt(&mut self, peer_id: &str) {
+        if self.both_create_awaiting_decrypt.remove(peer_id) {
+            self.delete_both_create_awaiting_decrypt(peer_id);
+        }
+    }
+
     pub(super) fn can_confirm_from_source(&self, peer_id: &str, source_event: &str) -> bool {
         // Both-create owner: we kept our own group and are waiting for the peer to
         // prove it adopted *our* group. Only a successful decrypt is group-aware
@@ -595,6 +614,39 @@ impl OfflineProtocol {
         self.try_send_welcome(recipient, "welcome_initial_send")
     }
 
+    /// Parks a Welcome that currently has no transport carrier: refresh the
+    /// carrier-relative TTL and schedule a slow re-check, WITHOUT consuming a
+    /// retry attempt, transitioning state, or emitting a `WelcomeSendAttempted`
+    /// event. A no-carrier send is a guaranteed failure, so re-attempting it at
+    /// the data-plane retry rate only churns storage I/O and app events while a
+    /// device is offline. The lifecycle stays in its current non-terminal state
+    /// (Created on the first send, Failed on a later retry) so the retry queue
+    /// re-polls it on [`WELCOME_NO_CARRIER_RETRY_SECS`]; `on_neighbor_discovered`
+    /// re-arms it immediately when a carrier surfaces the peer. Returns
+    /// `Ok(false)` (not sent).
+    fn park_welcome_no_carrier(&mut self, peer_id: &str) -> Result<bool> {
+        let snapshot = {
+            let Some(record) = self.welcome_lifecycles.get_mut(peer_id) else {
+                return Ok(false);
+            };
+            let now = Utc::now();
+            record.next_retry_at =
+                Some(now + ChronoDuration::seconds(WELCOME_NO_CARRIER_RETRY_SECS));
+            record.expires_at = now + ChronoDuration::seconds(WELCOME_LIFECYCLE_TTL_SECS);
+            record.last_reason_code = Some(crate::events::WelcomeReasonCode::TransportUnavailable);
+            record.last_transport_error = None;
+            record.clone()
+        };
+        self.persist_welcome_lifecycle_entry(&snapshot)?;
+        debug!(
+            peer_id = %peer_id,
+            state = snapshot.state.as_str(),
+            retry_in_secs = WELCOME_NO_CARRIER_RETRY_SECS,
+            "Welcome parked: no transport carrier, re-checking on slow interval"
+        );
+        Ok(false)
+    }
+
     pub(super) fn try_send_welcome(&mut self, peer_id: &str, source_event: &str) -> Result<bool> {
         let now = Utc::now();
         let mut record = self
@@ -611,9 +663,7 @@ impl OfflineProtocol {
         }
 
         // Only honor the TTL when a carrier actually exists: a Welcome that has
-        // never had a deliverable transport must not age out. With no carrier we
-        // fall through to the send attempt, which fails no-carrier and is kept
-        // alive (non-terminal) by apply_welcome_send_failure.
+        // never had a deliverable transport must not age out.
         let carrier_available = !self.transport_manager.get_available_transports().is_empty();
         if carrier_available && record.expires_at <= now {
             self.transition_welcome_state(peer_id, WelcomeDeliveryState::Expired, source_event)?;
@@ -630,6 +680,18 @@ impl OfflineProtocol {
                 crate::events::WelcomeReasonCode::RetryExhausted,
             );
             return Ok(false);
+        }
+
+        // No carrier at all: a send is guaranteed to fail, so do NOT burn the
+        // speculative attempt increment, the SendAttempted/Failed transitions
+        // (two persisted state changes + two info logs), and a
+        // `WelcomeSendAttempted` event on it every retry tick. Park the
+        // lifecycle on a slow carrier-relative interval instead and re-check
+        // later; `on_neighbor_discovered` re-arms it immediately when a carrier
+        // surfaces the peer. This keeps an offline device quiet rather than
+        // spinning storage I/O + app events at the data-plane retry rate.
+        if !carrier_available {
+            return self.park_welcome_no_carrier(peer_id);
         }
 
         record.attempt = record.attempt.saturating_add(1);
@@ -870,8 +932,17 @@ impl OfflineProtocol {
             return Ok(false);
         }
 
-        let delay_ms = self.compute_welcome_retry_delay_ms(peer_id, updated.attempt);
-        let retry_at = Utc::now() + ChronoDuration::milliseconds(delay_ms as i64);
+        // A no-carrier failure (the carrier raced away after the pre-send check,
+        // or an async transport-failed callback with no carrier) re-checks on the
+        // slow no-carrier interval rather than the data-plane backoff: there is
+        // nothing to deliver over until a carrier returns, and `try_send_welcome`
+        // parks subsequent no-carrier ticks cheaply anyway.
+        let retry_at = if no_carrier {
+            Utc::now() + ChronoDuration::seconds(WELCOME_NO_CARRIER_RETRY_SECS)
+        } else {
+            let delay_ms = self.compute_welcome_retry_delay_ms(peer_id, updated.attempt);
+            Utc::now() + ChronoDuration::milliseconds(delay_ms as i64)
+        };
 
         {
             let record = self.welcome_lifecycles.get_mut(peer_id).ok_or_else(|| {
@@ -1145,8 +1216,14 @@ impl OfflineProtocol {
                 if self.confirmed_sessions.contains(peer_id) {
                     return None;
                 }
-                if matches!(record.state, WelcomeDeliveryState::Failed)
-                    && record.next_retry_at.is_some_and(|retry_at| retry_at <= now)
+                // Failed = a normal retry-due Welcome. Created with a due
+                // next_retry_at = a no-carrier-parked Welcome (see
+                // `park_welcome_no_carrier`): a fresh Created entry has
+                // next_retry_at == None, so only parked ones match here.
+                if matches!(
+                    record.state,
+                    WelcomeDeliveryState::Failed | WelcomeDeliveryState::Created
+                ) && record.next_retry_at.is_some_and(|retry_at| retry_at <= now)
                 {
                     return Some(peer_id.clone());
                 }

--- a/crates/offline-protocol/src/protocol/session.rs
+++ b/crates/offline-protocol/src/protocol/session.rs
@@ -685,6 +685,27 @@ impl OfflineProtocol {
                 self.welcome_lifecycles
                     .insert(peer_id.to_string(), updated.clone());
                 self.persist_welcome_lifecycle_entry(&updated)?;
+
+                // Seed the confirmation-probe scheduler for this pending peer so
+                // the SENDER actively reconciles instead of waiting passively.
+                //
+                // The Welcome is now in flight but unconfirmed. The sender's only
+                // built-in convergence path would otherwise be the receiver's
+                // single proactive encrypted confirm on first Welcome receipt — a
+                // single point of failure with no retry (a lost fragment, a
+                // not-yet-ready encryptor, or the retransmit/owner_keep path on
+                // the receiver all strand it). By marking a probe due now,
+                // `run_throttled_reconciliation` (whose `has_pending_work` gate is
+                // otherwise false on the sender, since it has no pending encrypted
+                // messages) starts emitting `SESSION_CONFIRM_PROBE`s. The peer —
+                // which holds the session — replies with `SESSION_CONFIRM_ACK`,
+                // confirming us and marking this Welcome `Sent`. The entry is
+                // dropped once confirmed (`clear_confirmation_recovery_tracking`)
+                // or once the peer is no longer pending (`kick`'s retain), so this
+                // adds no steady-state work after convergence.
+                self.confirmation_probe_due_at
+                    .insert(peer_id.to_string(), Utc::now());
+
                 Ok(false)
             }
             Err(err) => {

--- a/crates/offline-protocol/src/protocol/storage.rs
+++ b/crates/offline-protocol/src/protocol/storage.rs
@@ -2,10 +2,10 @@
 
 use super::{
     storage_keys, OfflineProtocol, PendingMessage, ReceivedKeyPackage, SessionState,
-    WelcomeDeliveryState, WelcomeLifecycleRecord,
+    WelcomeDeliveryState, WelcomeLifecycleRecord, WELCOME_LIFECYCLE_TTL_SECS,
 };
 use crate::{Error, Result};
-use chrono::Utc;
+use chrono::{Duration as ChronoDuration, Utc};
 use offline_protocol_core::LamportClock;
 use offline_protocol_mls::MlsManager;
 use std::sync::{Arc, RwLock};
@@ -380,8 +380,11 @@ impl OfflineProtocol {
                     if matches!(
                         record.last_reason_code,
                         Some(crate::events::WelcomeReasonCode::RetryExhausted)
-                    ) || record.expires_at <= Utc::now()
-                    {
+                    ) {
+                        // Only genuine retry exhaustion (a present carrier that
+                        // kept failing) is terminal here. A stale TTL alone must
+                        // NOT expire a no-carrier Welcome on restart — the TTL
+                        // clock is carrier-relative and is refreshed below.
                         record.state = WelcomeDeliveryState::Expired;
                         warn!(
                             event = "welcome_lifecycle_repaired",
@@ -405,6 +408,25 @@ impl OfflineProtocol {
                         );
                     }
                     self.persist_welcome_lifecycle_entry(&record)?;
+                }
+                // The TTL clock is carrier-relative: a Welcome must not be
+                // restored already-expired after an offline period. Restart the
+                // window for any non-terminal lifecycle whose TTL has lapsed so
+                // it gets a fresh chance once a carrier (or the peer) reappears.
+                if matches!(record.state, WelcomeDeliveryState::Failed)
+                    && record.expires_at <= Utc::now()
+                {
+                    record.expires_at =
+                        Utc::now() + ChronoDuration::seconds(WELCOME_LIFECYCLE_TTL_SECS);
+                    self.persist_welcome_lifecycle_entry(&record)?;
+                    warn!(
+                        event = "welcome_lifecycle_repaired",
+                        session_or_group_id = %peer_id,
+                        repair_action = "ttl_refreshed_carrier_relative",
+                        state = record.state.as_str(),
+                        attempt = record.attempt,
+                        "welcome_lifecycle_repaired"
+                    );
                 }
                 if matches!(
                     record.state,

--- a/crates/offline-protocol/src/protocol/storage.rs
+++ b/crates/offline-protocol/src/protocol/storage.rs
@@ -510,6 +510,57 @@ impl OfflineProtocol {
     }
 
     // ========================================================================
+    // BOTH-CREATE OWNER GATE PERSISTENCE
+    // ========================================================================
+
+    /// Persists a both-create owner-gate entry (value-less; the key is the peer).
+    pub(crate) fn persist_both_create_awaiting_decrypt(&self, peer_id: &str) {
+        let Some(storage) = &self.message_storage else {
+            return;
+        };
+        if let Err(e) = storage.store(storage_keys::BOTH_CREATE_AWAITING_DECRYPT, peer_id, &[]) {
+            warn!(peer_id = %peer_id, error = %e, "Failed to persist both-create owner gate");
+        }
+    }
+
+    /// Deletes a both-create owner-gate entry once the peer has converged.
+    pub(crate) fn delete_both_create_awaiting_decrypt(&self, peer_id: &str) {
+        let Some(storage) = &self.message_storage else {
+            return;
+        };
+        if let Err(e) = storage.delete(storage_keys::BOTH_CREATE_AWAITING_DECRYPT, peer_id) {
+            warn!(peer_id = %peer_id, error = %e, "Failed to delete both-create owner gate");
+        }
+    }
+
+    /// Restores the both-create owner gate from storage on startup, so an owner
+    /// that restarted mid-convergence keeps requiring a group-aware decrypt
+    /// before confirming a still-pending peer. Stale entries for already-confirmed
+    /// peers are harmless (confirmation short-circuits) and are cleared on the
+    /// next confirm.
+    pub(crate) fn restore_both_create_awaiting_decrypt(&mut self) {
+        let Some(storage) = &self.message_storage else {
+            return;
+        };
+        let peer_ids = match storage.list_keys(storage_keys::BOTH_CREATE_AWAITING_DECRYPT) {
+            Ok(keys) => keys,
+            Err(e) => {
+                warn!(error = %e, "Failed to list both-create owner gate from storage");
+                return;
+            }
+        };
+        for peer_id in &peer_ids {
+            self.both_create_awaiting_decrypt.insert(peer_id.clone());
+        }
+        if !self.both_create_awaiting_decrypt.is_empty() {
+            info!(
+                count = self.both_create_awaiting_decrypt.len(),
+                "Restored both-create owner gate from storage"
+            );
+        }
+    }
+
+    // ========================================================================
     // TELEMETRY SCRUB-SECRET PERSISTENCE
     // ========================================================================
 

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -4128,6 +4128,133 @@ fn test_welcome_no_carrier_ticks_keep_lifecycle_alive() {
 }
 
 #[test]
+fn test_no_carrier_welcome_parks_without_churn() {
+    // Regression: a Welcome with no transport carrier must be PARKED (cheap,
+    // slow re-check), not re-attempted at the data-plane retry rate. Each wasted
+    // attempt previously incremented-then-rolled-back the attempt counter, ran
+    // two state transitions (two persists + two info logs), and emitted a
+    // WelcomeSendAttempted event — ~1 Hz of storage/event churn while a device
+    // is simply offline. A parked Welcome emits no attempt/failed events and
+    // schedules its next re-check on the slow no-carrier interval.
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.store_pending = true;
+    // Tiny data-plane backoff: if the no-carrier path WERE (incorrectly) using
+    // it, next_retry_at would land ~milliseconds out, not the slow interval.
+    config.reliability.retry.initial_delay_ms = 1;
+    config.reliability.retry.max_delay_ms = 5;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    let observed_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let observed_events_clone = observed_events.clone();
+    protocol.on_event(move |event| {
+        observed_events_clone.lock().unwrap().push(event);
+    });
+    protocol.start().unwrap();
+
+    let bob_storage = Arc::new(InMemoryStorage::new());
+    let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+    let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+    protocol.pending_key_packages.insert(
+        "bob".to_string(),
+        ReceivedKeyPackage {
+            key_package_data: bob_key_package.key_package_data,
+            local_expires_at_ms: Utc::now().timestamp_millis() as u64 + 60_000,
+        },
+    );
+
+    let _ = protocol.send_message(
+        "bob",
+        "queued-offline",
+        None::<MessagePriority>,
+        None::<String>,
+    );
+    for _ in 0..10 {
+        let _ = protocol.try_send_welcome("bob", "test_no_carrier_tick");
+    }
+
+    let lifecycle = protocol.welcome_lifecycles.get("bob").unwrap();
+    // Parked, not aged: still non-terminal and no attempt consumed.
+    assert_ne!(lifecycle.state, WelcomeDeliveryState::Expired);
+    assert_eq!(
+        lifecycle.attempt, 0,
+        "a parked no-carrier Welcome must not consume an attempt, got {}",
+        lifecycle.attempt
+    );
+    // Re-check is scheduled on the SLOW no-carrier interval, proving we did not
+    // fall through to the ~1ms data-plane backoff.
+    let next_retry = lifecycle
+        .next_retry_at
+        .expect("a parked Welcome must schedule a re-check");
+    let secs_out = (next_retry - Utc::now()).num_seconds();
+    assert!(
+        secs_out >= WELCOME_NO_CARRIER_RETRY_SECS - 2,
+        "parked Welcome must re-check on the slow no-carrier interval, got {secs_out}s"
+    );
+
+    // The churn we eliminated: no per-tick attempt/failed/expired events.
+    let events = observed_events.lock().unwrap();
+    let churn = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                Event::WelcomeSendAttempted { .. }
+                    | Event::WelcomeSendFailed { .. }
+                    | Event::WelcomeSendExpired { .. }
+            )
+        })
+        .count();
+    assert_eq!(
+        churn, 0,
+        "no-carrier ticks must not emit attempt/failed/expired churn, got {churn}"
+    );
+}
+
+#[test]
+fn test_both_create_gate_survives_owner_restart() {
+    // Regression: the both-create owner gate must persist. If an owner restarts
+    // mid-convergence and loses the gate, a stale plaintext probe/ack could
+    // confirm it, stop its Welcome retransmission, and strand the peer on a
+    // divergent group. With the gate restored, only a group-aware decrypt may
+    // confirm.
+    let config = create_test_config_for_user("alice");
+    let storage = Arc::new(InMemoryStorage::new());
+
+    let mut owner = OfflineProtocol::new(config.clone()).unwrap();
+    owner.initialize_mls(storage.clone()).unwrap();
+    owner.mark_both_create_awaiting_decrypt("bob");
+    assert!(owner.both_create_awaiting_decrypt.contains("bob"));
+    // The gate blocks a plaintext-ack confirmation (only a decrypt is accepted).
+    assert!(!owner.can_confirm_from_source("bob", "confirmation_ack_received"));
+
+    // Restart with the same storage: the gate must be restored.
+    let mut restarted = OfflineProtocol::new(config.clone()).unwrap();
+    restarted.initialize_mls(storage.clone()).unwrap();
+    assert!(
+        restarted.both_create_awaiting_decrypt.contains("bob"),
+        "both-create owner gate must survive a restart"
+    );
+    assert!(
+        !restarted.can_confirm_from_source("bob", "confirmation_ack_received"),
+        "restored gate must still block a plaintext-ack confirmation"
+    );
+
+    // Convergence clears it from storage too, so a later restart does not revive
+    // it (which would wrongly keep blocking confirmation of a converged peer).
+    restarted.clear_both_create_awaiting_decrypt("bob");
+    let mut after_converge = OfflineProtocol::new(config).unwrap();
+    after_converge.initialize_mls(storage).unwrap();
+    assert!(
+        !after_converge.both_create_awaiting_decrypt.contains("bob"),
+        "a cleared gate must not be restored after convergence"
+    );
+}
+
+#[test]
 fn test_welcome_sends_when_carrier_appears() {
     let mut config = create_test_config();
     config.encryption.enabled = true;

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -3908,6 +3908,254 @@ fn test_welcome_restore_promotes_retry_exhausted_failed_to_expired() {
 }
 
 #[test]
+fn test_welcome_no_carrier_ticks_keep_lifecycle_alive() {
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.store_pending = true;
+    config.reliability.retry.max_retries = 2;
+    config.reliability.retry.initial_delay_ms = 1;
+    config.reliability.retry.max_delay_ms = 5;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    // No transport is added, so every send fails with TransportNotAvailable.
+    let observed_events = Arc::new(Mutex::new(Vec::<Event>::new()));
+    let observed_events_clone = observed_events.clone();
+    protocol.on_event(move |event| {
+        observed_events_clone.lock().unwrap().push(event);
+    });
+    protocol.start().unwrap();
+
+    let bob_storage = Arc::new(InMemoryStorage::new());
+    let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+    let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+    protocol.pending_key_packages.insert(
+        "bob".to_string(),
+        ReceivedKeyPackage {
+            key_package_data: bob_key_package.key_package_data,
+            local_expires_at_ms: Utc::now().timestamp_millis() as u64 + 60_000,
+        },
+    );
+
+    let _ = protocol.send_message(
+        "bob",
+        "queued-offline",
+        None::<MessagePriority>,
+        None::<String>,
+    );
+
+    // Far more no-carrier attempts than max_retries — none may expire the
+    // Welcome, and the retry budget must not accumulate.
+    for _ in 0..10 {
+        let _ = protocol.try_send_welcome("bob", "test_no_carrier_tick");
+    }
+
+    let lifecycle = protocol.welcome_lifecycles.get("bob").unwrap();
+    assert_ne!(
+        lifecycle.state,
+        WelcomeDeliveryState::Expired,
+        "a no-carrier Welcome must never expire"
+    );
+    assert!(
+        lifecycle.attempt <= 1,
+        "no-carrier failures must not consume the retry budget, got attempt={}",
+        lifecycle.attempt
+    );
+
+    let events = observed_events.lock().unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, Event::WelcomeSendExpired { .. })),
+        "no-carrier ticks must not emit WelcomeSendExpired"
+    );
+}
+
+#[test]
+fn test_welcome_sends_when_carrier_appears() {
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.store_pending = true;
+    config.reliability.retry.max_retries = 2;
+    config.reliability.retry.initial_delay_ms = 1;
+    config.reliability.retry.max_delay_ms = 5;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+    protocol.start().unwrap();
+
+    let bob_storage = Arc::new(InMemoryStorage::new());
+    let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+    let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+    protocol.pending_key_packages.insert(
+        "bob".to_string(),
+        ReceivedKeyPackage {
+            key_package_data: bob_key_package.key_package_data,
+            local_expires_at_ms: Utc::now().timestamp_millis() as u64 + 60_000,
+        },
+    );
+
+    // Phase 1: no carrier — the Welcome stalls (non-terminal) without expiring.
+    let _ = protocol.send_message(
+        "bob",
+        "queued-offline",
+        None::<MessagePriority>,
+        None::<String>,
+    );
+    assert_ne!(
+        protocol.welcome_lifecycles.get("bob").unwrap().state,
+        WelcomeDeliveryState::Expired
+    );
+
+    // Phase 2: a transport appears; the stalled Welcome is delivered.
+    let mock = MockTransport::new(TransportType::BLE);
+    mock.set_status(TransportStatus::Available);
+    let mock_handle = mock.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    protocol
+        .try_send_welcome("bob", "test_carrier_appeared")
+        .unwrap();
+
+    let lifecycle = protocol.welcome_lifecycles.get("bob").unwrap();
+    assert_eq!(
+        lifecycle.state,
+        WelcomeDeliveryState::SendAttempted,
+        "the Welcome should be transmitted once a carrier exists"
+    );
+    assert!(
+        lifecycle.last_reason_code.is_none(),
+        "a successful send clears the failure reason"
+    );
+    assert!(
+        !mock_handle.sent_messages().is_empty(),
+        "the carrier should have received the Welcome"
+    );
+}
+
+#[test]
+fn test_welcome_restart_keeps_no_carrier_lifecycle_alive() {
+    let mut config = create_test_config_for_user("alice");
+    config.encryption.enabled = true;
+    config.encryption.store_pending = true;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(config.clone()).unwrap();
+    protocol.initialize_mls(storage.clone()).unwrap();
+
+    // A Welcome that stalled with no carrier and then aged past its TTL while
+    // the device was offline, with no retry scheduled.
+    let message = Message::new(
+        UserId::new("alice").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        "__MLS_WELCOME__dummy".to_string(),
+    );
+    protocol
+        .upsert_welcome_lifecycle("bob", "session:bob:1", message, "test_created")
+        .unwrap();
+    protocol
+        .transition_welcome_state("bob", WelcomeDeliveryState::SendAttempted, "test_attempted")
+        .unwrap();
+    protocol
+        .transition_welcome_state("bob", WelcomeDeliveryState::Failed, "test_failed")
+        .unwrap();
+    {
+        let record = protocol.welcome_lifecycles.get_mut("bob").unwrap();
+        record.last_reason_code = Some(crate::events::WelcomeReasonCode::TransportUnavailable);
+        record.next_retry_at = None;
+        record.expires_at = Utc::now() - ChronoDuration::seconds(1_000);
+    }
+    let persisted = protocol.welcome_lifecycles.get("bob").cloned().unwrap();
+    protocol
+        .persist_welcome_lifecycle_entry(&persisted)
+        .unwrap();
+
+    // Restart: the no-carrier Welcome must survive, not be promoted to Expired.
+    let mut restarted = OfflineProtocol::new(config).unwrap();
+    restarted.initialize_mls(storage).unwrap();
+
+    let restored = restarted.welcome_lifecycles.get("bob").unwrap();
+    assert_eq!(
+        restored.state,
+        WelcomeDeliveryState::Failed,
+        "a stale-TTL no-carrier Welcome must NOT be expired on restart"
+    );
+    assert!(restored.next_retry_at.is_some());
+    assert!(
+        restored.expires_at > Utc::now(),
+        "the TTL window should be restarted (carrier-relative) on restore"
+    );
+}
+
+#[test]
+fn test_welcome_expired_rearms_on_peer_rediscovery() {
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.store_pending = true;
+    config.reliability.retry.max_retries = 1;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    // A present-but-failing carrier: the first send fails (SendFailed), which
+    // with max_retries=1 exhausts the Welcome to Expired.
+    let mock = MockTransport::new(TransportType::BLE);
+    mock.set_status(TransportStatus::Available);
+    mock.set_fail_next_sends(1);
+    let mock_handle = mock.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
+
+    let bob_storage = Arc::new(InMemoryStorage::new());
+    let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+    let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+    protocol.pending_key_packages.insert(
+        "bob".to_string(),
+        ReceivedKeyPackage {
+            key_package_data: bob_key_package.key_package_data,
+            local_expires_at_ms: Utc::now().timestamp_millis() as u64 + 60_000,
+        },
+    );
+
+    let _ = protocol.send_message(
+        "bob",
+        "should-expire-then-recover",
+        None::<MessagePriority>,
+        None::<String>,
+    );
+    assert_eq!(
+        protocol.welcome_lifecycles.get("bob").unwrap().state,
+        WelcomeDeliveryState::Expired,
+        "carrier-present exhaustion should expire the Welcome"
+    );
+
+    // Sends now succeed (the single forced failure is spent). Rediscovering the
+    // peer must re-arm and re-send the expired Welcome.
+    protocol.on_neighbor_discovered("bob");
+
+    let lifecycle = protocol.welcome_lifecycles.get("bob").unwrap();
+    assert_ne!(
+        lifecycle.state,
+        WelcomeDeliveryState::Expired,
+        "rediscovery must revive an expired Welcome"
+    );
+    assert_eq!(lifecycle.state, WelcomeDeliveryState::SendAttempted);
+    assert!(
+        !mock_handle.sent_messages().is_empty(),
+        "the re-armed Welcome should have been transmitted"
+    );
+}
+
+#[test]
 fn test_welcome_transport_callbacks_out_of_order_converge_to_sent() {
     let mut config = create_test_config();
     config.encryption.enabled = true;

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -3654,6 +3654,75 @@ fn test_on_transport_send_confirmed_sends_immediate_probe() {
 }
 
 #[test]
+fn test_mesh_welcome_sender_probes_for_confirmation() {
+    // Regression: the Welcome SENDER on a mesh transport (BLE / WiFi-Direct) must
+    // actively probe the peer for confirmation, not wait passively for the peer's
+    // single proactive confirm. Mesh has no `on_transport_send_confirmed`, so if
+    // the Welcome send does not seed the probe scheduler, the sender's
+    // `run_throttled_reconciliation` `has_pending_work` gate stays false (it has
+    // no pending encrypted messages) and it never emits a SESSION_CONFIRM_PROBE.
+    // The Welcome then retransmits every confirm-timeout window until TTL — the
+    // observed "Welcome send confirmation timed out, attempt 1,2,3,4..." loop.
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.store_pending = true;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    // Mesh transport only — no Internet path to confirm the send for us.
+    let mut ble = MockTransport::new(TransportType::BLE);
+    ble.start().unwrap();
+    let transport_handle = ble.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(ble));
+    protocol.start().unwrap();
+
+    // Peer key package available, as after accepting a connection request.
+    let bob_storage = Arc::new(InMemoryStorage::new());
+    let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+    let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+    protocol.pending_key_packages.insert(
+        "bob".to_string(),
+        ReceivedKeyPackage {
+            key_package_data: bob_key_package.key_package_data,
+            local_expires_at_ms: Utc::now().timestamp_millis() as u64 + 60_000,
+        },
+    );
+
+    // Accepter path: create the 1:1 group and send the Welcome. This does NOT
+    // queue an app message, so it does not borrow the initiator's
+    // queue_message_for_session_establishment -> kick-reconciliation path; the
+    // probe must be seeded by the Welcome send itself.
+    protocol.establish_secure_session("bob").unwrap();
+
+    assert!(
+        protocol.confirmation_probe_due_at.contains_key("bob"),
+        "Welcome send should seed the confirmation-probe scheduler for the pending peer"
+    );
+
+    let messages_before = transport_handle.sent_messages().len();
+
+    // A process tick now has pending work, so reconciliation is not
+    // short-circuited and the sender emits a confirmation probe.
+    protocol.process().unwrap();
+
+    let messages_after = transport_handle.sent_messages();
+    assert!(
+        messages_after.len() > messages_before,
+        "Expected the sender to emit a confirmation probe on the next process tick"
+    );
+    assert!(
+        messages_after
+            .iter()
+            .any(|m| m.content.starts_with(internal_prefixes::SESSION_CONFIRM_PROBE)),
+        "Expected a SESSION_CONFIRM_PROBE to be emitted by the mesh Welcome sender"
+    );
+}
+
+#[test]
 fn test_welcome_terminal_lifecycle_can_be_overwritten() {
     let mut config = create_test_config();
     config.encryption.enabled = true;

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -3715,9 +3715,9 @@ fn test_mesh_welcome_sender_probes_for_confirmation() {
         "Expected the sender to emit a confirmation probe on the next process tick"
     );
     assert!(
-        messages_after
-            .iter()
-            .any(|m| m.content.starts_with(internal_prefixes::SESSION_CONFIRM_PROBE)),
+        messages_after.iter().any(|m| m
+            .content
+            .starts_with(internal_prefixes::SESSION_CONFIRM_PROBE)),
         "Expected a SESSION_CONFIRM_PROBE to be emitted by the mesh Welcome sender"
     );
 }
@@ -4251,6 +4251,43 @@ fn test_both_create_gate_survives_owner_restart() {
     assert!(
         !after_converge.both_create_awaiting_decrypt.contains("bob"),
         "a cleared gate must not be restored after convergence"
+    );
+}
+
+#[test]
+fn test_both_create_gate_cleared_on_session_delete() {
+    // Regression: deleting a 1:1 session (or repairing stale state) must clear
+    // the persisted both-create owner gate. A leaked gate entry would make
+    // `can_confirm_from_source` reject every non-decrypt source — including
+    // `welcome_received` — on the NEXT session with this peer, re-stranding it
+    // in Pending, and it would survive restart via the storage restore.
+    let config = create_test_config_for_user("alice");
+    let storage = Arc::new(InMemoryStorage::new());
+
+    let mut owner = OfflineProtocol::new(config.clone()).unwrap();
+    owner.initialize_mls(storage.clone()).unwrap();
+    owner.mark_both_create_awaiting_decrypt("bob");
+    assert!(owner.both_create_awaiting_decrypt.contains("bob"));
+    assert!(!owner.can_confirm_from_source("bob", "welcome_received"));
+
+    // Tearing the session down clears the gate from memory AND storage.
+    owner.manual_mls_delete_session("bob").unwrap();
+    assert!(
+        !owner.both_create_awaiting_decrypt.contains("bob"),
+        "session delete must clear the both-create owner gate in memory"
+    );
+    // The peer is now confirmable via a fresh Welcome again.
+    assert!(
+        owner.can_confirm_from_source("bob", "welcome_received"),
+        "a re-paired peer must not be blocked by a stale gate"
+    );
+
+    // A restart must not revive the cleared gate from storage.
+    let mut restarted = OfflineProtocol::new(config).unwrap();
+    restarted.initialize_mls(storage).unwrap();
+    assert!(
+        !restarted.both_create_awaiting_decrypt.contains("bob"),
+        "a deleted gate must not be restored after restart"
     );
 }
 

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -3499,6 +3499,19 @@ fn test_welcome_partial_success_after_retry_reaches_sent() {
     thread::sleep(Duration::from_millis(10));
     protocol.process().unwrap();
 
+    // A mesh welcome is now NON-TERMINAL until the peer proves the session: a
+    // successful (retried) transport send leaves the lifecycle SendAttempted
+    // with a confirm timeout, so a lost fragment keeps being re-sent instead of
+    // being falsely marked delivered.
+    let lifecycle = protocol.welcome_lifecycles.get("bob").unwrap();
+    assert_eq!(lifecycle.state, WelcomeDeliveryState::SendAttempted);
+    assert!(lifecycle.next_retry_at.is_some());
+
+    // The peer's session proof (here an ack) confirms the session and marks the
+    // welcome Sent, ending the retries.
+    protocol
+        .confirm_session_state("bob", "confirmation_ack_received")
+        .unwrap();
     assert_eq!(
         protocol.welcome_lifecycles.get("bob").unwrap().state,
         WelcomeDeliveryState::Sent
@@ -3734,6 +3747,15 @@ fn test_welcome_lifecycle_rejects_illegal_transition_from_sent() {
             None::<MessagePriority>,
             None::<String>,
         )
+        .unwrap();
+    // A mesh welcome is non-terminal until the peer proves the session; the
+    // peer's confirmation drives it to the terminal Sent state under test here.
+    assert_eq!(
+        protocol.welcome_lifecycles.get("bob").unwrap().state,
+        WelcomeDeliveryState::SendAttempted
+    );
+    protocol
+        .confirm_session_state("bob", "confirmation_ack_received")
         .unwrap();
     assert_eq!(
         protocol.welcome_lifecycles.get("bob").unwrap().state,

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -3723,6 +3723,91 @@ fn test_mesh_welcome_sender_probes_for_confirmation() {
 }
 
 #[test]
+fn test_adopter_resends_confirm_on_welcome_retransmit_without_owner_keep() {
+    // Regression (Bug B): a simple adopter with a lexicographically SMALLER
+    // user_id that already joined the owner's group must, on a Welcome
+    // RETRANSMIT, re-send its encrypted confirm so a lost first confirm
+    // self-heals — and must NOT misclassify the retransmit as a both-create race
+    // (owner_keep). The buggy path entered owner_keep (because has_existing is
+    // true and local < remote), which poisoned both_create_awaiting_decrypt and
+    // suppressed the confirm, stranding the owner in Pending forever.
+    let mut bob_config = create_test_config_for_user("bob");
+    bob_config.encryption.enabled = true;
+    bob_config.encryption.store_pending = true;
+
+    let mut bob = OfflineProtocol::new(bob_config).unwrap();
+    bob.initialize_mls(Arc::new(InMemoryStorage::new()))
+        .unwrap();
+
+    let mut bob_transport = MockTransport::new(TransportType::BLE);
+    bob_transport.start().unwrap();
+    let bob_transport_handle = bob_transport.clone();
+    bob.transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(bob_transport));
+    bob.start().unwrap();
+
+    // Owner "zoe" (lexicographically greater than "bob") creates the group and
+    // the Welcome. bob never creates its own group — it only joins zoe's, so bob
+    // has no outbound welcome lifecycle for zoe.
+    let zoe_manager = MlsManager::new("zoe", Arc::new(InMemoryStorage::new())).unwrap();
+    let bob_key_package = {
+        let manager = bob.mls_manager.as_ref().unwrap().read().unwrap();
+        manager.get_or_create_key_package().unwrap()
+    };
+    zoe_manager
+        .import_key_package("bob", &bob_key_package.key_package_data)
+        .unwrap();
+    let welcome = zoe_manager.create_session("bob").unwrap();
+    let welcome_content = format!(
+        "{}{}",
+        internal_prefixes::WELCOME,
+        serde_json::to_string(&welcome).unwrap()
+    );
+    let make_welcome_msg = || {
+        Message::new(
+            UserId::new("zoe").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test-app").unwrap(),
+            &welcome_content,
+        )
+    };
+
+    // First Welcome: bob joins and proactively confirms its own side.
+    bob.process_internal_message(&make_welcome_msg());
+    assert!(
+        bob.confirmed_sessions.contains("zoe"),
+        "adopter should confirm its session on first Welcome receipt"
+    );
+
+    let encrypted_before = bob_transport_handle
+        .sent_messages()
+        .iter()
+        .filter(|m| m.content.starts_with(internal_prefixes::ENCRYPTED))
+        .count();
+
+    // Welcome RETRANSMIT — the owner is still re-sending because it has not yet
+    // observed our confirm.
+    bob.process_internal_message(&make_welcome_msg());
+
+    // Must NOT be misclassified as a both-create owner.
+    assert!(
+        !bob.both_create_awaiting_decrypt.contains("zoe"),
+        "adopter retransmit must not enter owner_keep / poison both_create_awaiting_decrypt"
+    );
+
+    // Must re-send an encrypted confirm so a lost first confirm self-heals.
+    let encrypted_after = bob_transport_handle
+        .sent_messages()
+        .iter()
+        .filter(|m| m.content.starts_with(internal_prefixes::ENCRYPTED))
+        .count();
+    assert!(
+        encrypted_after > encrypted_before,
+        "adopter should re-send an encrypted confirm on Welcome retransmit"
+    );
+}
+
+#[test]
 fn test_welcome_terminal_lifecycle_can_be_overwritten() {
     let mut config = create_test_config();
     config.encryption.enabled = true;

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -25,6 +25,15 @@ pub(crate) const WELCOME_LIFECYCLE_TTL_SECS: i64 = 300;
 pub(crate) const WELCOME_RETRY_JITTER_RATIO: f64 = 0.2;
 /// Timeout waiting for explicit internet send confirmation for welcome.
 pub(crate) const WELCOME_INTERNET_CONFIRM_TIMEOUT_SECS: i64 = 10;
+/// Timeout waiting for a mesh (BLE / WiFi-Direct) welcome to be confirmed by
+/// the peer proving the session (probe / ack / welcome / decrypt). A mesh
+/// `send()` returning Ok only means the local stack accepted the bytes, not
+/// that the multi-fragment Welcome reassembled on the peer — so the lifecycle
+/// stays non-terminal and the retry queue re-sends the whole Welcome after this
+/// window, recovering from a lost fragment. Slightly longer than the internet
+/// timeout to allow a slow multi-fragment Welcome to assemble plus the probe
+/// round-trip before paying to re-fragment and re-send it.
+pub(crate) const WELCOME_MESH_CONFIRM_TIMEOUT_SECS: i64 = 15;
 /// Minimum interval between session reconciliation scans (list_sessions I/O).
 /// Keeps the expensive Keychain/Keystore I/O out of the hot path so that
 /// sendMessage() is not blocked by Mutex contention on every process tick.

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -34,6 +34,15 @@ pub(crate) const WELCOME_INTERNET_CONFIRM_TIMEOUT_SECS: i64 = 10;
 /// timeout to allow a slow multi-fragment Welcome to assemble plus the probe
 /// round-trip before paying to re-fragment and re-send it.
 pub(crate) const WELCOME_MESH_CONFIRM_TIMEOUT_SECS: i64 = 15;
+/// Retry cadence for a Welcome that has no transport carrier at all (the peer is
+/// simply unreachable right now). A send is guaranteed to fail with no carrier,
+/// so we do NOT burn the speculative send/transition/event churn on it every
+/// retry tick — we park it and re-check on this slow interval instead. The
+/// primary recovery is event-driven (`on_neighbor_discovered` → re-arm fires the
+/// instant a carrier surfaces the peer); this poll is only a safety net for a
+/// carrier returning without a fresh discovery event, so it is deliberately far
+/// slower than the data-plane retry interval to keep an offline device quiet.
+pub(crate) const WELCOME_NO_CARRIER_RETRY_SECS: i64 = 15;
 /// Minimum interval between session reconciliation scans (list_sessions I/O).
 /// Keeps the expensive Keychain/Keystore I/O out of the hot path so that
 /// sendMessage() is not blocked by Mutex contention on every process tick.
@@ -372,6 +381,12 @@ pub(crate) mod storage_keys {
     pub const SCRUB_SECRET: &str = "scrub_secret";
     /// Key ID for the single scrub-secret entry.
     pub const SCRUB_SECRET_ID: &str = "current";
+    /// Key type for peers we are the both-create "owner" of and are awaiting a
+    /// group-aware decrypt from before confirming (see
+    /// [`crate::protocol::OfflineProtocol`]'s `both_create_awaiting_decrypt`).
+    /// Persisted so an owner restart mid-convergence cannot let a stale plaintext
+    /// probe/ack prematurely confirm and strand the peer on a divergent group.
+    pub const BOTH_CREATE_AWAITING_DECRYPT: &str = "both_create_awaiting_decrypt";
 }
 
 /// Protocol state.

--- a/crates/offline-protocol/src/telemetry/record.rs
+++ b/crates/offline-protocol/src/telemetry/record.rs
@@ -127,6 +127,7 @@ mod tests {
         "protocol.relay.demoted_battery",
         "protocol.secure_session.established",
         "protocol.secure_session.failed",
+        "protocol.convergence.diag",
         "protocol.welcome.send_attempted",
         "protocol.welcome.send_succeeded",
         "protocol.welcome.send_failed",

--- a/crates/offline-protocol/src/telemetry/record.rs
+++ b/crates/offline-protocol/src/telemetry/record.rs
@@ -292,6 +292,7 @@ mod tests {
             | Event::RelayDemotedBattery { .. }
             | Event::SecureSessionEstablished { .. }
             | Event::SecureSessionFailed { .. }
+            | Event::ConvergenceDiag { .. }
             | Event::WelcomeSendAttempted { .. }
             | Event::WelcomeSendSucceeded { .. }
             | Event::WelcomeSendFailed { .. }
@@ -466,6 +467,11 @@ mod tests {
             Event::SecureSessionFailed {
                 peer_id: String::new(),
                 reason: String::new(),
+            },
+            Event::ConvergenceDiag {
+                stage: String::new(),
+                peer_id: String::new(),
+                detail: String::new(),
             },
             Event::WelcomeSendAttempted {
                 peer_id: String::new(),

--- a/crates/offline-protocol/src/telemetry/scrub_event.rs
+++ b/crates/offline-protocol/src/telemetry/scrub_event.rs
@@ -250,6 +250,13 @@ fn scrub_in_place(event: &mut Event, scrubber: &Scrubber) {
         Event::SecureSessionFailed { peer_id, reason: _ } => {
             hash_string(peer_id, scrubber);
         }
+        Event::ConvergenceDiag {
+            peer_id,
+            stage: _,
+            detail: _,
+        } => {
+            hash_string(peer_id, scrubber);
+        }
         Event::WelcomeSendAttempted {
             peer_id,
             group_id,
@@ -547,6 +554,7 @@ fn event_variant_exhaustiveness_ward(e: &Event) {
         | Event::RelayDemotedBattery { .. }
         | Event::SecureSessionEstablished { .. }
         | Event::SecureSessionFailed { .. }
+        | Event::ConvergenceDiag { .. }
         | Event::WelcomeSendAttempted { .. }
         | Event::WelcomeSendSucceeded { .. }
         | Event::WelcomeSendFailed { .. }

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -11,7 +11,7 @@ use crate::{Error, Result};
 use chrono::Utc;
 use offline_protocol_core::Message;
 use offline_protocol_router::{
-    DorsConfig, EscalationTriggerReason, TransportScore, TransportSelector,
+    display_routing_score, DorsConfig, EscalationTriggerReason, TransportScore, TransportSelector,
 };
 use offline_protocol_transport::{
     Error as TransportError, Transport, TransportMetrics, TransportStatus, TransportType,
@@ -264,8 +264,21 @@ impl TransportManager {
         reason_code: Option<RoutingReasonCode>,
         detailed_scores: Option<&[(TransportType, TransportScore)]>,
     ) -> RoutingDecision {
+        // Sanitize the internal fallback-demotion sentinel out of every score
+        // that leaves the engine. DORS keeps Internet's `total` negative to rank
+        // it last; telemetry/UniFFI consumers must see the real 0–125 quality
+        // score instead. This is the single chokepoint for all RoutingDecision
+        // emitters, so `winning_score` is also sanitized here defensively
+        // (idempotent for an already-positive value).
         let scores = match (self.routing_diagnostic, detailed_scores) {
-            (true, Some(detailed)) => detailed.to_vec(),
+            (true, Some(detailed)) => detailed
+                .iter()
+                .map(|(t, s)| {
+                    let mut s = s.clone();
+                    s.total = display_routing_score(s.total);
+                    (*t, s)
+                })
+                .collect(),
             _ => Vec::new(),
         };
         RoutingDecision {
@@ -273,7 +286,7 @@ impl TransportManager {
             phase,
             from,
             to,
-            winning_score,
+            winning_score: winning_score.map(display_routing_score),
             reason_code,
             scores,
         }
@@ -392,7 +405,13 @@ impl TransportManager {
             Some(d) => d.iter().map(|(t, s)| (*t, s.total)).collect(),
             None => self.selector.score_and_rank(message, &available),
         };
-        let scores: Vec<(String, f32)> = scored.iter().map(|(t, s)| (t.to_string(), *s)).collect();
+        // Sanitize the fallback-demotion sentinel out of the emitted scores (the
+        // `scored` vec itself keeps the raw totals — the fallback loop below
+        // relies on Internet ranking last).
+        let scores: Vec<(String, f32)> = scored
+            .iter()
+            .map(|(t, s)| (t.to_string(), display_routing_score(*s)))
+            .collect();
         self.emit_dors_event(Event::dors_score_updated(scores));
 
         self.emit_routing_decision(|| {
@@ -406,10 +425,12 @@ impl TransportManager {
                 detailed_slice,
             )
         });
+        // Telemetry-only; sanitize the fallback-demotion sentinel so the emitted
+        // selection score is the real 0–125 quality value, not the negative rank.
         let primary_score = scored
             .iter()
             .find(|(t, _)| *t == primary)
-            .map(|(_, s)| *s)
+            .map(|(_, s)| display_routing_score(*s))
             .unwrap_or(0.0);
         let selection_reason = if previous.is_none() {
             DorsReasonCode::InitialSelection


### PR DESCRIPTION
## Problem

Offline 1:1 messaging over BLE mesh did not reliably converge. Several distinct
failure modes stacked on top of each other:

- A **duplicate/retransmitted MLS Welcome** ran a destructive *delete-then-stage*
  adoption: it deleted the already-converged group and then failed to re-stage
  (the one-time key package was already consumed), **permanently bricking a
  working session**.
- A mesh `send()` returning `Ok` was treated as **delivery**, even though
  `WRITE_TYPE_NO_RESPONSE` only means the local stack accepted the bytes. A
  single lost fragment of a multi-fragment Welcome stranded the pair forever
  with no retry.
- The **both-create race** (both peers create a `session:` group) had no reliable
  convergence proof — a plaintext probe/ack could stop Welcome retransmission
  before the peer had actually adopted our group, stranding it on a divergent
  group.
- **Android 13+** rejects a second concurrent `writeCharacteristic` with
  `ERROR_GATT_WRITE_REQUEST_BUSY (201)` even for `NO_RESPONSE`, so back-to-back
  fragment writes silently self-collided and dropped fragments.
- **Asymmetric links** (a peer that connected to *our* GATT server) had no
  reliable egress — a reverse central write returns `SUCCESS` into a half-open
  link and is dropped on air.
- A notify sized for the **central link's MTU** overflowed the **peripheral
  link's MTU** and was truncated/dropped.
- **Per-fragment buffer eviction** tore still-arriving multi-fragment messages,
  handing the reassembler a permanent hole.
- An app-level relay bridge could **steal nearby peers from mesh** because the
  Internet transport was never demoted below mesh under the offline-first config.

## What changed

### MLS adoption — non-destructive stage-then-swap
- `join_group_replacing` stages the incoming Welcome **first** (which consumes
  the one-time key package), and only deletes/replaces the existing group once
  staging succeeds. A duplicate Welcome now fails staging with the existing group
  fully intact (idempotent adoption) instead of bricking it.
- `delete_group` warns instead of aborting when it cannot load the prior group,
  so adoption is not blocked once the key package is already spent.

### Protocol convergence + Welcome lifecycle
- **Both-create owner gate** (`both_create_awaiting_decrypt`, persisted): an owner
  that kept its own group confirms **only on a group-aware decrypt**, never on a
  plaintext probe/ack. Survives restart so a stale probe/ack can't prematurely
  confirm a still-diverged peer.
- **Proactive encrypted adopter confirm** (`__MLS_ENC_CONFIRM__`): after adopting
  the peer's group, the adopter proactively sends an MLS-encrypted confirm so a
  passive owner with no traffic still gets the group-aware decrypt it needs.
  Re-sent on every Welcome retransmit (lockstep self-heal). Consumed on receipt,
  never surfaced.
- **Non-terminal mesh Welcome**: a mesh send stays non-terminal until the peer
  proves the session; the retry queue re-sends on a confirm timeout, recovering
  from a lost fragment. The sender now **seeds the confirmation-probe scheduler**
  so it actively reconciles instead of waiting passively.
- **No-carrier parking**: a Welcome with no transport carrier is parked on a slow
  carrier-relative interval without consuming retry budget, aging out, or emitting
  per-tick churn. **Re-armed immediately** on `on_neighbor_discovered`, and TTL is
  carrier-relative across restart.

### Android BLE transport
- Per-peer **write gate** (`writeInFlight`): one outstanding write/notify per peer,
  released by the completion callback (fast path) or a watchdog (fallback).
- **Peripheral-notify egress** for asymmetric links, resolved by **peer identity**
  (not just address, since iOS uses distinct handles per direction).
- Message characteristic switched **NOTIFY → INDICATE** for ATT-confirmed
  per-fragment flow control.
- Per-peer MTU bounded by **min(central, peripheral)** link, keyed by **device
  identity**.
- **Backpressure** (`isBackedUp`) so the drain loop stops popping the Rust backlog
  into the bounded per-peer queue.
- **Whole-buffer idle eviction** keyed on the newest fragment (no longer tears a
  still-arriving message).

### iOS BLE transport
- Whole-buffer overflow drop + whole-buffer idle eviction (matches Android).
- `drainAndSendFragments()` on CCCD-subscribe completion, fixing the
  iOS→Android first-message stall.

### Router (DORS)
- **Internet-as-fallback demotion** when `prefer_online == false` and the message
  isn't internet-preferred: Internet ranks below every mesh transport but stays a
  candidate for genuinely remote peers. `display_routing_score` recovers the real
  0–125 score so the internal sentinel never leaks to telemetry/UniFFI.

### Telemetry / CI
- `ConvergenceDiag` receiver-side breadcrumbs (scrubbed `peer_id`; raw identifiers
  kept out of the unscrubbed `detail`).
- New Android CI job runs the RN module's JVM unit tests via a standalone harness.

## Verification

- **962 tests pass** across the changed crates (`offline-protocol-mls`,
  `-router`, `-transport`, `offline-protocol`), zero failures.
- New regression tests cover: non-destructive adopt on Welcome retransmit,
  both-create gate persistence/restart/clear, no-carrier park (no churn / never
  expires), carrier-appears delivery, expired-Welcome re-arm on rediscovery,
  mesh-sender probing, adopter resend-on-retransmit, DORS fallback + score
  sanitization, and whole-buffer inbound eviction.

### Coverage boundary (on-device-verified only)
The Android/iOS transport-level paths are framework-heavy and are **not** covered
by automated CI — validated on-device: the per-peer write gate, `sendViaNotify`,
`flushPeerMtu` min-MTU, `onWriteCompleted`, and the NOTIFY→INDICATE switch.

## Known limitations / follow-ups
- `join_group_replacing` is **non-atomic after staging**: a storage failure during
  `into_group` deletes the prior group before installing the new one ("lost group").
  Surfaced as `SecureSessionFailed`; recovery is a fresh key-package exchange. Rare
  (Keychain/Keystore write failure) and strictly better than the prior always-brick.
- A link that negotiates **below the fragment floor** is surfaced as a diagnostic
  but can still overflow a notify (honoring sub-floor notify sizing is a deeper
  fragmenter change, tracked separately).
- The DORS fallback sentinel is stored raw in the score history; any future
  consumer that *aggregates* the history must map through `display_routing_score`.

## Notes
- `__MLS_ENC_CONFIRM__` travels inside the encrypted envelope; confirm a
  previously-deployed SDK version doesn't render an unknown decrypted `__MLS_*__`
  marker (same class as the existing `__MLS_CONFIRM_*__` prefixes).
- `todo.md` (Kotlin 2.x null-safety) is intentionally **not** part of this PR.
