### PR TITLE
fix(protocol): authenticate group message + membership handlers off the sender

### DIFF
--- a/crates/offline-protocol-mls/src/manager.rs
+++ b/crates/offline-protocol-mls/src/manager.rs
@@ -762,6 +762,18 @@ impl MlsManager {
         Ok(Some(info))
     }
 
+    /// Returns `true` if local MLS group state exists for `group_id`.
+    ///
+    /// This is the authoritative test for "do we actually participate in this
+    /// group via MLS" — it gates on the stored group marker, not the member
+    /// send-cache (which relay reconciliation can populate without any MLS
+    /// state). Callers use it to distinguish a genuine legacy relay-only
+    /// (unencrypted) group, which has no MLS state, from an unauthenticated
+    /// plaintext frame spoofed against a group the node secures with MLS.
+    pub fn has_group(&self, group_id: &GroupId) -> Result<bool> {
+        Ok(self.group_manager.load_group(group_id)?.is_some())
+    }
+
     /// Updates the group name.
     pub fn set_group_name(&self, group_id: &GroupId, name: &str) -> Result<()> {
         let mut metadata = self

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -3561,6 +3561,35 @@ impl OfflineProtocol {
     // RELAY INBOUND — MLS-AWARE ROUTING
     // ========================================================================
 
+    /// Returns `true` if we hold local MLS state for `group_id`.
+    ///
+    /// The raw-emit fallbacks in [`Self::handle_relay_group_message_with_mls`]
+    /// attribute unauthenticated plaintext to a caller-supplied `sender`. That
+    /// is only ever acceptable for a genuine legacy relay-only (unencrypted)
+    /// group, which has no MLS state. If we secure this group with MLS, a real
+    /// member always sends MLS ciphertext, so plaintext naming the group is a
+    /// spoof — this test lets the caller drop it rather than surface a message
+    /// forged in a trusted member's name.
+    ///
+    /// Fail-closed: when MLS is initialized but the lookup cannot complete
+    /// (lock poisoned, invalid id), assume state may exist and return `true`
+    /// so a transient fault can never be leveraged to force a plaintext spoof
+    /// through. When MLS is not initialized at all, there is no group to
+    /// secure, so return `false` (genuine legacy).
+    fn has_mls_group_state(&self, group_id: &str) -> bool {
+        if !self.is_mls_initialized() {
+            return false;
+        }
+        let Ok(gid) = offline_protocol_mls::GroupId::new(group_id) else {
+            // An id we cannot even construct names no real MLS group.
+            return false;
+        };
+        match self.read_mls_guard() {
+            Ok(guard) => guard.has_group(&gid).unwrap_or(true),
+            Err(_) => true,
+        }
+    }
+
     /// Handles an inbound relay group message by routing through MLS
     /// decryption.
     ///
@@ -3571,7 +3600,11 @@ impl OfflineProtocol {
     /// messages are buffered for deferred retry. Content that is not MLS
     /// ciphertext (base64-undecodable, or base64 that is not MLS wire
     /// framing for a group without local state) is a legacy relay-only
-    /// group message and is emitted raw.
+    /// group message and is emitted raw — but only for a group we do *not*
+    /// secure with MLS. Plaintext naming a group we hold MLS state for is a
+    /// sender-spoofing attempt (a real member sends ciphertext) and is
+    /// dropped, since the raw emit would attribute attacker content to a
+    /// trusted member with no authentication.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn handle_relay_group_message_with_mls(
         &mut self,
@@ -3604,7 +3637,29 @@ impl OfflineProtocol {
         let ciphertext_bytes = match base64_decode(content) {
             Ok(bytes) => bytes,
             Err(_) => {
-                // Not ciphertext — emit as plaintext
+                // Plaintext content naming a group we secure with MLS cannot be
+                // legitimate: a real member always sends MLS ciphertext (which
+                // is base64 and decodes here). Emitting it raw would attribute
+                // attacker-chosen content to the unauthenticated inner `sender`
+                // — a message forged in a trusted member's name. Drop it. Only
+                // a genuine legacy relay-only group (no local MLS state) may be
+                // emitted as plaintext.
+                if self.has_mls_group_state(group_id) {
+                    warn!(
+                        group_id = %group_id,
+                        sender = %sender,
+                        "SECURITY: dropping non-MLS plaintext naming an MLS-secured group (sender spoofing)"
+                    );
+                    self.emit_event(Event::security_warning(
+                        sender.to_string(),
+                        crate::events::SecurityWarningCode::PlaintextReceiveRejected,
+                        "Plaintext group message rejected: the named group is secured with MLS, \
+                         so unauthenticated plaintext cannot be attributed to the claimed sender"
+                            .to_string(),
+                    ));
+                    return;
+                }
+                // Not ciphertext and no MLS state — legacy relay-only group.
                 self.emit_event(Event::group_message_received(
                     group_id.to_string(),
                     sender.to_string(),

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -2960,6 +2960,55 @@ fn test_handle_relay_group_message_mls_decrypt() {
 }
 
 #[test]
+fn test_relay_group_plaintext_naming_mls_group_is_dropped_not_spoofed() {
+    // Regression (group-message spoofing): the base64-undecodable raw-emit
+    // fallback attributes attacker-chosen content to the unauthenticated inner
+    // `sender`. For a group we secure with MLS, a real member always sends MLS
+    // ciphertext, so plaintext naming that group is a forgery and must be
+    // dropped rather than surfaced as a message from a trusted member. Only a
+    // genuine legacy relay-only group (no local MLS state) may emit plaintext
+    // (covered by `test_handle_relay_group_message_plaintext_passthrough`).
+    let (_alice, mut bob, group_id) = setup_alice_bob_group("Spoof Test");
+
+    let bob_events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = bob_events.clone();
+    bob.on_event(move |event| {
+        events_clone.lock().unwrap().push(event);
+    });
+
+    // Non-base64 plaintext naming Bob's real MLS group, forged as "alice".
+    bob.handle_relay_group_message_with_mls(
+        &group_id,
+        "alice",
+        "Spoofed message! definitely not base64",
+        "2026-03-13T00:00:00Z",
+        "msg-spoof-001",
+        None,
+        None,
+    );
+
+    let events = bob_events.lock().unwrap();
+    // The spoofed content must NOT be surfaced.
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            Event::GroupMessageReceived { content, .. }
+                if content == "Spoofed message! definitely not base64"
+        )),
+        "Plaintext naming an MLS-secured group must not be emitted as a group message"
+    );
+    // And the rejection must be observable as a security warning.
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            Event::SecurityWarning { reason_code, .. }
+                if *reason_code == crate::events::SecurityWarningCode::PlaintextReceiveRejected
+        )),
+        "Dropping a spoofed plaintext group message should emit a PlaintextReceiveRejected warning"
+    );
+}
+
+#[test]
 fn test_handle_relay_group_message_mls_unavailable_drops_message() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
     // Deliberately NOT initializing MLS
@@ -6594,6 +6643,79 @@ fn test_plaintext_removal_notification_from_relay_unverifiable_rejected() {
     assert!(
         removal.is_none(),
         "Should NOT process removal from non-member sender with unverifiable removed_by"
+    );
+}
+
+#[test]
+fn test_other_member_removal_from_non_admin_does_not_poison_send_cache() {
+    // Regression (fan-out cache poisoning): the "another member was removed"
+    // branch mutates `group_mesh.members`, the authority for group message
+    // fan-out. It must authorize off the authenticated wire `sender` (an
+    // admin), never the payload-named `removed_by` — otherwise any non-member
+    // could drop a real member from our send cache and silently deny them our
+    // group messages.
+    let (mut protocol, events) = setup_started_with_events();
+
+    let info = protocol.create_group("Cache Poison Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Promote "admin_alice" to admin and seed the send cache with a real
+    // member "bob" whom the attacker will try to drop.
+    {
+        let mls = protocol.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id).unwrap();
+        mls.set_member_role(&gid, "admin_alice", GroupRole::Admin)
+            .unwrap();
+    }
+    protocol.group_mesh.members.insert(
+        group_id.clone(),
+        vec![
+            "user123".to_string(),
+            "admin_alice".to_string(),
+            "bob".to_string(),
+        ],
+    );
+
+    // Non-admin "eve" forges a removal of "bob", naming the real admin in
+    // `removed_by`. Authorization is off `sender` (eve), not `removed_by`.
+    let payload = crate::protocol::GroupMemberRemovedPayload {
+        group_id: group_id.clone(),
+        user_id: "bob".to_string(),
+        removed_by: "admin_alice".to_string(),
+    };
+    let content = format!(
+        "{}{}",
+        internal_prefixes::GROUP_MEMBER_REMOVED,
+        serde_json::to_string(&payload).unwrap()
+    );
+    let message = make_message("eve", "user123", &content);
+    let result = protocol.process_internal_message(&message);
+    assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+
+    // bob must remain in the send cache, and no forged roster event fires.
+    {
+        let events = events.lock().unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::GroupMemberRemoved { .. })),
+            "Forged other-member removal from a non-admin must not emit an event"
+        );
+        let members = protocol.group_mesh.members.get(&group_id).unwrap();
+        assert!(
+            members.contains(&"bob".to_string()),
+            "Non-admin removal must not drop a real member from the fan-out cache"
+        );
+    }
+
+    // The same removal from the authenticated admin IS honored.
+    let message = make_message("admin_alice", "user123", &content);
+    let result = protocol.process_internal_message(&message);
+    assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+    let members = protocol.group_mesh.members.get(&group_id).unwrap();
+    assert!(
+        !members.contains(&"bob".to_string()),
+        "An admin-authorized removal should drop the member from the cache"
     );
 }
 

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -1059,9 +1059,46 @@ impl OfflineProtocol {
                         .relay_register_pending
                         .remove(&payload.group_id);
                 } else {
-                    // Another member was removed — just update the cache
-                    if let Some(members) = self.group_mesh.members.get_mut(&payload.group_id) {
-                        members.retain(|m| m != &payload.user_id);
+                    // Another member was removed. This mutates the group
+                    // fan-out send cache (`group_mesh.members`), which
+                    // `send_group_message_inner` reads verbatim — dropping a
+                    // real member here silently denies them our group messages
+                    // until the next commit's `refresh_group_members`. So
+                    // authorize it off the authenticated wire `sender`, never
+                    // the payload-named `removed_by`, exactly like the
+                    // self-removal branch above and every sibling membership
+                    // handler. `removed_by` is unauthenticated payload content;
+                    // naming a real admin in it is free. The SDK only sends
+                    // `__GROUP_MEMBER_REMOVED__` directly to the removed member
+                    // (see `remove_from_group`), so a frame naming a third
+                    // party is an admin's relay reconciliation or a forgery —
+                    // requiring the sender to be an admin drops the forgeries.
+                    match self.check_is_admin(&payload.group_id, sender) {
+                        Ok(true) => {
+                            if let Some(members) =
+                                self.group_mesh.members.get_mut(&payload.group_id)
+                            {
+                                members.retain(|m| m != &payload.user_id);
+                            }
+                        }
+                        Ok(false) => {
+                            error!(
+                                sender = %sender,
+                                group_id = %payload.group_id,
+                                removed = %payload.user_id,
+                                "SECURITY: Group member-removal from non-admin sender, ignoring"
+                            );
+                            return;
+                        }
+                        Err(e) => {
+                            warn!(
+                                sender = %sender,
+                                group_id = %payload.group_id,
+                                error = %e,
+                                "Failed to verify admin status for member-removal notification"
+                            );
+                            return;
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

A second-pass security audit found that **two siblings of the just-landed HIGH-2 eviction fix** (#152) still authorized off attacker-controlled payload fields instead of the authenticated wire `sender`. Both are exploitable by an unpinned **non-member** (unsigned control frames pass under the default `require_transport_identity = false`) against a group the victim secures with MLS. Neither is mitigated by the default `require_encryption = true` (that gates the send path, not these receive paths).

### 1. Group-message spoofing (HIGH)
`handle_relay_group_message_with_mls`'s base64-undecodable raw-emit fallback attributed content to the unauthenticated **inner** `payload.sender`. A non-member could send a `__GROUP_MSG__` frame with non-base64 content and `sender=<trusted member>`, and the victim's app rendered a fully spoofed group message from that member — defeating group-message sender authenticity, the core guarantee MLS provides.

**Fix:** plaintext naming a group we hold local MLS state for is now **dropped** (with a `PlaintextReceiveRejected` security warning) — a real member always sends MLS ciphertext. Only a genuine legacy relay-only group (no local MLS state) may still emit plaintext. Adds `MlsManager::has_group` as the authoritative "do we secure this group via MLS" test (stored group marker, not the relay-populated send cache). The `NotMlsCiphertext` branch is provably reachable only on `GroupNotFound`, so it is already legacy-only.

### 2. Fan-out cache poisoning (HIGH)
The `__GROUP_MEMBER_REMOVED__` *other-member* branch dropped `payload.user_id` from `group_mesh.members` with **no authorization**. Since `send_group_message_inner` reads that cache verbatim, any non-member could silently deny a real member our group messages (targeted, repeatable, until the next commit's `refresh_group_members`), plus forge a roster event.

**Fix:** authorize the cache mutation off `check_is_admin(sender)`, mirroring the self-removal branch and every sibling membership handler. The SDK only ever sends `__GROUP_MEMBER_REMOVED__` directly to the removed member, so no legitimate other-member flow is affected.

## Tests
- `test_relay_group_plaintext_naming_mls_group_is_dropped_not_spoofed`
- `test_other_member_removal_from_non_admin_does_not_poison_send_cache`

823 protocol + 40 mls tests green, `cargo fmt --all --check` clean, `cargo clippy --lib -D warnings` clean.

## Not in scope (deferred)
The same audit flagged, at MEDIUM or below and left open by request: `__GROUP_MEMBER_ADDED__` phantom-member injection, an unbounded/reboot-durable `pending_key_packages` map, 1:1↔group reflection (local UI context-confusion only), and `__MLS_KEY_PKG__` session_reset teardown.