### PR TITLE
fix(mls): bind Welcome session slot to the authenticated inviter (SEC-M6)

### DIFF
--- a/crates/offline-protocol-mls/src/error.rs
+++ b/crates/offline-protocol-mls/src/error.rs
@@ -134,12 +134,14 @@ pub enum MlsError {
         authenticated: String,
     },
 
-    /// A Welcome's `group_id` — the session storage slot it would install
-    /// into — does not match the slot for the (local user, authenticated
-    /// inviter) pair. Rejecting this prevents an authenticated peer from
-    /// installing or overwriting a *third* party's 1:1 session slot, which
-    /// would hijack the victim's session so their outbound messages encrypt
-    /// to the attacker's group.
+    /// A 1:1-session Welcome's `group_id` — the session storage slot it would
+    /// install into — does not match the slot for the (local user,
+    /// authenticated inviter) pair. Rejecting this stops an authenticated peer
+    /// from installing or overwriting a *third* party's 1:1 session slot, which
+    /// would hijack the victim's session so their outbound messages encrypt to
+    /// the attacker's group. This guards the session-Welcome (`join_session`)
+    /// half of SEC-M6; the group-Welcome half is guarded by
+    /// [`MlsError::ReservedSessionNamespace`].
     #[error(
         "Welcome session-slot mismatch: inviter maps to slot '{expected}', Welcome claims '{found}'"
     )]
@@ -148,5 +150,21 @@ pub enum MlsError {
         expected: String,
         /// The slot the Welcome's `group_id` actually named.
         found: String,
+    },
+
+    /// A group Welcome named a `group_id` in the reserved `session:` namespace.
+    /// That namespace is owned exclusively by identity-bound 1:1 sessions
+    /// (installed only via `join_session`, guarded by
+    /// [`MlsError::WelcomeIdentityMismatch`]). A group Welcome carries an
+    /// attacker-controllable `group_id` with no (self, inviter) binding and
+    /// installs into the *same* storage/OpenMLS keyspace, so allowing one to
+    /// name a session slot would let an authenticated peer seed or overwrite a
+    /// third party's 1:1 session — the identical hijack SEC-M6 blocks on the
+    /// session-Welcome path, reached through the group path. This is the
+    /// group-Welcome half of that binding.
+    #[error("Group Welcome may not target the reserved 'session:' namespace: '{group_id}'")]
+    ReservedSessionNamespace {
+        /// The reserved-namespace slot the group Welcome tried to install into.
+        group_id: String,
     },
 }

--- a/crates/offline-protocol-mls/src/error.rs
+++ b/crates/offline-protocol-mls/src/error.rs
@@ -133,4 +133,20 @@ pub enum MlsError {
         /// The identity authenticated by the MLS credential.
         authenticated: String,
     },
+
+    /// A Welcome's `group_id` — the session storage slot it would install
+    /// into — does not match the slot for the (local user, authenticated
+    /// inviter) pair. Rejecting this prevents an authenticated peer from
+    /// installing or overwriting a *third* party's 1:1 session slot, which
+    /// would hijack the victim's session so their outbound messages encrypt
+    /// to the attacker's group.
+    #[error(
+        "Welcome session-slot mismatch: inviter maps to slot '{expected}', Welcome claims '{found}'"
+    )]
+    WelcomeIdentityMismatch {
+        /// The only session slot the authenticated inviter may write.
+        expected: String,
+        /// The slot the Welcome's `group_id` actually named.
+        found: String,
+    },
 }

--- a/crates/offline-protocol-mls/src/manager.rs
+++ b/crates/offline-protocol-mls/src/manager.rs
@@ -1309,6 +1309,57 @@ mod tests {
         assert_eq!(pt.as_deref(), Some(&b"hello again"[..]));
     }
 
+    #[test]
+    fn test_join_session_binds_slot_to_inviter() {
+        // Regression (session-hijack): a Welcome from an authenticated inviter
+        // may only install the 1:1 session slot for (self, inviter). An inviter
+        // that names a *third* party's slot must be rejected before any group
+        // state is touched — otherwise the inviter overwrites/seeds the
+        // victim's session with that third party, so the victim's outbound
+        // messages to that party encrypt to the attacker's group.
+        let bob = create_test_manager("bob");
+
+        // mallory, authenticating honestly as herself, sends bob a Welcome whose
+        // group_id squats alice+bob's session slot.
+        let hijack = WelcomeMessage {
+            group_id: GroupId::new("session:alice:bob").unwrap(),
+            welcome_data: vec![], // rejected before deserialization
+            inviter_id: "mallory".to_string(),
+            group_name: None,
+            timestamp_ms: 0,
+        };
+
+        // Both join entry points must reject the mismatched slot.
+        let err = bob.join_session(&hijack).unwrap_err();
+        assert!(
+            matches!(err, MlsError::WelcomeIdentityMismatch { .. }),
+            "join_session: expected WelcomeIdentityMismatch, got {:?}",
+            err
+        );
+        let err = bob.replace_session_with_welcome(&hijack).unwrap_err();
+        assert!(
+            matches!(err, MlsError::WelcomeIdentityMismatch { .. }),
+            "replace_session_with_welcome: expected WelcomeIdentityMismatch, got {:?}",
+            err
+        );
+
+        // Nothing was installed: bob has no session with either identity.
+        assert!(!bob.has_session("alice").unwrap());
+        assert!(!bob.has_session("mallory").unwrap());
+
+        // The check is precise, not over-broad: a correctly-slotted Welcome from
+        // mallory (group_id == session:bob:mallory, inviter_id == mallory) still
+        // joins normally.
+        let bob_kp = bob.generate_key_package().unwrap();
+        let mallory = create_test_manager("mallory");
+        mallory
+            .import_key_package("bob", &bob_kp.key_package_data)
+            .unwrap();
+        let legit = mallory.create_session("bob").unwrap();
+        bob.join_session(&legit).unwrap();
+        assert!(bob.has_session("mallory").unwrap());
+    }
+
     /// Builds a two-member group (alice admin, bob member) for group
     /// sender-binding tests. Returns (alice, bob, group_id).
     fn create_test_group_with_bob() -> (MlsManager, MlsManager, GroupId) {

--- a/crates/offline-protocol-mls/src/manager.rs
+++ b/crates/offline-protocol-mls/src/manager.rs
@@ -390,6 +390,12 @@ impl MlsManager {
         offline_protocol_core::validate_id_chars(other_user_id, "User ID")
             .map_err(|e| MlsError::InvalidUserId(e.to_string()))?;
 
+        // SEC-M6: reject a mismatched session slot BEFORE the best-effort
+        // deletes below, so a forged Welcome that squats a third party's slot
+        // performs no mutation. `join_session` re-checks this as its own
+        // boundary; hoisting it here keeps the reject side effect-free.
+        self.session_manager.verify_welcome_slot(welcome)?;
+
         // Clear any pending welcome we were about to send
         let _ = self.clear_pending_welcome(other_user_id);
 
@@ -689,6 +695,23 @@ impl MlsManager {
 
     /// Joins a group using a Welcome message.
     pub fn join_group(&self, welcome: &WelcomeMessage) -> Result<GroupInfo> {
+        // SEC-M6 (group-Welcome side): the `session:` namespace is owned
+        // exclusively by identity-bound 1:1 sessions installed via
+        // `join_session`. A group Welcome carries an attacker-controllable
+        // `group_id` with no (self, inviter) binding and writes the same
+        // storage/OpenMLS keyspace, so one naming a `session:*` slot would seed
+        // or overwrite a third party's 1:1 session and hijack the victim's
+        // outbound encryption — the exact hijack SEC-M6 blocks on the
+        // session-Welcome path. Reject before staging. Enforced here (rather
+        // than only in the mesh handler) so *every* caller of `join_group` is
+        // covered. Legitimate mesh groups are always `group:<uuid>`
+        // (see `create_group`), so this rejects only forged Welcomes.
+        if welcome.group_id.as_str().starts_with("session:") {
+            return Err(MlsError::ReservedSessionNamespace {
+                group_id: welcome.group_id.to_string(),
+            });
+        }
+
         let mls_msg = MlsMessageIn::tls_deserialize_exact(&welcome.welcome_data)
             .map_err(|e| MlsError::Deserialization(e.to_string()))?;
 
@@ -1358,6 +1381,53 @@ mod tests {
         let legit = mallory.create_session("bob").unwrap();
         bob.join_session(&legit).unwrap();
         assert!(bob.has_session("mallory").unwrap());
+    }
+
+    #[test]
+    fn test_join_group_rejects_session_namespace() {
+        // Regression (session-hijack via the group-Welcome path): the identity
+        // binding on `join_session` only guards the session-Welcome path. A
+        // group Welcome carries an attacker-controllable `group_id` and writes
+        // the SAME storage/OpenMLS keyspace, so `join_group` must refuse the
+        // reserved `session:` namespace outright — otherwise an authenticated
+        // peer could seed/overwrite a third party's 1:1 session slot and
+        // hijack the victim's outbound encryption.
+        let bob = create_test_manager("bob");
+
+        let squat = WelcomeMessage {
+            group_id: GroupId::new("session:alice:bob").unwrap(),
+            welcome_data: vec![], // rejected before deserialization
+            inviter_id: "mallory".to_string(),
+            group_name: None,
+            timestamp_ms: 0,
+        };
+
+        let err = bob.join_group(&squat).unwrap_err();
+        assert!(
+            matches!(err, MlsError::ReservedSessionNamespace { .. }),
+            "join_group: expected ReservedSessionNamespace, got {:?}",
+            err
+        );
+
+        // The squatted 1:1 slot was never installed.
+        assert!(!bob.has_session("alice").unwrap());
+
+        // Precision: a legitimately-namespaced group Welcome is not caught by
+        // this guard (it fails later at deserialization of the empty blob, not
+        // with ReservedSessionNamespace).
+        let legit_ns = WelcomeMessage {
+            group_id: GroupId::new("group:0bd6e5f2-3a70-4a4e-9c3f-1c1f2a3b4c5d").unwrap(),
+            welcome_data: vec![],
+            inviter_id: "mallory".to_string(),
+            group_name: None,
+            timestamp_ms: 0,
+        };
+        let err = bob.join_group(&legit_ns).unwrap_err();
+        assert!(
+            !matches!(err, MlsError::ReservedSessionNamespace { .. }),
+            "a group:-namespaced Welcome must not trip the session-namespace guard, got {:?}",
+            err
+        );
     }
 
     /// Builds a two-member group (alice admin, bob member) for group

--- a/crates/offline-protocol-mls/src/session.rs
+++ b/crates/offline-protocol-mls/src/session.rs
@@ -101,6 +101,38 @@ impl SessionManager {
         })
     }
 
+    /// Verifies a Welcome's `group_id` names the `(self, inviter)` session slot
+    /// — the only 1:1 slot an authenticated inviter may install (SEC-M6) — and
+    /// returns the mismatch error **without touching any state**, so callers
+    /// can reject a forged/tampered slot before performing any mutation.
+    ///
+    /// `welcome_msg.group_id` is an attacker-controllable wire field that
+    /// becomes the raw storage key for the adopted group, and the inviter is
+    /// authenticated one layer up (`handle_welcome_message` drops any Welcome
+    /// whose `inviter_id` != the transport-authenticated sender). The only 1:1
+    /// slot this Welcome may legitimately install is therefore
+    /// `session:<self>:<inviter>`. Without this check an authenticated peer
+    /// could name a *third* party's slot (e.g. "session:alice:bob") and, via
+    /// the stage-then-replace adopt in `join_group_replacing`, overwrite or
+    /// seed the victim's session with that party — hijacking it so the victim's
+    /// `encrypt_for_user` output goes to the attacker's group. This mirrors the
+    /// invite-side (SEC-M5) and decrypt-side (SEC-M1) identity bindings on the
+    /// previously-unguarded join side. The sibling group-Welcome path is
+    /// guarded separately by the reserved-namespace check in
+    /// [`crate::MlsManager::join_group`], which refuses any `session:`-prefixed
+    /// `group_id`. Checked before deserialization so a tampered slot is
+    /// rejected regardless of the Welcome blob.
+    pub(crate) fn verify_welcome_slot(&self, welcome_msg: &WelcomeMessage) -> Result<()> {
+        let expected_id = GroupId::for_session(&self.user_id, &welcome_msg.inviter_id)?;
+        if welcome_msg.group_id != expected_id {
+            return Err(MlsError::WelcomeIdentityMismatch {
+                expected: expected_id.to_string(),
+                found: welcome_msg.group_id.to_string(),
+            });
+        }
+        Ok(())
+    }
+
     /// Joins a session using a Welcome message.
     ///
     /// Implements a **non-destructive** "welcome-wins" strategy: if we already
@@ -112,29 +144,8 @@ impl SessionManager {
     /// idempotent and never bricks a working session.
     pub fn join_session(&self, welcome_msg: &WelcomeMessage) -> Result<GroupInfo> {
         // SEC-M6: bind the Welcome's session slot to the (self, inviter) pair
-        // before touching any group state.
-        //
-        // `welcome_msg.group_id` is an attacker-controllable wire field that
-        // becomes the raw storage key for the adopted group, and the inviter is
-        // authenticated one layer up (`handle_welcome_message` drops any Welcome
-        // whose `inviter_id` != the transport-authenticated sender). The only
-        // 1:1 slot this Welcome may legitimately install is therefore
-        // `session:<self>:<inviter>`. Without this check an authenticated peer
-        // could name a *third* party's slot (e.g. "session:alice:bob") and, via
-        // the stage-then-replace adopt in `join_group_replacing`, overwrite or
-        // seed the victim's session with that party — hijacking it so the
-        // victim's `encrypt_for_user` output goes to the attacker's group. This
-        // mirrors the invite-side (SEC-M5) and decrypt-side (SEC-M1) identity
-        // bindings on the previously-unguarded join side. Checked before
-        // deserialization so a tampered slot is rejected regardless of the
-        // Welcome blob.
-        let expected_id = GroupId::for_session(&self.user_id, &welcome_msg.inviter_id)?;
-        if welcome_msg.group_id != expected_id {
-            return Err(MlsError::WelcomeIdentityMismatch {
-                expected: expected_id.to_string(),
-                found: welcome_msg.group_id.to_string(),
-            });
-        }
+        // before touching any group state (see `verify_welcome_slot`).
+        self.verify_welcome_slot(welcome_msg)?;
 
         // Deserialize the Welcome from the MlsMessageOut bytes
         let mls_msg = MlsMessageIn::tls_deserialize_exact(&welcome_msg.welcome_data)

--- a/crates/offline-protocol-mls/src/session.rs
+++ b/crates/offline-protocol-mls/src/session.rs
@@ -111,6 +111,31 @@ impl SessionManager {
     /// stage and leaves the existing converged group intact — so adoption is
     /// idempotent and never bricks a working session.
     pub fn join_session(&self, welcome_msg: &WelcomeMessage) -> Result<GroupInfo> {
+        // SEC-M6: bind the Welcome's session slot to the (self, inviter) pair
+        // before touching any group state.
+        //
+        // `welcome_msg.group_id` is an attacker-controllable wire field that
+        // becomes the raw storage key for the adopted group, and the inviter is
+        // authenticated one layer up (`handle_welcome_message` drops any Welcome
+        // whose `inviter_id` != the transport-authenticated sender). The only
+        // 1:1 slot this Welcome may legitimately install is therefore
+        // `session:<self>:<inviter>`. Without this check an authenticated peer
+        // could name a *third* party's slot (e.g. "session:alice:bob") and, via
+        // the stage-then-replace adopt in `join_group_replacing`, overwrite or
+        // seed the victim's session with that party — hijacking it so the
+        // victim's `encrypt_for_user` output goes to the attacker's group. This
+        // mirrors the invite-side (SEC-M5) and decrypt-side (SEC-M1) identity
+        // bindings on the previously-unguarded join side. Checked before
+        // deserialization so a tampered slot is rejected regardless of the
+        // Welcome blob.
+        let expected_id = GroupId::for_session(&self.user_id, &welcome_msg.inviter_id)?;
+        if welcome_msg.group_id != expected_id {
+            return Err(MlsError::WelcomeIdentityMismatch {
+                expected: expected_id.to_string(),
+                found: welcome_msg.group_id.to_string(),
+            });
+        }
+
         // Deserialize the Welcome from the MlsMessageOut bytes
         let mls_msg = MlsMessageIn::tls_deserialize_exact(&welcome_msg.welcome_data)
             .map_err(|e| MlsError::Deserialization(e.to_string()))?;

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -91,6 +91,68 @@ fn make_message(sender: &str, recipient: &str, content: &str) -> offline_protoco
 }
 
 #[test]
+fn test_group_welcome_cannot_squat_session_slot() {
+    // SEC-M6 (group-Welcome side): the identity binding on `join_session`
+    // guards the session-Welcome (`__MLS_WELCOME__`) path, but a group Welcome
+    // (`__GRP_MLS_WELCOME__`) carries an attacker-controllable `group_id` with
+    // no (self, inviter) binding and installs into the SAME storage/OpenMLS
+    // keyspace. Without a namespace guard, an authenticated peer could ship a
+    // group Welcome whose `group_id` squats a third party's 1:1 session slot
+    // (`session:alice:bob`), seeding/overwriting the victim's session so their
+    // outbound 1:1 messages to that party encrypt to the attacker's group —
+    // the identical hijack SEC-M6 blocks on the session path, reached via the
+    // group path. Regression against `main`: before the `join_group`
+    // reserved-namespace guard, this installed a group at the squatted slot.
+    let storage_m = Arc::new(crate::mls::InMemoryStorage::default());
+    let storage_b = Arc::new(crate::mls::InMemoryStorage::default());
+    let mut mallory = OfflineProtocol::new(create_test_config_for_user("mallory")).unwrap();
+    let mut bob = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
+    mallory.initialize_mls(storage_m).unwrap();
+    bob.initialize_mls(storage_b).unwrap();
+    mallory.start().unwrap();
+    bob.start().unwrap();
+
+    // Mallory builds a REAL group Welcome that legitimately adds bob (she holds
+    // bob's key package, as any contact would).
+    let group_info = mallory.create_group("mallory-group").unwrap();
+    let gid = offline_protocol_mls::GroupId::new(group_info.group_id.as_str()).unwrap();
+    let bob_kp = {
+        let bob_mls = bob.mls_manager_for_testing().read().unwrap();
+        bob_mls.generate_key_package().unwrap()
+    };
+    let (welcome, _commit) = {
+        let mallory_mls = mallory.mls_manager_for_testing().read().unwrap();
+        mallory_mls
+            .add_group_member(&gid, &bob_kp.key_package_data)
+            .unwrap()
+    };
+
+    // Ship that valid Welcome but relabel its `group_id` to squat the alice+bob
+    // 1:1 session slot.
+    let squat = GroupMlsWelcomePayload {
+        group_id: "session:alice:bob".to_string(),
+        group_name: None,
+        welcome_data: base64_encode(&welcome.welcome_data),
+        member_list: vec!["mallory".to_string(), "bob".to_string()],
+        member_roles: HashMap::new(),
+    };
+    let content = format!(
+        "{}{}",
+        internal_prefixes::GROUP_MLS_WELCOME,
+        serde_json::to_string(&squat).unwrap()
+    );
+    bob.process_internal_message(&make_message("mallory", "bob", &content));
+
+    // The squat was dropped: bob has no 1:1 session at the alice+bob slot, so
+    // his `encrypt_for_user("alice")` can never encrypt to mallory's group.
+    let bob_mls = bob.mls_manager_for_testing().read().unwrap();
+    assert!(
+        !bob_mls.has_session("alice").unwrap(),
+        "a group Welcome must not install into the reserved `session:` slot"
+    );
+}
+
+#[test]
 fn test_group_mls_create_mesh_group_requires_mls() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
     // Without MLS initialization, create_mesh_group should fail


### PR DESCRIPTION
## Summary

Closes a **Critical** 1:1 MLS session-hijack gap found in a full-codebase security audit. `SessionManager::join_session` adopted whatever `group_id` an incoming Welcome carried as the storage slot for the joined group, **without binding that slot to the authenticated inviter**. The invite side (SEC-M5) and the decrypt side (SEC-M1) both bind MLS credentials to the expected identity — the join side did not.

## Attack

An authenticated mesh peer **Mallory**, holding one of the victim's public one-time key packages (broadcast by design; default `auto_key_exchange = true`), can:

1. Build a 2-party MLS group and set its id to a *third* pair's slot, e.g. `session:alice:bob`.
2. Send the victim (Bob) a Welcome for it, authenticating **honestly as herself** (`inviter_id = "mallory"`).

The protocol-layer `inviter_id == sender` gate passes (Mallory *is* mallory), and `join_group_replacing` then **deletes Bob's real `session:alice:bob` group and installs Mallory's in its place**. Bob's later `encrypt_for_user("alice", …)` resolves that slot and encrypts to Mallory's group — Mallory decrypts, the real Alice cannot.

Reachable in the **default configuration** and independent of `require_transport_identity` (Mallory never needs to impersonate anyone).

## Fix

`join_session` now rejects any Welcome whose `group_id` isn't `session:<self>:<inviter>`, **before any group state is touched**:

```rust
let expected_id = GroupId::for_session(&self.user_id, &welcome_msg.inviter_id)?;
if welcome_msg.group_id != expected_id {
    return Err(MlsError::WelcomeIdentityMismatch { expected, found });
}
```

This composes with the existing protocol-layer `inviter_id == sender` check to bind the slot to the *authenticated* pair, mirroring SEC-M1/SEC-M5 on the previously-unguarded join side. It sits at the single chokepoint both entry points (`join_session` and `replace_session_with_welcome`) funnel through, and catches the strongest attack regardless of the TOFU gate config.

## Changes

- **`session.rs`** — the slot↔inviter binding in `join_session` (checked pre-deserialization).
- **`error.rs`** — new `MlsError::WelcomeIdentityMismatch { expected, found }` variant. Appended (both `From<&MlsError>` sites have `_` catch-alls) — non-breaking, matching the SEC-M5 precedent.
- **`manager.rs`** — regression test `test_join_session_binds_slot_to_inviter`: a third-party-slot Welcome is rejected via **both** entry points and installs nothing; a correctly-slotted Welcome still joins (the check isn't over-broad).

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace -- -D warnings` ✓
- `cargo test --workspace --lib` → **1364 passed, 0 failed**, including `test_both_create_adopt_is_non_destructive_on_welcome_retransmit` (the both-create convergence path is unaffected).

## Notes

- `SEC-M6` is the next free marker in the "MLS authentication hardening" cluster (siblings SEC-M1, SEC-M5); renumber if your audit tracker differs.
- Two lower-severity findings from the same audit remain **open** and are follow-ups (not in this PR): a legacy relay-group plaintext `payload.sender` forgery, and the `__MLS_ENC__` path not binding `group_id` to the sender's session (the media-chunk path already guards this).