### PR TITLE
fix(protocol): bound pending-decryption-queue memory against forged senders

### DIFF
--- a/crates/offline-protocol-core/src/lib.rs
+++ b/crates/offline-protocol-core/src/lib.rs
@@ -22,5 +22,5 @@ pub use service::{ServiceDescriptor, ServiceId};
 pub use sync::{MutexExt, RwLockExt};
 pub use types::{
     validate_id_chars, AppId, HopCount, IdValidationError, LamportClock, LocalInstant, Timestamp,
-    UserId, WallClockTimestamp, TTL,
+    UserId, WallClockTimestamp, MAX_ID_LEN, TTL,
 };

--- a/crates/offline-protocol-core/src/types.rs
+++ b/crates/offline-protocol-core/src/types.rs
@@ -33,6 +33,45 @@ pub enum IdValidationError {
         /// Label for the identifier kind being validated.
         type_name: String,
     },
+    /// The identifier exceeds [`MAX_ID_LEN`].
+    #[error("{type_name} exceeds the maximum length of {max} bytes ({len} bytes)")]
+    TooLong {
+        /// Label for the identifier kind being validated.
+        type_name: String,
+        /// Actual byte length that was rejected.
+        len: usize,
+        /// Maximum permitted byte length.
+        max: usize,
+    },
+}
+
+/// Maximum length, in bytes, of a [`UserId`] or [`AppId`].
+///
+/// Wire-supplied identifiers become map keys and are cloned into in-memory
+/// buffers (the pending-decryption queue, for one, retains a full `Message`
+/// clone), so an unbounded id is a resource-exhaustion vector: a peer could
+/// inflate `sender` to megabytes to evade the queue byte budgets or leak a
+/// per-id map entry. 256 bytes is far larger than any real identifier. MLS
+/// group ids keep their own, larger cap because they compose several ids
+/// behind a `:` namespace separator.
+pub const MAX_ID_LEN: usize = 256;
+
+/// Validates an identifier's length and character set. Shared by [`UserId`]
+/// and [`AppId`]. The length check runs first so a hostile megabyte-scale id
+/// is rejected before the O(n) character scan.
+///
+/// Not applied to MLS group ids, which validate per colon-separated segment
+/// via [`validate_id_chars`] directly and enforce their own larger total-length
+/// cap.
+fn validate_id(id: &str, type_name: &str) -> Result<(), IdValidationError> {
+    if id.len() > MAX_ID_LEN {
+        return Err(IdValidationError::TooLong {
+            type_name: type_name.to_string(),
+            len: id.len(),
+            max: MAX_ID_LEN,
+        });
+    }
+    validate_id_chars(id, type_name)
 }
 
 /// Validates that an identifier string is safe for use as a storage key.
@@ -91,8 +130,7 @@ impl UserId {
     /// Returns `Ok(UserId)` if valid, `Err` if the ID is empty.
     pub fn new(id: impl Into<String>) -> crate::Result<Self> {
         let id_str = id.into();
-        validate_id_chars(&id_str, "User ID")
-            .map_err(|e| crate::Error::InvalidUserId(e.to_string()))?;
+        validate_id(&id_str, "User ID").map_err(|e| crate::Error::InvalidUserId(e.to_string()))?;
         Ok(Self(id_str))
     }
 
@@ -131,8 +169,7 @@ impl AppId {
     /// Returns `Ok(AppId)` if valid, `Err` if the ID is empty.
     pub fn new(id: impl Into<String>) -> crate::Result<Self> {
         let id_str = id.into();
-        validate_id_chars(&id_str, "App ID")
-            .map_err(|e| crate::Error::InvalidAppId(e.to_string()))?;
+        validate_id(&id_str, "App ID").map_err(|e| crate::Error::InvalidAppId(e.to_string()))?;
         Ok(Self(id_str))
     }
 
@@ -453,6 +490,31 @@ mod tests {
     fn test_id_validation_error_display_includes_type_name() {
         let err = validate_id_chars("", "App ID").unwrap_err();
         assert_eq!(err.to_string(), "App ID cannot be empty");
+    }
+
+    #[test]
+    fn test_user_and_app_id_reject_oversized() {
+        // Boundary: exactly MAX_ID_LEN is accepted, one over is rejected.
+        assert!(UserId::new("a".repeat(MAX_ID_LEN)).is_ok());
+        assert!(AppId::new("a".repeat(MAX_ID_LEN)).is_ok());
+        assert!(matches!(
+            UserId::new("a".repeat(MAX_ID_LEN + 1)),
+            Err(crate::Error::InvalidUserId(_))
+        ));
+        assert!(matches!(
+            AppId::new("a".repeat(MAX_ID_LEN + 1)),
+            Err(crate::Error::InvalidAppId(_))
+        ));
+    }
+
+    #[test]
+    fn test_user_id_deserialize_rejects_oversized() {
+        // The wire path (custom Deserialize) is capped too, so a hostile
+        // megabyte-scale `sender` cannot be decoded into a UserId at all.
+        let oversized = format!("\"{}\"", "a".repeat(MAX_ID_LEN + 1));
+        assert!(serde_json::from_str::<UserId>(&oversized).is_err());
+        let ok = format!("\"{}\"", "a".repeat(MAX_ID_LEN));
+        assert!(serde_json::from_str::<UserId>(&ok).is_ok());
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol/decryption_queue.rs
+++ b/crates/offline-protocol/src/protocol/decryption_queue.rs
@@ -175,6 +175,24 @@ impl PendingDecryptionQueue {
         self.queues.values().map(VecDeque::len).max().unwrap_or(0)
     }
 
+    /// Returns whether an overflow-pressure counter is tracked for a peer.
+    #[cfg(test)]
+    pub(crate) fn has_overflow_hits(&self, peer_id: &str) -> bool {
+        self.peer_overflow_hits.contains_key(peer_id)
+    }
+
+    /// Returns the number of peers with a tracked overflow-pressure counter.
+    #[cfg(test)]
+    pub(crate) fn overflow_hits_tracked(&self) -> usize {
+        self.peer_overflow_hits.len()
+    }
+
+    /// Returns the retained-memory footprint the queue charges for a message.
+    #[cfg(test)]
+    pub(crate) fn message_footprint(message: &Message) -> usize {
+        Self::message_bytes(message)
+    }
+
     /// Overrides the `received_at` timestamp of the front entry for a peer (fault injection).
     #[cfg(test)]
     pub(crate) fn set_front_received_at(&mut self, peer_id: &str, at: Instant) {
@@ -213,14 +231,48 @@ impl PendingDecryptionQueue {
         self.metrics.pending_bytes_current = self.total_bytes;
     }
 
-    /// Payload footprint of a queued message: text content plus binary content.
+    /// Retained-memory footprint of a queued message, for budget accounting.
+    ///
+    /// The queue stores a full [`Message`] clone, so this must reflect every
+    /// owned field a peer can inflate — not just the text/binary payload.
+    /// Counting only `content`/`binary_content` (as this once did) let a
+    /// crafted message with a tiny payload but a megabyte-scale `sender` or
+    /// `metadata` map evade the per-peer/global byte budgets entirely and drive
+    /// the queue to OOM while `pending_bytes_current` reported near-zero. The id
+    /// fields (`sender`/`recipient`/`app_id`) are additionally length-capped at
+    /// the type boundary (`offline_protocol_core::MAX_ID_LEN`); `metadata` and
+    /// the media strings are not, so this accounting is what bounds them.
+    ///
+    /// Fixed per-entry overhead (queue node, index entry, the duplicated
+    /// `peer_id`/`message_id` strings) is intentionally *not* added here — the
+    /// per-peer and global *count* caps already bound that fixed cost; the byte
+    /// budget exists to bound variable field/payload bloat.
     fn message_bytes(message: &Message) -> usize {
+        let metadata_bytes: usize = message
+            .metadata
+            .iter()
+            .map(|(k, v)| k.len() + v.len())
+            .sum();
+        let media_bytes = message
+            .media_metadata
+            .as_ref()
+            .map(|m| {
+                m.mime_type.len()
+                    + m.file_name.len()
+                    + m.thumbnail_base64.as_ref().map(String::len).unwrap_or(0)
+            })
+            .unwrap_or(0);
         message.content.len()
             + message
                 .binary_content
                 .as_ref()
                 .map(|binary| binary.len())
                 .unwrap_or(0)
+            + message.sender.as_str().len()
+            + message.recipient.as_str().len()
+            + message.app_id.as_str().len()
+            + metadata_bytes
+            + media_bytes
     }
 
     fn peer_bytes_for(&self, peer_id: &str) -> usize {
@@ -274,6 +326,12 @@ impl PendingDecryptionQueue {
         if queue_empty {
             self.queues.remove(peer_id);
             self.peer_bytes.remove(peer_id);
+            // Prune the overflow-pressure counter alongside the queue. It is
+            // keyed by the (attacker-controllable) wire sender and was
+            // previously never removed, so a flood of distinct forged senders
+            // leaked one permanent entry each. A peer with no queued messages
+            // has no live pressure to track.
+            self.peer_overflow_hits.remove(peer_id);
         }
         self.update_peer_gauge(peer_id);
         Some(removed)
@@ -972,6 +1030,10 @@ impl PendingDecryptionQueue {
                 .saturating_sub(Self::message_bytes(&entry.message));
         }
         self.peer_bytes.remove(sender);
+        // Prune the overflow-pressure counter with the drained queue (see the
+        // matching cleanup in `remove_entry_by_sequence`) so it cannot outlive
+        // the peer's queued messages and leak per-sender.
+        self.peer_overflow_hits.remove(sender);
         self.update_peer_gauge(sender);
         self.update_current_gauge();
         self.cleanup_global_order_front();

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -14390,12 +14390,110 @@ fn test_pending_queue_byte_accounting_across_drain() {
     let m2 = pending_test_message_with_bytes("peer", 200);
     protocol.pending_queue.enqueue(&queue_config, "peer", &m1);
     protocol.pending_queue.enqueue(&queue_config, "peer", &m2);
-    assert_eq!(protocol.pending_queue.total_bytes(), 500);
-    assert_eq!(protocol.pending_queue.metrics().pending_bytes_current, 500);
+    // Footprint is the full retained size (payload + sender/recipient/app_id +
+    // metadata), not payload-only, so compute the expectation from the same
+    // accounting the queue uses rather than hardcoding the 300+200 payloads.
+    let expected = PendingDecryptionQueue::message_footprint(&m1)
+        + PendingDecryptionQueue::message_footprint(&m2);
+    assert_eq!(protocol.pending_queue.total_bytes(), expected);
+    assert_eq!(
+        protocol.pending_queue.metrics().pending_bytes_current,
+        expected
+    );
 
     let drained = protocol.pending_queue.drain_for_peer(&queue_config, "peer");
     assert_eq!(drained.len(), 2);
     assert_eq!(protocol.pending_queue.total_bytes(), 0);
+}
+
+#[test]
+fn test_pending_queue_byte_budget_counts_metadata_not_just_payload() {
+    // Regression (remote unauth OOM): a crafted encrypted message with a tiny
+    // payload but a large `metadata` map must be charged against the byte
+    // budget. Before the fix `message_bytes` counted only content+binary, so
+    // such a message slipped past the per-peer/global byte budgets and could
+    // drive the queue to multi-GB retention while the accounting reported
+    // near-zero. Reachable unauth via the `__MLS_ENC__` (GroupNotFound) path.
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.pending_queue.max_pending_bytes_per_peer = 4096;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    let queue_config = protocol.config.encryption.pending_queue.clone();
+
+    // ~3 KB of metadata behind a 2-byte payload.
+    let mut m1 = pending_test_message("peer", "hi");
+    m1.metadata.insert("blob".to_string(), "x".repeat(3000));
+    assert!(protocol
+        .pending_queue
+        .enqueue(&queue_config, "peer", &m1)
+        .is_empty());
+    assert!(
+        protocol.pending_queue.total_bytes() >= 3000,
+        "metadata bytes must be charged to the byte budget, got {}",
+        protocol.pending_queue.total_bytes()
+    );
+
+    // A second such message exceeds the 4096 budget, so the oldest is evicted
+    // (DropOldest default): memory stays bounded instead of growing per message.
+    let mut m2 = pending_test_message("peer", "hi");
+    m2.metadata.insert("blob".to_string(), "y".repeat(3000));
+    protocol.pending_queue.enqueue(&queue_config, "peer", &m2);
+    assert!(protocol.pending_queue.total_bytes() <= 4096);
+    assert_eq!(protocol.pending_queue.peer_queue_len("peer"), 1);
+}
+
+#[test]
+fn test_peer_overflow_hits_pruned_on_drain() {
+    // Regression (unbounded leak): `peer_overflow_hits` is keyed by the
+    // attacker-controllable wire sender and was never pruned. Draining a peer
+    // must drop its overflow-pressure counter so it cannot leak per-sender.
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.pending_queue.max_pending_per_peer = 1;
+    config.encryption.pending_queue.overflow_policy = crate::config::OverflowPolicy::DropNewest;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    let queue_config = protocol.config.encryption.pending_queue.clone();
+
+    let m1 = pending_test_message("peer", "a");
+    let m2 = pending_test_message("peer", "b");
+    protocol.pending_queue.enqueue(&queue_config, "peer", &m1);
+    // Second message trips the per-peer limit → records an overflow hit; with
+    // DropNewest the queue keeps m1 (non-empty), so the counter is retained.
+    protocol.pending_queue.enqueue(&queue_config, "peer", &m2);
+    assert!(protocol.pending_queue.has_overflow_hits("peer"));
+
+    protocol.pending_queue.drain_for_peer(&queue_config, "peer");
+    assert!(!protocol.pending_queue.has_overflow_hits("peer"));
+    assert_eq!(protocol.pending_queue.overflow_hits_tracked(), 0);
+}
+
+#[test]
+fn test_peer_overflow_hits_pruned_when_last_entry_evicted() {
+    // Same leak, via the other cleanup path: when the peer's last queued entry
+    // is removed (here by TTL expiry through `remove_entry_by_sequence`), its
+    // overflow-pressure counter must be pruned with the queue.
+    let mut config = create_test_config();
+    config.encryption.enabled = true;
+    config.encryption.pending_queue.max_pending_per_peer = 1;
+    config.encryption.pending_queue.overflow_policy = crate::config::OverflowPolicy::DropNewest;
+    config.encryption.pending_queue.pending_ttl_ms = 1000;
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+    let queue_config = protocol.config.encryption.pending_queue.clone();
+
+    let m1 = pending_test_message("peer", "a");
+    let m2 = pending_test_message("peer", "b");
+    protocol.pending_queue.enqueue(&queue_config, "peer", &m1);
+    protocol.pending_queue.enqueue(&queue_config, "peer", &m2);
+    assert!(protocol.pending_queue.has_overflow_hits("peer"));
+
+    // Age the sole remaining entry past its TTL and prune it.
+    let past = std::time::Instant::now() - std::time::Duration::from_millis(10_000);
+    protocol.pending_queue.set_front_received_at("peer", past);
+    protocol
+        .pending_queue
+        .prune_expired_for_peer(&queue_config, "peer", std::time::Instant::now());
+    assert!(!protocol.pending_queue.contains_peer("peer"));
+    assert!(!protocol.pending_queue.has_overflow_hits("peer"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes a remote, **unauthenticated** resource-exhaustion vector in the pending decryption queue that can OOM-kill the app on a mobile device, plus an unbounded memory leak sharing the same root cause. Found during a full-codebase security review.

The queue buffers `__MLS_ENC__` messages that arrive before their MLS session is ready (`GroupNotFound → SessionNotReady → enqueue_pending_decryption`). Because `__MLS_ENC__` is a **data-plane** prefix, this path bypasses the Ed25519 / TOFU control-message gate — a single peer needs no key material to reach it.

## The bugs

**H1 — byte-budget bypass → remote mobile OOM.** `PendingDecryptionQueue::message_bytes()` counted only `content + binary_content`, but the queue retains a full `Message` clone including the attacker-controlled `sender` (a `UserId`) and `metadata` (a `HashMap`). Both were **uncounted**, so the per-peer (4 MB) and global (32 MB) byte budgets were inert — only the *count* caps (64/peer, 4096 global) bound the queue. A crafted message with a tiny payload but a ~1 MB `sender`/`metadata` retains megabytes while `pending_bytes_current` reports near-zero; ~4096 such entries hold several GB → OOM.

**H2 — unbounded leak.** `peer_overflow_hits` is keyed by the wire `sender` and was only ever inserted, never pruned (`remove_entry_by_sequence`'s cleanup dropped `queues`/`peer_bytes` but not this map). A flood of distinct forged senders leaked one permanent entry each.

**Shared root cause.** `UserId`/`AppId` enforced **no maximum length** (unlike `GroupId`, capped at 4096), so one wire `sender` could be ~1 MB — bounded only by the 1 MB whole-message wire cap.

## The fix

- **`MAX_ID_LEN = 256`** at the `UserId`/`AppId` construction boundary (`core/types.rs`). The custom `Deserialize` runs through it, so an oversized id is rejected at the wire before it can be cloned or used as a map key. Kept **out of** `validate_id_chars` so MLS `GroupId` retains its per-segment policy (a `GroupId` may legitimately be a single 4096-char segment).
- **`message_bytes()`** now counts every owned field a peer can inflate: `content + binary_content + sender + recipient + app_id + metadata + media`. Fixed per-entry overhead is intentionally *not* added — the count caps already bound that; the byte budget exists to bound variable bloat.
- **`peer_overflow_hits`** pruned on both queue-empty paths (`remove_entry_by_sequence` queue-empty branch, `drain_for_peer`).

## Tests

5 new regression tests + 1 updated:
- `test_user_and_app_id_reject_oversized` / `test_user_id_deserialize_rejects_oversized` — cap enforced via constructor **and** wire deserialization.
- `test_pending_queue_byte_budget_counts_metadata_not_just_payload` — a tiny-payload/large-metadata message is charged to the budget; a second one evicts the first, so memory stays bounded.
- `test_peer_overflow_hits_pruned_on_drain` / `test_peer_overflow_hits_pruned_when_last_entry_evicted` — both cleanup paths prune the counter.
- `test_pending_queue_byte_accounting_across_drain` — updated to compute the true footprint (via a new `message_footprint` test accessor) instead of asserting the old payload-only total.

## Verify

- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --workspace --lib` — green (831 protocol / 51 core / 40 mls, 0 failures)

## Scope / follow-ups (not in this PR)

- Transport `receive_queue` (`transport/common.rs`) is an unbounded `VecDeque` — a sustained inbound flood can grow it. Separate MEDIUM; recommend a depth cap with drop-oldest.
- A metadata total-size cap on the receive path is now redundant for the queue OOM (H1 counts metadata) but remains reasonable defense-in-depth for other buffers.