### PR TITLE
fix(mls,protocol): close two HIGH auth holes (SEC-M6 embedded-id bypass, unauth group eviction)

### DIFF
--- a/crates/offline-protocol-mls/src/error.rs
+++ b/crates/offline-protocol-mls/src/error.rs
@@ -167,4 +167,24 @@ pub enum MlsError {
         /// The reserved-namespace slot the group Welcome tried to install into.
         group_id: String,
     },
+
+    /// A Welcome's embedded MLS group id (the id OpenMLS actually persists the
+    /// joined group under) does not match the wire `group_id` the caller
+    /// authenticated and keys storage by. The embedded id lives in the
+    /// Welcome's `GroupContext` and is chosen freely by the inviter at group
+    /// creation (`new_with_group_id`); every SEC-M5/M6 binding validates only
+    /// the wire field. Left unchecked, `into_group` would persist the group
+    /// under the attacker-chosen embedded id — seeding or overwriting an
+    /// arbitrary session/group slot the wire-id checks never inspected, the
+    /// same hijack SEC-M6 blocks, reached through the identifier it does not
+    /// cover. Rejecting binds the two before any state is written.
+    #[error(
+        "Welcome group-id mismatch: wire slot '{expected}', Welcome installs under '{embedded}'"
+    )]
+    WelcomeGroupIdMismatch {
+        /// The wire `group_id` the caller authenticated and keys storage by.
+        expected: String,
+        /// The group id embedded in the Welcome's GroupContext (attacker-chosen).
+        embedded: String,
+    },
 }

--- a/crates/offline-protocol-mls/src/group.rs
+++ b/crates/offline-protocol-mls/src/group.rs
@@ -293,6 +293,38 @@ impl GroupManager {
         }
     }
 
+    /// Binds a staged Welcome to the `group_id` the caller authenticated.
+    ///
+    /// OpenMLS derives the id it persists the joined group under from the
+    /// Welcome's embedded `GroupContext` — a value the inviter picks freely at
+    /// group creation (`MlsGroup::new_with_group_id`). Our storage marker
+    /// ([`save_group`]) and every [`load_group`]/`delete_group` lookup are
+    /// instead keyed by the caller-supplied wire `group_id`, and every
+    /// SEC-M5/M6 binding (`verify_welcome_slot`, the `session:`
+    /// reserved-namespace check) validates only that wire field. If the two
+    /// diverge, `into_group` writes the group under the *embedded* id, letting
+    /// an authenticated inviter seed or overwrite an arbitrary slot the
+    /// wire-id checks never inspected (e.g. embed `session:alice:bob` behind a
+    /// benign wire id that passes `verify_welcome_slot`) and hijack the
+    /// victim's session. Assert the two agree *before* `into_group` so no
+    /// cross-slot state is ever persisted. Legitimate Welcomes always carry
+    /// embedded == wire (both created via `new_with_group_id(group_id)`), so
+    /// this only rejects forgeries.
+    ///
+    /// Staging has already consumed the one-time key package by this point;
+    /// that only burns the package (inherent to any Welcome processing) and
+    /// does not touch existing group state.
+    fn verify_staged_group_id(staged: &StagedWelcome, group_id: &GroupId) -> Result<()> {
+        let embedded = staged.group_context().group_id().as_slice();
+        if embedded != group_id.as_str().as_bytes() {
+            return Err(MlsError::WelcomeGroupIdMismatch {
+                expected: group_id.to_string(),
+                embedded: String::from_utf8_lossy(embedded).into_owned(),
+            });
+        }
+        Ok(())
+    }
+
     /// Joins a group using a Welcome message.
     pub fn join_group(&self, welcome: Welcome, group_id: &GroupId) -> Result<MlsGroup> {
         let group_config = MlsGroupJoinConfig::builder()
@@ -300,8 +332,15 @@ impl GroupManager {
             .sender_ratchet_configuration(sender_ratchet_configuration())
             .build();
 
-        let group = StagedWelcome::new_from_welcome(&self.provider, &group_config, welcome, None)
-            .map_err(|e| MlsError::WelcomeProcessing(format!("Failed to stage welcome: {}", e)))?
+        let staged = StagedWelcome::new_from_welcome(&self.provider, &group_config, welcome, None)
+            .map_err(|e| MlsError::WelcomeProcessing(format!("Failed to stage welcome: {}", e)))?;
+
+        // Bind the Welcome's embedded group id to the authenticated wire id
+        // before persisting — otherwise `into_group` would install under the
+        // attacker-chosen embedded id. See `verify_staged_group_id`.
+        Self::verify_staged_group_id(&staged, group_id)?;
+
+        let group = staged
             .into_group(&self.provider)
             .map_err(|e| MlsError::WelcomeProcessing(format!("Failed to join group: {}", e)))?;
 
@@ -345,6 +384,14 @@ impl GroupManager {
         // A failure here leaves the existing group untouched (benign duplicate).
         let staged = StagedWelcome::new_from_welcome(&self.provider, &group_config, welcome, None)
             .map_err(|e| MlsError::WelcomeProcessing(format!("Failed to stage welcome: {}", e)))?;
+
+        // Bind the Welcome's embedded group id to the authenticated wire id
+        // before the destructive replace below. A forged Welcome whose embedded
+        // id differs from `group_id` would otherwise `into_group` under the
+        // embedded id and hijack that slot; rejecting here also leaves the
+        // existing group at `group_id` untouched (no `delete_group` runs). See
+        // `verify_staged_group_id`.
+        Self::verify_staged_group_id(&staged, group_id)?;
 
         // Staging consumed the key package; from here a failure is not
         // recoverable by retrying the same Welcome. Drop the prior group so its

--- a/crates/offline-protocol-mls/src/manager.rs
+++ b/crates/offline-protocol-mls/src/manager.rs
@@ -1430,6 +1430,111 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_join_group_rejects_embedded_group_id_mismatch() {
+        // Regression (HIGH-1): OpenMLS persists a joined group under the group
+        // id embedded in the Welcome's GroupContext — a value the inviter picks
+        // freely at creation (`new_with_group_id`) — while our storage marker
+        // and every load/delete lookup key off the *wire* `group_id`, which is
+        // all the SEC-M5/M6 bindings validate. If the two diverge, `into_group`
+        // would install the group under the attacker's embedded id: an
+        // arbitrary slot the wire-id checks never inspected. The join must bind
+        // embedded == wire and reject before any state is written.
+        let bob = create_test_manager("bob");
+        let mallory = create_test_manager("mallory");
+
+        // Mallory builds a real group whose EMBEDDED id is one value...
+        let bob_kp = bob.generate_key_package().unwrap();
+        let embedded = GroupId::new("group:11111111-1111-4111-8111-111111111111").unwrap();
+        let cred = mallory.get_credential().unwrap();
+        let signer = mallory.get_signer().unwrap();
+        mallory
+            .group_manager
+            .create_group(&embedded, &cred, &signer)
+            .unwrap();
+        let (welcome, _commit) = mallory
+            .add_group_member(&embedded, &bob_kp.key_package_data)
+            .unwrap();
+        assert_eq!(welcome.group_id, embedded);
+
+        // ...but presents it under a DIFFERENT wire group_id. The wire id clears
+        // the reserved-namespace guard (not `session:`), so only the embedded-id
+        // binding stands between the attacker and an arbitrary slot.
+        let wire = GroupId::new("group:22222222-2222-4222-8222-222222222222").unwrap();
+        let tampered = WelcomeMessage {
+            group_id: wire.clone(),
+            ..welcome
+        };
+
+        let err = bob.join_group(&tampered).unwrap_err();
+        assert!(
+            matches!(err, MlsError::WelcomeGroupIdMismatch { .. }),
+            "expected WelcomeGroupIdMismatch, got {:?}",
+            err
+        );
+
+        // Nothing was installed under EITHER id — the reject precedes into_group.
+        assert!(bob.group_manager.load_group(&wire).unwrap().is_none());
+        assert!(bob.group_manager.load_group(&embedded).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_welcome_embedded_id_cannot_hijack_session_slot() {
+        // Regression (HIGH-1, the SEC-M6 hijack reached through the embedded id).
+        // Bob has a live 1:1 session with Alice at `session:alice:bob`. Mallory,
+        // authenticating honestly as herself with a wire `group_id` that PASSES
+        // `verify_welcome_slot` (`session:bob:mallory`), sends a Welcome whose
+        // *embedded* GroupContext id squats `session:alice:bob`. Without the
+        // embedded-id binding, `into_group` overwrites Bob's Alice session so his
+        // next `encrypt_for_user("alice")` encrypts to Mallory's group. The
+        // binding must reject it and leave Bob's Alice session intact.
+        let alice = create_test_manager("alice");
+        let bob = create_test_manager("bob");
+        let bob_kp = bob.generate_key_package().unwrap();
+        alice
+            .import_key_package("bob", &bob_kp.key_package_data)
+            .unwrap();
+        let welcome = alice.create_session("bob").unwrap();
+        bob.join_session(&welcome).unwrap();
+        assert!(bob.has_session("alice").unwrap());
+
+        // Mallory crafts a group whose embedded id squats bob's alice slot.
+        let mallory = create_test_manager("mallory");
+        let bob_kp2 = bob.generate_key_package().unwrap();
+        let squat = GroupId::new("session:alice:bob").unwrap();
+        let cred = mallory.get_credential().unwrap();
+        let signer = mallory.get_signer().unwrap();
+        mallory
+            .group_manager
+            .create_group(&squat, &cred, &signer)
+            .unwrap();
+        let (mal_welcome, _commit) = mallory
+            .add_group_member(&squat, &bob_kp2.key_package_data)
+            .unwrap();
+
+        // Present it under a wire slot that passes verify_welcome_slot for mallory.
+        let attack = WelcomeMessage {
+            group_id: GroupId::new("session:bob:mallory").unwrap(),
+            welcome_data: mal_welcome.welcome_data,
+            inviter_id: "mallory".to_string(),
+            group_name: None,
+            timestamp_ms: 0,
+        };
+
+        let err = bob.join_session(&attack).unwrap_err();
+        assert!(
+            matches!(err, MlsError::WelcomeGroupIdMismatch { .. }),
+            "expected WelcomeGroupIdMismatch, got {:?}",
+            err
+        );
+
+        // Bob's Alice session survived and still encrypts to Alice's group.
+        assert!(bob.has_session("alice").unwrap());
+        let ct = bob.encrypt_for_user("alice", b"still private").unwrap();
+        let pt = alice.decrypt_from_user(&ct, "bob").unwrap();
+        assert_eq!(pt.as_deref(), Some(&b"still private"[..]));
+    }
+
     /// Builds a two-member group (alice admin, bob member) for group
     /// sender-binding tests. Returns (alice, bob, group_id).
     fn create_test_group_with_bob() -> (MlsManager, MlsManager, GroupId) {

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -6515,17 +6515,24 @@ fn test_plaintext_removal_notification_from_non_admin_member_rejected() {
 }
 
 #[test]
-fn test_plaintext_removal_notification_from_relay_allowed() {
+fn test_plaintext_removal_notification_from_nonmember_naming_admin_rejected() {
+    // Regression (HIGH-2): a non-member must not force-evict the victim by
+    // naming a real admin in the unauthenticated `removed_by` payload field.
+    // Authorization is bound to the authenticated wire `sender`, never
+    // `removed_by`. A genuine relay-forwarded removal keeps the removing admin
+    // as `message.sender` (relaying preserves origin, hop_count > 0), so it is
+    // covered by the admin-sender path (see
+    // `test_plaintext_removal_notification_from_admin_cleans_up`); a frame whose
+    // `sender` is a non-member relay/attacker carries no authenticated claim on
+    // behalf of the admin and must be dropped.
     let (mut protocol, events) = setup_started_with_events();
 
-    // Create a group — "user123" (test default) is creator/admin
-    let info = protocol.create_group("Relay Test").unwrap();
+    // Create a group — "user123" (test default) is creator/admin.
+    let info = protocol.create_group("Relay Evict Forgery Test").unwrap();
     let group_id = info.group_id.as_str().to_string();
 
-    // Simulate a relay-originated removal notification.
-    // The relay server ("relay-server") is NOT in the group member list.
-    // The removed_by field must reference a verified admin ("user123")
-    // so the handler can validate the removal is legitimate.
+    // A non-member sender names the real admin ("user123") in removed_by,
+    // trying to evict the local node from its own group.
     let payload = crate::protocol::GroupMemberRemovedPayload {
         group_id: group_id.clone(),
         user_id: "user123".to_string(),
@@ -6540,14 +6547,19 @@ fn test_plaintext_removal_notification_from_relay_allowed() {
     let result = protocol.process_internal_message(&message);
     assert!(matches!(result, Some(InternalMessageResult::Consumed)));
 
-    // Event should be emitted (removed_by is a verified admin)
+    // No eviction: the non-member sender is not an admin, so a real admin named
+    // in `removed_by` does not authorize the removal.
     let events = events.lock().unwrap();
-    let removal = events
-        .iter()
-        .find(|e| matches!(e, Event::GroupMemberRemoved { .. }));
     assert!(
-        removal.is_some(),
-        "Should emit GroupMemberRemoved from relay when removed_by is verified admin"
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::GroupMemberRemoved { .. })),
+        "Non-member naming an admin in removed_by must not force eviction"
+    );
+    drop(events);
+    assert!(
+        protocol.group_mesh.members.contains_key(&group_id),
+        "Group state must remain intact after a forged removal from a non-member"
     );
 }
 

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -996,30 +996,27 @@ impl OfflineProtocol {
                 // so we don't retain a stale group that can't encrypt/decrypt.
                 let self_removed = payload.user_id == self.config.user_id;
                 if self_removed {
-                    // SECURITY: Verify the sender is authorized to remove us.
-                    // If the sender is a known group member, they must be an admin.
-                    // If the sender is not a member (e.g. relay server), verify
-                    // that removed_by in the payload is a known admin to prevent
-                    // arbitrary non-member senders from forging removals.
-                    let sender_is_member = self
-                        .group_mesh
-                        .members
-                        .get(&payload.group_id)
-                        .map(|m| m.contains(&sender.to_string()))
-                        .unwrap_or(false);
-                    let admin_to_verify = if sender_is_member {
-                        sender
-                    } else {
-                        &payload.removed_by
-                    };
-                    match self.check_is_admin(&payload.group_id, admin_to_verify) {
+                    // SECURITY (HIGH-2): authorize this destructive local
+                    // teardown off the authenticated wire `sender`, never the
+                    // attacker-controlled `payload.removed_by`. A legitimate
+                    // removal notification is sent directly by the removing admin
+                    // (`remove_member` → `send_internal_message(member_id, …)`),
+                    // so its `sender` IS that admin. Requiring the sender to be
+                    // an admin matches every sibling membership handler (role
+                    // change, rename, commit) and forces a forger to impersonate
+                    // an admin identity — which the control-frame signature +
+                    // TOFU gate rejects for any pinned admin. The prior
+                    // `removed_by` fallback authenticated nothing: `removed_by`
+                    // is an unauthenticated payload field, so naming any real
+                    // admin passed the check and let an unpinned non-member
+                    // force-evict the victim (dropping local MLS group state).
+                    match self.check_is_admin(&payload.group_id, sender) {
                         Ok(true) => {}
                         Ok(false) => {
                             error!(
                                 sender = %sender,
-                                verified_id = %admin_to_verify,
                                 group_id = %payload.group_id,
-                                "SECURITY: Group removal notification with unverifiable admin, ignoring"
+                                "SECURITY: Group removal notification from non-admin sender, ignoring"
                             );
                             return;
                         }


### PR DESCRIPTION
## Summary

A second-pass security re-audit (multi-agent identify → adversarial-verify) turned up **two HIGH-severity holes in the group/session messaging layer**, one of which *defeats the SEC-M6 fix that just merged*. This closes both. The crypto primitives (OsRng, ciphersuite pinning, SEC-M1 sender auth, SEC-M5 key-package binding, wire bounds-checks, DORS metrics, the UniFFI boundary) all came back clean.

Two commits, one per fix — they're independent and land in different crates.

## SEC-M6 was bypassable via the Welcome's *embedded* group id

`verify_welcome_slot` and the `session:` reserved-namespace guard both validate `WelcomeMessage.group_id` — the **wire** field. But OpenMLS persists a joined group under the id embedded in the Welcome's `GroupContext`, which the inviter picks freely via `new_with_group_id`. Our storage marker and every `load`/`delete` key off the wire id, and nothing checked the two agree.

**Exploit:** an authenticated contact sends a Welcome with wire id `session:bob:mallory` (passes `verify_welcome_slot`) but embedded id `session:alice:bob`. `into_group` overwrites Bob's real Alice session; Bob's next `encrypt_for_user("alice")` encrypts to Mallory's group. Same hole via the group-Welcome path.

**Fix:** after staging, before `into_group`, assert the staged group's real `GroupContext` id equals the wire `group_id` (new `MlsError::WelcomeGroupIdMismatch`). Enforced in both `join_group` and `join_group_replacing`, so the session- and group-Welcome paths are covered at one choke point. Legit Welcomes always have embedded == wire, so only forgeries are rejected.

## Unauthenticated forced group eviction

The `__GROUP_MEMBER_REMOVED__` self-removal path authorized off the attacker-controlled `payload.removed_by` field (via `check_is_admin`, a pure role lookup with no origin binding) whenever the wire `sender` wasn't a cached member. Default config accepts unsigned frames from unpinned senders.

**Exploit:** any non-member who knows a group id and one admin's id (a former member, a relay node that saw group traffic, anyone) sends an unsigned `__GROUP_MEMBER_REMOVED__{removed_by: <admin>}` → victim runs `leave_group`, tears down caches, is evicted. No credentials required.

**Fix:** authorize off the authenticated wire `sender` and require *it* to be an admin — matching every sibling membership handler. A real removal is sent straight from the removing admin (so its `sender` is that admin; relayed copies keep the admin as `sender` with `hop_count > 0`). A forger now has to impersonate an admin identity, which the signature + TOFU gate rejects for any pinned admin. The `removed_by` fallback is gone.
