### PR TITLE
fix(transport): fix callback self-deadlock and correct transport crate docs

### DIFF
--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -1,11 +1,25 @@
-//! Bluetooth Low Energy (BLE) transport implementation.
+//! Bluetooth Low Energy (BLE) transport queue engine.
 //!
-//! This module provides the BLE transport layer for peer-to-peer communication.
-//! It handles:
-//! - Device discovery (advertising and scanning)
-//! - GATT server/client operations
-//! - Message transmission over BLE characteristics
-//! - Message fragmentation for large payloads
+//! No BLE radio is touched here. Advertising, scanning, GATT operations,
+//! and characteristic writes are all owned by the platform side
+//! (CoreBluetooth on iOS, `android.bluetooth` on Android). The Rust side
+//! handles:
+//! - Send/receive queues, metrics, and the peer registry
+//! - Message fragmentation for MTU-limited links, and reassembly of
+//!   incoming fragments with capacity-based eviction
+//! - Per-peer MTU accounting ([`BleTransport::set_peer_mtu`])
+//!
+//! The bridge contract: the platform reports adapter state via
+//! [`BleTransport::on_status_changed`] and peers via
+//! [`BleTransport::on_peer_discovered`] / [`BleTransport::on_peer_lost`],
+//! drains outbound fragments with [`BleTransport::get_next_fragment`]
+//! (woken by the [`BleTransport::set_on_fragments_available`] callback) and
+//! writes them to GATT characteristics, and injects received bytes via
+//! [`BleTransport::on_fragment_received`].
+//!
+//! Unlike the other transports, BLE's `start()` optimistically sets the
+//! status to `Available`; the platform overrides it via
+//! `on_status_changed()` if BLE is actually unavailable.
 
 use crate::constants::{
     BLE_FRAGMENT_TIMEOUT_SECS, BLE_MAX_FRAGMENT_ASSEMBLIES, BLE_MAX_FRAGMENT_COUNT,

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -851,9 +851,13 @@ impl BleTransport {
         }
 
         // Fire eviction callback outside the fragment_buffers lock to avoid
-        // lock ordering issues (callback may acquire shared_state).
+        // lock ordering issues (callback may acquire shared_state). The
+        // callback Arc is cloned out of its own mutex too, so a callback
+        // that re-enters the transport (e.g. set_fragment_eviction_callback)
+        // cannot self-deadlock.
         if let Some(info) = eviction_info {
-            if let Some(cb) = self.eviction_callback.lock().unwrap().as_ref() {
+            let cb = self.eviction_callback.lock().unwrap().clone();
+            if let Some(cb) = cb {
                 cb(info);
             }
         }
@@ -2235,6 +2239,39 @@ mod tests {
         assert!(
             captured[0].message_id.starts_with("msg-"),
             "evicted entry should be one of the pre-filled assemblies"
+        );
+    }
+
+    #[test]
+    fn test_fragment_eviction_callback_can_reenter_transport() {
+        let transport = Arc::new(BleTransport::new("test-device"));
+
+        let fired = Arc::new(Mutex::new(false));
+        let fired_clone = Arc::clone(&fired);
+        let transport_clone = Arc::clone(&transport);
+        transport.set_fragment_eviction_callback(Some(Arc::new(move |_info| {
+            // Re-enters the transport from inside the callback. If the
+            // eviction fired with the callback mutex held, re-locking it
+            // here would self-deadlock. Clearing the callback while it is
+            // executing is safe because the caller holds its own Arc clone.
+            transport_clone.set_fragment_eviction_callback(None);
+            *fired_clone.lock().unwrap() = true;
+        })));
+
+        // Fill the reassembly buffer to capacity, then push one more
+        // assembly to trigger an eviction (same setup as
+        // test_fragment_eviction_fires_callback).
+        for i in 0..BLE_MAX_FRAGMENT_ASSEMBLIES {
+            let msg_id = format!("msg-{i}");
+            let frag = encode_fragment(msg_id.as_bytes(), 0, 4, b"payload-data").unwrap();
+            assert!(transport.process_fragment(&frag).unwrap().is_none());
+        }
+        let trigger_frag = encode_fragment(b"new-msg", 0, 4, b"payload-data").unwrap();
+        assert!(transport.process_fragment(&trigger_frag).unwrap().is_none());
+
+        assert!(
+            *fired.lock().unwrap(),
+            "eviction callback should have fired"
         );
     }
 }

--- a/crates/offline-protocol-transport/src/internet.rs
+++ b/crates/offline-protocol-transport/src/internet.rs
@@ -1,7 +1,18 @@
-//! Internet transport implementation (TCP/WebSocket).
+//! Internet transport (TCP/WebSocket relay) queue engine.
 //!
-//! This module provides connectivity via standard internet protocols.
-//! It supports both direct TCP connections and WebSocket for web compatibility.
+//! No sockets are opened here. The platform side owns the actual TCP or
+//! WebSocket connection to the relay server; the Rust side manages the
+//! send/receive queues, metrics, heartbeat bookkeeping, and the
+//! confirmation loop.
+//!
+//! The bridge contract: the platform reports connectivity via
+//! [`InternetTransport::on_status_changed`] (nothing else makes this
+//! transport `Available`), polls [`InternetTransport::get_next_message`]
+//! for outbound wire bytes — unlike the other transports there is no
+//! messages-available callback — reports outcomes via
+//! [`InternetTransport::confirm_sent`] /
+//! [`InternetTransport::report_send_failure`], and injects inbound bytes
+//! via [`InternetTransport::on_data_received`].
 
 use crate::constants::{
     INTERNET_CONNECTION_TIMEOUT_SECS, INTERNET_DEFAULT_SERVER_ADDRESS,
@@ -44,8 +55,8 @@ impl Default for InternetConfig {
 
 /// Internet transport implementation.
 ///
-/// This provides connectivity via TCP/WebSocket to a central relay server.
-/// Useful for hybrid online/offline scenarios.
+/// Queue engine for a platform-managed TCP/WebSocket connection to a
+/// central relay server. Useful for hybrid online/offline scenarios.
 ///
 /// ## Lock ordering
 ///

--- a/crates/offline-protocol-transport/src/lib.rs
+++ b/crates/offline-protocol-transport/src/lib.rs
@@ -1,7 +1,34 @@
 //! Transport abstraction layer for the Offline Protocol SDK.
 //!
-//! This crate defines the transport trait and types for different
-//! transport mechanisms (BLE, Wi-Fi Direct, Internet).
+//! This crate defines the [`Transport`] trait and the transport state
+//! machines for BLE, Wi-Fi Direct, Internet, Nostr, and Reticulum.
+//!
+//! # This crate performs no network or radio I/O
+//!
+//! No sockets are opened and no radios are touched here. Each transport is
+//! a thread-safe protocol/queue engine — status, send/receive queues,
+//! metrics, and (for BLE) fragmentation state — driven from two sides:
+//!
+//! - **The protocol engine** talks to the [`Transport`] trait: `send()`
+//!   enqueues an outbound message, `receive()` dequeues an inbound one.
+//! - **A platform bridge** (Swift/Kotlin via the UniFFI bindings, or any
+//!   host program) owns the actual sockets, relays, and radios. It drains
+//!   the outbound queue (`get_next_message()` / `get_next_signed_event()` /
+//!   `get_next_fragment()`), performs the real I/O, reports the outcome
+//!   (`confirm_sent()` / `report_send_failure()`), injects inbound bytes
+//!   (`on_data_received()` / `on_fragment_received()`), and drives
+//!   availability (`on_status_changed()`).
+//!
+//! Without a platform bridge attached, `send()` queues messages that never
+//! go anywhere — and, BLE excepted, `start()` never makes a transport
+//! `Available` in the first place, so `send()` returns
+//! `TransportNotAvailable`. A pure-Rust consumer must play the bridge role
+//! itself: mark the transport available, drain the queues, and do its own
+//! I/O.
+//!
+//! Most transports signal pending outbound work through a
+//! `set_on_messages_available` callback instead of requiring a poll timer;
+//! [`InternetTransport`] is the exception and must be polled.
 //!
 //! All code in this crate is 100% safe Rust with no unsafe blocks.
 

--- a/crates/offline-protocol-transport/src/nostr.rs
+++ b/crates/offline-protocol-transport/src/nostr.rs
@@ -165,6 +165,18 @@ impl NostrTransport {
         *self.on_messages_available.lock().unwrap() = Some(callback);
     }
 
+    /// Notifies the platform that messages are ready to send.
+    ///
+    /// The callback Arc is cloned out of the mutex and the guard dropped
+    /// before the call, so a callback that re-enters the transport (e.g.
+    /// another `send()`) cannot self-deadlock on the callback mutex.
+    fn notify_messages_available(&self) {
+        let callback = self.on_messages_available.lock().unwrap().clone();
+        if let Some(cb) = callback {
+            cb();
+        }
+    }
+
     /// Called when connection status changes.
     ///
     /// Resets reconnect counter on successful connection.
@@ -530,9 +542,7 @@ impl Transport for NostrTransport {
         metrics.congestion = ((queue_len as f32) / 50.0).clamp(0.0, 1.0);
         drop(metrics);
 
-        if let Some(callback) = self.on_messages_available.lock().unwrap().as_ref() {
-            callback();
-        }
+        self.notify_messages_available();
 
         Ok(())
     }
@@ -809,6 +819,31 @@ mod tests {
         let msg = create_test_message();
         transport.send(&msg).unwrap();
         assert!(*called.lock().unwrap());
+    }
+
+    #[test]
+    fn test_messages_available_callback_reentrant_send() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let transport = Arc::new(NostrTransport::new("device1").unwrap());
+        transport.on_status_changed(TransportStatus::Available);
+
+        let reentered = Arc::new(AtomicBool::new(false));
+        let reentered_clone = Arc::clone(&reentered);
+        let transport_clone = Arc::clone(&transport);
+        transport.set_on_messages_available(Arc::new(move || {
+            // Re-enters send() from inside the callback. If send() held the
+            // callback mutex across this call, the inner send would
+            // self-deadlock re-locking it.
+            if !reentered_clone.swap(true, Ordering::SeqCst) {
+                transport_clone.send(&create_test_message()).unwrap();
+            }
+        }));
+
+        transport.send(&create_test_message()).unwrap();
+
+        assert!(reentered.load(Ordering::SeqCst));
+        assert_eq!(transport.send_queue.lock().unwrap().len(), 2);
     }
 
     #[test]

--- a/crates/offline-protocol-transport/src/nostr.rs
+++ b/crates/offline-protocol-transport/src/nostr.rs
@@ -1,9 +1,18 @@
-//! Nostr relay transport implementation.
+//! Nostr relay transport queue engine.
 //!
-//! This module provides connectivity via Nostr relays for censorship-resistant,
-//! decentralized messaging over WebSockets. The platform side manages actual
-//! relay connections and subscriptions; the Rust side manages queues, metrics,
-//! event signing, and the confirmation loop.
+//! Censorship-resistant, decentralized messaging over Nostr relays
+//! (WebSockets). No relay connection is opened here: the platform side
+//! manages the actual WebSocket connections and subscriptions; the Rust
+//! side manages queues, metrics, event signing, and the confirmation loop.
+//!
+//! The bridge contract: the platform reports relay connectivity via
+//! [`NostrTransport::on_status_changed`], drains signed events with
+//! [`NostrTransport::get_next_signed_event`] (woken by the
+//! [`NostrTransport::set_on_messages_available`] callback) and submits them
+//! to the relays, correlates relay `OK` responses back via
+//! [`NostrTransport::confirm_sent`] /
+//! [`NostrTransport::report_send_failure`], and injects inbound event
+//! payloads via [`NostrTransport::on_data_received`].
 //!
 //! Addressing uses public routing tags derived from device IDs
 //! ([`nostr_crypto::routing_tag_for_device_id`]); event signing uses a

--- a/crates/offline-protocol-transport/src/reticulum.rs
+++ b/crates/offline-protocol-transport/src/reticulum.rs
@@ -1,9 +1,18 @@
-//! Reticulum mesh transport implementation.
+//! Reticulum mesh transport queue engine.
 //!
-//! This module provides connectivity via the Reticulum network stack,
-//! supporting LoRa, TCP, UDP, serial, I2P, and other mediums.
-//! The platform side bridges to a running Reticulum daemon; the Rust
+//! Long-range, low-bandwidth, resilient mesh networking via the Reticulum
+//! network stack (LoRa, TCP, UDP, serial, I2P, and other mediums). No
+//! Reticulum link is opened here: the platform side bridges to a running
+//! Reticulum daemon (sidecar, TCP gateway, or embedded Python); the Rust
 //! side manages queues, metrics, and the confirmation loop.
+//!
+//! The bridge contract: the platform reports daemon connectivity via
+//! [`ReticulumTransport::on_status_changed`], drains outbound wire bytes
+//! with [`ReticulumTransport::get_next_message`] (woken by the
+//! [`ReticulumTransport::set_on_messages_available`] callback), reports
+//! outcomes via [`ReticulumTransport::confirm_sent`] /
+//! [`ReticulumTransport::report_send_failure`], and injects inbound bytes
+//! via [`ReticulumTransport::on_data_received`].
 
 use crate::constants::{
     RETICULUM_CONNECTION_TIMEOUT_SECS, RETICULUM_PENDING_CONFIRMATION_TIMEOUT_SECS,

--- a/crates/offline-protocol-transport/src/reticulum.rs
+++ b/crates/offline-protocol-transport/src/reticulum.rs
@@ -117,6 +117,18 @@ impl ReticulumTransport {
         *self.on_messages_available.lock().unwrap() = Some(callback);
     }
 
+    /// Notifies the platform that messages are ready to send.
+    ///
+    /// The callback Arc is cloned out of the mutex and the guard dropped
+    /// before the call, so a callback that re-enters the transport (e.g.
+    /// another `send()`) cannot self-deadlock on the callback mutex.
+    fn notify_messages_available(&self) {
+        let callback = self.on_messages_available.lock().unwrap().clone();
+        if let Some(cb) = callback {
+            cb();
+        }
+    }
+
     /// Called when connection status changes.
     ///
     /// Resets reconnect counter on successful connection.
@@ -350,9 +362,7 @@ impl Transport for ReticulumTransport {
         metrics.congestion = ((queue_len as f32) / 50.0).clamp(0.0, 1.0);
         drop(metrics);
 
-        if let Some(callback) = self.on_messages_available.lock().unwrap().as_ref() {
-            callback();
-        }
+        self.notify_messages_available();
 
         Ok(())
     }
@@ -612,6 +622,31 @@ mod tests {
         let msg = create_test_message();
         transport.send(&msg).unwrap();
         assert!(*called.lock().unwrap());
+    }
+
+    #[test]
+    fn test_messages_available_callback_reentrant_send() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let transport = Arc::new(ReticulumTransport::new("device1"));
+        transport.on_status_changed(TransportStatus::Available);
+
+        let reentered = Arc::new(AtomicBool::new(false));
+        let reentered_clone = Arc::clone(&reentered);
+        let transport_clone = Arc::clone(&transport);
+        transport.set_on_messages_available(Arc::new(move || {
+            // Re-enters send() from inside the callback. If send() held the
+            // callback mutex across this call, the inner send would
+            // self-deadlock re-locking it.
+            if !reentered_clone.swap(true, Ordering::SeqCst) {
+                transport_clone.send(&create_test_message()).unwrap();
+            }
+        }));
+
+        transport.send(&create_test_message()).unwrap();
+
+        assert!(reentered.load(Ordering::SeqCst));
+        assert_eq!(transport.send_queue.lock().unwrap().len(), 2);
     }
 
     #[test]

--- a/crates/offline-protocol-transport/src/traits.rs
+++ b/crates/offline-protocol-transport/src/traits.rs
@@ -21,8 +21,11 @@ pub enum TransportStatus {
 
 /// Trait for transport implementations.
 ///
-/// This trait defines the interface that all transport implementations must follow.
-/// Implementations handle the platform-specific details of sending and receiving messages.
+/// This is the engine-facing side of a transport: enqueue outbound
+/// messages, dequeue inbound ones, and report status and metrics. The
+/// implementations in this crate are I/O-free queue engines — the
+/// platform-specific delivery details live in the platform bridge (see the
+/// crate-level docs).
 pub trait Transport: Send + Sync + Any {
     /// Returns this transport as `&dyn Any` for safe downcasting.
     fn as_any(&self) -> &dyn Any;
@@ -35,7 +38,10 @@ pub trait Transport: Send + Sync + Any {
     /// Gets current metrics for this transport.
     fn metrics(&self) -> TransportMetrics;
 
-    /// Sends a message through this transport.
+    /// Queues a message for delivery through this transport.
+    ///
+    /// Implementations in this crate perform no I/O here: the message is
+    /// enqueued for the platform bridge to drain and put on the wire.
     ///
     /// # Arguments
     ///
@@ -43,10 +49,17 @@ pub trait Transport: Send + Sync + Any {
     ///
     /// # Returns
     ///
-    /// Returns `Ok(())` if the message was sent successfully, `Err` otherwise.
+    /// Returns `Ok(())` if the transport accepted the message, `Err`
+    /// otherwise (e.g. the transport is not `Available`). `Ok` means
+    /// enqueued, not delivered — the platform bridge confirms or fails
+    /// delivery asynchronously.
     fn send(&self, message: &Message) -> Result<()>;
 
     /// Attempts to receive a message from this transport.
+    ///
+    /// Messages arrive in this queue after the platform bridge injects
+    /// inbound bytes via the transport's `on_data_received` /
+    /// `on_fragment_received` methods.
     ///
     /// # Returns
     ///
@@ -55,8 +68,14 @@ pub trait Transport: Send + Sync + Any {
     fn receive(&self) -> Result<Option<Message>>;
 
     /// Starts the transport.
+    ///
+    /// This performs no I/O. Most implementations stay `Unavailable` until
+    /// the platform bridge reports connectivity via their
+    /// `on_status_changed()` method; BLE is the exception and optimistically
+    /// sets `Available` (the platform can still override it).
     fn start(&mut self) -> Result<()>;
 
-    /// Stops the transport.
+    /// Stops the transport, marking it `Disconnected` and clearing queued
+    /// state.
     fn stop(&mut self) -> Result<()>;
 }

--- a/crates/offline-protocol-transport/src/wifi_direct.rs
+++ b/crates/offline-protocol-transport/src/wifi_direct.rs
@@ -1,7 +1,18 @@
-//! Wi-Fi Direct transport implementation (Android P2P).
+//! Wi-Fi Direct transport (Android P2P) queue engine.
 //!
-//! This module provides high-bandwidth peer-to-peer connectivity via Wi-Fi Direct.
-//! This is primarily for Android devices and offers faster data transfer than BLE.
+//! High-bandwidth peer-to-peer transport, primarily for Android, with much
+//! higher throughput than BLE. No Wi-Fi radio is touched here: the platform
+//! side (Android `WifiP2pManager`) owns group negotiation, discovery, and
+//! the sockets; the Rust side manages the send/receive queues, the peer
+//! registry, and metrics.
+//!
+//! The bridge contract: the platform reports connectivity via
+//! [`WifiDirectTransport::on_status_changed`] and peers via
+//! [`WifiDirectTransport::on_peer_discovered`] /
+//! [`WifiDirectTransport::on_peer_lost`], drains outbound wire bytes with
+//! [`WifiDirectTransport::get_next_message`] (woken by the
+//! [`WifiDirectTransport::set_on_messages_available`] callback), and
+//! injects inbound bytes via [`WifiDirectTransport::on_data_received`].
 
 use crate::{Result, SharedCallback, Transport, TransportMetrics, TransportStatus, TransportType};
 use offline_protocol_core::Message;
@@ -47,7 +58,7 @@ impl Default for WifiDirectConfig {
 
 /// Wi-Fi Direct transport implementation.
 ///
-/// This provides high-bandwidth P2P connectivity via Wi-Fi Direct (Android).
+/// Queue engine for platform-managed Wi-Fi Direct (Android) P2P links.
 /// Offers much higher throughput than BLE for large data transfers.
 pub struct WifiDirectTransport {
     /// Local device ID


### PR DESCRIPTION
## Summary

Pre-launch audit findings **CQ-M6** and **CQ-H6** (TODO item 8, P1). Two commits:

### `fix(transport)`: callback-mutex self-deadlock (CQ-M6)

`NostrTransport::send()` and `ReticulumTransport::send()` invoked the messages-available callback while holding that callback's own mutex — the `MutexGuard` is the `if let` scrutinee, so it lives across the entire call. The callback is foreign Swift/Kotlin code (wired via `set_nostr_transport_callback` / `set_reticulum_transport_callback` in the uniffi crate) that may synchronously re-enter the transport; any re-entered path that re-locks the mutex (another `send()`, `set_on_messages_available()`) deadlocks the thread permanently — `std::sync::Mutex` is not reentrant.

- Nostr and Reticulum now use a private `notify_messages_available()` helper that clones the callback `Arc` out of the mutex and drops the guard before calling — byte-for-byte the pattern `WifiDirectTransport` already used.
- **Bonus find beyond the audit:** `ble.rs` fired the fragment-eviction callback while holding the `eviction_callback` mutex (right under a comment about firing it *outside* the buffers lock). Same class, same fix.
- Three regression tests re-enter the transport from inside the callbacks (re-entrant `send()` on Nostr/Reticulum; re-entrant `set_fragment_eviction_callback(None)` on BLE). Note: if the pattern regresses, these hang rather than fail — the nature of deadlock tests.

### `docs(transport)`: document the I/O-free queue-engine model (CQ-H6)

The crate performs **zero network/radio I/O**, but its docs claimed the transports "provide connectivity via TCP and WebSocket", "handle GATT server/client operations", etc. A pure-Rust consumer following those docs (`InternetTransport::new()` + `start()` + `send()`) gets `TransportNotAvailable` forever, because only a platform bridge drains the queues and only BLE's `start()` sets `Available`.

- `lib.rs`: crate-level architecture section — queue engine, platform-bridge contract (drain / confirm / fail / inject / status), explicit warning for pure-Rust consumers.
- `traits.rs`: `send()` returning `Ok` means *enqueued*, not delivered; `start()` availability semantics (BLE optimistic-Available exception).
- Per-module bridge contracts for `internet.rs` (incl. its poll-only exception — it has no wake callback), `wifi_direct.rs`, `ble.rs`, `nostr.rs`, `reticulum.rs`.

Deliberately excluded: the `Transport` trait seam redesign (`&mut self` start/stop, lifecycle methods on the trait) — tracked separately as TODO item 13.

## Test plan

- [x] `cargo test --workspace` green (incl. 170 transport tests, 3 new re-entrancy regressions)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] `cargo doc --package offline-protocol-transport --no-deps` — no broken intra-doc links