### PR TITLE
fix(protocol): authorize group-member-added off the relay path; cap pending key packages

### DIFF
--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -6786,6 +6786,51 @@ fn test_group_member_added_from_mesh_is_dropped_not_cache_poisoned() {
     );
 }
 
+#[test]
+fn test_group_member_added_over_internet_accepted_regardless_of_sender_documents_residual() {
+    // Documents the accepted residual of the H1 gate: the Internet-arrival
+    // check stops BLE/WiFi-mesh forgery but does NOT authenticate a malicious
+    // Internet peer relaying content through the store-and-forward relay. We
+    // deliberately do not additionally gate on the wire `sender` being an admin
+    // (as `__GROUP_MEMBER_REMOVED__` does): the mobile bindings synthesize this
+    // frame with `sender = added_by`, falling back to the literal "relay" when
+    // the relay notification omits `added_by`, so an admin check would drop
+    // those legitimate reconciliations. The residual is bounded — a spliced
+    // phantom is never in the MLS group and cannot decrypt (metadata leak
+    // only). This test locks the behavior so any future sender-based check is a
+    // conscious, reviewed change rather than an accidental regression.
+    let (mut protocol, _events) = setup_started_with_events();
+
+    let info = protocol.create_group("Residual Doc Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+    protocol
+        .group_mesh
+        .members
+        .insert(group_id.clone(), vec!["user123".to_string()]);
+
+    let payload = crate::protocol::GroupMemberAddedPayload {
+        group_id: group_id.clone(),
+        user_id: "eve".to_string(),
+        added_by: "user123".to_string(),
+        group_name: None,
+    };
+    let content = format!(
+        "{}{}",
+        internal_prefixes::GROUP_MEMBER_ADDED,
+        serde_json::to_string(&payload).unwrap()
+    );
+
+    // An arbitrary, non-admin, non-member `sender` over the Internet relay path.
+    let message = make_message("mallory", "user123", &content);
+    let result = protocol.process_internal_message_via(&message, Some(TransportType::Internet));
+    assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+    let members = protocol.group_mesh.members.get(&group_id).unwrap();
+    assert!(
+        members.contains(&"eve".to_string()),
+        "Internet-arrival GROUP_MEMBER_ADDED is accepted regardless of sender (documented residual)"
+    );
+}
+
 // ========================================================================
 // KEY PACKAGE REPLENISHMENT AFTER WELCOME
 // ========================================================================

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -6719,6 +6719,73 @@ fn test_other_member_removal_from_non_admin_does_not_poison_send_cache() {
     );
 }
 
+#[test]
+fn test_group_member_added_from_mesh_is_dropped_not_cache_poisoned() {
+    // Regression (H1): `__GROUP_MEMBER_ADDED__` splices `payload.user_id` into
+    // `group_mesh.members`, the group fan-out send cache that
+    // `send_group_message_inner` reads verbatim. It is a relay reconciliation
+    // frame injected by the mobile bindings from a relay notification, so it
+    // only ever legitimately arrives over the Internet transport (a real MLS
+    // add is surfaced from the authenticated roster by `refresh_group_members`,
+    // not through this handler). Without the arrival gate, a mesh/BLE peer that
+    // forges this frame injects itself as a silent recipient of every
+    // subsequent group MLS ciphertext (a membership/activity metadata leak) and
+    // forges a roster event. A non-Internet arrival must be dropped; an
+    // Internet arrival is honored.
+    let (mut protocol, events) = setup_started_with_events();
+
+    let info = protocol.create_group("Add Poison Test").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    // Seed the fan-out cache with the real roster.
+    protocol
+        .group_mesh
+        .members
+        .insert(group_id.clone(), vec!["user123".to_string()]);
+
+    let payload = crate::protocol::GroupMemberAddedPayload {
+        group_id: group_id.clone(),
+        user_id: "eve".to_string(),
+        added_by: "user123".to_string(),
+        group_name: None,
+    };
+    let content = format!(
+        "{}{}",
+        internal_prefixes::GROUP_MEMBER_ADDED,
+        serde_json::to_string(&payload).unwrap()
+    );
+
+    // (1) Mesh arrival (non-Internet) must be dropped: no cache mutation, no
+    // roster event.
+    let message = make_message("eve", "user123", &content);
+    let result = protocol.process_internal_message_via(&message, Some(TransportType::BLE));
+    assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+    {
+        let members = protocol.group_mesh.members.get(&group_id).unwrap();
+        assert!(
+            !members.contains(&"eve".to_string()),
+            "Mesh-forged __GROUP_MEMBER_ADDED__ must not splice a phantom into the fan-out cache"
+        );
+        let events = events.lock().unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::GroupMemberAdded { .. })),
+            "Mesh-forged __GROUP_MEMBER_ADDED__ must not emit a roster event"
+        );
+    }
+
+    // (2) The same frame delivered over the Internet relay path is honored.
+    let message = make_message("user123", "user123", &content);
+    let result = protocol.process_internal_message_via(&message, Some(TransportType::Internet));
+    assert!(matches!(result, Some(InternalMessageResult::Consumed)));
+    let members = protocol.group_mesh.members.get(&group_id).unwrap();
+    assert!(
+        members.contains(&"eve".to_string()),
+        "Internet-arrival relay reconciliation should update the fan-out cache"
+    );
+}
+
 // ========================================================================
 // KEY PACKAGE REPLENISHMENT AFTER WELCOME
 // ========================================================================

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -5,7 +5,7 @@ use super::{
     GroupCreatedPayload, GroupErrorPayload, GroupInfoPayload, GroupMemberAddedPayload,
     GroupMemberRemovedPayload, GroupMessageReceivedPayload, InternalMessageResult,
     KeyPackagePayload, OfflineProtocol, PresencePayload, ReadReceiptPayload, ReceivedKeyPackage,
-    TypingIndicatorPayload, UserGroupsPayload, MAX_READ_RECEIPT_IDS,
+    TypingIndicatorPayload, UserGroupsPayload, MAX_PENDING_KEY_PACKAGES, MAX_READ_RECEIPT_IDS,
 };
 use crate::events::{DecryptionFailureCode, Event};
 use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsOperationContext};
@@ -61,6 +61,35 @@ impl OfflineProtocol {
                 key_package_data: payload.key_package_data,
                 local_expires_at_ms,
             };
+            // SECURITY (resource exhaustion): `pending_key_packages` is keyed by
+            // the wire-claimed `sender`, and every insert also writes a durable
+            // entry via `persist_peer_key_package` (iOS Keychain / Android
+            // Keystore). Under the default config an unpinned peer can flood
+            // distinct forged senders, so bound the map exactly like
+            // `known_peers`: at capacity, evict the soonest-to-expire entry and
+            // drop its persisted copy before inserting, so neither memory nor
+            // durable storage grows without bound or survives a reboot
+            // re-inflated. A refreshed existing peer (already present) never
+            // triggers eviction.
+            if !self.pending_key_packages.contains_key(sender)
+                && self.pending_key_packages.len() >= MAX_PENDING_KEY_PACKAGES
+            {
+                if let Some(victim) = self
+                    .pending_key_packages
+                    .iter()
+                    .min_by_key(|(_, p)| p.local_expires_at_ms)
+                    .map(|(id, _)| id.clone())
+                {
+                    debug!(
+                        peer_id = %sender,
+                        evicted = %victim,
+                        cap = MAX_PENDING_KEY_PACKAGES,
+                        "Pending key packages at capacity, evicting soonest-to-expire"
+                    );
+                    self.pending_key_packages.remove(&victim);
+                    self.delete_peer_key_package_from_storage(&victim);
+                }
+            }
             self.pending_key_packages
                 .insert(sender.to_string(), pkg.clone());
             self.persist_peer_key_package(sender, &pkg);
@@ -967,6 +996,30 @@ impl OfflineProtocol {
 
         if let Some(data) = content.strip_prefix(internal_prefixes::GROUP_MEMBER_ADDED) {
             if let Ok(payload) = serde_json::from_str::<GroupMemberAddedPayload>(data) {
+                // SECURITY: `__GROUP_MEMBER_ADDED__` is a relay reconciliation
+                // frame — the mobile bindings inject it from a relay
+                // notification that arrives over the Internet transport. It has
+                // no in-SDK mesh producer (a real MLS add is surfaced from the
+                // authenticated roster by `refresh_group_members`, not here).
+                // The mutation below splices `payload.user_id` into
+                // `group_mesh.members`, the group fan-out send cache that
+                // `send_group_message_inner` reads verbatim, so an accepted
+                // forgery makes us deliver every subsequent group MLS ciphertext
+                // to an attacker-chosen id (a silent recipient — they cannot
+                // decrypt, but it leaks membership/activity metadata) and forges
+                // a roster event. Gate on Internet arrival exactly like
+                // `__GROUP_CREATED__` above: a BLE/WiFi-mesh attacker can never
+                // present `arrival_transport == Internet`, which drops the
+                // forgery while preserving legitimate relay reconciliation.
+                if arrival_transport != Some(TransportType::Internet) {
+                    warn!(
+                        group_id = %payload.group_id,
+                        user_id = %payload.user_id,
+                        sender = %sender,
+                        "SECURITY: dropping __GROUP_MEMBER_ADDED__ not delivered over the Internet relay path (mesh forgery)"
+                    );
+                    return;
+                }
                 info!(group_id = %payload.group_id, user_id = %payload.user_id, "Group member added");
                 // Reconcile local member cache if we have MLS state for this group
                 if let Some(members) = self.group_mesh.members.get_mut(&payload.group_id) {

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -5,7 +5,8 @@ use super::{
     GroupCreatedPayload, GroupErrorPayload, GroupInfoPayload, GroupMemberAddedPayload,
     GroupMemberRemovedPayload, GroupMessageReceivedPayload, InternalMessageResult,
     KeyPackagePayload, OfflineProtocol, PresencePayload, ReadReceiptPayload, ReceivedKeyPackage,
-    TypingIndicatorPayload, UserGroupsPayload, MAX_PENDING_KEY_PACKAGES, MAX_READ_RECEIPT_IDS,
+    TypingIndicatorPayload, UserGroupsPayload, MAX_KEY_PACKAGE_LIFETIME_MS,
+    MAX_PENDING_KEY_PACKAGES, MAX_READ_RECEIPT_IDS,
 };
 use crate::events::{DecryptionFailureCode, Event};
 use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsOperationContext};
@@ -50,13 +51,22 @@ impl OfflineProtocol {
             }
 
             let now_ms = Utc::now().timestamp_millis() as u64;
-            let local_expires_at_ms = if payload.remaining_lifetime_ms > 0 {
-                now_ms.saturating_add(payload.remaining_lifetime_ms)
+            // Clamp the peer-supplied lifetime to `MAX_KEY_PACKAGE_LIFETIME_MS`.
+            // It is an unauthenticated wire field that becomes the eviction sort
+            // key (soonest-to-expire) for `pending_key_packages`; without a
+            // ceiling a flood of forged senders claiming a maximal lifetime
+            // would pin their entries as latest-to-expire and preferentially
+            // evict legitimate peers. A legacy sender omitting the field (0)
+            // falls back to the same default. This only bounds the *cached*
+            // expiry — OpenMLS enforces real key-package validity at use time.
+            let lifetime_ms = if payload.remaining_lifetime_ms > 0 {
+                payload
+                    .remaining_lifetime_ms
+                    .min(MAX_KEY_PACKAGE_LIFETIME_MS)
             } else {
-                // Legacy sender didn't include remaining_lifetime_ms;
-                // assume 30-day default lifetime.
-                now_ms.saturating_add(30 * 24 * 60 * 60 * 1000)
+                MAX_KEY_PACKAGE_LIFETIME_MS
             };
+            let local_expires_at_ms = now_ms.saturating_add(lifetime_ms);
             let pkg = ReceivedKeyPackage {
                 key_package_data: payload.key_package_data,
                 local_expires_at_ms,
@@ -1011,6 +1021,22 @@ impl OfflineProtocol {
                 // `__GROUP_CREATED__` above: a BLE/WiFi-mesh attacker can never
                 // present `arrival_transport == Internet`, which drops the
                 // forgery while preserving legitimate relay reconciliation.
+                //
+                // Residual (accepted): this does NOT authenticate a malicious
+                // *Internet* peer who can address us through the store-and-
+                // forward relay (which forwards peer content verbatim). We do
+                // not additionally gate on the wire `sender` being an admin —
+                // as the sibling `__GROUP_MEMBER_REMOVED__` path does — because
+                // this frame has no signed sender to check: the mobile bindings
+                // synthesize it from a relay notification with `sender =
+                // added_by`, falling back to the literal `"relay"` when the
+                // notification omits `added_by` (see InternetManager.{swift,kt}),
+                // so an admin check would drop those legitimate reconciliations.
+                // The residual is bounded: a spliced phantom cannot decrypt
+                // (it is never in the MLS group), so it leaks only membership/
+                // activity metadata, the `members.get_mut` guard below limits
+                // the splice to groups we already track, and crypto membership
+                // stays MLS-authoritative via `refresh_group_members`.
                 if arrival_transport != Some(TransportType::Internet) {
                     warn!(
                         group_id = %payload.group_id,

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -4,7 +4,7 @@ use super::{
     internal_prefixes, lock_shared_state, ConnectionAcceptedPayload, ConnectionRequestPayload,
     KeyPackagePayload, OfflineProtocol, OutboundMediaTransfer, OutboundSendPreparation,
     OutboxEntry, PendingMessage, PresencePayload, ProtocolState, ReadReceiptPayload,
-    TypingIndicatorPayload, WelcomeDeliveryState, MAX_READ_RECEIPT_IDS,
+    TypingIndicatorPayload, WelcomeDeliveryState, MAX_KEY_PACKAGE_SENT_TO, MAX_READ_RECEIPT_IDS,
     SEND_FAIL_REASON_RECIPIENT_UNREACHABLE,
 };
 use crate::constants::{
@@ -2417,6 +2417,16 @@ impl OfflineProtocol {
 
         match self.transport_manager.send(&message) {
             Ok(()) => {
+                // SECURITY (resource exhaustion): `key_package_sent_to` is keyed
+                // by the wire-claimed peer id, so a forged-sender key-package
+                // flood (each reply routes through here) would grow it without
+                // bound. Reset at capacity like `plaintext_receive_warned` — the
+                // only cost of forgetting a peer is one idempotent re-send.
+                if !self.key_package_sent_to.contains(peer_id)
+                    && self.key_package_sent_to.len() >= MAX_KEY_PACKAGE_SENT_TO
+                {
+                    self.key_package_sent_to.clear();
+                }
                 self.key_package_sent_to.insert(peer_id.to_string());
                 debug!(peer_id = %peer_id, message_id = %message.id, "Sent key package");
                 Ok(())

--- a/crates/offline-protocol/src/protocol/storage.rs
+++ b/crates/offline-protocol/src/protocol/storage.rs
@@ -185,25 +185,36 @@ impl OfflineProtocol {
         };
         let session_set: std::collections::HashSet<_> = sessions.into_iter().collect();
 
+        let mut pruned = 0usize;
         for peer_id in peer_ids {
+            if session_set.contains(&peer_id) {
+                continue;
+            }
             // Bound restore to the same cap as the live insert path so a
             // pre-existing over-cap durable store (e.g. a flood that landed
-            // before the cap existed) cannot re-inflate memory without limit on
-            // boot. Excess persisted entries are left on disk rather than loaded.
+            // before the cap existed) cannot re-inflate memory on boot. Rather
+            // than leaving the overflow to linger on disk forever — where it
+            // would re-inflate memory on a future boot and waste durable
+            // storage — prune it so the store shrinks to the cap in a single
+            // boot. Dropping a cached package only costs a recoverable
+            // re-exchange, exactly like the live eviction path. Overflow is
+            // deleted without loading it, so peak memory stays cap-bounded.
             if self.pending_key_packages.len() >= MAX_PENDING_KEY_PACKAGES {
-                warn!(
-                    cap = MAX_PENDING_KEY_PACKAGES,
-                    "Peer key package restore reached capacity; leaving remaining persisted entries on disk"
-                );
-                break;
-            }
-            if session_set.contains(&peer_id) {
+                self.delete_peer_key_package_from_storage(&peer_id);
+                pruned += 1;
                 continue;
             }
             if let Some(pkg) = self.load_peer_key_package_from_storage(&peer_id) {
                 info!(peer_id = %peer_id, "Restored peer key package from storage");
                 self.pending_key_packages.insert(peer_id, pkg);
             }
+        }
+        if pruned > 0 {
+            warn!(
+                cap = MAX_PENDING_KEY_PACKAGES,
+                pruned,
+                "Peer key package store exceeded the cap on restore; pruned overflow from durable storage"
+            );
         }
 
         Ok(())

--- a/crates/offline-protocol/src/protocol/storage.rs
+++ b/crates/offline-protocol/src/protocol/storage.rs
@@ -2,7 +2,8 @@
 
 use super::{
     storage_keys, OfflineProtocol, PendingMessage, ReceivedKeyPackage, SessionState,
-    WelcomeDeliveryState, WelcomeLifecycleRecord, WELCOME_LIFECYCLE_TTL_SECS,
+    WelcomeDeliveryState, WelcomeLifecycleRecord, MAX_PENDING_KEY_PACKAGES,
+    WELCOME_LIFECYCLE_TTL_SECS,
 };
 use crate::{Error, Result};
 use chrono::{Duration as ChronoDuration, Utc};
@@ -185,6 +186,17 @@ impl OfflineProtocol {
         let session_set: std::collections::HashSet<_> = sessions.into_iter().collect();
 
         for peer_id in peer_ids {
+            // Bound restore to the same cap as the live insert path so a
+            // pre-existing over-cap durable store (e.g. a flood that landed
+            // before the cap existed) cannot re-inflate memory without limit on
+            // boot. Excess persisted entries are left on disk rather than loaded.
+            if self.pending_key_packages.len() >= MAX_PENDING_KEY_PACKAGES {
+                warn!(
+                    cap = MAX_PENDING_KEY_PACKAGES,
+                    "Peer key package restore reached capacity; leaving remaining persisted entries on disk"
+                );
+                break;
+            }
             if session_set.contains(&peer_id) {
                 continue;
             }

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -7707,6 +7707,84 @@ fn test_peer_key_package_persisted_and_restored_after_restart() {
 }
 
 #[test]
+fn test_pending_key_packages_capped_evicts_soonest_to_expire() {
+    // Regression (H2): `pending_key_packages` is keyed by the wire-claimed
+    // `sender`, and every insert also writes a durable Keychain/Keystore entry,
+    // so an unpinned peer flooding distinct forged `__MLS_KEY_PKG__` senders
+    // (accepted under the default config) would grow both memory and durable
+    // storage without bound and re-inflate on every reboot. The map must be
+    // capped like `known_peers`: at capacity a new peer evicts the
+    // soonest-to-expire entry (and its persisted copy) rather than growing past
+    // the cap.
+    let mut config = create_test_config();
+    // Keep the flooded entry resident: with auto-exchange off the handler just
+    // inserts it, instead of auto-establishing and consuming it.
+    config.encryption.auto_key_exchange = false;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    let storage = Arc::new(InMemoryStorage::new());
+    protocol.initialize_mls(storage).unwrap();
+
+    // Fill the map to capacity. One entry ("victim") is the unambiguous
+    // soonest-to-expire; the rest expire far in the future.
+    protocol.pending_key_packages.insert(
+        "victim".to_string(),
+        ReceivedKeyPackage {
+            key_package_data: vec![0],
+            local_expires_at_ms: 1, // smallest expiry -> the eviction target
+        },
+    );
+    for i in 0..(MAX_PENDING_KEY_PACKAGES - 1) {
+        protocol.pending_key_packages.insert(
+            format!("filler_{i}"),
+            ReceivedKeyPackage {
+                key_package_data: vec![0],
+                local_expires_at_ms: 1_000_000_000_000 + i as u64,
+            },
+        );
+    }
+    assert_eq!(
+        protocol.pending_key_packages.len(),
+        MAX_PENDING_KEY_PACKAGES
+    );
+
+    // A new forged sender arrives — this must evict, not grow past the cap.
+    let key_pkg_payload = KeyPackagePayload {
+        user_id: "attacker".to_string(),
+        // Invalid bytes are fine: the insert precedes any MLS use of the data.
+        key_package_data: vec![1, 2, 3],
+        remaining_lifetime_ms: 60 * 60 * 1000,
+        timestamp_ms: 0,
+        session_reset: false,
+    };
+    let content = format!(
+        "{}{}",
+        internal_prefixes::KEY_PACKAGE,
+        serde_json::to_string(&key_pkg_payload).unwrap()
+    );
+    let message = Message::new(
+        UserId::new("attacker").unwrap(),
+        UserId::new("user123").unwrap(),
+        AppId::new("test-app").unwrap(),
+        &content,
+    );
+    let _ = protocol.process_internal_message(&message);
+
+    assert_eq!(
+        protocol.pending_key_packages.len(),
+        MAX_PENDING_KEY_PACKAGES,
+        "map must stay bounded at the cap, not grow past it"
+    );
+    assert!(
+        protocol.pending_key_packages.contains_key("attacker"),
+        "the new key package should be inserted"
+    );
+    assert!(
+        !protocol.pending_key_packages.contains_key("victim"),
+        "the soonest-to-expire entry should have been evicted"
+    );
+}
+
+#[test]
 fn test_establishment_state_returns_correct_states() {
     let storage = Arc::new(InMemoryStorage::new());
     let bob_storage = Arc::new(InMemoryStorage::new());

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -7785,6 +7785,110 @@ fn test_pending_key_packages_capped_evicts_soonest_to_expire() {
 }
 
 #[test]
+fn test_received_key_package_lifetime_is_clamped() {
+    // Regression (H2 follow-up): `remaining_lifetime_ms` is an unauthenticated
+    // wire field that becomes the eviction sort key for `pending_key_packages`
+    // (soonest-to-expire is evicted first). A forged sender claiming a maximal
+    // lifetime must not pin its entry as latest-to-expire and starve legitimate
+    // peers, so the cached expiry is clamped to MAX_KEY_PACKAGE_LIFETIME_MS.
+    let mut config = create_test_config();
+    // Keep the entry resident (no auto-establish) so we can inspect its expiry.
+    config.encryption.auto_key_exchange = false;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    let storage = Arc::new(InMemoryStorage::new());
+    protocol.initialize_mls(storage).unwrap();
+
+    let before_ms = chrono::Utc::now().timestamp_millis() as u64;
+    let key_pkg_payload = KeyPackagePayload {
+        user_id: "attacker".to_string(),
+        key_package_data: vec![1, 2, 3],
+        remaining_lifetime_ms: u64::MAX, // attacker claims a maximal lifetime
+        timestamp_ms: 0,
+        session_reset: false,
+    };
+    let content = format!(
+        "{}{}",
+        internal_prefixes::KEY_PACKAGE,
+        serde_json::to_string(&key_pkg_payload).unwrap()
+    );
+    let message = Message::new(
+        UserId::new("attacker").unwrap(),
+        UserId::new("user123").unwrap(),
+        AppId::new("test-app").unwrap(),
+        &content,
+    );
+    let _ = protocol.process_internal_message(&message);
+    let after_ms = chrono::Utc::now().timestamp_millis() as u64;
+
+    let pkg = protocol
+        .pending_key_packages
+        .get("attacker")
+        .expect("key package should be inserted");
+    // Expiry is anchored to *our* clock and bounded by the clamp: it lands in
+    // [before + MAX, after + MAX], never u64::MAX (which the unclamped
+    // saturating_add would have produced).
+    assert!(
+        pkg.local_expires_at_ms >= before_ms.saturating_add(MAX_KEY_PACKAGE_LIFETIME_MS)
+            && pkg.local_expires_at_ms <= after_ms.saturating_add(MAX_KEY_PACKAGE_LIFETIME_MS),
+        "a maximal claimed lifetime must be clamped to MAX_KEY_PACKAGE_LIFETIME_MS (got {})",
+        pkg.local_expires_at_ms
+    );
+}
+
+#[test]
+fn test_restore_peer_key_packages_prunes_overflow_from_storage() {
+    // Regression (H2 follow-up): a pre-cap over-sized durable store (a flood
+    // that landed before MAX_PENDING_KEY_PACKAGES existed) must not re-inflate
+    // memory on boot or linger on disk forever. The restore loop bounds memory
+    // to the cap AND prunes the on-disk overflow so the store shrinks to the
+    // cap in a single boot.
+    let storage = Arc::new(InMemoryStorage::new());
+    let overflow = 5;
+    let total = MAX_PENDING_KEY_PACKAGES + overflow;
+
+    // Persist more than the cap of non-expired, non-session peer key packages,
+    // writing straight to durable storage to bypass the live insert cap.
+    {
+        let mut writer = OfflineProtocol::new(create_test_config()).unwrap();
+        writer.initialize_mls(storage.clone()).unwrap();
+        let pkg = ReceivedKeyPackage {
+            key_package_data: vec![0],
+            local_expires_at_ms: u64::MAX, // never expired
+        };
+        for i in 0..total {
+            writer.persist_peer_key_package(&format!("peer_{i}"), &pkg);
+        }
+    }
+    assert_eq!(
+        storage
+            .list_keys(storage_keys::PEER_KEY_PACKAGES)
+            .unwrap()
+            .len(),
+        total,
+        "precondition: durable store holds more than the cap"
+    );
+
+    // Boot a fresh instance against the same storage; initialize_mls runs the
+    // restore path.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol.initialize_mls(storage.clone()).unwrap();
+
+    assert_eq!(
+        protocol.pending_key_packages.len(),
+        MAX_PENDING_KEY_PACKAGES,
+        "restore must bound memory to the cap"
+    );
+    assert_eq!(
+        storage
+            .list_keys(storage_keys::PEER_KEY_PACKAGES)
+            .unwrap()
+            .len(),
+        MAX_PENDING_KEY_PACKAGES,
+        "overflow must be pruned from durable storage, not left to linger"
+    );
+}
+
+#[test]
 fn test_establishment_state_returns_correct_states() {
     let storage = Arc::new(InMemoryStorage::new());
     let bob_storage = Arc::new(InMemoryStorage::new());

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -155,6 +155,26 @@ pub(crate) const MAX_BLOCKED_USERS: usize = 10_000;
 /// memory stays capped.
 pub(crate) const MAX_PLAINTEXT_RECEIVE_WARNED_PEERS: usize = 1000;
 
+/// Maximum number of pending (received-but-unused) peer key packages retained
+/// in memory and in durable `MlsStorage`.
+///
+/// Keyed by the wire-claimed `sender`, so — like [`MAX_KNOWN_PEERS`] — an
+/// unpinned peer can flood distinct forged ids under the default config. Each
+/// entry is also written to durable secure storage (`persist_peer_key_package`,
+/// iOS Keychain / Android Keystore) and re-loaded on boot, so without this cap
+/// a flood grows durable storage without bound and re-inflates memory on every
+/// restart. At capacity a new peer evicts the soonest-to-expire entry and drops
+/// its persisted copy; the restore-on-boot loop is capped the same way.
+pub(crate) const MAX_PENDING_KEY_PACKAGES: usize = 1000;
+
+/// Maximum number of peers remembered in `key_package_sent_to` (the "already
+/// sent our key package to this peer" set).
+///
+/// Wire-claimed ids grow this set in lockstep with a key-package flood, so it
+/// resets at capacity like [`MAX_PLAINTEXT_RECEIVE_WARNED_PEERS`]: the only cost
+/// of forgetting a peer is a one-time idempotent re-send of our key package.
+pub(crate) const MAX_KEY_PACKAGE_SENT_TO: usize = 1000;
+
 /// Minimum age (in milliseconds) a TOFU entry must have before it can be
 /// evicted by LRU. This prevents a cache-filling attack where an adversary
 /// rapidly registers many fake identities to evict legitimate pinned keys.

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -175,6 +175,20 @@ pub(crate) const MAX_PENDING_KEY_PACKAGES: usize = 1000;
 /// of forgetting a peer is a one-time idempotent re-send of our key package.
 pub(crate) const MAX_KEY_PACKAGE_SENT_TO: usize = 1000;
 
+/// Maximum lifetime (in milliseconds) honored for a *received* peer key
+/// package's cached expiry.
+///
+/// `remaining_lifetime_ms` arrives on the wire unauthenticated and becomes the
+/// eviction sort key for [`MAX_PENDING_KEY_PACKAGES`] (the soonest-to-expire
+/// entry is evicted first). Without a ceiling, a flood of forged senders
+/// claiming a maximal lifetime would pin their entries as latest-to-expire and
+/// preferentially evict legitimate peers. Key packages are minted with a 30-day
+/// lifetime (`DEFAULT_KEY_PACKAGE_LIFETIME_SECS` in `offline-protocol-mls`), so
+/// a larger value is never legitimate. This bound is purely cache bookkeeping —
+/// OpenMLS enforces real key-package validity at use time — so clamping only
+/// affects when we drop the *cached* copy, never crypto correctness.
+pub(crate) const MAX_KEY_PACKAGE_LIFETIME_MS: u64 = 30 * 24 * 60 * 60 * 1000;
+
 /// Minimum age (in milliseconds) a TOFU entry must have before it can be
 /// evicted by LRU. This prevents a cache-filling attack where an adversary
 /// rapidly registers many fake identities to evict legitimate pinned keys.


### PR DESCRIPTION
## Summary

Fixes the two remaining **HIGH** findings from the full-codebase security re-audit (2026-07-13). Both are instances of the theme the recent membership-auth commits have been closing: *trust the authenticated wire sender / arrival, and bound attacker-keyed state.* No behavior change on legitimate flows; the crypto core and all previously-landed HIGH fixes were re-verified sound.

### H1 — `__GROUP_MEMBER_ADDED__` performed zero authorization
The handler splices `payload.user_id` into `group_mesh.members`, the group fan-out send cache read verbatim by `send_group_message_inner`. A BLE/WiFi-mesh peer forging this frame injected itself as a **silent recipient of every subsequent group MLS ciphertext** (a membership/activity metadata leak — it cannot decrypt) and forged a roster event. It was **not closed even by strict identity mode** (the handler checked nothing).

It has no in-SDK mesh producer — the only legitimate source is relay injection over the **Internet** transport (the mobile bindings' `InternetManager`), and a real MLS add is surfaced from the authenticated roster by `refresh_group_members`, not through this handler. **Fix:** gate the cache mutation and the event on `arrival_transport == Some(TransportType::Internet)`, exactly like the existing `__GROUP_CREATED__` handler — a mesh attacker can never present Internet arrival, and legitimate relay reconciliation is preserved.

### H2 — `pending_key_packages` was uncapped and durably persisted
It was the only attacker-keyed map without a cap, and every insert also wrote a durable Keychain/Keystore entry (`persist_peer_key_package`) re-loaded uncapped on boot. An unpinned peer flooding distinct forged `__MLS_KEY_PKG__` senders (accepted under the default config) grew **memory *and* durable secure storage without bound**, surviving reboot and able to evict the app's own secrets. **Fix:**
- Cap the map at `MAX_PENDING_KEY_PACKAGES` (1000, mirroring `MAX_KNOWN_PEERS`) with soonest-to-expire eviction that also drops the persisted copy — bounds both memory and durable storage.
- Cap the restore-on-boot loop the same way, so a pre-existing over-cap store can't re-inflate memory.
- Reset the companion `key_package_sent_to` set at capacity (`MAX_KEY_PACKAGE_SENT_TO`), closing the lockstep RAM growth + outbound amplification.

## Files
- `types.rs` — new `MAX_PENDING_KEY_PACKAGES`, `MAX_KEY_PACKAGE_SENT_TO`
- `message_dispatch.rs` — H1 Internet-arrival gate; H2 eviction at insert
- `send.rs` — H2 `key_package_sent_to` cap
- `storage.rs` — H2 restore-loop cap

## Testing
- New regression tests: `test_group_member_added_from_mesh_is_dropped_not_cache_poisoned`, `test_pending_key_packages_capped_evicts_soonest_to_expire`
- **825** protocol lib tests green
- `cargo clippy --workspace -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Out of scope (deferred)
The audit's remaining MEDIUM/LOW findings (1:1↔group context-confusion, require signatures for destructive handlers on the fail-open path, `__GROUP_INFO__`/`__USER_GROUPS__` display-forgery, zeroize transient key buffers, `wss://` lint, FFI `encrypted` flag) are documented but not addressed here.