### PR TITLE
ci(release): drop x86_64 (Intel) macOS build from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,10 +185,6 @@ jobs:
             target: aarch64-apple-darwin
             runner: macos-14
             lib_name: liboffline_protocol_uniffi.dylib
-          - arch: x86_64
-            target: x86_64-apple-darwin
-            runner: macos-13
-            lib_name: liboffline_protocol_uniffi.dylib
     steps:
       - uses: actions/checkout@v4
 
@@ -414,10 +410,6 @@ jobs:
             artifact: desktop-macos-arm64
             lib_subdir: macos-arm64
             plat_name: macosx_14_0_arm64
-          - platform: macos-x86_64
-            artifact: desktop-macos-x86_64
-            lib_subdir: macos-x86_64
-            plat_name: macosx_13_0_x86_64
           - platform: linux-x86_64
             artifact: desktop-linux-x86_64
             lib_subdir: linux-x86_64


### PR DESCRIPTION
## What

Removes the **x86_64 (Intel) macOS** build from the release workflow:
- `build-desktop-macos` matrix — drop the `arch: x86_64` / `macos-13` entry
- `python-package` matrix — drop the `macos-x86_64` wheel built from that artifact

## Why

The `macos-13` (Intel) runner pool is scarce and heavily queued. On the **v0.11.0** release run the x86_64 macOS job sat ~10 min waiting for a runner, then **failed outright** after 12m — cascading so `Create Release & Publish to npm` never executed (0.11.0 was never published). Every release is exposed to this.

## Impact

- ✅ **No effect on the npm release** — `@offline-protocol/mesh-sdk` consumes only iOS + Android libs; desktop macOS libs aren't in its path.
- ✅ **arm64 macOS Python wheel unaffected** (built on `macos-14`, ~2 min).
- ⚠️ **Intel-Mac Python wheels are no longer produced.** They were CI artifacts only (retention 5 days) and were never published to PyPI, so there's no published-package impact.

Alternative considered: cross-compile `x86_64-apple-darwin` on a `macos-14` runner to keep Intel coverage without the `macos-13` queue. Opted to drop entirely given Intel Macs are EOL and the wheels aren't published.

## Follow-up

Re-cutting `v0.11.0` on top of this so the release runs without the `macos-13` dependency.