### PR TITLE
fix(bindings): 16 KB page-size alignment for Android .so (forward-port of v0.11.1)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,17 +1,29 @@
 # Cargo configuration for cross-compilation
 
 # Android targets
+#
+# All Android .so files are linked with 16 KB page-size alignment: Google Play
+# requires it for 64-bit libraries in apps targeting Android 15+, and the CI
+# NDK (r26b) defaults to 4 KB (16 KB only became the NDK default in r28).
+# Applied to all four ABIs for uniformity — 32-bit tolerates the flag at the
+# cost of a few KB of padding. Enforced by scripts/check-elf-alignment.py in
+# both build paths; note env RUSTFLAGS would override these (cargo precedence),
+# which the alignment gate turns into a loud failure instead of a regression.
 [target.aarch64-linux-android]
 linker = "aarch64-linux-android21-clang"
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384", "-C", "link-arg=-Wl,-z,common-page-size=16384"]
 
 [target.armv7-linux-androideabi]
 linker = "armv7a-linux-androideabi21-clang"
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384", "-C", "link-arg=-Wl,-z,common-page-size=16384"]
 
 [target.i686-linux-android]
 linker = "i686-linux-android21-clang"
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384", "-C", "link-arg=-Wl,-z,common-page-size=16384"]
 
 [target.x86_64-linux-android]
 linker = "x86_64-linux-android21-clang"
+rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384", "-C", "link-arg=-Wl,-z,common-page-size=16384"]
 
 # iOS targets (using default settings - no configuration needed)
 # iOS linking is handled automatically by Xcode toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,11 @@ jobs:
             exit 1
           fi
 
+          # Google Play requires 16 KB page-size alignment (flags live in
+          # .cargo/config.toml); fail this ABI's build rather than ship 4 KB.
+          python3 bindings/react-native/scripts/check-elf-alignment.py \
+            "jniLibs/${{ matrix.abi }}/libuniffi_offline_protocol.so"
+
       - name: Upload ${{ matrix.abi }} library
         uses: actions/upload-artifact@v4
         with:
@@ -517,6 +522,10 @@ jobs:
           for abi in arm64-v8a armeabi-v7a x86_64 x86; do
             test -f "bindings/react-native/android/src/main/jniLibs/$abi/libuniffi_offline_protocol.so"
           done
+
+          echo "Checking 16 KB page-size alignment (Google Play requirement)..."
+          python3 bindings/react-native/scripts/check-elf-alignment.py \
+            bindings/react-native/android/src/main/jniLibs/*/libuniffi_offline_protocol.so
 
           echo "Checking Android Kotlin bindings..."
           test -d bindings/react-native/android/src/main/java/uniffi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Adaptive TTL no longer collapses at ~25,650 estimated devices (CQ-M1).** The size-based TTL boost computed "extra hundreds of devices" in a `usize` and narrowed it with a bare `as u8` cast, which wraps modulo 256: at an estimated 25,650+ devices the boost silently vanished — TTL fell back to the small-network base instead of the configured maximum, exactly when reach matters most — and oscillated as the network grew further. The count now saturates at the cast boundary; the existing max-TTL clamp bounds the result as before.
 - **Periodic cleanup sweeps no longer risk a panic on freshly-booted devices.** The group-message dedup, pending-commit, pending-group-message, and service-discovery dedup sweeps computed their expiry cutoff as `Instant::now() - TTL`, which panics on underflow — and on platforms where the monotonic clock starts at boot (Linux, Android, embedded), that subtraction underflows whenever the process is younger than the TTL, e.g. a messaging service auto-started at boot running its first sweep within 5 minutes. Entry ages are now compared with `saturating_duration_since` instead.
 
+## [0.11.1] — 2026-07-12
+
+Hotfix cut from `v0.11.0` — no API or behavior changes. Consumers only need a version bump.
+
+### Fixed
+
+- **Android native libraries are now 16 KB page-size aligned (Google Play requirement).**
+  `libuniffi_offline_protocol.so` in `0.11.0` and earlier had 4 KB-aligned `PT_LOAD` segments on every ABI, which Google Play now rejects (as a blocking error) for apps targeting Android 15+ on 64-bit devices. All four ABIs (`arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`) are now linked with `-Wl,-z,max-page-size=16384` via per-target rustflags in `.cargo/config.toml`, and both build paths (release CI and `build-uniffi-android.sh`) gate on a new `check-elf-alignment.py` so a future toolchain change cannot silently regress alignment. Verify with `readelf -l <lib.so>` — every `LOAD` segment shows `Align 0x4000`.
+
+### Changed
+
+- **JNA dependency bumped from 5.13.0 to 5.19.1** in the Android library. JNA 5.13.0's `libjnidispatch.so` is not 16 KB-aligned on `x86_64` and crashes at runtime on 16 KB-page devices (fixed upstream in JNA 5.17.0). No API impact; apps already forcing a newer JNA via Gradle resolution are unaffected.
+
 ## [0.11.0] — 2026-07-01
 
 ### Licensing

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -67,8 +67,11 @@ repositories {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
 
-    // JNA required for UniFFI-generated Kotlin bindings
-    implementation 'net.java.dev.jna:jna:5.13.0@aar'
+    // JNA required for UniFFI-generated Kotlin bindings.
+    // Keep >= 5.17.0: earlier libjnidispatch.so is not 16 KB page-aligned on
+    // every ABI (Google Play requirement) and 5.17.0 fixed runtime crashes on
+    // 16 KB-page devices (java-native-access/jna#1618).
+    implementation 'net.java.dev.jna:jna:5.19.1@aar'
 
     // OkHttp for WebSocket support in InternetManager
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offline-protocol/mesh-sdk",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Offline-first mesh networking SDK with intelligent transport switching for React Native",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/react-native/scripts/build-uniffi-android.sh
+++ b/bindings/react-native/scripts/build-uniffi-android.sh
@@ -159,7 +159,11 @@ for i in "${!ABIS[@]}"; do
   # Copy library to jniLibs
   # UniFFI generates code that looks for "uniffi_offline_protocol" which JNA converts to "libuniffi_offline_protocol.so"
   cp "$so_path" "$OUTPUT_DIR/$abi/libuniffi_offline_protocol.so"
-  
+
+  # Google Play requires 16 KB page-size alignment (flags live in
+  # .cargo/config.toml); fail here rather than package a 4 KB-aligned lib.
+  python3 "$SCRIPT_DIR/check-elf-alignment.py" "$OUTPUT_DIR/$abi/libuniffi_offline_protocol.so"
+
   echo "✅ Built and copied library for $abi"
 done
 

--- a/bindings/react-native/scripts/check-elf-alignment.py
+++ b/bindings/react-native/scripts/check-elf-alignment.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Verify ELF shared libraries are 16 KB page-size aligned.
+
+Google Play requires 16 KB page-size support (PT_LOAD p_align >= 0x4000) for
+64-bit native libraries in apps targeting Android 15+. We enforce it on all
+ABIs for uniformity. The alignment comes from the per-target rustflags in
+.cargo/config.toml; this check exists so a toolchain or config change can
+never silently regress it (NDK <= r27 defaults to 4 KB).
+
+Python (stdlib-only) rather than readelf/llvm-objdump so the same check runs
+unchanged on macOS dev machines and Linux CI without toolchain lookups.
+
+Usage: check-elf-alignment.py <lib.so> [lib.so ...]
+Exits non-zero if any PT_LOAD segment of any input is under-aligned.
+"""
+
+import struct
+import sys
+
+REQUIRED_ALIGN = 0x4000  # 16 KB
+
+PT_LOAD = 1
+
+
+def load_aligns(path):
+    """Return the p_align of every PT_LOAD program header in an ELF file."""
+    with open(path, "rb") as f:
+        data = f.read()
+    if data[:4] != b"\x7fELF":
+        raise ValueError(f"{path}: not an ELF file")
+    is64 = data[4] == 2
+    endian = "<" if data[5] == 1 else ">"
+    if is64:
+        (e_phoff,) = struct.unpack_from(endian + "Q", data, 0x20)
+        e_phentsize, e_phnum = struct.unpack_from(endian + "HH", data, 0x36)
+    else:
+        (e_phoff,) = struct.unpack_from(endian + "I", data, 0x1C)
+        e_phentsize, e_phnum = struct.unpack_from(endian + "HH", data, 0x2A)
+    aligns = []
+    for i in range(e_phnum):
+        off = e_phoff + i * e_phentsize
+        (p_type,) = struct.unpack_from(endian + "I", data, off)
+        if p_type == PT_LOAD:
+            if is64:
+                (p_align,) = struct.unpack_from(endian + "Q", data, off + 0x30)
+            else:
+                (p_align,) = struct.unpack_from(endian + "I", data, off + 0x1C)
+            aligns.append(p_align)
+    if not aligns:
+        raise ValueError(f"{path}: no PT_LOAD segments found")
+    return aligns
+
+
+def main(argv):
+    if not argv:
+        print("usage: check-elf-alignment.py <lib.so> [lib.so ...]", file=sys.stderr)
+        return 2
+    failed = False
+    for path in argv:
+        try:
+            aligns = load_aligns(path)
+        except (OSError, ValueError, struct.error) as e:
+            print(f"ERROR {e}")
+            failed = True
+            continue
+        shown = ", ".join(hex(a) for a in aligns)
+        if all(a >= REQUIRED_ALIGN for a in aligns):
+            print(f"OK    {path}: PT_LOAD align [{shown}]")
+        else:
+            print(
+                f"FAIL  {path}: PT_LOAD align [{shown}] — "
+                f"all segments must be >= {hex(REQUIRED_ALIGN)} (16 KB pages)"
+            )
+            failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Google Play now hard-blocks apps targeting Android 15+ whose 64-bit native libraries are not 16 KB page-aligned. Every `libuniffi_offline_protocol.so` shipped in `@offline-protocol/mesh-sdk@0.11.0` has 4 KB-aligned `PT_LOAD` segments (verified against the published npm tarball), which is currently blocking MINE's Play Store release (OFF-1835).

**Root cause:** both build paths — release CI (NDK r26b) and `build-uniffi-android.sh` — link with plain `cargo build` and no `max-page-size` flag; 16 KB only became the NDK default in r28.

## Changes

- **`.cargo/config.toml`** — per-Android-target rustflags add `-Wl,-z,max-page-size=16384` + `common-page-size=16384` for all four ABIs (Play only mandates 64-bit, but uniform alignment costs a few KB of padding and keeps audits unambiguous). Scoped per-target, so iOS/desktop/other builds are untouched.
- **`scripts/check-elf-alignment.py`** (new, stdlib-only) — fails on any `PT_LOAD` with `p_align < 0x4000`. Wired as a gate in `release.yml` (per-ABI after each matrix build + on the assembled `jniLibs` before publish) and in the local build script, so a future toolchain change cannot silently regress alignment. Note: env `RUSTFLAGS` would override config rustflags (cargo precedence) — the gate turns that into a loud failure.
- **JNA 5.13.0 → 5.19.1** — 5.13.0's `libjnidispatch.so` is 4 KB-aligned on x86_64 and crashes at runtime on 16 KB-page devices (fixed upstream in 5.17.0, java-native-access/jna#1618). 5.19.1 verified 16 KB-aligned on all ABIs.
- Version bump to 0.11.1 + CHANGELOG.

No API, UDL, or behavior changes; no bindings regeneration needed.

## Verification

- Release **dry run** from the hotfix branch (real r26b toolchain, gates active, publish skipped): [run 29164711762](https://github.com/Offline-Protocol/offline-protocol-sdk/actions/runs/29164711762) — green across the full matrix.
- Downloaded that run's artifacts: all four ABIs show `PT_LOAD align [0x4000, 0x4000, 0x4000, 0x4000]`.
- Local NDK 27.1 build (a 4 KB-default toolchain) produces `0x4000` — proves the flag itself, not an NDK default.
- Gate self-tested both directions: passes CI-built libs, exit 1 on the published 0.11.0 artifact.

## Release mechanics

main is 109 commits past `v0.11.0` with unreleased breaking changes, so **v0.11.1 will be tagged from `hotfix/16kb-page-alignment`** (same three commits cherry-picked here; tag push pending). This PR forward-ports the fix to main; the CHANGELOG conflict with `[Unreleased]` was resolved by placing `[0.11.1]` beneath it.