### PR TITLE
docs: fix rotted native integration guides and dead security contact

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -63,30 +63,38 @@ protocol.on('relay_promoted', () => {
 
 ## For Android Developers
 
+> Native (no React Native) integration needs the full `ProtocolConfig` and permission
+> setup. See the [Android Integration Guide](docs/android-integration.md) for the complete
+> walkthrough — the snippet below is just the shape.
+
 ### 1. Build Rust Library
 
 ```bash
 cargo build --release --target aarch64-linux-android
 ```
 
+This produces `liboffline_protocol_uniffi.so`.
+
 ### 2. Add to Android Project
 
-Copy `liboffline_protocol.so` to `app/src/main/jniLibs/arm64-v8a/`
+Copy it into `app/src/main/jniLibs/arm64-v8a/` as `libuniffi_offline_protocol.so` (the name
+UniFFI's loader expects). The `scripts/build-uniffi-android.sh` helper builds every ABI and
+renames automatically.
 
 ### 3. Use in Kotlin
 
 ```kotlin
-val protocol = OfflineProtocol(ProtocolConfig(
-    appId = "my-app",
-    userId = "user123"
-))
+import uniffi.offline_protocol.*
 
+// Build `config` with the full ProtocolConfig(...) — see the Android integration guide.
+val protocol = OfflineProtocol(config)
 protocol.start()
 
 val messageId = protocol.sendMessage(
     recipient = "friend",
     content = "Hello!",
-    priority = MessagePriority.HIGH
+    priority = MessagePriority.HIGH,
+    replyToMsg = null,
 )
 ```
 
@@ -94,31 +102,35 @@ val messageId = protocol.sendMessage(
 
 ## For iOS Developers
 
+> Native (no React Native) integration needs the full `ProtocolConfig` and permission
+> setup. See the [iOS Integration Guide](docs/ios-integration.md) for the complete
+> walkthrough — the snippet below is just the shape.
+
 ### 1. Build Rust Library
 
 ```bash
 cargo build --release --target aarch64-apple-ios
 ```
 
+This produces `liboffline_protocol_uniffi.a`.
+
 ### 2. Add to Xcode
 
-Add `liboffline_protocol.a` to your project frameworks.
+Add `liboffline_protocol_uniffi.a` (or the device/simulator slices from
+`scripts/build-uniffi-ios.sh`) and the generated `offline_protocol.swift` to your project.
 
 ### 3. Use in Swift
 
 ```swift
-let config = ProtocolConfig(
-    appId: "my-app",
-    userId: "user123"
-)
+// Build `config` with the full ProtocolConfig(...) — see the iOS integration guide.
+let mesh = try OfflineProtocol(config: config)
+try mesh.start()
 
-let protocol = try OfflineProtocol(config: config)
-try protocol.start()
-
-let messageId = try protocol.sendMessage(
+let messageId = try mesh.sendMessage(
     recipient: "friend",
     content: "Hello!",
-    priority: .high
+    priority: .high,
+    replyToMsg: nil
 )
 ```
 
@@ -146,7 +158,7 @@ Make sure you've run:
 
 ### Android: "Library not found"
 
-Ensure `liboffline_protocol.so` is in correct `jniLibs` folder for your architecture.
+Ensure `libuniffi_offline_protocol.so` is in the correct `jniLibs` folder for your architecture.
 
 ### iOS: "Undefined symbols"
 
@@ -159,4 +171,3 @@ Link against the Rust static library in Xcode Build Settings.
 - [Integration Guide](examples/react-native-app/INTEGRATION_GUIDE.md) - Step-by-step project setup
 - [GitHub Issues](https://github.com/Offline-Protocol/offline-protocol-sdk/issues)
 - [All Documentation](docs/)
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you discover a security vulnerability in the Offline Protocol SDK, please rep
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, please email security concerns to the repository maintainers via the contact information in the repository. Include:
+Instead, please email **gm@offlineprotocol.com** with the details. Include:
 
 1. A description of the vulnerability
 2. Steps to reproduce the issue

--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -28,7 +28,7 @@ Offline-first mesh networking SDK for React Native. Enables peer-to-peer messagi
 |----------|---------|
 | React Native | >= 0.70.0 |
 | iOS | >= 13.0 |
-| Android | >= API 26 (Android 8.0) |
+| Android | >= API 24 (Android 7.0) |
 | Node.js | >= 16 |
 
 ---
@@ -1147,4 +1147,11 @@ If you see the linking error message:
 
 ## License
 
-ISC
+The Offline Protocol SDK is **dual-licensed**:
+
+- **AGPL-3.0-only** — see [LICENSE](../../LICENSE). Free for use in projects that comply
+  with AGPL-3.0, including its network-use source-disclosure requirement (section 13).
+- **Commercial License** — for proprietary apps that cannot or do not wish to comply with
+  the AGPL. See [LICENSE-COMMERCIAL.md](./LICENSE-COMMERCIAL.md) (contact legal@offlineprotocol.com).
+
+You may use the SDK under **either** license; you do not need both.

--- a/crates/offline-protocol-router/src/dors.rs
+++ b/crates/offline-protocol-router/src/dors.rs
@@ -113,7 +113,7 @@ const INTERNET_FALLBACK_DEMOTION: f32 = 10_000.0;
 /// Recovers the real 0–125 quality score from a (possibly demoted) routing
 /// `total` for telemetry / display.
 ///
-/// [`INTERNET_FALLBACK_DEMOTION`] is a pure *ranking* device: it pushes the
+/// `INTERNET_FALLBACK_DEMOTION` is a pure *ranking* device: it pushes the
 /// Internet transport below every mesh score so selection only escalates to it
 /// as a last resort. That sentinel must never leak to app-facing telemetry
 /// (events, routing decisions, the UniFFI boundary) — a dashboard reading a

--- a/docs/android-integration.md
+++ b/docs/android-integration.md
@@ -31,19 +31,27 @@ cargo build --release --target x86_64-linux-android
 
 ### 3. Copy Native Libraries
 
-Copy the compiled `.so` files to your Android project:
+Each build produces `liboffline_protocol_uniffi.so`. UniFFI's Kotlin loader looks for
+`libuniffi_offline_protocol.so`, so copy each ABI's output under **that** name:
 
 ```
 android/app/src/main/jniLibs/
-├── arm64-v8a/liboffline_protocol.so
-├── armeabi-v7a/liboffline_protocol.so
-└── x86_64/liboffline_protocol.so
+├── arm64-v8a/libuniffi_offline_protocol.so
+├── armeabi-v7a/libuniffi_offline_protocol.so
+└── x86_64/libuniffi_offline_protocol.so
 ```
+
+The `bindings/react-native/scripts/build-uniffi-android.sh` helper builds every ABI and
+renames automatically (and regenerates the Kotlin bindings).
 
 ### 4. Use in Kotlin
 
+The generated Kotlin bindings live in the `uniffi.offline_protocol` package, so import
+that (not `com.offlineprotocol.*`, which is the React Native wrapper).
+
 ```kotlin
-import com.offlineprotocol.OfflineProtocol
+import uniffi.offline_protocol.*
+import org.json.JSONObject
 
 class MainActivity : AppCompatActivity() {
     private lateinit var protocol: OfflineProtocol
@@ -51,39 +59,59 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Initialize protocol
+        // ProtocolConfig has 16 required fields (+ 4 with defaults). See
+        // docs/configuration.md for what each one controls.
         val config = ProtocolConfig(
             appId = "my-android-app",
-            userId = "user123"
+            userId = "user123",
+            bleEnabled = true,
+            wifiDirectEnabled = true,
+            internetEnabled = true,
+            reticulumEnabled = false,
+            nostrEnabled = false,
+            preferOnline = false,
+            initialTtl = 8.toUByte(),
+            encryptionEnabled = true,
+            autoKeyExchange = true,
+            storePending = true,
+            maxPendingPerPeer = 100.toULong(),
+            maxPendingGlobal = 1_000.toULong(),
+            pendingTtlMs = 604_800_000.toULong(),
+            overflowPolicy = OverflowPolicy.DROP_OLDEST,
+            // requireEncryption (true), maxGroupMembers (256u), groupRelayEnabled (true),
+            // and requireTransportIdentity (false) use their defaults.
         )
 
         protocol = OfflineProtocol(config)
+
+        // Events are delivered as JSON strings via the EventCallback interface.
+        protocol.setEventCallback(MeshEventHandler())
         protocol.start()
 
-        // Set up event listener
-        protocol.setEventListener { event ->
-            when (event) {
-                is Event.MessageReceived -> {
-                    Log.d("Protocol", "Received: ${event.content}")
-                }
-                is Event.TransportSwitched -> {
-                    Log.d("Protocol", "Switched to ${event.to}")
-                }
-                else -> {}
-            }
-        }
-
-        // Send a message
+        // Send a message (priority is required; replyToMsg is optional)
         val messageId = protocol.sendMessage(
             recipient = "user456",
             content = "Hello from Android!",
-            priority = MessagePriority.HIGH
+            priority = MessagePriority.HIGH,
+            replyToMsg = null,
         )
     }
 
     override fun onDestroy() {
         super.onDestroy()
         protocol.stop()
+    }
+}
+
+class MeshEventHandler : EventCallback {
+    override fun onEvent(eventJson: String) {
+        val obj = JSONObject(eventJson)
+        when (obj.optString("type")) {
+            "message_received" ->
+                Log.d("Protocol", "Received from ${obj.optString("sender")}: ${obj.optString("content")}")
+            "transport_switched" ->
+                Log.d("Protocol", "Transport switched: $eventJson")
+        }
     }
 }
 ```
@@ -117,19 +145,21 @@ Create and manage encrypted groups over the mesh. The group creator is automatic
 
 ```kotlin
 // Create a group
-val group = protocol.meshCreateGroup("Project Team")
+val group = protocol.createGroup("Project Team")
 
 // Invite a member (admin only)
-protocol.meshInviteToGroup(group.groupId, "bob")
+protocol.inviteToGroup(group.groupId, "bob")
 
 // Send an encrypted group message
-val messageIds = protocol.meshSendGroupMessage(
+val messageIds = protocol.sendGroupMessage(
     groupId = group.groupId,
-    content = "Hello team!"
+    content = "Hello team!",
+    priority = null,
+    replyToMsg = null,
 )
 
 // Remove a member (admin only)
-protocol.meshRemoveFromGroup(group.groupId, "bob")
+protocol.removeFromGroup(group.groupId, "bob")
 
 // Get group info (members, epoch, etc.)
 val info = protocol.getGroupInfo(group.groupId)
@@ -139,7 +169,7 @@ info?.let { println("Members: ${it.members}") }
 protocol.renameGroup(group.groupId, "New Team Name")
 
 // Leave a group
-protocol.meshLeaveGroup(group.groupId)
+protocol.leaveGroup(group.groupId)
 ```
 
 ### Group Role Management
@@ -158,18 +188,18 @@ val roles = protocol.getGroupRoles(groupId)
 // mapOf("alice" to "admin", "bob" to "admin", "charlie" to "member")
 ```
 
-Listen for role changes and renames:
+Role changes and renames arrive through the same `EventCallback` as every other event —
+JSON strings whose `type` is `group_role_changed` or `group_renamed`. Extend your
+`onEvent(eventJson:)` to handle them:
 
 ```kotlin
-protocol.setEventListener { event ->
-    when (event) {
-        is Event.GroupRoleChanged -> {
-            Log.d("Protocol", "${event.userId} is now ${event.newRole} (by ${event.changedBy})")
-        }
-        is Event.GroupRenamed -> {
-            Log.d("Protocol", "Group ${event.groupId} renamed to ${event.newName} by ${event.renamedBy}")
-        }
-        else -> {}
+override fun onEvent(eventJson: String) {
+    val obj = JSONObject(eventJson)
+    when (obj.optString("type")) {
+        "group_role_changed" ->
+            Log.d("Protocol", "${obj.optString("user_id")} is now ${obj.optString("new_role")} (by ${obj.optString("changed_by")})")
+        "group_renamed" ->
+            Log.d("Protocol", "Group ${obj.optString("group_id")} renamed to ${obj.optString("new_name")} by ${obj.optString("renamed_by")}")
     }
 }
 ```
@@ -206,4 +236,3 @@ Rust Core (100% safe)
 - Message sending: <1ms overhead
 - Memory safe: Zero buffer overflows or memory leaks
 - Battery efficient: Optimized BLE and relay logic
-

--- a/docs/ios-integration.md
+++ b/docs/ios-integration.md
@@ -186,7 +186,7 @@ Rust Core (100% safe)
 
 ## Group Messaging (MLS-Encrypted Mesh)
 
-Create and manage encrypted groups over the mesh. The group creator is automatically an admin.
+Create and manage encrypted groups over the mesh. The group creator is automatically an admin. The snippets below assume you've unwrapped your started instance into a non-optional `offlineProtocol` (e.g. `guard let offlineProtocol = self.offlineProtocol else { return }`).
 
 ```swift
 // Create a group

--- a/docs/ios-integration.md
+++ b/docs/ios-integration.md
@@ -29,66 +29,109 @@ cargo build --release --target aarch64-apple-ios
 cargo build --release --target aarch64-apple-ios-sim
 ```
 
-### 3. Create XCFramework
+Each build produces `liboffline_protocol_uniffi.a` under `target/<triple>/release/`
+(the crate's `[lib] name` is `offline_protocol_uniffi`).
+
+### 3. Package the Library and Generate Bindings
+
+The recommended path is the helper script, which builds the device/simulator slices **and**
+regenerates the UniFFI Swift bindings:
 
 ```bash
-# Combine into universal library
-lipo -create \\
-    target/aarch64-apple-ios/release/liboffline_protocol.a \\
-    -output liboffline_protocol.a
-
-# Add to Xcode project under Frameworks
+# From bindings/react-native
+./scripts/build-uniffi-ios.sh
 ```
+
+It produces, under `bindings/react-native/ios/`:
+
+- `liboffline_protocol_uniffi_device.a` (device)
+- `liboffline_protocol_uniffi_sim.a` (simulator, fat)
+- `Generated/offline_protocol.swift` and `Generated/offline_protocolFFI.modulemap`
+
+Add the `.a` for your build target plus `offline_protocol.swift` to your Xcode project. To
+do it by hand instead, `lipo`-combine the per-arch `liboffline_protocol_uniffi.a` outputs
+and run `uniffi-bindgen generate --language swift` to produce the Swift bindings.
 
 ### 4. Use in Swift
 
-```swift
-import OfflineProtocolSDK
+The generated `offline_protocol.swift` declares the public types (`OfflineProtocol`,
+`ProtocolConfig`, `EventCallback`, `MessagePriority`, …). When it compiles into your app
+target no extra `import` is needed — the low-level FFI is exposed to it as the
+`offline_protocolFFI` clang module referenced from the generated file.
 
-class ViewController: UIViewController {
-    var protocol: OfflineProtocol?
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        // Initialize protocol
-        let config = ProtocolConfig(
-            appId: "my-ios-app",
-            userId: "user123"
-        )
-        
-        do {
-            protocol = try OfflineProtocol(config: config)
-            try protocol?.start()
-            
-            // Set up event handler
-            protocol?.onEvent { event in
-                switch event {
-                case .messageReceived(let msg):
-                    print("Received: \\(msg.content)")
-                case .transportSwitched(let evt):
-                    print("Switched to \\(evt.to)")
-                default:
-                    break
-                }
-            }
-            
-            // Send a message
-            let messageId = try protocol?.sendMessage(
-                recipient: "user456",
-                content: "Hello from iOS!",
-                priority: .high
-            )
-            
-            print("Message sent: \\(messageId ?? "")")
-            
-        } catch {
-            print("Error: \\(error)")
+```swift
+import Foundation
+
+// Events are delivered as JSON strings — implement `EventCallback` to receive them.
+final class MeshEventHandler: EventCallback {
+    func onEvent(eventJson: String) {
+        guard let data = eventJson.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = obj["type"] as? String else { return }
+
+        switch type {
+        case "message_received":
+            let sender = obj["sender"] as? String ?? "?"
+            let content = obj["content"] as? String ?? ""
+            print("Received from \(sender): \(content)")
+        case "transport_switched":
+            print("Transport switched: \(eventJson)")
+        default:
+            break
         }
     }
-    
-    deinit {
-        try? protocol?.stop()
+}
+
+final class MeshController {
+    private var offlineProtocol: OfflineProtocol?
+    private let eventHandler = MeshEventHandler()
+
+    func startMesh() {
+        // ProtocolConfig has 16 required fields (+ 4 with defaults). See
+        // docs/configuration.md for what each one controls.
+        let config = ProtocolConfig(
+            appId: "my-ios-app",
+            userId: "user123",
+            bleEnabled: true,
+            wifiDirectEnabled: false,   // iOS does not support Wi-Fi Direct
+            internetEnabled: true,
+            reticulumEnabled: false,
+            nostrEnabled: false,
+            preferOnline: false,
+            initialTtl: 8,
+            encryptionEnabled: true,
+            autoKeyExchange: true,
+            storePending: true,
+            maxPendingPerPeer: 100,
+            maxPendingGlobal: 1000,
+            pendingTtlMs: 604_800_000,   // 7 days
+            overflowPolicy: .dropOldest
+            // requireEncryption (true), maxGroupMembers (256), groupRelayEnabled (true),
+            // and requireTransportIdentity (false) use their defaults.
+        )
+
+        do {
+            let mesh = try OfflineProtocol(config: config)
+            mesh.setEventCallback(callback: eventHandler)
+            try mesh.start()
+
+            // Send a message (priority is required; replyToMsg is optional)
+            let messageId = try mesh.sendMessage(
+                recipient: "user456",
+                content: "Hello from iOS!",
+                priority: .high,
+                replyToMsg: nil
+            )
+            print("Message sent: \(messageId)")
+
+            offlineProtocol = mesh
+        } catch {
+            print("Error: \(error)")
+        }
+    }
+
+    func stopMesh() {
+        try? offlineProtocol?.stop()
     }
 }
 ```
@@ -147,30 +190,32 @@ Create and manage encrypted groups over the mesh. The group creator is automatic
 
 ```swift
 // Create a group
-let group = try protocol.meshCreateGroup(groupName: "Project Team")
+let group = try offlineProtocol.createGroup(groupName: "Project Team")
 
 // Invite a member (admin only)
-try protocol.meshInviteToGroup(groupId: group.groupId, inviteeUserId: "bob")
+try offlineProtocol.inviteToGroup(groupId: group.groupId, inviteeUserId: "bob")
 
 // Send an encrypted group message
-let messageIds = try protocol.meshSendGroupMessage(
+let messageIds = try offlineProtocol.sendGroupMessage(
     groupId: group.groupId,
-    content: "Hello team!"
+    content: "Hello team!",
+    priority: nil,
+    replyToMsg: nil
 )
 
 // Remove a member (admin only)
-try protocol.meshRemoveFromGroup(groupId: group.groupId, memberId: "bob")
+try offlineProtocol.removeFromGroup(groupId: group.groupId, memberId: "bob")
 
 // Get group info (members, epoch, etc.)
-if let info = try protocol.getGroupInfo(groupId: group.groupId) {
+if let info = try offlineProtocol.getGroupInfo(groupId: group.groupId) {
     print("Members: \(info.members)")
 }
 
 // Rename a group (admin only)
-try protocol.renameGroup(groupId: group.groupId, newName: "New Team Name")
+try offlineProtocol.renameGroup(groupId: group.groupId, newName: "New Team Name")
 
 // Leave a group
-try protocol.meshLeaveGroup(groupId: group.groupId)
+try offlineProtocol.leaveGroup(groupId: group.groupId)
 ```
 
 ### Group Role Management
@@ -179,25 +224,31 @@ Groups use role-based access control: **Admin** and **Member**.
 
 ```swift
 // Promote a member to admin (admin only)
-try protocol.setMemberRole(groupId: groupId, userId: "bob", role: "admin")
+try offlineProtocol.setMemberRole(groupId: groupId, userId: "bob", role: "admin")
 
 // Check a member's role
-let role = try protocol.getMemberRole(groupId: groupId, userId: "bob") // "admin" or "member"
+let role = try offlineProtocol.getMemberRole(groupId: groupId, userId: "bob") // "admin" or "member"
 
 // Get all roles
-let roles = try protocol.getGroupRoles(groupId: groupId)
+let roles = try offlineProtocol.getGroupRoles(groupId: groupId)
 // ["alice": "admin", "bob": "admin", "charlie": "member"]
 ```
 
-Listen for role changes and renames:
+Role changes and renames arrive through the same `EventCallback` as every other event —
+JSON strings whose `type` is `group_role_changed` or `group_renamed`. Handle them inside
+your `onEvent(eventJson:)`:
 
 ```swift
-protocol.onEvent { event in
-    switch event {
-    case .groupRoleChanged(let evt):
-        print("\(evt.userId) is now \(evt.newRole) (changed by \(evt.changedBy))")
-    case .groupRenamed(let evt):
-        print("Group \(evt.groupId) renamed to \(evt.newName) by \(evt.renamedBy)")
+func onEvent(eventJson: String) {
+    guard let data = eventJson.data(using: .utf8),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let type = obj["type"] as? String else { return }
+
+    switch type {
+    case "group_role_changed":
+        print("\(obj["user_id"] ?? "?") is now \(obj["new_role"] ?? "?") (by \(obj["changed_by"] ?? "?"))")
+    case "group_renamed":
+        print("Group \(obj["group_id"] ?? "?") renamed to \(obj["new_name"] ?? "?") by \(obj["renamed_by"] ?? "?")")
     default:
         break
     }
@@ -215,7 +266,7 @@ Reset a peer's TOFU-pinned public key when you need to re-establish trust (e.g.,
 
 ```swift
 // Reset trust pin for a peer
-let removed = try protocol.resetTofuForPeer(peerId: "bob")
+let removed = try offlineProtocol.resetTofuForPeer(peerId: "bob")
 // removed == true if an entry was cleared, false if none existed
 ```
 
@@ -233,4 +284,3 @@ iOS does **not** support Wi-Fi Direct. Available transports:
 - Message sending: <1ms overhead
 - Memory safe: Zero buffer overflows or memory leaks
 - Battery efficient: Optimized for iOS power management
-

--- a/docs/mls-integration.md
+++ b/docs/mls-integration.md
@@ -172,17 +172,24 @@ Use the manual MLS APIs (described below) when you need:
 
 ### 1. Initialize MLS
 
-The SDK includes built-in secure storage using platform-native APIs (iOS Keychain, Android EncryptedSharedPreferences). Just call initialize:
+MLS persists key material through a secure-storage backend that you provide by implementing
+`MlsStorageProvider` (iOS Keychain, Android Keystore / EncryptedSharedPreferences, or your own
+scheme). Pass your provider to `initializeMls` — see [Custom Storage](#custom-storage-advanced)
+for a complete provider implementation:
 
 ```swift
-// iOS - uses Keychain automatically
-try protocol.initializeMlsWithSecureStorage()
+// iOS — `storage` is your MlsStorageProvider (e.g. Keychain-backed)
+try mesh.initializeMls(storage: storage)
 ```
 
 ```kotlin
-// Android - uses EncryptedSharedPreferences automatically
-protocol.initializeMlsWithSecureStorage()
+// Android — `storage` is your MlsStorageProvider (e.g. EncryptedSharedPreferences-backed)
+protocol.initializeMls(storage)
 ```
+
+> **React Native:** the wrapper bundles a Keychain / EncryptedSharedPreferences provider, so RN
+> apps can just call `initializeMlsWithSecureStorage()` — or let `start()` initialize MLS
+> automatically when encryption is enabled.
 
 ### 2. Generate and Share Key Packages
 
@@ -190,7 +197,7 @@ Key packages allow others to initiate encrypted sessions with you:
 
 ```swift
 // Generate a key package
-let keyPackage = try protocol.mlsGenerateKeyPackage()
+let keyPackage = try mesh.mlsGenerateKeyPackage()
 
 // Upload to your server for distribution
 uploadKeyPackage(keyPackage.keyPackageData, userId: keyPackage.userId)
@@ -202,19 +209,19 @@ uploadKeyPackage(keyPackage.keyPackageData, userId: keyPackage.userId)
 
 ```swift
 // First, import the recipient's key package
-try protocol.mlsImportKeyPackage(
+try mesh.mlsImportKeyPackage(
     userId: "bob",
     keyPackageData: bobsKeyPackage
 )
 
 // Send an encrypted message
-let encrypted = try protocol.mlsEncryptForUser(
+let encrypted = try mesh.mlsEncryptForUser(
     otherUserId: "bob",
     plaintext: "Hello, Bob!".data(using: .utf8)!
 )
 
 // Send the encrypted message using existing transport
-_ = try protocol.sendMessage(
+_ = try mesh.sendMessage(
     recipient: "bob",
     content: encryptedToJson(encrypted),
     priority: .medium,
@@ -226,13 +233,13 @@ _ = try protocol.sendMessage(
 
 ```swift
 // Create a group (creator becomes admin)
-let group = try protocol.createGroup(groupName: "Project Team")
+let group = try mesh.createGroup(groupName: "Project Team")
 
 // Invite members (admin only — handles key exchange + Welcome automatically)
-try protocol.inviteToGroup(groupId: group.groupId, inviteeUserId: "alice")
+try mesh.inviteToGroup(groupId: group.groupId, inviteeUserId: "alice")
 
 // Send encrypted group message (MLS encryption + mesh fan-out)
-let messageIds = try protocol.sendGroupMessage(
+let messageIds = try mesh.sendGroupMessage(
     groupId: group.groupId,
     content: "Hello team!",
     priority: nil,
@@ -240,12 +247,12 @@ let messageIds = try protocol.sendGroupMessage(
 )
 
 // Get group info
-if let info = try protocol.getGroupInfo(groupId: group.groupId) {
+if let info = try mesh.getGroupInfo(groupId: group.groupId) {
     print("Members: \(info.members), Epoch: \(info.epoch)")
 }
 
 // Rename a group (admin only, broadcasts to all members)
-try protocol.renameGroup(groupId: group.groupId, newName: "Engineering Team")
+try mesh.renameGroup(groupId: group.groupId, newName: "Engineering Team")
 ```
 
 ### 4. Receive and Decrypt Messages
@@ -254,7 +261,7 @@ try protocol.renameGroup(groupId: group.groupId, newName: "Engineering Team")
 // When receiving a message, check if it was encrypted
 if message.metadata["encrypted"] == "true" {
     let encrypted = parseEncryptedMessage(message.content)
-    if let plaintext = try protocol.mlsDecrypt(encrypted: encrypted) {
+    if let plaintext = try mesh.mlsDecrypt(encrypted: encrypted) {
         let text = String(data: plaintext, encoding: .utf8)
         // Handle decrypted message
     }
@@ -263,7 +270,7 @@ if message.metadata["encrypted"] == "true" {
 // When receiving a Welcome message (invited to group)
 if let welcomeData = message.metadata["mls_welcome"] {
     let welcome = parseWelcomeMessage(welcomeData)
-    let groupInfo = try protocol.mlsProcessWelcome(welcome: welcome)
+    let groupInfo = try mesh.mlsProcessWelcome(welcome: welcome)
     // Now you're part of the group
 }
 ```
@@ -272,14 +279,14 @@ if let welcomeData = message.metadata["mls_welcome"] {
 
 ## Custom Storage (Advanced)
 
-The SDK includes built-in secure storage, but you can provide a custom implementation if needed (e.g., for custom backup strategies, additional encryption layers, or testing).
+The React Native wrapper ships built-in secure storage; native (Swift/Kotlin) integrations provide their own by implementing `MlsStorageProvider`. A custom provider is also useful for custom backup strategies, additional encryption layers, or testing.
 
 ### Using Custom Storage
 
 ```swift
 // iOS - custom storage
 let customStorage = MyCustomMlsStorage()
-try protocol.initializeMls(storage: customStorage)
+try mesh.initializeMls(storage: customStorage)
 ```
 
 ```kotlin
@@ -371,19 +378,19 @@ DELETE /keys/{userId}/{pkgId} # Delete used key package
 
 ```swift
 // Get pending key packages to upload
-let pending = protocol.mlsGetPendingKeyPackages()
+let pending = mesh.mlsGetPendingKeyPackages()
 
 for pkg in pending {
     // Upload to server
     try await uploadKeyPackage(pkg)
     
     // Mark as synced
-    try protocol.mlsMarkKeyPackageSynced(packageId: pkg.packageId)
+    try mesh.mlsMarkKeyPackageSynced(packageId: pkg.packageId)
 }
 
 // Fetch a contact's key package before messaging
 let keyPackageData = try await fetchKeyPackage(userId: "bob")
-try protocol.mlsImportKeyPackage(userId: "bob", keyPackageData: keyPackageData)
+try mesh.mlsImportKeyPackage(userId: "bob", keyPackageData: keyPackageData)
 ```
 
 ### Offline Key Exchange
@@ -461,6 +468,11 @@ MLS control payloads (key package / welcome / ciphertext envelopes) are encoded 
 ---
 
 ## API Reference
+
+> The method names in these tables follow the **React Native / JS wrapper** API — including the
+> `mesh*` group helpers and `initializeMlsWithSecureStorage()`. The native UniFFI bindings expose
+> the same operations under their generated names (e.g. `createGroup`, `inviteToGroup`,
+> `sendGroupMessage`, `initializeMls(storage)`), as shown in the Swift/Kotlin snippets above.
 
 ### Initialization
 

--- a/docs/mls-integration.md
+++ b/docs/mls-integration.md
@@ -214,10 +214,11 @@ let encrypted = try protocol.mlsEncryptForUser(
 )
 
 // Send the encrypted message using existing transport
-protocol.sendMessage(
+_ = try protocol.sendMessage(
     recipient: "bob",
     content: encryptedToJson(encrypted),
-    priority: .medium
+    priority: .medium,
+    replyToMsg: nil
 )
 ```
 
@@ -225,24 +226,26 @@ protocol.sendMessage(
 
 ```swift
 // Create a group (creator becomes admin)
-let group = try protocol.meshCreateGroup(groupName: "Project Team")
+let group = try protocol.createGroup(groupName: "Project Team")
 
 // Invite members (admin only — handles key exchange + Welcome automatically)
-try protocol.meshInviteToGroup(groupId: group.groupId, inviteeUserId: "alice")
+try protocol.inviteToGroup(groupId: group.groupId, inviteeUserId: "alice")
 
 // Send encrypted group message (MLS encryption + mesh fan-out)
-let messageIds = try protocol.meshSendGroupMessage(
+let messageIds = try protocol.sendGroupMessage(
     groupId: group.groupId,
-    content: "Hello team!"
+    content: "Hello team!",
+    priority: nil,
+    replyToMsg: nil
 )
 
 // Get group info
-if let info = try protocol.meshGetGroupInfo(groupId: group.groupId) {
+if let info = try protocol.getGroupInfo(groupId: group.groupId) {
     print("Members: \(info.members), Epoch: \(info.epoch)")
 }
 
 // Rename a group (admin only, broadcasts to all members)
-try protocol.meshRenameGroup(groupId: group.groupId, newName: "Engineering Team")
+try protocol.renameGroup(groupId: group.groupId, newName: "Engineering Team")
 ```
 
 ### 4. Receive and Decrypt Messages


### PR DESCRIPTION
## What

Fixes the confirmed-valid **documentation** issues surfaced by the production-readiness review. All changes are docs-only (the one `dors.rs` change is a doc-comment fix that repairs `cargo doc`).

## Native integration guides — `docs/ios-integration.md`, `docs/android-integration.md`, `QUICKSTART.md`

These were the worst-rotted area — none of the snippets compiled. Rewrote them against the actual UDL + generated Swift/Kotlin bindings:

- **Library names**: `liboffline_protocol.{so,a}` → the real `libuniffi_offline_protocol.so` (the name UniFFI's loader expects) / `liboffline_protocol_uniffi.a`, with pointers to the `build-uniffi-{ios,android}.sh` helpers.
- **Imports**: dropped the nonexistent `import OfflineProtocolSDK`; `com.offlineprotocol.OfflineProtocol` → `import uniffi.offline_protocol.*`.
- **Swift reserved word**: `var protocol` → `offlineProtocol` / `mesh`.
- **Config**: 2-arg `ProtocolConfig(...)` → the real **16 required fields** (+ 4 defaulted), using `.toUByte()`/`.toULong()` on Android to match the project's own idiom.
- **Events**: fake typed `onEvent`/`setEventListener` API → the real `EventCallback.onEvent(eventJson:)` parsing the actual `{"type": ...}` JSON.
- **`sendMessage`**: added the required 4th arg (`replyToMsg`).
- **Group methods**: RN-only `mesh*` names → the real native names (`createGroup`, `inviteToGroup`, `sendGroupMessage`, `removeFromGroup`, `leaveGroup`).

Also fixed the same-class `mesh*` bug (plus a `try`-less 3-arg `sendMessage`) in the **native Swift** block of `docs/mls-integration.md`. Its RN/JS reference tables and `await` blocks were left untouched — `mesh*`/`mls*` are the correct JS-wrapper names there. `docs/reticulum.md` / `docs/nostr.md` were left alone (their configs honestly show `// ... other fields`).

## Other review items

- **`SECURITY.md`**: the dead-end "contact information in the repository" → **gm@offlineprotocol.com** (a real address).
- **`bindings/react-native/README.md`**: `## License: ISC` → the real **AGPL-3.0-only + commercial** dual-license; fixed minSdk (**26 → 24**, matching `build.gradle`).
- **`crates/offline-protocol-router/src/dors.rs`**: de-linked a public doc comment's intra-doc reference to the private `INTERNET_FALLBACK_DEMOTION` const.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc -p offline-protocol-router --no-deps` now builds clean (was a hard error).
- Swept `docs/` — no lingering wrong lib names, fake modules, or `mesh*` in native code blocks; the correct RN/JS `mesh*` usages are preserved.
