### PR TITLE
fix(ble,mls,router): restore offline Android↔iOS message delivery

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/InboundFragmentBuffer.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/InboundFragmentBuffer.kt
@@ -209,7 +209,16 @@ internal class InboundFragmentBuffer(
     companion object {
         const val DEFAULT_MAX_PER_PEER: Int = 100
         const val DEFAULT_MAX_PEERS: Int = 32
-        const val DEFAULT_TIMEOUT_MS: Long = 5_000L
+        // Idle window (reset by each fragment) before a partial buffer is evicted.
+        // This holds inbound fragments only until the sender's device-id resolves —
+        // a GATT connect+read throttled to one attempt per MIN_RECONNECT_INTERVAL
+        // (5s) and prone to GATT-133 retries. At 5s a first-contact multi-fragment
+        // MLS Welcome that arrives in a burst could be evicted before resolution
+        // completes, losing the Welcome before it ever reaches the Rust reassembler.
+        // 15s comfortably exceeds the reverse-resolution worst case while staying
+        // well under the 30s Rust reassembly window; memory stays bounded by the
+        // per-peer / peer caps above.
+        const val DEFAULT_TIMEOUT_MS: Long = 15_000L
 
         val DEFAULT_MAIN_THREAD_CHECK: () -> Unit = {
             check(Looper.myLooper() == Looper.getMainLooper()) {

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -120,7 +120,12 @@ public class BleManager: NSObject, TransportManager {
     // owned by fragmentQueue. ALL reads and writes MUST occur inside fragmentQueue.async.
     // evictPeer() dispatches removals to fragmentQueue to honour this contract.
     private var pendingFragments: [UUID: [(Data, Date)]] = [:]
-    private let PENDING_FRAGMENT_TIMEOUT: TimeInterval = 5.0 // For incoming fragments waiting for device ID
+    // Idle window for incoming fragments waiting for the sender's device-id to
+    // resolve (a GATT connect+read, throttled to ~5s and prone to retries). 5s was
+    // too short: a first-contact multi-fragment MLS Welcome arriving in a burst
+    // could be evicted before resolution completed and be lost before reassembly.
+    // 15s exceeds the reverse-resolution worst case; the per-peer cap bounds memory.
+    private let PENDING_FRAGMENT_TIMEOUT: TimeInterval = 15.0
     private let PENDING_OUTBOUND_FRAGMENT_TIMEOUT: TimeInterval = 30.0 // For outbound fragments that failed to send
     private let MAX_PENDING_FRAGMENTS_PER_PEER = 100
     // Track outbound fragments with timestamps for timeout handling (owned by fragmentQueue)
@@ -142,7 +147,24 @@ public class BleManager: NSObject, TransportManager {
     private var peripheralReady = false
     private var isGattServiceReady = false
     private var pendingAdvertiseAfterServiceReady = false
-    private var subscribedCentrals: Set<UUID> = []
+    // Peripheral-role NOTIFY egress (the iOS mirror of Android's
+    // PeripheralGattServer.notifyFragment path, PR #120/#121). Lets iOS reply to a
+    // peer that connected to US as central — so we hold no `CBPeripheral` for it —
+    // by pushing a notification over the link IT opened, instead of trying to
+    // reverse-connect as central (which iOS backgrounding routinely blocks). Absent
+    // this, iOS can only send over a link it opened, so iOS→Android stalls whenever
+    // Android is central / iOS is peripheral.
+    //
+    // `subscribedCentralsById` is guarded by `notifyLock` so the fragment drain
+    // (fragmentQueue) can test notify-reachability while CoreBluetooth's peripheral
+    // delegates (main queue) mutate it. The `notifyOutbound` queue and the actual
+    // `peripheralManager.updateValue` call stay main-queue-only — CBPeripheralManager
+    // must be driven from its delegate queue (init'd with `queue: nil` ⇒ main) — so
+    // the drain hands fragments to the main-queue pump via `enqueueNotifyOutbound`.
+    private let notifyLock = NSLock()
+    private var subscribedCentralsById: [UUID: CBCentral] = [:]
+    /// Per-recipient NOTIFY outbound queue, drained by `pumpNotifyOutbound`. Main-queue only.
+    private var notifyOutbound: [String: [(data: Data, timestamp: Date)]] = [:]
     private var lastMeshAdvertisement: MeshAdvertisementData?
     
     // Metrics
@@ -452,8 +474,11 @@ public class BleManager: NSObject, TransportManager {
         lastProactiveScanRefresh = nil
         lastForcedBleRefresh = nil
         aggressiveDiscoveryStarted = nil
-        subscribedCentrals.removeAll()
-        
+        notifyLock.lock()
+        subscribedCentralsById.removeAll()
+        notifyLock.unlock()
+        notifyOutbound.removeAll()
+
         // Clean up managers
         centralManager = nil
         peripheralManager = nil
@@ -1098,6 +1123,18 @@ public class BleManager: NSObject, TransportManager {
 
                 let hasPeripheral = self.findPeripheral(for: recipientId) != nil
                 if !hasPeripheral {
+                    // No central link to this peer. If it subscribed to OUR GATT
+                    // server (the Android-central / iOS-peripheral topology), reply
+                    // over THAT link via NOTIFY instead of trying to reverse-connect
+                    // as central — which iOS backgrounding routinely blocks, the exact
+                    // fragile path Android abandoned in PR #120. Without this, iOS can
+                    // only ever send over a link it opened, so iOS→Android stalls in
+                    // this (common) topology.
+                    if self.notifyTarget(for: recipientId) != nil {
+                        self.enqueueNotifyOutbound(recipientId: recipientId, data: data)
+                        consecutiveSkips = 0
+                        continue
+                    }
                     self.enqueuePendingOutboundFragment(recipientId: recipientId, data: data)
                     if let identifier = self.connections.peripheralIdentifier(for: recipientId),
                        reconnectAttempted.insert(identifier).inserted {
@@ -1264,7 +1301,134 @@ public class BleManager: NSObject, TransportManager {
     }
 
     private func currentConnectionCount() -> Int {
-        return connections.connectedPeripheralCount() + subscribedCentrals.count
+        return connections.connectedPeripheralCount() + subscribedCentralCount()
+    }
+
+    // MARK: - Peripheral-role NOTIFY egress (iOS mirror of Android #120/#121)
+
+    private func subscribedCentralCount() -> Int {
+        notifyLock.lock()
+        let count = subscribedCentralsById.count
+        notifyLock.unlock()
+        return count
+    }
+
+    /// Resolves a recipient device-id to a subscribed `CBCentral` we can notify, or
+    /// nil if the peer is not notify-subscribed to our GATT server. Cross-references
+    /// the retained centrals (under `notifyLock`) with the thread-safe connection
+    /// registry, so it is safe to call from any queue (the drain runs on
+    /// `fragmentQueue`; the pump runs on main). Mirrors Android's
+    /// `subscribedNotifyAddressFor` device-scoped resolution.
+    private func notifyTarget(for recipientId: String) -> CBCentral? {
+        notifyLock.lock()
+        let centrals = subscribedCentralsById
+        notifyLock.unlock()
+        for (identifier, central) in centrals {
+            if connections.centralDeviceId(for: identifier) == recipientId
+                || connections.peripheralDeviceId(for: identifier) == recipientId {
+                return central
+            }
+        }
+        return nil
+    }
+
+    /// Hands a fragment to the main-queue NOTIFY pump. Safe to call from the
+    /// fragment drain (`fragmentQueue`): the queue mutation and `updateValue` run on
+    /// main, where CBPeripheralManager lives. FIFO is preserved because `main.async`
+    /// is ordered and the drain pulls fragments from Rust in order.
+    private func enqueueNotifyOutbound(recipientId: String, data: Data) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            var queue = self.notifyOutbound[recipientId] ?? []
+            queue.append((data: data, timestamp: Date()))
+            if queue.count > self.MAX_PENDING_FRAGMENTS_PER_PEER {
+                let overflow = queue.count - self.MAX_PENDING_FRAGMENTS_PER_PEER
+                queue.removeFirst(overflow)
+                self.emitDiagnostic("warning", "NOTIFY outbound queue capped, dropping oldest",
+                                    context: ["recipientId": recipientId, "dropped": overflow,
+                                              "max": self.MAX_PENDING_FRAGMENTS_PER_PEER])
+            }
+            self.notifyOutbound[recipientId] = queue
+            self.pumpNotifyOutbound()
+        }
+    }
+
+    /// Drains queued NOTIFY fragments to their subscribed centrals via
+    /// `updateValue`. On a `false` return the controller's transmit queue is full;
+    /// we stop and resume from `peripheralManagerIsReadyToUpdateSubscribers` — the
+    /// peripheral-side analog of the central `canSendWriteWithoutResponse`
+    /// backpressure the write path already honours. Main-queue only.
+    private func pumpNotifyOutbound() {
+        guard let pm = peripheralManager, let characteristic = messageCharacteristic else { return }
+        let now = Date()
+        var sentBytes: UInt64 = 0
+        var sentFragments: UInt64 = 0
+        for recipientId in Array(notifyOutbound.keys) {
+            guard var queue = notifyOutbound[recipientId] else { continue }
+            queue = queue.filter { now.timeIntervalSince($0.timestamp) < PENDING_OUTBOUND_FRAGMENT_TIMEOUT }
+            guard let central = notifyTarget(for: recipientId) else {
+                // No longer notify-reachable. Drop the queued fragments; the
+                // reliability layer (MLS Welcome retransmit / RetryQueue) re-drives
+                // delivery over whatever path is available next.
+                notifyOutbound.removeValue(forKey: recipientId)
+                continue
+            }
+            var transmitQueueFull = false
+            while let head = queue.first {
+                if pm.updateValue(head.data, for: characteristic, onSubscribedCentrals: [central]) {
+                    queue.removeFirst()
+                    sentBytes += UInt64(head.data.count)
+                    sentFragments += 1
+                    meshController.markPeerActive(recipientId)
+                    meshController.markPeerActive(deviceId)
+                } else {
+                    transmitQueueFull = true
+                    break
+                }
+            }
+            if queue.isEmpty {
+                notifyOutbound.removeValue(forKey: recipientId)
+            } else {
+                notifyOutbound[recipientId] = queue
+            }
+            // A `false` return means the shared transmit queue is full for the whole
+            // peripheral, not just this central — stop and wait for the ready callback.
+            if transmitQueueFull { break }
+        }
+        // Fold the byte/fragment counters on `fragmentQueue`, which owns them
+        // (`sendFragmentData` mutates them there), so this main-queue pump does not
+        // race the drain on the non-atomic counters.
+        if sentBytes > 0 || sentFragments > 0 {
+            fragmentQueue.async { [weak self] in
+                self?.bytesSent += sentBytes
+                self?.fragmentsSent += sentFragments
+            }
+        }
+    }
+
+    /// Reports the MIN usable payload over the links we can egress on (central WRITE
+    /// and peripheral NOTIFY) to the Rust fragmenter, which sizes every fragment to
+    /// one per-peer value regardless of carrier. Without the min, a fragment sized
+    /// for the larger central-write link overflows the NOTIFY link and is truncated
+    /// on air — the iOS analog of the bug PR #121 fixed on Android. Values are read
+    /// live from CoreBluetooth (both are already ATT-header-adjusted). A sub-floor
+    /// value is left for Rust's `set_peer_mtu` to reject and clamp to its 185-byte
+    /// floor, so we do not duplicate that constant here. Main-queue only.
+    private func reflectEgressMtu(forDeviceId deviceId: String) {
+        var candidates: [Int] = []
+        if let peripheral = findPeripheral(for: deviceId) {
+            candidates.append(peripheral.maximumWriteValueLength(for: .withoutResponse))
+        }
+        if let central = notifyTarget(for: deviceId) {
+            candidates.append(central.maximumUpdateValueLength)
+        }
+        guard let smallest = candidates.min(), smallest > 0 else { return }
+        do {
+            try protocolInstance.bleSetPeerMtu(peerId: deviceId, maxPayload: UInt32(smallest))
+        } catch {
+            emitDiagnostic("warning", "reflectEgressMtu bleSetPeerMtu failed",
+                           context: ["deviceId": deviceId, "error": error.localizedDescription])
+        }
     }
 
     /// Tears down the protocol-side state for a peer that has been lost —
@@ -1576,6 +1740,15 @@ public class BleManager: NSObject, TransportManager {
     }
     
     private func processPendingFragments(for centralId: UUID, deviceId: String) {
+        // A device-id just resolved for this link. If the peer is notify-reachable,
+        // clamp the Rust fragmenter to the NOTIFY link's payload (min with any
+        // central-write link) and flush any queued NOTIFY fragments. Runs on the
+        // caller's (main) queue — every caller is a CoreBluetooth delegate — which is
+        // required: `pumpNotifyOutbound` drives CBPeripheralManager. This is not
+        // gated on inbound fragments existing, so it also covers a central that
+        // subscribed before we knew its device-id.
+        reflectEgressMtu(forDeviceId: deviceId)
+        pumpNotifyOutbound()
         fragmentQueue.async { [weak self] in
             guard let self = self else { return }
             guard let fragments = self.pendingFragments.removeValue(forKey: centralId) else {
@@ -3018,12 +3191,16 @@ extension BleManager: CBPeripheralManagerDelegate {
             return
         }
         
-        // Track this central as subscribed for connection count
-        subscribedCentrals.insert(central.identifier)
+        // Retain this central so we can NOTIFY it (peripheral-role egress) and so it
+        // counts toward the connection budget. Stored under `notifyLock` because the
+        // fragment drain tests notify-reachability off the main queue.
+        notifyLock.lock()
+        subscribedCentralsById[central.identifier] = central
+        notifyLock.unlock()
         print("[BleManager] Central subscribed: \(central.identifier)")
         emitDiagnostic("info", "Central subscribed to characteristic", context: [
             "central": central.identifier.uuidString,
-            "totalSubscribed": subscribedCentrals.count
+            "totalSubscribed": subscribedCentralCount()
         ])
 
         if connections.centralDeviceId(for: central.identifier) == nil && connections.peripheralDeviceId(for: central.identifier) == nil {
@@ -3038,13 +3215,32 @@ extension BleManager: CBPeripheralManagerDelegate {
     
     public func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral, didUnsubscribeFrom characteristic: CBCharacteristic) {
         print("[BleManager] Central unsubscribed from characteristic: \(characteristic.uuid)")
-        subscribedCentrals.remove(central.identifier)
+        let deviceId = connections.centralDeviceId(for: central.identifier)
+            ?? connections.peripheralDeviceId(for: central.identifier)
+        notifyLock.lock()
+        subscribedCentralsById.removeValue(forKey: central.identifier)
+        notifyLock.unlock()
         emitDiagnostic("info", "Central unsubscribed", context: [
             "central": central.identifier.uuidString,
             "characteristic": characteristic.uuid.uuidString,
-            "remainingSubscribed": subscribedCentrals.count
+            "remainingSubscribed": subscribedCentralCount()
         ])
         connections.removeCentralDeviceId(for: central.identifier)
+        // The NOTIFY link to this peer is gone: drop anything queued for it and
+        // re-report the per-peer MTU (now only a central-write link, if any, binds).
+        if let deviceId = deviceId {
+            notifyOutbound.removeValue(forKey: deviceId)
+            reflectEgressMtu(forDeviceId: deviceId)
+        }
+    }
+
+    /// CoreBluetooth signals the peripheral transmit queue has space again after a
+    /// prior `updateValue` returned false (transmit-queue-full backpressure). Resume
+    /// draining queued NOTIFY fragments. Without this, a multi-fragment NOTIFY (an
+    /// MLS Welcome) that hits backpressure would stall until the next unrelated
+    /// drain. Mirrors the central-side `peripheralIsReady(toSendWriteWithoutResponse:)`.
+    public func peripheralManagerIsReadyToUpdateSubscribers(_ peripheral: CBPeripheralManager) {
+        pumpNotifyOutbound()
     }
 }
 

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -3239,7 +3239,15 @@ extension BleManager: CBPeripheralManagerDelegate {
     /// draining queued NOTIFY fragments. Without this, a multi-fragment NOTIFY (an
     /// MLS Welcome) that hits backpressure would stall until the next unrelated
     /// drain. Mirrors the central-side `peripheralIsReady(toSendWriteWithoutResponse:)`.
-    public func peripheralManagerIsReadyToUpdateSubscribers(_ peripheral: CBPeripheralManager) {
+    // iOS 26.5 SDK renamed the Swift import of this delegate method to
+    // `peripheralManagerIsReady(toUpdateSubscribers:)` and marked the old
+    // auto-imported name unavailable, so the old spelling is a hard compile error
+    // on new Xcode. The underlying ObjC selector is unchanged, so pin it with an
+    // explicit `@objc(...)`: that keeps CoreBluetooth dispatching to this method on
+    // older SDKs (where the new Swift name is not the protocol requirement) while
+    // satisfying the renamed requirement on 26.5+.
+    @objc(peripheralManagerIsReadyToUpdateSubscribers:)
+    public func peripheralManagerIsReady(toUpdateSubscribers peripheral: CBPeripheralManager) {
         pumpNotifyOutbound()
     }
 }

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -690,7 +690,32 @@ impl TransportSelector {
                     .find(|(t, _)| *t == current)
                     .map(|(_, s)| s.total)
                 {
-                    if !self.should_switch(current, current_score, best_transport, best_score) {
+                    // A negative current total is the Internet fallback-demotion
+                    // sentinel (prefer_online=false; see `score_transport`). Anti-flap
+                    // (cooldown/hysteresis/stability) must NOT pin the demoted fallback
+                    // over an available, real-scored mesh transport. The fallback only
+                    // became `current` because a *prior* send found the mesh peer
+                    // unreachable and escalated to Internet — which also re-armed the
+                    // switch cooldown (TransportManager::send → set_current_transport).
+                    // The instant the mesh peer is back in the available set (its
+                    // non-negative score outranks the sentinel) we must switch to it, or
+                    // the next send rides the relay through the whole cooldown and an
+                    // off-relay nearby peer is silently bypassed.
+                    let current_is_demoted_fallback = current_score < 0.0 && best_score >= 0.0;
+                    if current_is_demoted_fallback {
+                        debug!(
+                            current = ?current,
+                            current_score = current_score,
+                            candidate = ?best_transport,
+                            candidate_score = best_score,
+                            "DORS: leaving demoted Internet fallback for an available mesh transport (bypassing cooldown)"
+                        );
+                    } else if !self.should_switch(
+                        current,
+                        current_score,
+                        best_transport,
+                        best_score,
+                    ) {
                         debug!(
                             current = ?current,
                             current_score = current_score,
@@ -1967,6 +1992,47 @@ mod tests {
             first, second,
             "cooldown must block immediate re-switch; should stay on {:?}",
             first
+        );
+    }
+
+    /// Regression (Android↔iOS off-relay stall): the demoted Internet fallback
+    /// must never be retained over an available mesh transport, even while the
+    /// switch cooldown is active. The cold-start path pins `current = Internet`
+    /// (BLE had no peers, the send escalated to Internet via the fallback loop,
+    /// which re-armed the cooldown); the instant a BLE peer is discovered the next
+    /// selection must switch to BLE rather than riding the relay through the whole
+    /// cooldown — which silently bypasses a nearby peer that is off the relay.
+    /// Pre-fix this returned Internet for `switch_cooldown_secs`.
+    #[test]
+    fn test_demoted_internet_fallback_yields_to_mesh_despite_cooldown() {
+        // Default config => prefer_online = false (Internet demoted) with a
+        // non-zero switch cooldown, so absent the bypass the cooldown pins Internet.
+        let message = create_test_message();
+        let mut selector = TransportSelector::new();
+        assert!(
+            selector.config.switch_cooldown_secs > 0,
+            "test depends on a non-zero default cooldown to prove the bypass",
+        );
+
+        // Cold start: only Internet is up (BLE has no peers yet). Internet is
+        // selected and becomes `current`, arming the cooldown timer.
+        let mut internet_only = HashMap::new();
+        internet_only.insert(TransportType::Internet, create_test_metrics(None, 0.0, 0));
+        assert_eq!(
+            selector.select_transport(&message, &internet_only),
+            Some(TransportType::Internet),
+            "cold start with only Internet available must select Internet",
+        );
+
+        // A BLE peer is discovered a moment later; the cooldown is still active.
+        let mut both = HashMap::new();
+        both.insert(TransportType::Internet, create_test_metrics(None, 0.0, 0));
+        both.insert(TransportType::BLE, create_test_metrics(Some(-60), 0.1, 5));
+        assert_eq!(
+            selector.select_transport(&message, &both),
+            Some(TransportType::BLE),
+            "a freshly-available mesh transport must win immediately over the \
+             demoted Internet fallback, bypassing the switch cooldown",
         );
     }
 

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -187,6 +187,21 @@ pub struct BleTransport {
     /// error. Surface via [`Self::fragment_fallback_count`] so
     /// production alerts fire the first time the invariant breaks.
     fragment_fallback_count: Arc<AtomicU64>,
+    /// Count of [`Transport::send`] calls that returned
+    /// [`PeerNotReachable`](crate::Error::PeerNotReachable) for a recipient that
+    /// was **not** among the connected BLE peers, *while other peers WERE
+    /// connected* (the peers map was non-empty).
+    ///
+    /// "No BLE peers at all" is the ordinary offline case and is **not** counted —
+    /// DORS escalating that send to Internet is exactly right. A non-empty map
+    /// missing only this recipient is the suspicious case: the device is meshing
+    /// with someone, just not the addressed id. The dominant cause is a
+    /// `recipient` ↔ `ble_peer_discovered` device-id **keying mismatch** (e.g. an
+    /// app addressing a message by a user id that differs from the advertised mesh
+    /// id), which makes a physically-in-range peer look unreachable and silently
+    /// routes the message to Internet. Surfacing it turns a silent misroute into
+    /// an observable signal. Exposed via [`Self::recipient_not_among_peers_count`].
+    recipient_not_among_peers_count: Arc<AtomicU64>,
     /// Platform callback invoked when new fragments are available to send.
     /// Called from `send()` after enqueueing — the platform layer should
     /// respond by calling `get_next_fragment()` and performing the BLE write.
@@ -213,6 +228,7 @@ impl BleTransport {
             peer_mtus: Arc::new(Mutex::new(HashMap::new())),
             undersized_mtu_reports: Arc::new(AtomicU64::new(0)),
             fragment_fallback_count: Arc::new(AtomicU64::new(0)),
+            recipient_not_among_peers_count: Arc::new(AtomicU64::new(0)),
             on_fragments_available: Arc::new(Mutex::new(None)),
             eviction_callback: Arc::new(Mutex::new(None)),
         }
@@ -349,6 +365,17 @@ impl BleTransport {
     /// regressing to the 185-byte floor. Surface in dashboards.
     pub fn fragment_fallback_count(&self) -> u64 {
         self.fragment_fallback_count.load(Ordering::Relaxed)
+    }
+
+    /// Monotonic count of [`Transport::send`] calls whose recipient was not among
+    /// the connected BLE peers **while other peers were connected**.
+    ///
+    /// Zero in healthy operation. A sustained non-zero value means messages to
+    /// in-range peers are being silently routed off BLE — almost always a
+    /// `recipient` ↔ `ble_peer_discovered` device-id keying mismatch in the host
+    /// app. Surface in dashboards alongside [`Self::fragment_fallback_count`].
+    pub fn recipient_not_among_peers_count(&self) -> u64 {
+        self.recipient_not_among_peers_count.load(Ordering::Relaxed)
     }
 
     /// Sets the platform-specific handle.
@@ -1108,6 +1135,23 @@ impl Transport for BleTransport {
         {
             let peers = self.peers.lock().unwrap();
             if !peers.contains_key(&recipient) {
+                // Distinguish "no BLE peers at all" (ordinary offline; escalate to
+                // the next transport) from "meshing with other peers but not this
+                // recipient" — the latter is the keying-mismatch signal that
+                // silently routes an in-range peer's message to Internet. Count and
+                // warn only the latter so the metric isn't drowned out by the
+                // benign no-peers case. See `recipient_not_among_peers_count`.
+                if !peers.is_empty() {
+                    self.recipient_not_among_peers_count
+                        .fetch_add(1, Ordering::Relaxed);
+                    tracing::warn!(
+                        recipient = %recipient,
+                        connected_peers = peers.len(),
+                        "ble: send recipient is not among the connected BLE peers while \
+                         other peers are connected — likely a recipient↔device-id keying \
+                         mismatch; this send will fall back off BLE"
+                    );
+                }
                 return Err(crate::Error::PeerNotReachable(format!(
                     "BLE: no connected peer for recipient {}",
                     recipient
@@ -1237,6 +1281,35 @@ mod tests {
         assert_eq!(transport.status(), TransportStatus::Available);
         transport.stop().unwrap();
         assert_eq!(transport.status(), TransportStatus::Disconnected);
+    }
+
+    #[test]
+    fn test_ble_recipient_not_among_peers_count_signals_keying_mismatch() {
+        let mut transport = BleTransport::new("test-device");
+        transport.start().unwrap();
+
+        // No BLE peers at all: PeerNotReachable, but this is the ordinary offline
+        // case (escalating to the next transport is correct) and must NOT be counted.
+        assert!(matches!(
+            transport.send(&small_message()).unwrap_err(),
+            crate::Error::PeerNotReachable(_)
+        ));
+        assert_eq!(transport.recipient_not_among_peers_count(), 0);
+
+        // Meshing with another peer ("alice") but not the addressed recipient
+        // ("bob"): the keying-mismatch signal — a physically-present mesh whose
+        // ids don't match the send target. This MUST be counted.
+        transport.on_peer_discovered(peer_device("alice"));
+        assert!(matches!(
+            transport.send(&small_message()).unwrap_err(),
+            crate::Error::PeerNotReachable(_)
+        ));
+        assert_eq!(transport.recipient_not_among_peers_count(), 1);
+
+        // Recipient now connected: send succeeds and the counter does not move.
+        transport.on_peer_discovered(peer_device("bob"));
+        transport.send(&small_message()).unwrap();
+        assert_eq!(transport.recipient_not_among_peers_count(), 1);
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -577,6 +577,36 @@ impl OfflineProtocol {
                                     &group_id,
                                     MlsOperationContext::Receive,
                                 );
+
+                                // Surface the app-facing established event for the
+                                // both-create owner. `can_confirm_from_source` restricts a
+                                // `both_create_awaiting_decrypt` owner to confirm ONLY via a
+                                // group-aware decrypt (a plaintext probe/ack is rejected), so
+                                // this is its sole convergence path — and the one place it can
+                                // tell the app the session exists. `confirm_session_state`
+                                // deliberately skips emission for `decrypt_success` (it does
+                                // not know the group id), deferring to this call site exactly
+                                // as the Welcome-receive path above does for the adopter.
+                                // Without this the owner has a fully working 1:1 session (it
+                                // sends and receives) but the app never receives
+                                // `secure_session_established`, so UI gated on a known secure
+                                // session — e.g. the demo's group-creation contact list —
+                                // silently excludes the peer. Gate on `session:` so multi-party
+                                // group decrypts (which also reach this arm) are not reported as
+                                // 1:1 sessions. Reaching `Ok(true)` here implies we own the 1:1
+                                // group (an adopter would already be Confirmed via
+                                // `welcome_received` and return `Ok(false)`), so
+                                // `initiated_by_local` is true.
+                                if group_id.starts_with("session:") {
+                                    if let Ok(state) = lock_shared_state(&self.shared_state) {
+                                        state.emit_event(Event::secure_session_established(
+                                            sender_owned.clone(),
+                                            group_id.clone(),
+                                            true,
+                                            true,
+                                        ));
+                                    }
+                                }
                             }
                             Ok(false) => {}
                             Err(e) => {

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -265,35 +265,45 @@ impl OfflineProtocol {
                                     }
                                 }
                             }
-                        } else if self.welcome_lifecycles.contains_key(sender) {
+                        } else if self.welcome_lifecycles.contains_key(sender)
+                            && !self.confirmed_sessions.contains(sender)
+                        {
                             info!(
                                 sender = %sender,
                                 local_id = %local_id,
                                 "Welcome-wins tiebreaker: keeping local session (local < remote); \
                                  awaiting group-aware decrypt before confirming our Welcome"
                             );
-                            // Genuine both-create owner: we created our OWN group for this
-                            // peer AND sent a Welcome (hence an outbound welcome lifecycle
-                            // exists). Keep our group, but do NOT confirm our outbound
+                            // Genuine both-create owner that is NOT yet converged: we
+                            // created our OWN group for this peer AND sent a Welcome (hence
+                            // an outbound welcome lifecycle exists) and have not yet
+                            // confirmed. Keep our group, but do NOT confirm our outbound
                             // Welcome merely because we received the peer's — that is no
                             // proof they adopted ours. Keep retransmitting until a decrypt
-                            // proves they adopted our group.
+                            // proves they adopted our group. The `!confirmed` guard is
+                            // load-bearing: once converged, a late Welcome retransmit must
+                            // NOT re-arm (and re-persist) `both_create_awaiting_decrypt` on
+                            // an already-confirmed session — that stale, persisted gate
+                            // would later block confirmation on a re-pair where this device
+                            // adopts, stranding it. A converged owner falls through to the
+                            // resend-confirm branch instead.
                             owner_keep = true;
                         } else {
-                            // NOT a both-create owner: we have no outbound welcome
-                            // lifecycle for this peer, so we never created our own group —
-                            // we joined THEIR group via an earlier Welcome. This is the
-                            // owner re-sending its Welcome because it has not yet observed
-                            // our confirm. Re-send the encrypted confirm so a lost first
-                            // confirm self-heals in lockstep with the owner's
-                            // retransmission. Critically, do NOT enter owner_keep: we are
-                            // the adopter, and gating on decrypt here (plus poisoning
+                            // Either (a) the adopter: we have no outbound welcome lifecycle
+                            // for this peer, so we never created our own group — we joined
+                            // THEIR group via an earlier Welcome, and this is the owner
+                            // re-sending its Welcome because it has not yet observed our
+                            // confirm; or (b) an already-converged owner whose `!confirmed`
+                            // guard above sent it here. In both cases re-send the encrypted
+                            // confirm so a lost confirm self-heals in lockstep with the
+                            // owner's retransmission. Critically, do NOT enter owner_keep:
+                            // for the adopter, gating on decrypt here (plus poisoning
                             // both_create_awaiting_decrypt) would suppress our confirm and
                             // strand the owner in Pending forever — the convergence bug.
                             debug!(
                                 sender = %sender,
                                 local_id = %local_id,
-                                "Welcome retransmit for an already-adopted session; re-sending encrypted confirm"
+                                "Welcome retransmit for an already-adopted/converged session; re-sending encrypted confirm"
                             );
                             resend_confirm_on_retransmit = true;
                         }

--- a/crates/offline-protocol/src/protocol/session.rs
+++ b/crates/offline-protocol/src/protocol/session.rs
@@ -555,12 +555,26 @@ impl OfflineProtocol {
             return false;
         }
 
+        // A successful group decrypt is definitive, group-aware proof that the
+        // peer adopted our 1:1 group. `decrypt_success` is raised only inside
+        // `DecryptResult::Success` (see message_dispatch.rs): ciphertext on the
+        // single stored `session:<a>:<b>` group actually decrypted, which is
+        // possible only if the peer is a member. It must therefore confirm the
+        // session regardless of our *local* Welcome's delivery state. Gating it on
+        // a still-active local Welcome (the lifecycle match below) strands a
+        // both-create owner whose own Welcome timed out to `Failed`/`Expired` on a
+        // lossy or asymmetric BLE link (the Android↔iOS case): the owner decrypts
+        // the peer's messages but never confirms, so every outbound send fails
+        // `SessionNotReady` — it can receive but never reply. The both-create gate
+        // above is preserved, so a both-create owner is still restricted to *only*
+        // decrypt_success (a plaintext probe/ack can never confirm it).
+        if source_event == "decrypt_success" {
+            return true;
+        }
+
         if !matches!(
             source_event,
-            "decrypt_success"
-                | "confirmation_ack_received"
-                | "confirmation_probe_received"
-                | "confirmation_retry"
+            "confirmation_ack_received" | "confirmation_probe_received" | "confirmation_retry"
         ) {
             return true;
         }
@@ -573,8 +587,9 @@ impl OfflineProtocol {
             None => matches!(
                 source_event,
                 // Compatibility path for sessions created before welcome lifecycle
-                // persistence existed. Decrypt-based confirmation stays blocked
-                // until we have explicit local welcome delivery evidence.
+                // persistence existed. A plaintext probe/ack/retry can confirm here
+                // (it is the only evidence such a legacy session has); a group-aware
+                // decrypt already returned true above and never reaches this arm.
                 "confirmation_ack_received" | "confirmation_probe_received" | "confirmation_retry"
             ),
         }

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -4791,6 +4791,126 @@ fn test_both_create_owner_confirms_via_decrypt_after_welcome_expired() {
     );
 }
 
+/// Regression (Android↔iOS group creation): the 1:1 session OWNER — the side that
+/// created the session group and sent the Welcome — confirms only when it decrypts
+/// the peer's first group-aware message (the `decrypt_success` path). That path must
+/// surface the app-facing `SecureSessionEstablished` event, exactly as the adopter's
+/// Welcome-receive path does. Before the fix the owner confirmed silently: 1:1 send
+/// and receive both worked, but the app never learned the session existed, so any UI
+/// gated on a known secure session — the demo's "contacts with secure sessions"
+/// group-creation list — silently excluded the peer ("no contact available to create
+/// a group"). A both-create owner is the acute case: `can_confirm_from_source` forces
+/// it to converge ONLY through decrypt, so without this emission the peer could never
+/// be added to a group from the owner's device.
+#[test]
+fn test_session_owner_emits_established_on_decrypt_confirmation() {
+    let mut alice_config = create_test_config_for_user("alice");
+    alice_config.encryption.enabled = true;
+    alice_config.encryption.store_pending = true;
+
+    let mut bob_config = create_test_config_for_user("bob");
+    bob_config.encryption.enabled = true;
+    bob_config.encryption.store_pending = true;
+
+    let alice_storage = Arc::new(InMemoryStorage::new());
+    let bob_storage = Arc::new(InMemoryStorage::new());
+
+    let mut alice = OfflineProtocol::new(alice_config).unwrap();
+    let mut bob = OfflineProtocol::new(bob_config).unwrap();
+
+    alice.initialize_mls(alice_storage).unwrap();
+    bob.initialize_mls(bob_storage).unwrap();
+
+    let mut alice_transport = MockTransport::new(TransportType::BLE);
+    alice_transport.start().unwrap();
+    let alice_transport_handle = alice_transport.clone();
+    alice
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(alice_transport));
+
+    // Capture the owner's events before any session work begins.
+    let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_handle = Arc::clone(&events);
+    alice.on_event(move |event| {
+        events_handle.lock().unwrap().push(event);
+    });
+    alice.start().unwrap();
+
+    let mut bob_transport = MockTransport::new(TransportType::BLE);
+    bob_transport.start().unwrap();
+    let bob_transport_handle = bob_transport.clone();
+    bob.transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(bob_transport));
+    bob.start().unwrap();
+
+    // Alice (owner) creates the session group + Welcome from Bob's key package.
+    let bob_key_package = {
+        let manager = bob.mls_manager.as_ref().unwrap().read().unwrap();
+        manager.get_or_create_key_package().unwrap()
+    };
+    alice.pending_key_packages.insert(
+        "bob".to_string(),
+        ReceivedKeyPackage {
+            key_package_data: bob_key_package.key_package_data,
+            local_expires_at_ms: Utc::now().timestamp_millis() as u64 + 60_000,
+        },
+    );
+    alice
+        .send_message("bob", "bootstrap", None::<MessagePriority>, None::<String>)
+        .unwrap();
+
+    // Bob adopts Alice's group from the Welcome.
+    let welcome_wire = alice_transport_handle
+        .sent_messages()
+        .into_iter()
+        .find(|msg| msg.content.starts_with(internal_prefixes::WELCOME))
+        .map(|msg| msg.content)
+        .expect("expected welcome message sent by owner");
+    let welcome_msg = Message::new(
+        UserId::new("alice").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        &welcome_wire,
+    );
+    let _ = bob.process_internal_message(&welcome_msg);
+
+    // The owner has only SENT a Welcome — it must stay Pending (and silent) until a
+    // group-aware decrypt proves the peer adopted the group.
+    assert!(
+        !alice.confirmed_sessions.contains("bob"),
+        "owner must stay Pending until it decrypts a group-aware message from the peer"
+    );
+
+    // Bob sends an encrypted message; Alice (owner) decrypts it and confirms.
+    bob.send_message("alice", "hello", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    let encrypted_from_bob = bob_transport_handle
+        .sent_messages()
+        .into_iter()
+        .rev()
+        .find(|msg| msg.content.starts_with(internal_prefixes::ENCRYPTED))
+        .expect("expected encrypted message sent by adopter");
+    let _ = alice.process_internal_message(&encrypted_from_bob);
+
+    assert!(
+        alice.confirmed_sessions.contains("bob"),
+        "owner must confirm the session on decrypt_success"
+    );
+    let captured = events.lock().unwrap();
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            Event::SecureSessionEstablished {
+                peer_id,
+                is_session,
+                initiated_by_local,
+                ..
+            } if peer_id == "bob" && *is_session && *initiated_by_local
+        )),
+        "owner must emit SecureSessionEstablished so the app learns the 1:1 session exists"
+    );
+}
+
 #[test]
 fn test_welcome_delayed_confirmation_after_timeout_converges_to_sent() {
     let mut config = create_test_config();

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -4710,6 +4710,87 @@ fn test_session_confirms_via_ack_when_welcome_is_send_attempted() {
     );
 }
 
+/// Regression (Android↔iOS "receives but never sends"): a both-create owner
+/// whose own Welcome timed out to the terminal `Expired` state on a lossy /
+/// asymmetric BLE link must STILL confirm the session the moment it decrypts a
+/// real group message from the peer. A successful group decrypt is definitive
+/// proof the peer adopted our group; gating decrypt-confirmation on a still-active
+/// local Welcome left the owner able to receive but never reply (every outbound
+/// send → SessionNotReady). The both-create gate is preserved: a plaintext probe
+/// must NOT confirm such an owner — only a decrypt may.
+#[test]
+fn test_both_create_owner_confirms_via_decrypt_after_welcome_expired() {
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.store_pending = true;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    protocol.initialize_mls(storage).unwrap();
+
+    // We are the both-create owner: we created our own group for "bob" and sent a
+    // Welcome that never reached `Sent` — retries exhausted it to `Expired`.
+    let bob_storage = Arc::new(InMemoryStorage::new());
+    let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+    let bob_key_package = bob_manager.get_or_create_key_package().unwrap();
+    {
+        let manager = protocol.mls_manager.as_ref().unwrap().read().unwrap();
+        manager
+            .import_key_package("bob", &bob_key_package.key_package_data)
+            .unwrap();
+        manager.create_session("bob").unwrap();
+    }
+    protocol
+        .ensure_session_state_entry("bob", "test_setup")
+        .unwrap();
+
+    let welcome_msg = protocol
+        .create_message("bob", "placeholder", Some(MessagePriority::High), None)
+        .unwrap();
+    protocol
+        .upsert_welcome_lifecycle("bob", "session:bob:user123", welcome_msg, "test_setup")
+        .unwrap();
+    // Drive the welcome through to the terminal Expired state along its legal
+    // lifecycle path (SendAttempted -> Failed -> Expired) — what a Welcome that
+    // times out after retry exhaustion actually does.
+    protocol
+        .transition_welcome_state("bob", WelcomeDeliveryState::SendAttempted, "test_setup")
+        .unwrap();
+    protocol
+        .transition_welcome_state("bob", WelcomeDeliveryState::Failed, "test_setup")
+        .unwrap();
+    protocol
+        .transition_welcome_state("bob", WelcomeDeliveryState::Expired, "test_setup")
+        .unwrap();
+    // Both-create owner: confirmation is gated on a group-aware decrypt.
+    protocol.mark_both_create_awaiting_decrypt("bob");
+
+    // A plaintext probe is NOT proof of adoption — the gate must still reject it.
+    assert!(
+        !protocol.can_confirm_from_source("bob", "confirmation_probe_received"),
+        "a plaintext probe must not confirm a both-create owner"
+    );
+
+    // A successful group decrypt IS definitive proof — it must confirm even though
+    // our local Welcome is Expired. Pre-fix this returned false, leaving the owner
+    // permanently able to receive but never send.
+    assert!(
+        protocol.can_confirm_from_source("bob", "decrypt_success"),
+        "a group decrypt must confirm the owner regardless of an expired local Welcome"
+    );
+    assert!(
+        matches!(
+            protocol.confirm_session_state("bob", "decrypt_success"),
+            Ok(true)
+        ),
+        "confirm_session_state must transition Pending->Confirmed on decrypt_success"
+    );
+    assert!(
+        protocol.confirmed_sessions.contains("bob"),
+        "session must be confirmed so outbound sends stop failing SessionNotReady"
+    );
+}
+
 #[test]
 fn test_welcome_delayed_confirmation_after_timeout_converges_to_sent() {
     let mut config = create_test_config();

--- a/examples/demo-app/ios/Podfile
+++ b/examples/demo-app/ios/Podfile
@@ -34,6 +34,26 @@ target 'OfflineDemo' do
       # :ccache_enabled => true
     )
 
+    # fmt 11.0.2 (hard-pinned by RCT-Folly -> React Native 0.82) does not compile
+    # under Xcode 26.5 / clang 21: clang defines __cpp_consteval, so fmt's base.h
+    # selects FMT_USE_CONSTEVAL=1 and its consteval format-string check fails with
+    # "call to consteval function ... is not a constant expression". base.h sets
+    # FMT_USE_CONSTEVAL via a raw #if/#elif chain with NO #ifndef guard, so a
+    # -DFMT_USE_CONSTEVAL=0 compile flag is silently overridden — the value must be
+    # forced in the header. Rewrite the two `#define FMT_USE_CONSTEVAL 1` lines to
+    # 0. Idempotent; re-applied on every `pod install`. Demo-app only — the SDK
+    # sources are untouched.
+    fmt_base = File.join(installer.sandbox.root, 'fmt', 'include', 'fmt', 'base.h')
+    if File.exist?(fmt_base)
+      original = File.read(fmt_base)
+      patched = original.gsub('#  define FMT_USE_CONSTEVAL 1',
+                              '#  define FMT_USE_CONSTEVAL 0')
+      if patched != original
+        File.write(fmt_base, patched)
+        Pod::UI.puts 'Patched fmt/base.h: forced FMT_USE_CONSTEVAL=0 (Xcode 26.5 / clang 21)'.yellow
+      end
+    end
+
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |build_config|
         build_config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'

--- a/examples/demo-app/ios/Podfile.lock
+++ b/examples/demo-app/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - MeshSdk (0.10.0):
+  - MeshSdk (0.11.0):
     - React-Core
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -2657,7 +2657,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  MeshSdk: 11fc68ea0b66fd6e0c76397177108a4f648f917c
+  MeshSdk: a2eb21a52b8a6ab8525824421bbcd76c87d09c46
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a
   RCTRequired: e2c574c1b45231f7efb0834936bd609d75072b63
@@ -2727,6 +2727,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb
 
-PODFILE CHECKSUM: 4b4f66ccf85d5682c7d482df4ef11267374fec0d
+PODFILE CHECKSUM: cdeff5cea62acd208f013bf81c309c760b26359a
 
 COCOAPODS: 1.16.2

--- a/examples/demo-app/package-lock.json
+++ b/examples/demo-app/package-lock.json
@@ -37,8 +37,8 @@
     },
     "../../bindings/react-native": {
       "name": "@offline-protocol/mesh-sdk",
-      "version": "0.10.0",
-      "license": "ISC",
+      "version": "0.11.0",
+      "license": "AGPL-3.0-only",
       "devDependencies": {
         "@types/react-native": "^0.72.8",
         "react-native": "^0.82.0",
@@ -11393,7 +11393,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
## What

An app on the SDK (fernweh_v2) couldn't reliably send messages between Android and iOS. A deep audit of the BLE / MLS / DORS paths found **three independent SDK bugs**, all biting the same asymmetric topology, plus two robustness gaps. PRs #120/#121 had fixed the asymmetric Android↔iOS BLE link **on Android only** — this restores the iOS half and the backend bugs that bite the same path.

When Android and iOS meet over BLE, one is GATT-central (writes) and the other GATT-peripheral (notifies). The role is a race, and with iOS backgrounded the steady state is **Android-central / iOS-peripheral** — where every one of these bugs hurts most.

## Root causes & fixes

### 1. iOS had no GATT-peripheral data path *(feat — the deepest fix)*
`BleManager.swift` had **zero** notify egress (no `peripheralManager.updateValue` anywhere) — iOS could only send over a link it opened as central. When Android is central, iOS→Android stalled. Added the iOS mirror of Android #120/#121: retain subscribed `CBCentral`s, route notify-reachable recipients from the fragment drain to a main-queue `updateValue` pump with `peripheralManagerIsReadyToUpdateSubscribers` backpressure, and report `min(write, notify)` MTU to avoid on-air truncation.

### 2. MLS "receives but never sends" *(fix)*
`can_confirm_from_source` gated decrypt-based confirmation on the local Welcome still being in-flight. A both-create owner whose Welcome timed out (`Expired`) could decrypt the peer's messages but never confirm → every reply failed `SessionNotReady`. A successful group decrypt now confirms unconditionally (it's cryptographic proof of convergence). Also stops re-arming the `both_create` gate on an already-confirmed session (a persisted-gate leak that bricked a later re-pair).

### 3. DORS pinned the Internet relay ~20s *(fix)*
The #120 demotion fixed Internet's *ranking* but not its *retention*: cold-start fallback set Internet as `current` and re-armed the switch cooldown, so a freshly-discovered BLE peer was bypassed for the cooldown window. Now the demoted negative-score fallback is never retained over an available mesh transport.

### Robustness gaps *(while at it)*
- BLE `recipient_not_among_peers_count` — surfaces the silent `recipient`↔device-id keying mismatch that misroutes an in-range peer to Internet.
- First-contact inbound buffer raised 5s → 15s (both platforms) so a multi-fragment Welcome isn't evicted before the sender's device-id resolves.

## Verification

- `cargo test`: **protocol 661, router 128, transport 160** — 0 failures, **3 new regression tests**.
- `cargo clippy --workspace -- -D warnings`: clean. `cargo fmt --all -- --check`: clean. `cargo build --workspace`: green.

## ⚠️ iOS notify egress needs device validation

There is no iOS/Xcode toolchain in the dev environment, so `BleManager.swift` **could not be compiled or device-tested**. It mirrors the proven Android design and the thread model was audited (main-queue CBPeripheralManager, lock-guarded shared state, `fragmentQueue`-folded counters), but please run on real hardware:

- [ ] `npm run build:uniffi:ios` compiles `BleManager.swift`.
- [ ] Force **Android=central / iOS=peripheral**; iOS→Android send arrives via NOTIFY (pre-fix it stalled).
- [ ] Fresh 1:1 session in that topology → multi-fragment MLS Welcome converges (no "Welcome send confirmation timed out").
- [ ] Rapid large messages iOS→Android → backpressure resumes (no permanent stall).
- [ ] Regression: iOS=central topology (central-write path) still works.

## Deferred

The `U1≠U2` inbound-attribution case (iOS can't attribute an inbound central-write when an RPA peer's central vs peripheral handles differ) is left for a follow-up — it needs an in-band identity handshake, not a port of existing code.
