### PR TITLE
chore: strip dependency debuginfo so the dev loop stops thrashing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # CI builds are always from a cache-restored or cold state; incremental
+  # compilation only adds overhead and bloats the rust-cache snapshots.
+  CARGO_INCREMENTAL: 0
 
 jobs:
   fmt:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,20 +9,24 @@ Offline Protocol SDK: an offline-first messaging protocol in Rust with multi-tra
 ## Common Commands
 
 ```bash
-# Build
-cargo build --workspace
-cargo build --workspace --release
+# Verify loop (lint subsumes typecheck; don't run a separate `cargo build` first —
+# it only adds a third artifact set, including the expensive uniffi cdylib link)
+cargo clippy --workspace -- -D warnings
+cargo test --workspace --lib                    # all unit tests; skips the empty per-crate doctest passes
 
 # Test
-cargo test --workspace                          # all tests
+cargo test --workspace                          # full run incl. doctests (what CI runs)
 cargo test --package offline-protocol-core      # single crate
 cargo test test_message_creation                # single test
 cargo test -- --nocapture                       # with stdout
 
-# Lint & format (must pass before commits)
-cargo clippy --workspace -- -D warnings
-cargo fmt --workspace
-cargo fmt --workspace -- --check                # check only
+# Build (only when you need the compiled artifacts, e.g. the uniffi cdylib)
+cargo build --workspace
+cargo build --workspace --release
+
+# Format (must pass before commits; fmt takes --all, not --workspace)
+cargo fmt --all
+cargo fmt --all -- --check                      # check only
 
 # Docs
 cargo doc --workspace --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,16 @@ offline-protocol = { path = "crates/offline-protocol" }
 opt-level = 0
 debug = true
 
+# Dependencies are never stepped into during debugging; skipping their
+# debuginfo cuts target/debug size and compile/link I/O dramatically
+# (this repo's dev artifacts were ~49 GB with full dep debuginfo).
+[profile.dev.package."*"]
+debug = false
+
+# Same for build scripts and proc macros (serde_derive, uniffi, tls_codec_derive).
+[profile.dev.build-override]
+debug = false
+
 [profile.release]
 opt-level = 3
 debug = false


### PR DESCRIPTION
## Summary

The local `--workspace` verify loop (build + clippy + test) was taking ~20 minutes on a 12-core machine. Profiling showed the runs at **7–11% CPU** — the time was paging, not compiling: `target/debug` had grown to **49 GB** (full debuginfo for all 296 dependencies + 930 never-GC'd incremental caches) on a disk that was 95% full.

### Changes

- **`Cargo.toml`**: `[profile.dev.package."*"] debug = false` and `[profile.dev.build-override] debug = false`. Dependencies, build scripts, and proc macros drop their debuginfo; the 9 workspace crates keep full debug, so backtraces and debugging of our own code are unaffected.
- **`CLAUDE.md`**: document the fast verify loop — `cargo clippy` (subsumes typecheck; no separate `cargo build` needed) + `cargo test --workspace --lib` (skips 9 empty per-crate doctest passes; every doc example in the workspace is `ignore`d). Also fixes `cargo fmt --workspace` → `cargo fmt --all` (the former was never valid).
- **`ci.yml`**: `CARGO_INCREMENTAL: 0` — CI builds restore from rust-cache and never reuse incremental state, so incremental is pure overhead and cache bloat. CI still runs the full `cargo test --workspace` including doctests.

### Measured impact (same machine, all 1303 tests passing)

| Command | Before | After |
|---|---|---|
| `cargo clippy --workspace` (iteration) | 2m 56s | 2.6s (31s fully cold) |
| `cargo test --workspace` | 12m 40s | 21s cold / 5.8s warm (`--lib`) |
| `target/debug` size | 49 GB | 1.5 GB |

## Test plan

- [x] `cargo test --workspace --lib --locked` — 1303 tests, 0 failures (run twice: cold and warm)
- [x] `cargo clippy --workspace --locked -- -D warnings` — clean
- [x] No dependency or lockfile changes (`--locked` throughout); release/minisize profiles untouched, so mobile artifacts are unaffected