### PR TITLE
refactor: recover poisoned locks, drop dead ack path, reject non-UTF-8 plaintext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/offline-protocol-core/Cargo.toml
+++ b/crates/offline-protocol-core/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 

--- a/crates/offline-protocol-core/src/lib.rs
+++ b/crates/offline-protocol-core/src/lib.rs
@@ -13,11 +13,13 @@
 pub mod error;
 pub mod message;
 pub mod service;
+pub mod sync;
 pub mod types;
 
 pub use error::{Error, Result};
 pub use message::{ContentType, ForwardInfo, MediaMetadata, Message, MessageId, MessagePriority};
 pub use service::{ServiceDescriptor, ServiceId};
+pub use sync::{MutexExt, RwLockExt};
 pub use types::{
     validate_id_chars, AppId, HopCount, LamportClock, LocalInstant, Timestamp, UserId,
     WallClockTimestamp, TTL,

--- a/crates/offline-protocol-core/src/sync.rs
+++ b/crates/offline-protocol-core/src/sync.rs
@@ -1,0 +1,122 @@
+//! Poison-recovering lock extensions.
+//!
+//! The SDK runs on mobile platforms where a process crash is worse than
+//! operating on potentially inconsistent state. A panic on one thread while
+//! holding a lock poisons it; with plain `.lock().unwrap()` every later
+//! access panics too, permanently wedging the node. Mutex poisoning in Rust
+//! is advisory — the protected data is still structurally valid — so these
+//! helpers recover the guard via [`std::sync::PoisonError::into_inner`] and
+//! log a warning with the caller's location for observability.
+//!
+//! Use these in code driven by foreign (FFI) threads and in event-emission
+//! paths that must keep flowing. Test code should keep `.lock().unwrap()`
+//! so poisoning fails loudly.
+
+use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// Extension trait adding poison-recovering locking to [`Mutex`].
+pub trait MutexExt<T> {
+    /// Locks the mutex, recovering the guard if it is poisoned.
+    ///
+    /// On poison, logs a warning naming the call site and returns the inner
+    /// guard anyway.
+    fn lock_or_recover(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T> MutexExt<T> for Mutex<T> {
+    #[track_caller]
+    fn lock_or_recover(&self) -> MutexGuard<'_, T> {
+        let location = std::panic::Location::caller();
+        self.lock().unwrap_or_else(|e| {
+            tracing::warn!(location = %location, "Mutex poisoned — recovering with inner value");
+            e.into_inner()
+        })
+    }
+}
+
+/// Extension trait adding poison-recovering locking to [`RwLock`].
+pub trait RwLockExt<T> {
+    /// Acquires a read guard, recovering it if the lock is poisoned.
+    ///
+    /// On poison, logs a warning naming the call site and returns the inner
+    /// guard anyway.
+    fn read_or_recover(&self) -> RwLockReadGuard<'_, T>;
+
+    /// Acquires a write guard, recovering it if the lock is poisoned.
+    ///
+    /// On poison, logs a warning naming the call site and returns the inner
+    /// guard anyway.
+    fn write_or_recover(&self) -> RwLockWriteGuard<'_, T>;
+}
+
+impl<T> RwLockExt<T> for RwLock<T> {
+    #[track_caller]
+    fn read_or_recover(&self) -> RwLockReadGuard<'_, T> {
+        let location = std::panic::Location::caller();
+        self.read().unwrap_or_else(|e| {
+            tracing::warn!(location = %location, "RwLock poisoned — recovering with inner value");
+            e.into_inner()
+        })
+    }
+
+    #[track_caller]
+    fn write_or_recover(&self) -> RwLockWriteGuard<'_, T> {
+        let location = std::panic::Location::caller();
+        self.write().unwrap_or_else(|e| {
+            tracing::warn!(location = %location, "RwLock poisoned — recovering with inner value");
+            e.into_inner()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    fn poison_mutex(lock: &Arc<Mutex<Vec<u32>>>) {
+        let cloned = Arc::clone(lock);
+        let _ = thread::spawn(move || {
+            let _guard = cloned.lock().unwrap();
+            panic!("poison the lock");
+        })
+        .join();
+    }
+
+    #[test]
+    fn mutex_recovers_after_poison() {
+        let lock = Arc::new(Mutex::new(vec![1u32]));
+        poison_mutex(&lock);
+        assert!(lock.is_poisoned());
+
+        let mut guard = lock.lock_or_recover();
+        guard.push(2);
+        assert_eq!(*guard, vec![1, 2]);
+        drop(guard);
+
+        // Subsequent recoveries keep working too.
+        assert_eq!(lock.lock_or_recover().len(), 2);
+    }
+
+    #[test]
+    fn mutex_unpoisoned_behaves_normally() {
+        let lock = Mutex::new(7u32);
+        assert_eq!(*lock.lock_or_recover(), 7);
+    }
+
+    #[test]
+    fn rwlock_recovers_after_poison() {
+        let lock = Arc::new(RwLock::new(vec![1u32]));
+        let cloned = Arc::clone(&lock);
+        let _ = thread::spawn(move || {
+            let _guard = cloned.write().unwrap();
+            panic!("poison the lock");
+        })
+        .join();
+        assert!(lock.is_poisoned());
+
+        lock.write_or_recover().push(2);
+        assert_eq!(*lock.read_or_recover(), vec![1, 2]);
+    }
+}

--- a/crates/offline-protocol-reliability/src/ack_manager.rs
+++ b/crates/offline-protocol-reliability/src/ack_manager.rs
@@ -17,12 +17,13 @@ pub struct AckEvictionInfo {
 }
 
 /// Status of an ACK.
+///
+/// There is no `Received` state: an acknowledged message is removed from
+/// tracking entirely via [`AckManager::remove_ack`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AckStatus {
     /// Waiting for ACK.
     Pending,
-    /// ACK received.
-    Received,
     /// ACK timed out.
     TimedOut,
 }
@@ -216,29 +217,11 @@ impl AckManager {
         }
     }
 
-    /// Records that an ACK was received for a message.
-    ///
-    /// # Arguments
-    ///
-    /// * `message_id` - ID of the message that was acknowledged
-    ///
-    /// # Returns
-    ///
-    /// Returns `true` if the ACK was expected and recorded, `false` if not found.
-    pub fn record_ack_received(&mut self, message_id: &MessageId) -> bool {
-        if let Some(pending) = self.pending_acks.get_mut(message_id) {
-            pending.status = AckStatus::Received;
-            true
-        } else {
-            false
-        }
-    }
-
     /// Returns all ACKs that have timed out and marks them as `TimedOut`.
     ///
     /// Note: This does NOT remove entries from the map. Entries are kept so that:
     /// - `increment_retry_count()` can reset them when the message is retried
-    /// - Late ACKs can still be matched via `record_ack_received()`
+    /// - Late ACKs can still be matched via `remove_ack()`
     ///
     /// Entries are eventually removed by:
     /// - `remove_ack()` when ACK is received or max retries exceeded
@@ -335,11 +318,11 @@ mod tests {
         assert!(manager.is_waiting_for_ack(&msg_id));
         assert_eq!(manager.pending_count(), 1);
 
-        // Receive ACK
-        assert!(manager.record_ack_received(&msg_id));
-
-        let pending = manager.get_pending_ack(&msg_id).unwrap();
-        assert_eq!(pending.status, AckStatus::Received);
+        // Receive ACK: the entry is removed from tracking entirely
+        let removed = manager.remove_ack(&msg_id).unwrap();
+        assert_eq!(removed.message_id, msg_id);
+        assert!(!manager.is_waiting_for_ack(&msg_id));
+        assert_eq!(manager.pending_count(), 0);
     }
 
     #[test]
@@ -510,8 +493,8 @@ mod tests {
         let mut manager = AckManager::new();
         let msg_id = MessageId::new();
 
-        // Recording ACK for non-existent message should return false
-        assert!(!manager.record_ack_received(&msg_id));
+        // Removing an ACK for a non-existent message should return None
+        assert!(manager.remove_ack(&msg_id).is_none());
     }
 
     #[test]

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -27,7 +27,7 @@ use crate::constants::{
     FRAGMENT_VERSION, MAX_REASONABLE_BLE_PAYLOAD,
 };
 use crate::{Result, SharedCallback, Transport, TransportMetrics, TransportStatus, TransportType};
-use offline_protocol_core::Message;
+use offline_protocol_core::{Message, MutexExt};
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -253,18 +253,18 @@ impl BleTransport {
     /// The platform layer (Swift/Kotlin) implements this to wake up and call
     /// `get_next_fragment()` instead of polling on a timer.
     pub fn set_on_fragments_available(&self, callback: Arc<dyn Fn() + Send + Sync>) {
-        *self.on_fragments_available.lock().unwrap() = Some(callback);
+        *self.on_fragments_available.lock_or_recover() = Some(callback);
     }
 
     /// Registers a callback that fires when a fragment assembly is evicted
     /// from the reassembly cache due to capacity pressure.
     pub fn set_fragment_eviction_callback(&self, callback: Option<FragmentEvictionCallback>) {
-        *self.eviction_callback.lock().unwrap() = callback;
+        *self.eviction_callback.lock_or_recover() = callback;
     }
 
     /// Notifies the platform that fragments are ready to send.
     fn notify_fragments_available(&self) {
-        let callback = self.on_fragments_available.lock().unwrap().clone();
+        let callback = self.on_fragments_available.lock_or_recover().clone();
         if let Some(cb) = callback {
             cb();
         }
@@ -303,7 +303,7 @@ impl BleTransport {
         // path free of an extra mutex acquisition in release builds.
         #[cfg(debug_assertions)]
         {
-            if !self.peers.lock().unwrap().contains_key(peer_id) {
+            if !self.peers.lock_or_recover().contains_key(peer_id) {
                 tracing::warn!(
                     peer = %peer_id,
                     max_payload,
@@ -321,7 +321,7 @@ impl BleTransport {
                 floor = BLE_MAX_FRAGMENT_SIZE,
                 "ble: undersized MTU report; dropping stored entry and falling back"
             );
-            self.peer_mtus.lock().unwrap().remove(peer_id);
+            self.peer_mtus.lock_or_recover().remove(peer_id);
             return;
         }
         let clamped = max_payload.min(MAX_REASONABLE_BLE_PAYLOAD);
@@ -332,8 +332,7 @@ impl BleTransport {
             "ble: stored per-peer MTU"
         );
         self.peer_mtus
-            .lock()
-            .unwrap()
+            .lock_or_recover()
             .insert(peer_id.to_string(), clamped);
     }
 
@@ -341,15 +340,14 @@ impl BleTransport {
     /// renegotiation).
     pub fn clear_peer_mtu(&self, peer_id: &str) {
         tracing::debug!(peer = %peer_id, "ble: cleared per-peer MTU");
-        self.peer_mtus.lock().unwrap().remove(peer_id);
+        self.peer_mtus.lock_or_recover().remove(peer_id);
     }
 
     /// Returns the maximum fragment payload to use for a given peer, falling
     /// back to [`BLE_MAX_FRAGMENT_SIZE`] when no negotiated value is on file.
     pub fn peer_mtu(&self, peer_id: &str) -> usize {
         self.peer_mtus
-            .lock()
-            .unwrap()
+            .lock_or_recover()
             .get(peer_id)
             .copied()
             .unwrap_or(BLE_MAX_FRAGMENT_SIZE)
@@ -411,7 +409,7 @@ impl BleTransport {
 
     /// Called when a peer device is discovered.
     pub fn on_peer_discovered(&self, peer: PeerDevice) {
-        let mut peers = self.peers.lock().unwrap();
+        let mut peers = self.peers.lock_or_recover();
         peers.insert(peer.device_id.clone(), peer);
     }
 
@@ -421,8 +419,8 @@ impl BleTransport {
     /// stale value from the previous link. Platforms may still call
     /// [`Self::clear_peer_mtu`] directly for mid-link renegotiation paths.
     pub fn on_peer_lost(&self, device_id: &str) {
-        self.peers.lock().unwrap().remove(device_id);
-        self.peer_mtus.lock().unwrap().remove(device_id);
+        self.peers.lock_or_recover().remove(device_id);
+        self.peer_mtus.lock_or_recover().remove(device_id);
     }
 
     /// Called when a message is received from a peer.
@@ -454,44 +452,44 @@ impl BleTransport {
     /// (`undersized_mtu_reports`, `fragment_fallback_count`) are preserved.
     pub fn on_status_changed(&self, status: TransportStatus) {
         let previous = {
-            let mut guard = self.status.lock().unwrap();
+            let mut guard = self.status.lock_or_recover();
             let prev = *guard;
             *guard = status;
             prev
         };
 
         if previous == TransportStatus::Available && status != TransportStatus::Available {
-            self.peers.lock().unwrap().clear();
-            self.peer_mtus.lock().unwrap().clear();
-            self.fragment_buffers.lock().unwrap().clear();
-            self.send_queue.lock().unwrap().clear();
-            self.pending_fragments.lock().unwrap().clear();
-            self.receive_queue.lock().unwrap().clear();
+            self.peers.lock_or_recover().clear();
+            self.peer_mtus.lock_or_recover().clear();
+            self.fragment_buffers.lock_or_recover().clear();
+            self.send_queue.lock_or_recover().clear();
+            self.pending_fragments.lock_or_recover().clear();
+            self.receive_queue.lock_or_recover().clear();
             self.update_queue_metric();
         }
     }
 
     /// Gets all discovered peers.
     pub fn get_peers(&self) -> Vec<PeerDevice> {
-        let peers = self.peers.lock().unwrap();
+        let peers = self.peers.lock_or_recover();
         peers.values().cloned().collect()
     }
 
     /// Gets a specific peer by device ID.
     pub fn get_peer(&self, device_id: &str) -> Option<PeerDevice> {
-        let peers = self.peers.lock().unwrap();
+        let peers = self.peers.lock_or_recover();
         peers.get(device_id).cloned()
     }
 
     /// Updates transport metrics.
     pub fn update_metrics(&self, metrics: TransportMetrics) {
-        *self.metrics.lock().unwrap() = metrics;
+        *self.metrics.lock_or_recover() = metrics;
     }
 
     fn update_queue_metric(&self) {
-        let send_len = self.send_queue.lock().unwrap().len();
-        let fragment_len = self.pending_fragments.lock().unwrap().len();
-        let mut metrics = self.metrics.lock().unwrap();
+        let send_len = self.send_queue.lock_or_recover().len();
+        let fragment_len = self.pending_fragments.lock_or_recover().len();
+        let mut metrics = self.metrics.lock_or_recover();
         metrics.queue_depth = send_len + fragment_len;
         let heuristic_capacity = 50_f32;
         metrics.congestion = ((metrics.queue_depth as f32) / heuristic_capacity).clamp(0.0, 1.0);
@@ -499,7 +497,7 @@ impl BleTransport {
 
     /// Records a successful send for metrics tracking.
     pub fn record_send_success(&self) {
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self.metrics.lock_or_recover();
         metrics.success_count = metrics.success_count.saturating_add(1);
         let total = metrics.success_count + metrics.failure_count;
         if total > 0 {
@@ -511,7 +509,7 @@ impl BleTransport {
 
     /// Records a failed send for metrics tracking.
     pub fn record_send_failure(&self) {
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self.metrics.lock_or_recover();
         metrics.failure_count = metrics.failure_count.saturating_add(1);
         let total = metrics.success_count + metrics.failure_count;
         if total > 0 {
@@ -523,7 +521,7 @@ impl BleTransport {
 
     fn record_latency(&self, latency_ms: u128) {
         let value = latency_ms.min(u128::from(u32::MAX)) as u32;
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self.metrics.lock_or_recover();
         metrics.latency_ms = Some(match metrics.latency_ms {
             Some(existing) => {
                 let ema = (existing as f32 * 0.7) + (value as f32 * 0.3);
@@ -534,7 +532,7 @@ impl BleTransport {
     }
 
     fn cleanup_fragment_buffers(&self) {
-        let mut buffers = self.fragment_buffers.lock().unwrap();
+        let mut buffers = self.fragment_buffers.lock_or_recover();
         let now = SystemTime::now();
         let mut expired = Vec::new();
 
@@ -563,15 +561,15 @@ impl BleTransport {
 
     /// Gets current queue depth for metrics.
     pub fn get_queue_depth(&self) -> usize {
-        let send_len = self.send_queue.lock().unwrap().len();
-        let fragment_len = self.pending_fragments.lock().unwrap().len();
+        let send_len = self.send_queue.lock_or_recover().len();
+        let fragment_len = self.pending_fragments.lock_or_recover().len();
         send_len + fragment_len
     }
 
     /// Processes the send queue (to be called by platform implementation).
     pub fn dequeue_send(&self) -> Option<(String, Message)> {
         let result = {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             queue.pop_front()
         };
 
@@ -584,7 +582,7 @@ impl BleTransport {
 
     /// Checks if there are messages to send.
     pub fn has_pending_sends(&self) -> bool {
-        let queue = self.send_queue.lock().unwrap();
+        let queue = self.send_queue.lock_or_recover();
         !queue.is_empty()
     }
 
@@ -663,11 +661,11 @@ impl BleTransport {
         // by a single thread — safe today (no path holds `peers` while
         // taking `peer_mtus`) but one refactor away from an AB/BA
         // deadlock. Keep this as two statements.
-        let cached_mtu = self.peer_mtus.lock().unwrap().get(recipient).copied();
+        let cached_mtu = self.peer_mtus.lock_or_recover().get(recipient).copied();
         let mtu = match cached_mtu {
             Some(mtu) => mtu,
             None => {
-                let is_direct_peer = self.peers.lock().unwrap().contains_key(recipient);
+                let is_direct_peer = self.peers.lock_or_recover().contains_key(recipient);
                 if is_direct_peer {
                     self.fragment_fallback_count.fetch_add(1, Ordering::Relaxed);
                     // Debug-only: surface the contract break with a
@@ -774,7 +772,7 @@ impl BleTransport {
 
         {
             // Multi-fragment message - add to reassembly buffer
-            let mut buffers = self.fragment_buffers.lock().unwrap();
+            let mut buffers = self.fragment_buffers.lock_or_recover();
             let now = SystemTime::now();
 
             if !buffers.contains_key(&fragment.message_id)
@@ -870,7 +868,7 @@ impl BleTransport {
         // that re-enters the transport (e.g. set_fragment_eviction_callback)
         // cannot self-deadlock.
         if let Some(info) = eviction_info {
-            let cb = self.eviction_callback.lock().unwrap().clone();
+            let cb = self.eviction_callback.lock_or_recover().clone();
             if let Some(cb) = cb {
                 cb(info);
             }
@@ -911,7 +909,7 @@ impl BleTransport {
         match self.process_fragment(&fragment_data) {
             Ok(Some(message)) => {
                 // Message complete - queue it
-                let mut queue = self.receive_queue.lock().unwrap();
+                let mut queue = self.receive_queue.lock_or_recover();
                 queue.push_back(message.clone());
                 // Note: sender/recipient are intentionally not logged to protect user privacy
                 tracing::debug!(
@@ -948,7 +946,7 @@ impl BleTransport {
             Ok(Some(mut message)) => {
                 message.set_transport_peer_id(peer_id)?;
                 let msg_id = message.id.clone();
-                let mut queue = self.receive_queue.lock().unwrap();
+                let mut queue = self.receive_queue.lock_or_recover();
                 queue.push_back(message);
                 tracing::debug!(
                     message_id = %msg_id,
@@ -973,7 +971,7 @@ impl BleTransport {
     pub fn get_next_fragment(&self) -> Result<Option<(String, Vec<u8>)>> {
         // Check for pending fragments first
         if let Some(fragment) = {
-            let mut pending = self.pending_fragments.lock().unwrap();
+            let mut pending = self.pending_fragments.lock_or_recover();
             pending.pop_front()
         } {
             self.update_queue_metric();
@@ -982,7 +980,7 @@ impl BleTransport {
 
         // No serialized fragments waiting – pull a fresh message from the queue
         let maybe_message = {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             queue.pop_front()
         };
 
@@ -999,7 +997,7 @@ impl BleTransport {
         }
 
         {
-            let mut pending = self.pending_fragments.lock().unwrap();
+            let mut pending = self.pending_fragments.lock_or_recover();
             for fragment in fragments {
                 pending.push_back((recipient.clone(), fragment));
             }
@@ -1008,7 +1006,7 @@ impl BleTransport {
         self.update_queue_metric();
 
         let result = {
-            let mut pending = self.pending_fragments.lock().unwrap();
+            let mut pending = self.pending_fragments.lock_or_recover();
             pending.pop_front()
         };
 
@@ -1020,7 +1018,7 @@ impl BleTransport {
     /// Re-queues a fragment at the front of the pending queue (used when platform send fails).
     pub fn requeue_fragment(&self, recipient: &str, fragment_data: Vec<u8>) {
         {
-            let mut pending = self.pending_fragments.lock().unwrap();
+            let mut pending = self.pending_fragments.lock_or_recover();
             pending.push_front((recipient.to_string(), fragment_data));
         }
 
@@ -1131,11 +1129,11 @@ impl Transport for BleTransport {
     }
 
     fn status(&self) -> TransportStatus {
-        *self.status.lock().unwrap()
+        *self.status.lock_or_recover()
     }
 
     fn metrics(&self) -> TransportMetrics {
-        self.metrics.lock().unwrap().clone()
+        self.metrics.lock_or_recover().clone()
     }
 
     fn send(&self, message: &Message) -> Result<()> {
@@ -1151,7 +1149,7 @@ impl Transport for BleTransport {
         let recipient = message.recipient.as_str().to_string();
 
         {
-            let peers = self.peers.lock().unwrap();
+            let peers = self.peers.lock_or_recover();
             if !peers.contains_key(&recipient) {
                 // Distinguish "no BLE peers at all" (ordinary offline; escalate to
                 // the next transport) from "meshing with other peers but not this
@@ -1178,7 +1176,7 @@ impl Transport for BleTransport {
         }
 
         {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             queue.push_back((recipient, message.clone()));
         }
 
@@ -1189,14 +1187,14 @@ impl Transport for BleTransport {
     }
 
     fn receive(&self) -> Result<Option<Message>> {
-        let mut queue = self.receive_queue.lock().unwrap();
+        let mut queue = self.receive_queue.lock_or_recover();
         Ok(queue.pop_front())
     }
 
     fn start(&mut self) -> Result<()> {
         // Set status to Available when starting
         // Platform can still override this via on_status_changed() if BLE is not available
-        *self.status.lock().unwrap() = TransportStatus::Available;
+        *self.status.lock_or_recover() = TransportStatus::Available;
         Ok(())
     }
 
@@ -1208,7 +1206,7 @@ impl Transport for BleTransport {
         // will re-seed state into what is supposed to be an at-rest
         // transport. Android/iOS bindings enforce this by draining
         // their own GATT state before calling into the Rust stop path.
-        *self.status.lock().unwrap() = TransportStatus::Disconnected;
+        *self.status.lock_or_recover() = TransportStatus::Disconnected;
         // Drain every per-session cache on teardown so a subsequent
         // start() observes no state from the prior session. Every
         // reconnect re-runs peer discovery, fragment reassembly, and
@@ -1219,12 +1217,12 @@ impl Transport for BleTransport {
         // would let stale reassembly state outlive the peer it came
         // from. The `undersized_mtu_reports` counter is a monotonic
         // lifetime metric and is intentionally *not* reset here.
-        self.peers.lock().unwrap().clear();
-        self.peer_mtus.lock().unwrap().clear();
-        self.fragment_buffers.lock().unwrap().clear();
-        self.send_queue.lock().unwrap().clear();
-        self.pending_fragments.lock().unwrap().clear();
-        self.receive_queue.lock().unwrap().clear();
+        self.peers.lock_or_recover().clear();
+        self.peer_mtus.lock_or_recover().clear();
+        self.fragment_buffers.lock_or_recover().clear();
+        self.send_queue.lock_or_recover().clear();
+        self.pending_fragments.lock_or_recover().clear();
+        self.receive_queue.lock_or_recover().clear();
         self.update_queue_metric();
         Ok(())
     }

--- a/crates/offline-protocol-transport/src/common.rs
+++ b/crates/offline-protocol-transport/src/common.rs
@@ -7,13 +7,13 @@
 
 use crate::constants::DEFAULT_MAX_MESSAGE_SIZE;
 use crate::{Error, Result, TransportMetrics};
-use offline_protocol_core::Message;
+use offline_protocol_core::{Message, MutexExt};
 use std::collections::VecDeque;
 use std::sync::Mutex;
 
 /// Queues a received message.
 pub fn on_message_received(receive_queue: &Mutex<VecDeque<Message>>, message: Message) {
-    receive_queue.lock().unwrap().push_back(message);
+    receive_queue.lock_or_recover().push_back(message);
 }
 
 /// Sets the transport peer identity on a message and queues it.
@@ -31,7 +31,7 @@ pub fn on_message_received_from(
         );
         return;
     }
-    receive_queue.lock().unwrap().push_back(message);
+    receive_queue.lock_or_recover().push_back(message);
 }
 
 /// Deserialises raw bytes into a message and queues it.
@@ -42,7 +42,7 @@ pub fn on_data_received(receive_queue: &Mutex<VecDeque<Message>>, data: Vec<u8>)
     }
     match deserialize_message(&data) {
         Ok(message) => {
-            receive_queue.lock().unwrap().push_back(message);
+            receive_queue.lock_or_recover().push_back(message);
             Ok(())
         }
         Err(e) => {
@@ -65,7 +65,7 @@ pub fn on_data_received_from(
     match deserialize_message(&data) {
         Ok(mut message) => {
             message.set_transport_peer_id(peer_id)?;
-            receive_queue.lock().unwrap().push_back(message);
+            receive_queue.lock_or_recover().push_back(message);
             Ok(())
         }
         Err(e) => {
@@ -89,12 +89,12 @@ pub fn deserialize_message(data: &[u8]) -> Result<Message> {
 
 /// Stores an opaque platform handle.
 pub fn set_platform_handle(handle_lock: &Mutex<Option<usize>>, handle: usize) {
-    *handle_lock.lock().unwrap() = Some(handle);
+    *handle_lock.lock_or_recover() = Some(handle);
 }
 
 /// Retrieves the stored platform handle.
 pub fn platform_handle(handle_lock: &Mutex<Option<usize>>) -> Option<usize> {
-    *handle_lock.lock().unwrap()
+    *handle_lock.lock_or_recover()
 }
 
 /// Recalculates `delivery_ratio` and `drop_rate` from the current success/failure counts.

--- a/crates/offline-protocol-transport/src/internet.rs
+++ b/crates/offline-protocol-transport/src/internet.rs
@@ -19,7 +19,7 @@ use crate::constants::{
     INTERNET_HEARTBEAT_INTERVAL_SECS, INTERNET_PENDING_CONFIRMATION_TIMEOUT_SECS,
 };
 use crate::{Result, Transport, TransportMetrics, TransportStatus, TransportType};
-use offline_protocol_core::Message;
+use offline_protocol_core::{Message, MutexExt};
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -153,7 +153,7 @@ impl InternetTransport {
     /// - Reconnect counter is reset on successful connection
     pub fn on_status_changed(&self, status: TransportStatus) {
         let previous_status = {
-            let mut guard = self.status.lock().unwrap();
+            let mut guard = self.status.lock_or_recover();
             let prev = *guard;
             *guard = status;
             prev
@@ -163,8 +163,8 @@ impl InternetTransport {
         if status == TransportStatus::Available {
             // Acquire send_queue before reconnect_attempts to respect lock
             // ordering (send_queue is #3, reconnect_attempts is #6).
-            let queue_len = self.send_queue.lock().unwrap().len();
-            *self.reconnect_attempts.lock().unwrap() = 0;
+            let queue_len = self.send_queue.lock_or_recover().len();
+            *self.reconnect_attempts.lock_or_recover() = 0;
 
             if queue_len > 0 {
                 tracing::info!(
@@ -180,7 +180,7 @@ impl InternetTransport {
             // platform can no longer report outcomes for in-flight messages.
             self.fail_all_pending();
 
-            let queue_len = self.send_queue.lock().unwrap().len();
+            let queue_len = self.send_queue.lock_or_recover().len();
             if queue_len > 0 {
                 tracing::warn!(
                     pending_messages = queue_len,
@@ -258,7 +258,7 @@ impl InternetTransport {
         self.drain_expired_pending();
 
         let (message, queue_depth) = {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             match queue.pop_front() {
                 Some(m) => {
                     let depth = queue.len();
@@ -276,12 +276,12 @@ impl InternetTransport {
         let data = self.serialize_message(&message)?;
 
         {
-            let mut pending = self.pending_confirmation.lock().unwrap();
+            let mut pending = self.pending_confirmation.lock_or_recover();
             pending.insert(message_id.clone(), Instant::now());
         }
 
         {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.queue_depth = queue_depth;
         }
 
@@ -294,12 +294,12 @@ impl InternetTransport {
     /// enabling DORS to make accurate routing decisions.
     pub fn confirm_sent(&self, message_id: &str) {
         let was_pending = {
-            let mut pending = self.pending_confirmation.lock().unwrap();
+            let mut pending = self.pending_confirmation.lock_or_recover();
             pending.remove(message_id).is_some()
         };
 
         if was_pending {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.success_count = metrics.success_count.saturating_add(1);
             recalculate_delivery_ratios(&mut metrics);
             tracing::trace!(
@@ -318,12 +318,12 @@ impl InternetTransport {
     /// Platform reports that a message failed to send (e.g., WebSocket error).
     pub fn report_send_failure(&self, message_id: &str) {
         let was_pending = {
-            let mut pending = self.pending_confirmation.lock().unwrap();
+            let mut pending = self.pending_confirmation.lock_or_recover();
             pending.remove(message_id).is_some()
         };
 
         if was_pending {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.failure_count = metrics.failure_count.saturating_add(1);
             recalculate_delivery_ratios(&mut metrics);
             tracing::trace!(
@@ -347,7 +347,7 @@ impl InternetTransport {
         let mut expired_count: u32 = 0;
 
         {
-            let mut pending = self.pending_confirmation.lock().unwrap();
+            let mut pending = self.pending_confirmation.lock_or_recover();
             pending.retain(|_id, enqueued_at| {
                 if now.duration_since(*enqueued_at) >= timeout {
                     expired_count += 1;
@@ -374,7 +374,7 @@ impl InternetTransport {
     /// per-message expiry timeout.
     fn fail_all_pending(&self) {
         let count = {
-            let mut pending = self.pending_confirmation.lock().unwrap();
+            let mut pending = self.pending_confirmation.lock_or_recover();
             let count = u32::try_from(pending.len()).unwrap_or(u32::MAX);
             pending.clear();
             count
@@ -391,14 +391,14 @@ impl InternetTransport {
 
     /// Records `count` delivery failures in transport metrics.
     fn record_bulk_failures(&self, count: u32) {
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self.metrics.lock_or_recover();
         metrics.failure_count = metrics.failure_count.saturating_add(count);
         recalculate_delivery_ratios(&mut metrics);
     }
 
     /// Returns the count of messages currently awaiting confirmation from the platform.
     pub fn pending_confirmation_count(&self) -> usize {
-        self.pending_confirmation.lock().unwrap().len()
+        self.pending_confirmation.lock_or_recover().len()
     }
 
     /// Checks if reconnection should be attempted.
@@ -407,25 +407,25 @@ impl InternetTransport {
             return false;
         }
 
-        let attempts = *self.reconnect_attempts.lock().unwrap();
+        let attempts = *self.reconnect_attempts.lock_or_recover();
         self.config.max_reconnect_attempts == 0 || attempts < self.config.max_reconnect_attempts
     }
 
     /// Increments reconnection attempt counter.
     /// Uses saturating addition to prevent overflow.
     pub fn increment_reconnect_attempts(&self) {
-        let mut attempts = self.reconnect_attempts.lock().unwrap();
+        let mut attempts = self.reconnect_attempts.lock_or_recover();
         *attempts = attempts.saturating_add(1);
     }
 
     /// Updates heartbeat timestamp.
     pub fn update_heartbeat(&self) {
-        *self.last_heartbeat.lock().unwrap() = Some(Instant::now());
+        *self.last_heartbeat.lock_or_recover() = Some(Instant::now());
     }
 
     /// Checks if heartbeat is needed.
     pub fn needs_heartbeat(&self) -> bool {
-        let last = *self.last_heartbeat.lock().unwrap();
+        let last = *self.last_heartbeat.lock_or_recover();
         match last {
             Some(instant) => {
                 instant.elapsed() >= Duration::from_secs(INTERNET_HEARTBEAT_INTERVAL_SECS)
@@ -442,7 +442,7 @@ impl InternetTransport {
     /// so adding a new confirmation-loop field doesn't require updating this
     /// function — it's preserved by default.
     pub fn update_metrics(&self, incoming: TransportMetrics) {
-        let mut current = self.metrics.lock().unwrap();
+        let mut current = self.metrics.lock_or_recover();
         current.rssi = incoming.rssi;
         current.latency_ms = incoming.latency_ms;
         current.bandwidth_bps = incoming.bandwidth_bps;
@@ -467,11 +467,11 @@ impl Transport for InternetTransport {
     }
 
     fn status(&self) -> TransportStatus {
-        *self.status.lock().unwrap()
+        *self.status.lock_or_recover()
     }
 
     fn metrics(&self) -> TransportMetrics {
-        self.metrics.lock().unwrap().clone()
+        self.metrics.lock_or_recover().clone()
     }
 
     fn send(&self, message: &Message) -> Result<()> {
@@ -483,11 +483,11 @@ impl Transport for InternetTransport {
         }
 
         // Add to send queue
-        let mut queue = self.send_queue.lock().unwrap();
+        let mut queue = self.send_queue.lock_or_recover();
         queue.push_back(message.clone());
 
         // Update metrics
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self.metrics.lock_or_recover();
         metrics.queue_depth = queue.len();
         metrics.congestion = ((metrics.queue_depth as f32) / 25.0).clamp(0.0, 1.0);
 
@@ -495,7 +495,7 @@ impl Transport for InternetTransport {
     }
 
     fn receive(&self) -> Result<Option<Message>> {
-        let mut queue = self.receive_queue.lock().unwrap();
+        let mut queue = self.receive_queue.lock_or_recover();
         Ok(queue.pop_front())
     }
 
@@ -507,7 +507,7 @@ impl Transport for InternetTransport {
 
     fn stop(&mut self) -> Result<()> {
         self.fail_all_pending();
-        *self.status.lock().unwrap() = TransportStatus::Disconnected;
+        *self.status.lock_or_recover() = TransportStatus::Disconnected;
         Ok(())
     }
 }

--- a/crates/offline-protocol-transport/src/nostr.rs
+++ b/crates/offline-protocol-transport/src/nostr.rs
@@ -23,7 +23,7 @@ use crate::constants::{NOSTR_CONNECTION_TIMEOUT_SECS, NOSTR_PENDING_CONFIRMATION
 use crate::nostr_crypto::{self, NostrKeypair};
 use crate::{Result, SharedCallback, Transport, TransportMetrics, TransportStatus, TransportType};
 use base64::Engine;
-use offline_protocol_core::Message;
+use offline_protocol_core::{Message, MutexExt, RwLockExt};
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
@@ -171,7 +171,7 @@ impl NostrTransport {
 
     /// Sets the callback invoked when outgoing messages are queued.
     pub fn set_on_messages_available(&self, callback: Arc<dyn Fn() + Send + Sync>) {
-        *self.on_messages_available.lock().unwrap() = Some(callback);
+        *self.on_messages_available.lock_or_recover() = Some(callback);
     }
 
     /// Notifies the platform that messages are ready to send.
@@ -180,7 +180,7 @@ impl NostrTransport {
     /// before the call, so a callback that re-enters the transport (e.g.
     /// another `send()`) cannot self-deadlock on the callback mutex.
     fn notify_messages_available(&self) {
-        let callback = self.on_messages_available.lock().unwrap().clone();
+        let callback = self.on_messages_available.lock_or_recover().clone();
         if let Some(cb) = callback {
             cb();
         }
@@ -192,15 +192,15 @@ impl NostrTransport {
     /// Fails all pending confirmations on disconnect.
     pub fn on_status_changed(&self, status: TransportStatus) {
         let previous_status = {
-            let mut guard = self.status.lock().unwrap();
+            let mut guard = self.status.lock_or_recover();
             let prev = *guard;
             *guard = status;
             prev
         };
 
         if status == TransportStatus::Available {
-            let queue_len = self.send_queue.lock().unwrap().len();
-            *self.reconnect_attempts.lock().unwrap() = 0;
+            let queue_len = self.send_queue.lock_or_recover().len();
+            *self.reconnect_attempts.lock_or_recover() = 0;
 
             if queue_len > 0 {
                 tracing::info!(
@@ -214,7 +214,7 @@ impl NostrTransport {
         {
             self.fail_all_pending();
 
-            let queue_len = self.send_queue.lock().unwrap().len();
+            let queue_len = self.send_queue.lock_or_recover().len();
             if queue_len > 0 {
                 tracing::warn!(
                     pending_messages = queue_len,
@@ -268,7 +268,7 @@ impl NostrTransport {
         self.drain_expired_pending();
 
         let message = {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             match queue.pop_front() {
                 Some(m) => m,
                 None => return Ok(None),
@@ -279,8 +279,7 @@ impl NostrTransport {
         let data = self.serialize_message(&message)?;
 
         self.pending_confirmation
-            .lock()
-            .unwrap()
+            .lock_or_recover()
             .insert(message_id.clone(), Instant::now());
 
         Ok(Some((message_id, data)))
@@ -288,10 +287,13 @@ impl NostrTransport {
 
     /// Platform confirms a message was sent successfully.
     pub fn confirm_sent(&self, message_id: &str) {
-        let removed = self.pending_confirmation.lock().unwrap().remove(message_id);
+        let removed = self
+            .pending_confirmation
+            .lock_or_recover()
+            .remove(message_id);
 
         if removed.is_some() {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.success_count = metrics.success_count.saturating_add(1);
             recalculate_delivery_ratios(&mut metrics);
         }
@@ -299,10 +301,13 @@ impl NostrTransport {
 
     /// Platform reports a send failure.
     pub fn report_send_failure(&self, message_id: &str) {
-        let removed = self.pending_confirmation.lock().unwrap().remove(message_id);
+        let removed = self
+            .pending_confirmation
+            .lock_or_recover()
+            .remove(message_id);
 
         if removed.is_some() {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.failure_count = metrics.failure_count.saturating_add(1);
             recalculate_delivery_ratios(&mut metrics);
         }
@@ -316,18 +321,18 @@ impl NostrTransport {
         if self.config.max_reconnect_attempts == 0 {
             return true;
         }
-        *self.reconnect_attempts.lock().unwrap() < self.config.max_reconnect_attempts
+        *self.reconnect_attempts.lock_or_recover() < self.config.max_reconnect_attempts
     }
 
     /// Increments the reconnection attempt counter.
     pub fn increment_reconnect_attempts(&self) {
-        let mut attempts = self.reconnect_attempts.lock().unwrap();
+        let mut attempts = self.reconnect_attempts.lock_or_recover();
         *attempts = attempts.saturating_add(1);
     }
 
     /// Updates transport metrics, preserving confirmation-loop counts.
     pub fn update_metrics(&self, incoming: TransportMetrics) {
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self.metrics.lock_or_recover();
         let prev_success = metrics.success_count;
         let prev_failure = metrics.failure_count;
         *metrics = incoming;
@@ -338,12 +343,12 @@ impl NostrTransport {
 
     /// Checks if there are messages waiting to be sent.
     pub fn has_pending_sends(&self) -> bool {
-        !self.send_queue.lock().unwrap().is_empty()
+        !self.send_queue.lock_or_recover().is_empty()
     }
 
     /// Returns the number of messages awaiting platform confirmation.
     pub fn pending_confirmation_count(&self) -> usize {
-        self.pending_confirmation.lock().unwrap().len()
+        self.pending_confirmation.lock_or_recover().len()
     }
 
     // ========================================================================
@@ -358,7 +363,7 @@ impl NostrTransport {
     /// persisted one, so platforms should read it after protocol
     /// initialization, not cache it across that boundary.
     pub fn public_key_hex(&self) -> String {
-        self.keypair.read().unwrap().public_key_hex().to_string()
+        self.keypair.read_or_recover().public_key_hex().to_string()
     }
 
     /// Returns this device's public routing tag (the `#p` value peers use to
@@ -378,7 +383,7 @@ impl NostrTransport {
     pub fn install_signing_secret(&self, secret: &[u8]) -> Result<()> {
         let keypair = NostrKeypair::from_install_secret(secret)?;
         let pubkey = keypair.public_key_hex().to_string();
-        *self.keypair.write().unwrap() = keypair;
+        *self.keypair.write_or_recover() = keypair;
         tracing::debug!(
             pubkey = %pubkey,
             "Installed persisted Nostr signing key"
@@ -396,7 +401,7 @@ impl NostrTransport {
         self.drain_expired_pending();
 
         let message = {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             match queue.pop_front() {
                 Some(m) => m,
                 None => return Ok(None),
@@ -411,7 +416,7 @@ impl NostrTransport {
             let content_base64 = base64::engine::general_purpose::STANDARD.encode(&data);
 
             let recipient_tag = nostr_crypto::routing_tag_for_device_id(&recipient_device_id)?;
-            let keypair = self.keypair.read().unwrap();
+            let keypair = self.keypair.read_or_recover();
             let event =
                 nostr_crypto::NostrEvent::create_dm(&keypair, &recipient_tag, &content_base64)?;
             drop(keypair);
@@ -422,10 +427,9 @@ impl NostrTransport {
 
         match result {
             Ok((event_id, event_json)) => {
-                self.sign_retry_counts.lock().unwrap().remove(&message_id);
+                self.sign_retry_counts.lock_or_recover().remove(&message_id);
                 self.pending_confirmation
-                    .lock()
-                    .unwrap()
+                    .lock_or_recover()
                     .insert(message_id.clone(), Instant::now());
 
                 Ok(Some(SignedNostrEvent {
@@ -436,7 +440,7 @@ impl NostrTransport {
             }
             Err(e) => {
                 let retry_count = {
-                    let mut counts = self.sign_retry_counts.lock().unwrap();
+                    let mut counts = self.sign_retry_counts.lock_or_recover();
                     let count = counts.entry(message_id.clone()).or_insert(0);
                     *count += 1;
                     *count
@@ -444,11 +448,11 @@ impl NostrTransport {
 
                 if retry_count < MAX_SIGN_RETRIES {
                     // Re-enqueue for another attempt.
-                    self.send_queue.lock().unwrap().push_front(message);
+                    self.send_queue.lock_or_recover().push_front(message);
                 } else {
                     // Permanent failure — report it so metrics are updated and
                     // the queue is not blocked by an undeliverable message.
-                    self.sign_retry_counts.lock().unwrap().remove(&message_id);
+                    self.sign_retry_counts.lock_or_recover().remove(&message_id);
                     self.report_send_failure(&message_id);
                     tracing::error!(
                         message_id = %message_id,
@@ -476,13 +480,13 @@ impl NostrTransport {
     /// Fails all pending confirmations and records them as failures.
     fn fail_all_pending(&self) {
         let pending = {
-            let mut map = self.pending_confirmation.lock().unwrap();
+            let mut map = self.pending_confirmation.lock_or_recover();
             let count = map.len();
             map.clear();
             count
         };
         if pending > 0 {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.failure_count = metrics.failure_count.saturating_add(pending as u32);
             recalculate_delivery_ratios(&mut metrics);
         }
@@ -495,7 +499,7 @@ impl NostrTransport {
         let mut expired_count = 0u32;
 
         {
-            let mut pending = self.pending_confirmation.lock().unwrap();
+            let mut pending = self.pending_confirmation.lock_or_recover();
             pending.retain(|_, enqueued_at| {
                 if now.duration_since(*enqueued_at) > timeout {
                     expired_count += 1;
@@ -507,7 +511,7 @@ impl NostrTransport {
         }
 
         if expired_count > 0 {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.failure_count = metrics.failure_count.saturating_add(expired_count);
             recalculate_delivery_ratios(&mut metrics);
         }
@@ -524,15 +528,15 @@ impl Transport for NostrTransport {
     }
 
     fn status(&self) -> TransportStatus {
-        *self.status.lock().unwrap()
+        *self.status.lock_or_recover()
     }
 
     fn metrics(&self) -> TransportMetrics {
-        self.metrics.lock().unwrap().clone()
+        self.metrics.lock_or_recover().clone()
     }
 
     fn send(&self, message: &Message) -> Result<()> {
-        let status = *self.status.lock().unwrap();
+        let status = *self.status.lock_or_recover();
         if status != TransportStatus::Available {
             return Err(crate::Error::TransportNotAvailable(format!(
                 "Nostr transport is {:?}",
@@ -541,12 +545,12 @@ impl Transport for NostrTransport {
         }
 
         let queue_len = {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             queue.push_back(message.clone());
             queue.len()
         };
 
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self.metrics.lock_or_recover();
         metrics.queue_depth = queue_len;
         metrics.congestion = ((queue_len as f32) / 50.0).clamp(0.0, 1.0);
         drop(metrics);
@@ -557,7 +561,7 @@ impl Transport for NostrTransport {
     }
 
     fn receive(&self) -> Result<Option<Message>> {
-        let mut queue = self.receive_queue.lock().unwrap();
+        let mut queue = self.receive_queue.lock_or_recover();
         Ok(queue.pop_front())
     }
 
@@ -568,10 +572,10 @@ impl Transport for NostrTransport {
     }
 
     fn stop(&mut self) -> Result<()> {
-        *self.status.lock().unwrap() = TransportStatus::Disconnected;
+        *self.status.lock_or_recover() = TransportStatus::Disconnected;
         self.fail_all_pending();
-        self.send_queue.lock().unwrap().clear();
-        self.receive_queue.lock().unwrap().clear();
+        self.send_queue.lock_or_recover().clear();
+        self.receive_queue.lock_or_recover().clear();
         Ok(())
     }
 }

--- a/crates/offline-protocol-transport/src/reticulum.rs
+++ b/crates/offline-protocol-transport/src/reticulum.rs
@@ -18,7 +18,7 @@ use crate::constants::{
     RETICULUM_CONNECTION_TIMEOUT_SECS, RETICULUM_PENDING_CONFIRMATION_TIMEOUT_SECS,
 };
 use crate::{Result, SharedCallback, Transport, TransportMetrics, TransportStatus, TransportType};
-use offline_protocol_core::Message;
+use offline_protocol_core::{Message, MutexExt};
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -123,7 +123,7 @@ impl ReticulumTransport {
 
     /// Sets the callback invoked when outgoing messages are queued.
     pub fn set_on_messages_available(&self, callback: Arc<dyn Fn() + Send + Sync>) {
-        *self.on_messages_available.lock().unwrap() = Some(callback);
+        *self.on_messages_available.lock_or_recover() = Some(callback);
     }
 
     /// Notifies the platform that messages are ready to send.
@@ -132,7 +132,7 @@ impl ReticulumTransport {
     /// before the call, so a callback that re-enters the transport (e.g.
     /// another `send()`) cannot self-deadlock on the callback mutex.
     fn notify_messages_available(&self) {
-        let callback = self.on_messages_available.lock().unwrap().clone();
+        let callback = self.on_messages_available.lock_or_recover().clone();
         if let Some(cb) = callback {
             cb();
         }
@@ -144,15 +144,15 @@ impl ReticulumTransport {
     /// Fails all pending confirmations on disconnect.
     pub fn on_status_changed(&self, status: TransportStatus) {
         let previous_status = {
-            let mut guard = self.status.lock().unwrap();
+            let mut guard = self.status.lock_or_recover();
             let prev = *guard;
             *guard = status;
             prev
         };
 
         if status == TransportStatus::Available {
-            let queue_len = self.send_queue.lock().unwrap().len();
-            *self.reconnect_attempts.lock().unwrap() = 0;
+            let queue_len = self.send_queue.lock_or_recover().len();
+            *self.reconnect_attempts.lock_or_recover() = 0;
 
             if queue_len > 0 {
                 tracing::info!(
@@ -166,7 +166,7 @@ impl ReticulumTransport {
         {
             self.fail_all_pending();
 
-            let queue_len = self.send_queue.lock().unwrap().len();
+            let queue_len = self.send_queue.lock_or_recover().len();
             if queue_len > 0 {
                 tracing::warn!(
                     pending_messages = queue_len,
@@ -220,7 +220,7 @@ impl ReticulumTransport {
         self.drain_expired_pending();
 
         let message = {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             match queue.pop_front() {
                 Some(m) => m,
                 None => return Ok(None),
@@ -231,8 +231,7 @@ impl ReticulumTransport {
         let data = self.serialize_message(&message)?;
 
         self.pending_confirmation
-            .lock()
-            .unwrap()
+            .lock_or_recover()
             .insert(message_id.clone(), Instant::now());
 
         Ok(Some((message_id, data)))
@@ -240,10 +239,13 @@ impl ReticulumTransport {
 
     /// Platform confirms a message was sent successfully.
     pub fn confirm_sent(&self, message_id: &str) {
-        let removed = self.pending_confirmation.lock().unwrap().remove(message_id);
+        let removed = self
+            .pending_confirmation
+            .lock_or_recover()
+            .remove(message_id);
 
         if removed.is_some() {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.success_count = metrics.success_count.saturating_add(1);
             recalculate_delivery_ratios(&mut metrics);
         }
@@ -251,10 +253,13 @@ impl ReticulumTransport {
 
     /// Platform reports a send failure.
     pub fn report_send_failure(&self, message_id: &str) {
-        let removed = self.pending_confirmation.lock().unwrap().remove(message_id);
+        let removed = self
+            .pending_confirmation
+            .lock_or_recover()
+            .remove(message_id);
 
         if removed.is_some() {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.failure_count = metrics.failure_count.saturating_add(1);
             recalculate_delivery_ratios(&mut metrics);
         }
@@ -268,18 +273,18 @@ impl ReticulumTransport {
         if self.config.max_reconnect_attempts == 0 {
             return true;
         }
-        *self.reconnect_attempts.lock().unwrap() < self.config.max_reconnect_attempts
+        *self.reconnect_attempts.lock_or_recover() < self.config.max_reconnect_attempts
     }
 
     /// Increments the reconnection attempt counter.
     pub fn increment_reconnect_attempts(&self) {
-        let mut attempts = self.reconnect_attempts.lock().unwrap();
+        let mut attempts = self.reconnect_attempts.lock_or_recover();
         *attempts = attempts.saturating_add(1);
     }
 
     /// Updates transport metrics, preserving confirmation-loop counts.
     pub fn update_metrics(&self, incoming: TransportMetrics) {
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self.metrics.lock_or_recover();
         let prev_success = metrics.success_count;
         let prev_failure = metrics.failure_count;
         *metrics = incoming;
@@ -290,19 +295,19 @@ impl ReticulumTransport {
 
     /// Checks if there are messages waiting to be sent.
     pub fn has_pending_sends(&self) -> bool {
-        !self.send_queue.lock().unwrap().is_empty()
+        !self.send_queue.lock_or_recover().is_empty()
     }
 
     /// Fails all pending confirmations and records them as failures.
     fn fail_all_pending(&self) {
         let pending = {
-            let mut map = self.pending_confirmation.lock().unwrap();
+            let mut map = self.pending_confirmation.lock_or_recover();
             let count = map.len();
             map.clear();
             count
         };
         if pending > 0 {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.failure_count = metrics.failure_count.saturating_add(pending as u32);
             recalculate_delivery_ratios(&mut metrics);
         }
@@ -315,7 +320,7 @@ impl ReticulumTransport {
         let mut expired_count = 0u32;
 
         {
-            let mut pending = self.pending_confirmation.lock().unwrap();
+            let mut pending = self.pending_confirmation.lock_or_recover();
             pending.retain(|_, enqueued_at| {
                 if now.duration_since(*enqueued_at) > timeout {
                     expired_count += 1;
@@ -327,7 +332,7 @@ impl ReticulumTransport {
         }
 
         if expired_count > 0 {
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.failure_count = metrics.failure_count.saturating_add(expired_count);
             recalculate_delivery_ratios(&mut metrics);
         }
@@ -344,15 +349,15 @@ impl Transport for ReticulumTransport {
     }
 
     fn status(&self) -> TransportStatus {
-        *self.status.lock().unwrap()
+        *self.status.lock_or_recover()
     }
 
     fn metrics(&self) -> TransportMetrics {
-        self.metrics.lock().unwrap().clone()
+        self.metrics.lock_or_recover().clone()
     }
 
     fn send(&self, message: &Message) -> Result<()> {
-        let status = *self.status.lock().unwrap();
+        let status = *self.status.lock_or_recover();
         if status != TransportStatus::Available {
             return Err(crate::Error::TransportNotAvailable(format!(
                 "Reticulum transport is {:?}",
@@ -361,12 +366,12 @@ impl Transport for ReticulumTransport {
         }
 
         let queue_len = {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             queue.push_back(message.clone());
             queue.len()
         };
 
-        let mut metrics = self.metrics.lock().unwrap();
+        let mut metrics = self.metrics.lock_or_recover();
         metrics.queue_depth = queue_len;
         metrics.congestion = ((queue_len as f32) / 50.0).clamp(0.0, 1.0);
         drop(metrics);
@@ -377,7 +382,7 @@ impl Transport for ReticulumTransport {
     }
 
     fn receive(&self) -> Result<Option<Message>> {
-        let mut queue = self.receive_queue.lock().unwrap();
+        let mut queue = self.receive_queue.lock_or_recover();
         Ok(queue.pop_front())
     }
 
@@ -388,10 +393,10 @@ impl Transport for ReticulumTransport {
     }
 
     fn stop(&mut self) -> Result<()> {
-        *self.status.lock().unwrap() = TransportStatus::Disconnected;
+        *self.status.lock_or_recover() = TransportStatus::Disconnected;
         self.fail_all_pending();
-        self.send_queue.lock().unwrap().clear();
-        self.receive_queue.lock().unwrap().clear();
+        self.send_queue.lock_or_recover().clear();
+        self.receive_queue.lock_or_recover().clear();
         Ok(())
     }
 }

--- a/crates/offline-protocol-transport/src/wifi_direct.rs
+++ b/crates/offline-protocol-transport/src/wifi_direct.rs
@@ -15,7 +15,7 @@
 //! injects inbound bytes via [`WifiDirectTransport::on_data_received`].
 
 use crate::{Result, SharedCallback, Transport, TransportMetrics, TransportStatus, TransportType};
-use offline_protocol_core::Message;
+use offline_protocol_core::{Message, MutexExt};
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
@@ -104,12 +104,12 @@ impl WifiDirectTransport {
 
     /// Registers a callback that fires when new outgoing messages become available.
     pub fn set_on_messages_available(&self, callback: Arc<dyn Fn() + Send + Sync>) {
-        *self.on_messages_available.lock().unwrap() = Some(callback);
+        *self.on_messages_available.lock_or_recover() = Some(callback);
     }
 
     /// Notifies the platform that messages are ready to send.
     fn notify_messages_available(&self) {
-        let callback = self.on_messages_available.lock().unwrap().clone();
+        let callback = self.on_messages_available.lock_or_recover().clone();
         if let Some(cb) = callback {
             cb();
         }
@@ -137,13 +137,13 @@ impl WifiDirectTransport {
 
     /// Called when a peer device is discovered.
     pub fn on_peer_discovered(&self, peer: WifiDirectPeer) {
-        let mut peers = self.peers.lock().unwrap();
+        let mut peers = self.peers.lock_or_recover();
         peers.insert(peer.device_address.clone(), peer);
     }
 
     /// Called when a peer device is lost.
     pub fn on_peer_lost(&self, device_address: &str) {
-        let mut peers = self.peers.lock().unwrap();
+        let mut peers = self.peers.lock_or_recover();
         peers.remove(device_address);
     }
 
@@ -153,17 +153,17 @@ impl WifiDirectTransport {
     /// and queues are drained so a subsequent reconnect starts clean.
     pub fn on_status_changed(&self, status: TransportStatus) {
         let previous = {
-            let mut guard = self.status.lock().unwrap();
+            let mut guard = self.status.lock_or_recover();
             let prev = *guard;
             *guard = status;
             prev
         };
 
         if previous == TransportStatus::Available && status != TransportStatus::Available {
-            self.peers.lock().unwrap().clear();
-            self.send_queue.lock().unwrap().clear();
-            self.receive_queue.lock().unwrap().clear();
-            let mut metrics = self.metrics.lock().unwrap();
+            self.peers.lock_or_recover().clear();
+            self.send_queue.lock_or_recover().clear();
+            self.receive_queue.lock_or_recover().clear();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.queue_depth = 0;
             metrics.congestion = 0.0;
         }
@@ -190,19 +190,19 @@ impl WifiDirectTransport {
 
     /// Gets all discovered peers.
     pub fn get_peers(&self) -> Vec<WifiDirectPeer> {
-        let peers = self.peers.lock().unwrap();
+        let peers = self.peers.lock_or_recover();
         peers.values().cloned().collect()
     }
 
     /// Gets a specific peer by device address.
     pub fn get_peer(&self, device_address: &str) -> Option<WifiDirectPeer> {
-        let peers = self.peers.lock().unwrap();
+        let peers = self.peers.lock_or_recover();
         peers.get(device_address).cloned()
     }
 
     /// Updates transport metrics.
     pub fn update_metrics(&self, metrics: TransportMetrics) {
-        *self.metrics.lock().unwrap() = metrics;
+        *self.metrics.lock_or_recover() = metrics;
     }
 
     /// Serializes a message to JSON bytes.
@@ -239,7 +239,7 @@ impl WifiDirectTransport {
     /// Returns (recipient, serialized_data) or None if no messages to send.
     pub fn get_next_message(&self) -> Result<Option<(String, Vec<u8>)>> {
         let (recipient, message) = {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             match queue.pop_front() {
                 Some((r, m)) => (r, m),
                 None => return Ok(None),
@@ -253,7 +253,7 @@ impl WifiDirectTransport {
 
     /// Checks if there are messages to send.
     pub fn has_pending_sends(&self) -> bool {
-        let queue = self.send_queue.lock().unwrap();
+        let queue = self.send_queue.lock_or_recover();
         !queue.is_empty()
     }
 }
@@ -268,11 +268,11 @@ impl Transport for WifiDirectTransport {
     }
 
     fn status(&self) -> TransportStatus {
-        *self.status.lock().unwrap()
+        *self.status.lock_or_recover()
     }
 
     fn metrics(&self) -> TransportMetrics {
-        self.metrics.lock().unwrap().clone()
+        self.metrics.lock_or_recover().clone()
     }
 
     fn send(&self, message: &Message) -> Result<()> {
@@ -286,11 +286,11 @@ impl Transport for WifiDirectTransport {
         // Determine recipient and add to send queue
         let recipient = message.recipient.as_str().to_string();
         {
-            let mut queue = self.send_queue.lock().unwrap();
+            let mut queue = self.send_queue.lock_or_recover();
             queue.push_back((recipient, message.clone()));
 
             // Update metrics
-            let mut metrics = self.metrics.lock().unwrap();
+            let mut metrics = self.metrics.lock_or_recover();
             metrics.queue_depth = queue.len();
             metrics.congestion = ((metrics.queue_depth as f32) / 20.0).clamp(0.0, 1.0);
         }
@@ -302,7 +302,7 @@ impl Transport for WifiDirectTransport {
     }
 
     fn receive(&self) -> Result<Option<Message>> {
-        let mut queue = self.receive_queue.lock().unwrap();
+        let mut queue = self.receive_queue.lock_or_recover();
         Ok(queue.pop_front())
     }
 
@@ -312,11 +312,11 @@ impl Transport for WifiDirectTransport {
     }
 
     fn stop(&mut self) -> Result<()> {
-        *self.status.lock().unwrap() = TransportStatus::Disconnected;
-        self.peers.lock().unwrap().clear();
-        self.send_queue.lock().unwrap().clear();
-        self.receive_queue.lock().unwrap().clear();
-        let mut metrics = self.metrics.lock().unwrap();
+        *self.status.lock_or_recover() = TransportStatus::Disconnected;
+        self.peers.lock_or_recover().clear();
+        self.send_queue.lock_or_recover().clear();
+        self.receive_queue.lock_or_recover().clear();
+        let mut metrics = self.metrics.lock_or_recover();
         metrics.queue_depth = 0;
         metrics.congestion = 0.0;
         Ok(())

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -405,7 +405,13 @@ impl OfflineProtocol {
         drop(mls_guard);
 
         if let Some(plaintext) = decrypt_result {
-            let text = String::from_utf8_lossy(&plaintext).to_string();
+            let Ok(text) = String::from_utf8(plaintext) else {
+                warn!(
+                    group_id = %payload.group_id,
+                    "Decrypted group payload is not valid UTF-8, dropping"
+                );
+                return InternalMessageResult::Consumed;
+            };
             let msg_id = message.id.as_str().to_string();
             let timestamp = chrono::Utc::now().to_rfc3339();
             info!(group_id = %payload.group_id, "Decrypted mesh group message");
@@ -2831,18 +2837,25 @@ impl OfflineProtocol {
         };
 
         match plaintext {
-            Some(pt) => {
-                let text = String::from_utf8_lossy(&pt).to_string();
-                self.emit_event(Event::group_message_received(
-                    group_id.to_string(),
-                    sender.to_string(),
-                    text,
-                    timestamp.to_string(),
-                    message_id.to_string(),
-                    reply_to_msg,
-                    forward_info_event,
-                ));
-            }
+            Some(pt) => match String::from_utf8(pt) {
+                Ok(text) => {
+                    self.emit_event(Event::group_message_received(
+                        group_id.to_string(),
+                        sender.to_string(),
+                        text,
+                        timestamp.to_string(),
+                        message_id.to_string(),
+                        reply_to_msg,
+                        forward_info_event,
+                    ));
+                }
+                Err(_) => {
+                    warn!(
+                        group_id = %group_id,
+                        "Decrypted relay group payload is not valid UTF-8, dropping"
+                    );
+                }
+            },
             None => {
                 warn!(
                     group_id = %group_id,

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -462,6 +462,7 @@ impl OfflineProtocol {
                     group_id: String,
                 },
                 Empty,
+                NonUtf8Plaintext,
                 SessionNotReady {
                     sender: String,
                 },
@@ -477,15 +478,23 @@ impl OfflineProtocol {
             let result = if let Some(mls) = self.mls_manager.clone() {
                 if let Ok(manager) = mls.read() {
                     match manager.decrypt(&encrypted, sender) {
-                        Ok(Some(plaintext)) => {
-                            let text = String::from_utf8_lossy(&plaintext).to_string();
-                            debug!(sender = %sender, "Decrypted message successfully");
-                            DecryptResult::Success {
-                                text,
-                                sender: sender.to_string(),
-                                group_id: encrypted.group_id.as_str().to_string(),
+                        Ok(Some(plaintext)) => match String::from_utf8(plaintext) {
+                            Ok(text) => {
+                                debug!(sender = %sender, "Decrypted message successfully");
+                                DecryptResult::Success {
+                                    text,
+                                    sender: sender.to_string(),
+                                    group_id: encrypted.group_id.as_str().to_string(),
+                                }
                             }
-                        }
+                            Err(_) => {
+                                warn!(
+                                    sender = %sender,
+                                    "Decrypted payload is not valid UTF-8, rejecting"
+                                );
+                                DecryptResult::NonUtf8Plaintext
+                            }
+                        },
                         Ok(None) => {
                             warn!(sender = %sender, "Decryption returned empty");
                             DecryptResult::Empty
@@ -596,6 +605,17 @@ impl OfflineProtocol {
                             sender.to_string(),
                             DecryptionFailureCode::InvalidCiphertext,
                             "Failed to decrypt MLS message (empty plaintext)".to_string(),
+                        ));
+                    }
+                    Some(InternalMessageResult::Consumed)
+                }
+                DecryptResult::NonUtf8Plaintext => {
+                    if let Ok(state) = lock_shared_state(&self.shared_state) {
+                        state.emit_event(Event::message_decryption_failed(
+                            message.id.clone(),
+                            sender.to_string(),
+                            DecryptionFailureCode::InvalidPayload,
+                            "Decrypted payload is not valid UTF-8".to_string(),
                         ));
                     }
                     Some(InternalMessageResult::Consumed)

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -31,7 +31,7 @@ use crate::telemetry::{
 };
 use crate::{Error, EstablishmentState, Event, ProtocolConfig, Result, TransportManager};
 use chrono::{DateTime, Utc};
-use offline_protocol_core::{LamportClock, Message, MessageId};
+use offline_protocol_core::{LamportClock, Message, MessageId, MutexExt};
 use offline_protocol_mls::{EncryptedMessage, MlsManager, MlsStorage, WelcomeMessage};
 use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
 use offline_protocol_router::{
@@ -569,14 +569,13 @@ impl OfflineProtocol {
         let shared_routing = self.shared_state.clone();
         self.transport_manager
             .set_routing_decision_callback(Some(Arc::new(move |decision| {
-                if let Ok(s) = shared_routing.lock() {
-                    if let Some(ctx) = &s.telemetry {
-                        let record = TelemetryRecord::Routing(Box::new(decision));
-                        // Dispatch is panic-isolated so a sink that panics
-                        // here cannot unwind through the live `MutexGuard`
-                        // and poison `SharedState`.
-                        dispatch_record(&ctx.sink, &record);
-                    }
+                let s = shared_routing.lock_or_recover();
+                if let Some(ctx) = &s.telemetry {
+                    let record = TelemetryRecord::Routing(Box::new(decision));
+                    // Dispatch is panic-isolated so a sink that panics
+                    // here cannot unwind through the live `MutexGuard`
+                    // and poison `SharedState`.
+                    dispatch_record(&ctx.sink, &record);
                 }
             })));
 
@@ -623,9 +622,7 @@ impl OfflineProtocol {
         let shared = self.shared_state.clone();
         self.transport_manager
             .set_dors_event_callback(Some(Arc::new(move |event| {
-                if let Ok(s) = shared.lock() {
-                    s.emit_event(event);
-                }
+                shared.lock_or_recover().emit_event(event);
             })));
 
         // NOTE: the structured routing-decision callback is wired by
@@ -636,18 +633,17 @@ impl OfflineProtocol {
         // Wire BLE fragment eviction callback so app receives FragmentAssemblyEvicted.
         if let Some(ble_arc) = self.transport_manager.get_transport(TransportType::BLE) {
             let shared = self.shared_state.clone();
-            if let Ok(transport) = ble_arc.lock() {
-                if let Some(ble) = transport.as_any().downcast_ref::<BleTransport>() {
-                    ble.set_fragment_eviction_callback(Some(Arc::new(move |info| {
-                        if let Ok(s) = shared.lock() {
-                            s.emit_event(Event::fragment_assembly_evicted(
-                                info.message_id,
-                                info.completion_percent,
-                                "capacity".to_string(),
-                            ));
-                        }
-                    })));
-                }
+            let transport = ble_arc.lock_or_recover();
+            if let Some(ble) = transport.as_any().downcast_ref::<BleTransport>() {
+                ble.set_fragment_eviction_callback(Some(Arc::new(move |info| {
+                    shared
+                        .lock_or_recover()
+                        .emit_event(Event::fragment_assembly_evicted(
+                            info.message_id,
+                            info.completion_percent,
+                            "capacity".to_string(),
+                        ));
+                })));
             }
         }
 
@@ -687,10 +683,9 @@ impl OfflineProtocol {
         // preserves the wiring without requiring the app to re-install.
         self.transport_manager.set_dors_event_callback(None);
         if let Some(ble_arc) = self.transport_manager.get_transport(TransportType::BLE) {
-            if let Ok(transport) = ble_arc.lock() {
-                if let Some(ble) = transport.as_any().downcast_ref::<BleTransport>() {
-                    ble.set_fragment_eviction_callback(None);
-                }
+            let transport = ble_arc.lock_or_recover();
+            if let Some(ble) = transport.as_any().downcast_ref::<BleTransport>() {
+                ble.set_fragment_eviction_callback(None);
             }
         }
 

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -9643,6 +9643,71 @@ fn test_mls_enc_spoofed_sender_security_rejected() {
 }
 
 #[test]
+fn test_mls_enc_non_utf8_plaintext_rejected() {
+    // SEC-L6: a decrypted payload that is not valid UTF-8 must be dropped
+    // with a MessageDecryptionFailed event instead of surfacing a lossily
+    // mangled string. Compliant senders always encrypt UTF-8 on the text
+    // path (media chunks decrypt separately as bytes), so only a buggy or
+    // malicious peer can produce this.
+    let mut alice = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
+    let storage = Arc::new(crate::mls::InMemoryStorage::new());
+    alice.initialize_mls(storage).unwrap();
+
+    let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_handle = Arc::clone(&events);
+    alice.on_event(move |event| {
+        events_handle.lock().unwrap().push(event);
+    });
+
+    let bob_storage = Arc::new(crate::mls::InMemoryStorage::new());
+    let bob_manager = MlsManager::new("bob", bob_storage).unwrap();
+    let bob_kp = bob_manager.generate_key_package().unwrap();
+
+    // Establish a converged alice <-> bob session.
+    let welcome = {
+        let mls = alice.mls_manager.as_ref().unwrap().clone();
+        let manager = mls.read().unwrap();
+        manager
+            .import_key_package("bob", &bob_kp.key_package_data)
+            .unwrap();
+        manager.create_session("bob").unwrap()
+    };
+    bob_manager.join_session(&welcome).unwrap();
+
+    // Bob encrypts bytes that are not valid UTF-8.
+    let encrypted = bob_manager
+        .encrypt_for_user("alice", &[0xFF, 0xFE, 0xFD])
+        .unwrap();
+    let content = format!(
+        "{}{}",
+        internal_prefixes::ENCRYPTED,
+        serde_json::to_string(&encrypted).unwrap()
+    );
+    let message = Message::new(
+        UserId::new("bob").unwrap(),
+        UserId::new("alice").unwrap(),
+        AppId::new("test-app").unwrap(),
+        &content,
+    );
+
+    let result = alice.process_internal_message(&message);
+    assert!(
+        matches!(result, Some(InternalMessageResult::Consumed)),
+        "non-UTF-8 plaintext must be consumed, not surfaced as Decrypted"
+    );
+
+    let captured = events.lock().unwrap();
+    assert!(
+        captured.iter().any(|e| matches!(
+            e,
+            Event::MessageDecryptionFailed { code, .. }
+                if *code == DecryptionFailureCode::InvalidPayload
+        )),
+        "non-UTF-8 plaintext must emit MessageDecryptionFailed with InvalidPayload"
+    );
+}
+
+#[test]
 fn test_welcome_with_mismatched_inviter_id_rejected() {
     // Honest peers set `inviter_id` to their own id (see
     // SessionManager::create_session). A Welcome whose payload inviter_id


### PR DESCRIPTION
## Summary

Item 12 of the pre-launch audit TODO (P3 code hygiene): audit findings **CQ-M5**, **CQ-M8/H2**, **SEC-L6**.

- **Poison recovery (CQ-M5):** new `MutexExt::lock_or_recover` / `RwLockExt::{read,write}_or_recover` extension traits in `offline-protocol-core::sync` — on poison they log a warning with the caller's `file:line` (`#[track_caller]`) and recover the guard via `into_inner()`, extending the convention already used by the uniffi crate. All **178** non-test `.lock().unwrap()` sites in the FFI-driven transports (BLE, Nostr, WiFi Direct, Reticulum, Internet, common) now funnel through them, so one panicking foreign callback can no longer wedge the node into permanent panics. The 5 poison-*swallowing* `if let Ok(s) = shared.lock()` event-callback closures in `protocol/mod.rs` now recover too instead of silently dropping DORS/fragment-eviction events. Mock transport and test modules deliberately keep loud unwraps.
- **Dead ack code (CQ-M8; H2 refuted as dead):** deleted `record_ack_received` (zero production callers — the live path is `remove_ack`) and the now-unconstructable `AckStatus::Received` variant; docs and tests reworked to the real contract.
- **Non-UTF-8 plaintext (SEC-L6):** all three text decrypt paths (1:1, mesh group, relay group) now validate with `String::from_utf8` instead of silently mangling via `from_utf8_lossy`. The 1:1 path emits `MessageDecryptionFailed(InvalidPayload)`; group paths warn and drop, matching their existing failure handling. Media chunks decrypt on a separate bytes path and are unaffected. New test: `test_mls_enc_non_utf8_plaintext_rejected`.

No wire-format, UDL, or binding changes. The removed reliability APIs are workspace-internal (not re-exported).

## Verification

- `cargo test --workspace`: 1,257 tests green, 0 failures (includes new poison-recovery + non-UTF-8 rejection tests)
- `cargo clippy --workspace -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- Grep gates: zero production `.lock().unwrap()` left in the transport crate; only intentional `from_utf8_lossy` uses remain (MLS error-message formatting)