### PR TITLE
fix(ble): floor notify egress to the 185-byte cap when the peripheral-link MTU is unobserved

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -45,6 +45,41 @@ private class LogThrottler(private val defaultIntervalMs: Long = 5000L) {
 }
 
 /**
+ * Computes the effective per-peer ATT payload to flush to the Rust fragmenter
+ * from the two link directions' known payloads.
+ *
+ * A single fragment stream must fit BOTH the central link we opened and the
+ * peripheral/NOTIFY link the peer opened to us, so the result is the **minimum**
+ * of whatever is known. The subtlety this captures: the notify link's MTU is only
+ * observable via the GATT-server `onMtuChanged`, which is unreliable for the
+ * server role and often never fires (an iOS central negotiates a smaller MTU on
+ * the link it opens to us, or none). Without a peripheral value the `min()` would
+ * collapse to the (larger) central payload, and a multi-fragment notify — an MLS
+ * Welcome — would egress at central size, overflow the notify link, and be
+ * silently truncated on air (the offline 1:1 Welcome-delivery stall).
+ *
+ * So when the peer has an active notify subscription ([notifySubscribed]) but no
+ * observed peripheral payload, the peripheral term falls back to the conservative
+ * [floor] (the 185-byte fragment cap every BLE link can carry) until a real value
+ * arrives. A real observed payload always wins — [peripheralStaged] is consulted
+ * first — so the floor never demotes a link whose MTU we actually know.
+ *
+ * Returns null only when neither direction is known AND the peer is not
+ * notify-subscribed, signalling the caller to clear the Rust entry (the
+ * fragmenter then reverts to its own floor). Pure and side-effect free so the
+ * floor/min arithmetic is unit-testable without the Android BLE stack.
+ */
+internal fun computeEffectivePayload(
+    central: Int?,
+    peripheralStaged: Int?,
+    notifySubscribed: Boolean,
+    floor: Int,
+): Int? {
+    val peripheral = peripheralStaged ?: if (notifySubscribed) floor else null
+    return listOfNotNull(central, peripheral).minOrNull()
+}
+
+/**
  * BLE transport facade implementing [TransportManager] for Bluetooth Low
  * Energy communication. Ensures iOS ↔ Android cross-platform compatibility.
  *
@@ -2050,7 +2085,11 @@ class BleTransportFacade(
      * resolves ([CentralGattClient.Host.onDeviceIdResolved]), and when a link
      * tears down (to restore the surviving link's MTU). If neither direction has
      * a value the Rust entry is cleared so the fragmenter reverts to its
-     * 185-byte floor rather than retaining a dead link's value. Idempotent and
+     * 185-byte floor rather than retaining a dead link's value — unless the peer
+     * is still notify-subscribed, in which case the peripheral term is floored to
+     * the 185-byte fragment cap (via [computeEffectivePayload]) so a notify-
+     * egressed message (an MLS Welcome) is never sized for the central link when
+     * the notify link's own MTU was never observed. Idempotent and
      * main-thread only. The per-address staged values are NOT removed on flush
      * (they are inputs to the min); link-teardown paths clear the dropped
      * direction's per-device slot explicitly.
@@ -2067,8 +2106,28 @@ class BleTransportFacade(
         peripheralMaxPayloads[address]?.let { peripheralPayloadByDevice[deviceId] = it }
 
         val central = centralPayloadByDevice[deviceId]
-        val peripheral = peripheralPayloadByDevice[deviceId]
-        val effective = listOfNotNull(central, peripheral).minOrNull()
+        // The notify link's MTU is only observable via the GATT-server
+        // onMtuChanged, which is unreliable for the server role and often never
+        // fires (an iOS central negotiates a smaller MTU on the link it opens to
+        // us, or none). Without a peripheral value the min() would collapse to the
+        // central payload and a multi-fragment notify — an MLS Welcome — would
+        // overflow the notify link and be silently truncated on air. So when any
+        // notify-subscribed address maps to this peer but no peripheral payload is
+        // on file, [computeEffectivePayload] floors the peripheral term to the
+        // 185-byte fragment cap until a real value arrives. The subscription check
+        // is device-scoped, not address-scoped: the two links can use different BLE
+        // addresses for the same peer (iOS uses distinct handles per direction), so
+        // we match by device id exactly as the notify-egress resolution does.
+        val peripheralStaged = peripheralPayloadByDevice[deviceId]
+        val notifySubscribed = peripheralGattServer?.subscribedAddresses()?.any {
+            connections.deviceIdForAddress(it) == deviceId
+        } == true
+        val effective = computeEffectivePayload(
+            central = central,
+            peripheralStaged = peripheralStaged,
+            notifySubscribed = notifySubscribed,
+            floor = MAX_FRAGMENT_SIZE,
+        )
         if (effective == null) {
             // Both directions gone — drop the Rust entry so the fragmenter falls
             // back to the floor instead of keeping a stale per-peer size, and the
@@ -2110,7 +2169,7 @@ class BleTransportFacade(
                     "address" to address,
                     "deviceId" to deviceId,
                     "centralPayload" to (central ?: -1),
-                    "peripheralPayload" to (peripheral ?: -1),
+                    "peripheralPayload" to (peripheralStaged ?: -1),
                     "effectivePayload" to effective,
                 ),
             )
@@ -3256,6 +3315,27 @@ class BleTransportFacade(
                 if (deviceId != null) {
                     flushPeerMtu(address, deviceId)
                 }
+            }
+        }
+
+        override fun onCentralSubscribed(device: BluetoothDevice) {
+            // A central enabled notifications on the link it opened to us. Its
+            // notify-link MTU may never be reported (server-role onMtuChanged is
+            // unreliable), so re-flush now: flushPeerMtu applies the 185-byte
+            // notify floor for a subscribed peer whose peripheral MTU is still
+            // unknown, bounding multi-fragment notify egress (the MLS Welcome).
+            // The CCCD subscribe lands after the central-link MTU flush, so without
+            // this the floor would never be applied for this peer until some later
+            // unrelated flush. If the device id isn't resolved yet, the
+            // onDeviceIdResolved -> flushPeerMtu path applies the floor later (it
+            // will see the subscription).
+            if (shuttingDown) return
+            mainHandler.post {
+                if (shuttingDown) return@post
+                assertMainThread("onCentralSubscribed.reflush")
+                val address = device.address
+                val deviceId = connections.deviceIdForAddress(address) ?: return@post
+                flushPeerMtu(address, deviceId)
             }
         }
 

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -3397,6 +3397,26 @@ class BleTransportFacade(
             }
         }
 
+        override fun onCentralUnsubscribed(device: BluetoothDevice) {
+            // A central disabled notifications on the link it opened to us. The peer
+            // is no longer notify-reachable, so re-flush: flushPeerMtu drops the
+            // 185-byte notify floor now that subscribedNotifyAddressFor no longer
+            // resolves, relaxing the per-peer MTU back to min(central, peripheral) —
+            // or clearing it when neither direction's MTU is known. Without this, a
+            // peer that subscribed (pinning the floor) and then unsubscribed on a
+            // live link would keep the stale 185 floor, throttling its central-write
+            // egress, until some later unrelated flush. Symmetric with
+            // onCentralSubscribed.
+            if (shuttingDown) return
+            mainHandler.post {
+                if (shuttingDown) return@post
+                assertMainThread("onCentralUnsubscribed.reflush")
+                val address = device.address
+                val deviceId = connections.deviceIdForAddress(address) ?: return@post
+                flushPeerMtu(address, deviceId)
+            }
+        }
+
         override fun onInboundFragment(device: BluetoothDevice, bytes: ByteArray) {
             if (shuttingDown) return
             Log.i(TAG, "MESSAGE CHARACTERISTIC WRITE from ${device.address}, processing...")

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -80,6 +80,31 @@ internal fun computeEffectivePayload(
 }
 
 /**
+ * Resolves, by PEER IDENTITY, the subscribed peripheral-link address that
+ * belongs to [deviceId] — or null if no notify-subscribed central maps to this
+ * peer.
+ *
+ * This is the SINGLE device-scoped resolution shared by the per-peer MTU floor
+ * ([BleTransportFacade.flushPeerMtu]) and the notify egress
+ * ([BleTransportFacade.sendFragmentData]). Keeping one predicate is load-bearing:
+ * the floor must be applied for exactly the peers the notify path can reach, or a
+ * multi-fragment notify (an MLS Welcome) sized for the larger central link
+ * overflows the unobserved notify link and is silently truncated on air. The two
+ * links can use DIFFERENT BLE addresses for the same peer (iOS uses distinct
+ * handles per direction), so we match by device id, not address.
+ *
+ * [resolveDeviceId] maps a subscribed address to the device id it registered
+ * under ([MeshConnectionRegistry.deviceIdForAddress]); a subscribed address that
+ * has not resolved to any device id (null) never matches. Pure and side-effect
+ * free so the resolution is unit-testable without the Android BLE stack.
+ */
+internal fun resolveSubscribedAddress(
+    deviceId: String,
+    subscribedAddresses: Collection<String>,
+    resolveDeviceId: (String) -> String?,
+): String? = subscribedAddresses.firstOrNull { resolveDeviceId(it) == deviceId }
+
+/**
  * BLE transport facade implementing [TransportManager] for Bluetooth Low
  * Energy communication. Ensures iOS ↔ Android cross-platform compatibility.
  *
@@ -2062,6 +2087,21 @@ class BleTransportFacade(
     private fun currentConnectionCount(): Int = connections.connectionCount()
 
     /**
+     * The subscribed peripheral-link address that maps to [deviceId] by identity,
+     * or null if the peer is not notify-subscribed. Wraps [resolveSubscribedAddress]
+     * over the live GATT-server subscription set and the connection registry so the
+     * MTU floor and the notify egress resolve notify-reachability identically — see
+     * [resolveSubscribedAddress] for why that shared predicate is load-bearing.
+     * Main-thread only (reads [connections] and the GATT-server snapshot).
+     */
+    private fun subscribedNotifyAddressFor(deviceId: String): String? {
+        val server = peripheralGattServer ?: return null
+        return resolveSubscribedAddress(deviceId, server.subscribedAddresses()) {
+            connections.deviceIdForAddress(it)
+        }
+    }
+
+    /**
      * Recomputes and flushes the effective per-peer ATT payload into the Rust
      * transport keyed by [deviceId]. The core stores ONE MTU per peer but a
      * peer can be reachable over two links with different MTUs — the central
@@ -2111,17 +2151,15 @@ class BleTransportFacade(
         // fires (an iOS central negotiates a smaller MTU on the link it opens to
         // us, or none). Without a peripheral value the min() would collapse to the
         // central payload and a multi-fragment notify — an MLS Welcome — would
-        // overflow the notify link and be silently truncated on air. So when any
-        // notify-subscribed address maps to this peer but no peripheral payload is
-        // on file, [computeEffectivePayload] floors the peripheral term to the
-        // 185-byte fragment cap until a real value arrives. The subscription check
-        // is device-scoped, not address-scoped: the two links can use different BLE
-        // addresses for the same peer (iOS uses distinct handles per direction), so
-        // we match by device id exactly as the notify-egress resolution does.
+        // overflow the notify link and be silently truncated on air. So when the
+        // peer is notify-subscribed but no peripheral payload is on file,
+        // [computeEffectivePayload] floors the peripheral term to the 185-byte
+        // fragment cap until a real value arrives. Notify-reachability is resolved
+        // by [subscribedNotifyAddressFor] — the SAME device-scoped resolution the
+        // notify egress uses — so the floor is applied for exactly the peers the
+        // notify path can reach.
         val peripheralStaged = peripheralPayloadByDevice[deviceId]
-        val notifySubscribed = peripheralGattServer?.subscribedAddresses()?.any {
-            connections.deviceIdForAddress(it) == deviceId
-        } == true
+        val notifySubscribed = subscribedNotifyAddressFor(deviceId) != null
         val effective = computeEffectivePayload(
             central = central,
             peripheralStaged = peripheralStaged,
@@ -2140,6 +2178,26 @@ class BleTransportFacade(
                 Log.w(TAG, "bleClearPeerMtu failed for $deviceId", e)
             }
             return
+        }
+        // The notify floor took effect AND it caps a central link that could carry
+        // more: the per-peer MTU is ONE value used for BOTH directions, so flooring
+        // for the unobserved notify link also throttles central-write egress to the
+        // 185-byte cap until a real peripheral MTU is observed (then
+        // min(central, peripheral) relaxes it). The trade is correct — silent notify
+        // truncation is the alternative — and self-healing, but surface it so a
+        // convergence/throughput investigation can see WHY a higher-MTU central link
+        // is fragmenting at 185. (Honoring per-direction fragment sizes, which would
+        // remove the trade, is a deeper fragmenter change tracked separately.)
+        if (peripheralStaged == null && notifySubscribed && central != null && central > MAX_FRAGMENT_SIZE) {
+            emitDiagnostic(
+                "info",
+                "BLE per-peer MTU floored to notify cap; central egress throttled until peripheral MTU observed",
+                mapOf(
+                    "deviceId" to deviceId,
+                    "centralPayload" to central,
+                    "floor" to MAX_FRAGMENT_SIZE,
+                ),
+            )
         }
         // A link that negotiated BELOW the fragment floor is a real offline-
         // failure case: Rust rejects a sub-floor MTU and reverts to the 185-byte
@@ -2690,9 +2748,9 @@ class BleTransportFacade(
             if (address != null && server.isSubscribed(address)) {
                 address
             } else {
-                server.subscribedAddresses().firstOrNull { subscribed ->
-                    connections.deviceIdForAddress(subscribed) == recipientId
-                }
+                // Resolve by identity through the shared device-scoped predicate —
+                // the same one the MTU floor uses, so floor and egress never desync.
+                subscribedNotifyAddressFor(recipientId)
             }
         }
         if (notifyAddress != null) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
@@ -129,6 +129,15 @@ class PeripheralGattServer(
          * floor for this peer.
          */
         fun onCentralSubscribed(device: BluetoothDevice)
+        /**
+         * A remote central disabled notifications (CCCD unsubscribe) on the link it
+         * opened to our GATT server. The transport re-flushes the per-peer MTU so
+         * the notify floor applied on [onCentralSubscribed] is dropped now that the
+         * peer is no longer notify-reachable, relaxing the per-peer size back to the
+         * observed link MTU(s) — or clearing it when neither direction is known.
+         * Symmetric with [onCentralSubscribed].
+         */
+        fun onCentralUnsubscribed(device: BluetoothDevice)
         /** Return the current device-ID bytes, or null to fail the read. */
         fun provideDeviceIdBytes(device: BluetoothDevice): ByteArray?
         /** Return the current signed-identity bytes, or null to fail the read. */
@@ -792,6 +801,14 @@ class PeripheralGattServer(
                                     "subscribedCount" to subscribedCentralAddresses.size,
                                 ),
                             )
+                            // This central is no longer notify-subscribed. Signal the
+                            // transport to re-flush so the per-peer MTU floor applied
+                            // on subscribe is dropped (the peer is no longer notify-
+                            // reachable); without it the stale 185 floor would persist
+                            // and throttle central egress until some later unrelated
+                            // flush. Mirrors the ENABLE path; only enqueues work, so it
+                            // does not delay the CCCD ack sent below.
+                            listener.onCentralUnsubscribed(device)
                         }
                     }
                     if (responseNeeded) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
@@ -203,14 +203,17 @@ class PeripheralGattServer(
 
     /**
      * Addresses of centrals that have written ENABLE_NOTIFICATION_VALUE to
-     * the CCCD. Kept purely for observability — the facade currently routes
-     * outbound fragments through client-side writes, never server-side
-     * notifications, so nothing reads this set beyond the diagnostic
-     * emissions in [onDescriptorWriteRequest]. Keyed by address (not
-     * [BluetoothDevice]) so the contract matches [MeshConnectionRegistry]'s
-     * stated "stable for the lifetime of a single LL connection" guarantee
-     * instead of relying on [BluetoothDevice.equals] delegating to the
-     * address string.
+     * the CCCD. Load-bearing, not merely observability: the facade reads this set
+     * (via [subscribedAddresses] / [isSubscribed]) to (a) resolve the asymmetric-
+     * link notify egress — replying over the connection the peer opened to us
+     * rather than a reverse central write — and (b) apply the per-peer MTU floor
+     * for a notify-subscribed peer whose notify-link MTU was never observed. A
+     * [ConcurrentHashMap]-backed set: mutated here on the GATT-server binder thread
+     * (CCCD writes) and read on the main thread, so the cross-thread access is safe.
+     * Keyed by address (not [BluetoothDevice]) so the contract matches
+     * [MeshConnectionRegistry]'s stated "stable for the lifetime of a single LL
+     * connection" guarantee instead of relying on [BluetoothDevice.equals]
+     * delegating to the address string.
      */
     private val subscribedCentralAddresses: MutableSet<String> =
         ConcurrentHashMap.newKeySet()

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/PeripheralGattServer.kt
@@ -119,6 +119,16 @@ class PeripheralGattServer(
          *  sized for OUR central link to the peer is not over-sized for this
          *  notify link — the cause of the offline 1:1 Welcome-delivery stall. */
         fun onPeripheralMtuNegotiated(device: BluetoothDevice, maxPayload: Int)
+        /**
+         * A remote central enabled notifications (CCCD subscribe) on the link it
+         * opened to our GATT server. The transport re-flushes the per-peer MTU so
+         * the notify-link floor is applied even when this link's MTU has not been
+         * (and may never be) observed via the server-role onMtuChanged that backs
+         * [onPeripheralMtuNegotiated]. The subscribe typically lands after the
+         * central-link MTU flush, so it is the transport's signal to apply the
+         * floor for this peer.
+         */
+        fun onCentralSubscribed(device: BluetoothDevice)
         /** Return the current device-ID bytes, or null to fail the read. */
         fun provideDeviceIdBytes(device: BluetoothDevice): ByteArray?
         /** Return the current signed-identity bytes, or null to fail the read. */
@@ -758,6 +768,16 @@ class PeripheralGattServer(
                                     "subscribedCount" to subscribedCentralAddresses.size,
                                 ),
                             )
+                            // This central is now notify-subscribed. Its notify-link
+                            // MTU may never be reported (server-role onMtuChanged is
+                            // unreliable) and the subscribe typically lands after the
+                            // central-link MTU flush, so signal the transport to
+                            // re-flush and apply the notify floor for this peer. Fired
+                            // synchronously on the binder thread (the listener reposts
+                            // to main), mirroring onPeripheralMtuNegotiated; it runs
+                            // before sendResponse below but only enqueues work, so it
+                            // does not delay the CCCD ack.
+                            listener.onCentralSubscribed(device)
                         }
                         CccdAction.DISABLE -> {
                             subscribedCentralAddresses.remove(device.address)

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/EffectivePayloadTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/EffectivePayloadTest.kt
@@ -13,8 +13,8 @@ import org.junit.Test
  * link, or a multi-fragment MLS Welcome egressed over the notify link overflows
  * it and is silently truncated on air, stalling 1:1 MLS convergence (the owner
  * loops "Welcome send confirmation timed out"). 514 is the typical central-link
- * payload; 185 is [BLE]'s conservative fragment cap that every notify link can
- * carry.
+ * payload; 185 is [BleTransportFacade]'s conservative fragment cap that every
+ * notify link can carry.
  */
 class EffectivePayloadTest {
     private val floor = 185

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/EffectivePayloadTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/EffectivePayloadTest.kt
@@ -1,0 +1,110 @@
+package com.offlineprotocol.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [computeEffectivePayload] — the per-peer ATT payload the BLE
+ * transport flushes to the Rust fragmenter.
+ *
+ * The regression these guard against: a notify-subscribed peer whose peripheral
+ * (notify-link) MTU was never observed must NOT be sized for the larger central
+ * link, or a multi-fragment MLS Welcome egressed over the notify link overflows
+ * it and is silently truncated on air, stalling 1:1 MLS convergence (the owner
+ * loops "Welcome send confirmation timed out"). 514 is the typical central-link
+ * payload; 185 is [BLE]'s conservative fragment cap that every notify link can
+ * carry.
+ */
+class EffectivePayloadTest {
+    private val floor = 185
+
+    @Test
+    fun `floors to 185 when subscribed and peripheral MTU unobserved`() {
+        // Central negotiated 514, notify-link MTU never reported, peer IS
+        // notify-subscribed -> floor to 185 rather than collapse to 514.
+        assertEquals(
+            185,
+            computeEffectivePayload(
+                central = 514,
+                peripheralStaged = null,
+                notifySubscribed = true,
+                floor = floor,
+            ),
+        )
+    }
+
+    @Test
+    fun `a real peripheral MTU wins over the floor`() {
+        // When the notify link's MTU IS observed, use min(central, peripheral);
+        // the floor must never demote a link whose payload we actually know.
+        assertEquals(
+            200,
+            computeEffectivePayload(
+                central = 514,
+                peripheralStaged = 200,
+                notifySubscribed = true,
+                floor = floor,
+            ),
+        )
+    }
+
+    @Test
+    fun `min still applies when peripheral is the larger of the two`() {
+        assertEquals(
+            300,
+            computeEffectivePayload(
+                central = 300,
+                peripheralStaged = 480,
+                notifySubscribed = true,
+                floor = floor,
+            ),
+        )
+    }
+
+    @Test
+    fun `no floor when the peer is not notify-subscribed`() {
+        // Not subscribed: an unknown peripheral term stays unknown, so the
+        // effective payload is just the central link's.
+        assertEquals(
+            514,
+            computeEffectivePayload(
+                central = 514,
+                peripheralStaged = null,
+                notifySubscribed = false,
+                floor = floor,
+            ),
+        )
+    }
+
+    @Test
+    fun `null when nothing is known and not subscribed`() {
+        // Neither link known and not subscribed -> clear the Rust entry (caller
+        // lets the fragmenter revert to its own floor).
+        assertNull(
+            computeEffectivePayload(
+                central = null,
+                peripheralStaged = null,
+                notifySubscribed = false,
+                floor = floor,
+            ),
+        )
+    }
+
+    @Test
+    fun `floors to 185 when subscribed even with no central link`() {
+        // A peer subscribed to our notify with no central link and no observed
+        // peripheral MTU still gets an explicit 185 floor (not a clear), so the
+        // notify egress is bounded and Rust's fragment_fallback_count is not
+        // falsely ticked for a recipient that is a registered direct peer.
+        assertEquals(
+            185,
+            computeEffectivePayload(
+                central = null,
+                peripheralStaged = null,
+                notifySubscribed = true,
+                floor = floor,
+            ),
+        )
+    }
+}

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/SubscribedAddressResolutionTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/SubscribedAddressResolutionTest.kt
@@ -1,0 +1,102 @@
+package com.offlineprotocol.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [resolveSubscribedAddress] — the device-scoped resolution that
+ * ties the per-peer MTU floor ([BleTransportFacade.flushPeerMtu]) to the notify
+ * egress ([BleTransportFacade.sendFragmentData]). Both call sites resolve
+ * notify-reachability through this one predicate, so the floor is applied for
+ * exactly the peers the notify path can reach.
+ *
+ * The regression these guard against: if the floor and the egress ever disagreed
+ * about which peers are notify-subscribed, a multi-fragment MLS Welcome egressed
+ * over an unobserved notify link would be sized for the larger central link,
+ * overflow the notify link, and be silently truncated on air — stalling 1:1 MLS
+ * convergence. Resolution is by DEVICE ID because the two links can use different
+ * BLE addresses for the same peer (iOS uses distinct handles per direction).
+ */
+class SubscribedAddressResolutionTest {
+    /**
+     * Stand-in for [MeshConnectionRegistry.deviceIdForAddress]: an in-memory
+     * address -> deviceId map where an unregistered address resolves to null.
+     */
+    private fun resolverOf(vararg pairs: Pair<String, String>): (String) -> String? {
+        val map = pairs.toMap()
+        return { address -> map[address] }
+    }
+
+    @Test
+    fun `resolves the subscribed address that maps to the device by identity`() {
+        // The peer subscribed under a peripheral-link address ("periph") distinct
+        // from the central link we hold ("central"); both resolve to the same id.
+        val resolve = resolverOf("central" to "peerA", "periph" to "peerA")
+        assertEquals(
+            "periph",
+            resolveSubscribedAddress(
+                deviceId = "peerA",
+                subscribedAddresses = listOf("periph"),
+                resolveDeviceId = resolve,
+            ),
+        )
+    }
+
+    @Test
+    fun `null when no subscribed address maps to the device`() {
+        // Every subscribed address belongs to OTHER peers -> not notify-reachable.
+        val resolve = resolverOf("p1" to "peerB", "p2" to "peerC")
+        assertNull(
+            resolveSubscribedAddress(
+                deviceId = "peerA",
+                subscribedAddresses = listOf("p1", "p2"),
+                resolveDeviceId = resolve,
+            ),
+        )
+    }
+
+    @Test
+    fun `a subscribed address that has not resolved to any device never matches`() {
+        // The address subscribed but its device-id read has not completed
+        // (deviceIdForAddress -> null); it must not match any real peer.
+        val resolve = resolverOf() // every lookup returns null
+        assertNull(
+            resolveSubscribedAddress(
+                deviceId = "peerA",
+                subscribedAddresses = listOf("unresolved"),
+                resolveDeviceId = resolve,
+            ),
+        )
+    }
+
+    @Test
+    fun `picks the matching address among non-matching distractors`() {
+        val resolve = resolverOf(
+            "other1" to "peerB",
+            "mine" to "peerA",
+            "other2" to "peerC",
+        )
+        assertEquals(
+            "mine",
+            resolveSubscribedAddress(
+                deviceId = "peerA",
+                subscribedAddresses = listOf("other1", "mine", "other2"),
+                resolveDeviceId = resolve,
+            ),
+        )
+    }
+
+    @Test
+    fun `null when nothing is subscribed`() {
+        // No CCCD subscribers at all -> the peer is not notify-reachable even
+        // though its central link is known.
+        assertNull(
+            resolveSubscribedAddress(
+                deviceId = "peerA",
+                subscribedAddresses = emptyList(),
+                resolveDeviceId = resolverOf("central" to "peerA"),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Problem

A 1:1 MLS secure session never converges over pure BLE. The Welcome owner (accepter) egresses the multi-fragment MLS Welcome over the **peripheral/NOTIFY** link (it is the GATT server on the link the peer opened), but the adopter never receives it — so the owner loops `Welcome send confirmation timed out (attempt 1, 2, 3…)`.

## Root cause

`flushPeerMtu` flushes `min(central, peripheral)` to Rust as the per-peer fragment size. The notify link's MTU is only observable via the GATT-**server** `onMtuChanged`, which is unreliable for the server role and often never fires — especially with an iOS central, which negotiates a smaller MTU (or none) on the link it opens to us. With no peripheral value, `min()` collapses to the central payload (514), the multi-fragment Welcome egresses as 512-byte notify fragments, **overflows the notify link, and is silently truncated on air**.

The per-device MTU refactor in #120 did **not** close this — it still reads `peripheral = peripheralPayloadByDevice[deviceId]`, which stays null when the notify MTU is never observed.

## Fix

- Floor the peripheral term to the 185-byte fragment cap (`MAX_FRAGMENT_SIZE`) for a notify-subscribed peer whose peripheral MTU is unknown, so the per-peer size is one any notify link can carry.
- Re-flush on CCCD subscribe (`onCentralSubscribed`), which lands **after** the central-link MTU flush, so the floor is actually applied.
- The subscribe check is **device-scoped** (`subscribedAddresses().any { deviceIdForAddress(it) == deviceId }`), not address-scoped — the two links can use different BLE addresses for the same peer (iOS uses distinct handles per direction), so it holds for the asymmetric Android↔iOS topology that is the actual failure mode.
- A real observed peripheral MTU still wins (consulted first); the floor only applies when truly unknown. Teardown is unchanged: the subscription set is cleared before the disconnect re-flush, so the floor disengages and the surviving central link restores.

The floor/min arithmetic is extracted to a pure `computeEffectivePayload()` with unit tests. **Kotlin bridge only — no Rust/UniFFI/.so changes.**

## Verification

Ran the CI task locally (Gradle 8.9 / JDK 17 via `android-ci-harness`):
`gradle :offlineprotocol:testDebugUnitTest` → **green, 60 tests, 0 failures** (incl. 6 new `EffectivePayloadTest` cases). `compileDebugKotlin` clean, no new warnings.

Expected on-device after rebuild: the flush diagnostic flips to `peripheralPayload: -1, effectivePayload: 185`, notify `fragmentSize` drops from 512 to ~183, and the owner logs `Welcome send succeeded`. (Rust re-fragments retries under the current MTU, so convergence completes on the next Welcome retry.)

## Follow-up (out of scope)

The iOS Swift bridge reverse direction (iOS notifying Android) may carry the same latent gap — flagged for a separate audit, not touched here.
