### PR TITLE
feat(protocol): persist store-and-forward outbox across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Persistent store-and-forward outbox — undelivered messages survive app restarts.**
+  The outbox that holds messages awaiting delivery/ACK was purely in-memory, so a message queued while offline was lost if the app was killed before a carrier appeared. When message persistence is enabled (automatically via `initialize_mls`, or explicitly via `enable_message_persistence`), each main-outbox entry is now persisted through the existing `MlsStorage` key-value interface under a new `"outbox"` key type and restored on startup. Restored entries re-drive delivery on `start()` via the existing outbox-flush path.
+  - *Carrier-relative TTL*: the outbox lifetime clock is not wall-clock. An entry whose lifetime lapsed while the app was closed is refreshed on restore rather than immediately reaped, so a message that never had a delivery opportunity gets a fresh window once a carrier (or the peer) reappears — mirroring the Welcome-lifecycle restart behavior.
+  - *Bounded and self-healing*: the restored set is pruned to the in-memory capacity (newest kept), corrupted records are dropped from storage and skipped, and an entry delivered-then-crashed before its delete is resent and de-duplicated by the receiver's re-ACK path (at-least-once, matching the existing contract).
+  - *Media excluded by design*: the file-chunk (media) outbox is intentionally **not** persisted. File transfers are not durable, so a resurrected chunk could never complete its transfer — media transfers must be re-initiated by the app after a restart.
+  - No FFI, UDL, binding, or event changes; the storage contract is additive (older SDKs ignore the unknown `"outbox"` key type).
+
 ## [0.12.0] — 2026-07-13
 
 First npm release since **v0.11.0** (0.11.0 is the latest published version). This

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -392,8 +392,10 @@ impl OfflineProtocol {
     /// - manager publication is transactional: restore must succeed before
     ///   `mls_manager` becomes visible to callers
     ///
-    /// The same storage is also used for persisting pending messages,
-    /// ensuring they survive app crashes/restarts.
+    /// The same storage is also used for persisting pending messages and the
+    /// store-and-forward outbox (under the `outbox` key type), ensuring both
+    /// survive app crashes/restarts. The media (file-chunk) outbox is not
+    /// persisted — file transfers must be re-initiated after a restart.
     pub fn initialize_mls(&mut self, storage: Arc<dyn MlsStorage>) -> Result<()> {
         if self.mls_manager.is_some() {
             return Ok(());
@@ -413,6 +415,7 @@ impl OfflineProtocol {
         let previous_lamport_clock = self.lamport_clock.value();
         let previous_tofu_keys = self.known_peer_public_keys.clone();
         let previous_blocked_users = self.blocked_users.clone();
+        let previous_outbox = self.outbox.clone();
 
         // Also use this storage for pending message persistence
         self.message_storage = Some(storage);
@@ -436,6 +439,7 @@ impl OfflineProtocol {
             self.restore_session_states_from_manager(manager.clone())?;
             self.restore_peer_key_packages(&manager)?;
             self.restore_welcome_lifecycles()?;
+            self.restore_outbox()?;
             self.restore_both_create_awaiting_decrypt();
             Ok(())
         })();
@@ -448,6 +452,7 @@ impl OfflineProtocol {
             self.lamport_clock = LamportClock::from_value(previous_lamport_clock);
             self.known_peer_public_keys = previous_tofu_keys;
             self.blocked_users = previous_blocked_users;
+            self.outbox = previous_outbox;
             return Err(err);
         }
 
@@ -460,9 +465,11 @@ impl OfflineProtocol {
 
     /// Enables message persistence using the provided storage backend.
     ///
-    /// This allows pending messages to survive app crashes/restarts even
-    /// when MLS encryption is not used. The storage backend should be a
-    /// platform-native secure storage implementation.
+    /// This allows pending messages and the store-and-forward outbox to
+    /// survive app crashes/restarts even when MLS encryption is not used. The
+    /// storage backend should be a platform-native secure storage
+    /// implementation. The media (file-chunk) outbox is not persisted — file
+    /// transfers must be re-initiated after a restart.
     ///
     /// Note: If you call `initialize_mls()`, message persistence is
     /// automatically enabled using the same storage.
@@ -474,6 +481,7 @@ impl OfflineProtocol {
         self.restore_lamport_clock();
         self.restore_tofu_keys();
         self.restore_blocked_users();
+        self.restore_outbox()?;
         info!("Message persistence enabled");
         Ok(())
     }
@@ -674,6 +682,14 @@ impl OfflineProtocol {
         self.flush_restored_confirmed_pending_messages();
         self.kick_pending_session_reconciliation("start");
         self.process_welcome_retry_queue()?;
+
+        // Re-drive delivery of any outbox entries restored from a previous
+        // session. They land here in the "stranded" state (not in the retry
+        // queue, not awaiting an ACK), which flush_outbox_all already recovers:
+        // it sends immediately where a transport is available and re-enqueues
+        // the rest with backoff. Runs at start() rather than at restore time
+        // because transports aren't up yet during initialize_mls.
+        self.flush_outbox_all();
 
         Ok(())
     }

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -1508,6 +1508,9 @@ impl OfflineProtocol {
                     &mut self.outbox
                 };
                 outbox.remove(&oldest_id);
+                if !is_media {
+                    self.clear_outbox_entry_from_storage(&oldest_id);
+                }
                 self.handle_outbound_media_chunk_failed(&oldest_id, "outbox eviction");
             }
         }
@@ -1517,6 +1520,7 @@ impl OfflineProtocol {
         } else {
             &mut self.outbox
         };
+        let is_new = !outbox.contains_key(&message.id);
         outbox
             .entry(message.id.clone())
             .or_insert_with(|| OutboxEntry {
@@ -1526,6 +1530,13 @@ impl OfflineProtocol {
                 last_sent_at: Utc::now(),
                 last_transport: None,
             });
+        // Persist newly-created main-outbox entries so they survive a restart.
+        // media entries are intentionally not persisted.
+        if is_new && !is_media {
+            if let Some(entry) = self.outbox.get(&message.id) {
+                self.persist_outbox_entry(entry);
+            }
+        }
     }
 
     pub(super) fn mark_message_sent(
@@ -1539,7 +1550,8 @@ impl OfflineProtocol {
         }
 
         let now = Utc::now();
-        let outbox = if Self::is_media_outbox_message(message) {
+        let is_media = Self::is_media_outbox_message(message);
+        let outbox = if is_media {
             &mut self.media_outbox
         } else {
             &mut self.outbox
@@ -1561,12 +1573,22 @@ impl OfflineProtocol {
         entry.attempt_count = attempt_hint.unwrap_or(entry.attempt_count.saturating_add(1));
         entry.last_sent_at = now;
         entry.last_transport = transport;
+
+        // Persist the updated main-outbox entry so its latest attempt state
+        // survives a restart. Media entries are not persisted.
+        if !is_media {
+            if let Some(entry) = self.outbox.get(&message.id) {
+                self.persist_outbox_entry(entry);
+            }
+        }
     }
 
     pub(super) fn remove_outbox_entry(&mut self, message_id: &MessageId) -> Option<OutboxEntry> {
-        self.outbox
-            .remove(message_id)
-            .or_else(|| self.media_outbox.remove(message_id))
+        if let Some(entry) = self.outbox.remove(message_id) {
+            self.clear_outbox_entry_from_storage(message_id);
+            return Some(entry);
+        }
+        self.media_outbox.remove(message_id)
     }
 
     pub(super) fn cleanup_outbox(&mut self) {
@@ -1592,6 +1614,7 @@ impl OfflineProtocol {
             }
             self.retry_queue.remove(&message_id.as_str());
             self.outbox.remove(&message_id);
+            self.clear_outbox_entry_from_storage(&message_id);
             self.handle_outbound_media_chunk_failed(&message_id, "outbox lifetime exceeded");
         }
 

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -1556,6 +1556,7 @@ impl OfflineProtocol {
         } else {
             &mut self.outbox
         };
+        let is_new = !outbox.contains_key(&message.id);
         let entry = outbox
             .entry(message.id.clone())
             .or_insert_with(|| OutboxEntry {
@@ -1574,9 +1575,14 @@ impl OfflineProtocol {
         entry.last_sent_at = now;
         entry.last_transport = transport;
 
-        // Persist the updated main-outbox entry so its latest attempt state
-        // survives a restart. Media entries are not persisted.
-        if !is_media {
+        // Persist only when the entry is newly created here. The success path
+        // never calls ensure_outbox_entry, so this is the one point a
+        // successfully-sent message first enters the durable outbox before its
+        // ACK. Later attempts don't re-persist: the durable copy already exists
+        // and attempt/timestamp churn isn't restore-critical (the TTL is
+        // refreshed on restore anyway), which keeps secure-storage writes off
+        // the retry hot path. Media entries are never persisted.
+        if is_new && !is_media {
             if let Some(entry) = self.outbox.get(&message.id) {
                 self.persist_outbox_entry(entry);
             }

--- a/crates/offline-protocol/src/protocol/storage.rs
+++ b/crates/offline-protocol/src/protocol/storage.rs
@@ -528,22 +528,31 @@ impl OfflineProtocol {
 
     /// Restores the store-and-forward outbox from storage on startup.
     ///
-    /// Rebuilds `self.outbox` from persisted entries. The retry queue and ACK
-    /// manager start empty, so every restored entry lands in the "stranded"
-    /// state that [`Self::flush_outbox_all`] already recovers — a flush on
-    /// `start()` re-drives delivery.
+    /// Merges persisted entries into `self.outbox` — it is *not* cleared first.
+    /// An entry queued before persistence was enabled lives only in memory and,
+    /// if it succeeded at the transport but is awaiting an ACK, is not in the
+    /// retry queue either; clearing would strand it with no recovery path (the
+    /// ACK-timeout path drops a message that is missing from the outbox). Where
+    /// an id exists in both, storage is authoritative and overwrites.
+    ///
+    /// The retry queue and ACK manager start empty, so every restored entry
+    /// lands in the "stranded" state that [`Self::flush_outbox_all`] already
+    /// recovers — a flush on `start()` re-drives delivery.
     ///
     /// Recovery rules, mirroring the other restore paths:
     /// - corrupted entries are dropped from storage and skipped;
     /// - any stray media entry is dropped (they must never be resurrected);
+    /// - the total is pruned to `MAX_OUTBOX_ENTRIES`, keeping the newest by
+    ///   `last_sent_at`;
     /// - the TTL clock is carrier-relative: an entry whose `last_sent_at` has
     ///   already lapsed the outbox lifetime is refreshed rather than restored
     ///   already-expired, so it gets a fresh delivery window once a carrier
-    ///   reappears (mirrors the Welcome lifecycle repair);
-    /// - the total is pruned to `MAX_OUTBOX_ENTRIES`, keeping the newest by
-    ///   `last_sent_at`.
+    ///   reappears (mirrors the Welcome lifecycle repair). This runs *after*
+    ///   the prune, so a refreshed (now-stamped) clock can't sort as the newest
+    ///   and crowd genuinely-fresh entries out of the kept set;
+    /// - pre-existing in-memory entries not yet in storage are persisted, so
+    ///   memory and storage are consistent once restore returns.
     pub(crate) fn restore_outbox(&mut self) -> Result<()> {
-        self.outbox.clear();
         let Some(storage) = &self.message_storage else {
             return Ok(());
         };
@@ -566,7 +575,7 @@ impl OfflineProtocol {
                 continue;
             };
 
-            let mut entry = match serde_json::from_slice::<OutboxEntry>(&data) {
+            let entry = match serde_json::from_slice::<OutboxEntry>(&data) {
                 Ok(entry) => entry,
                 Err(e) => {
                     warn!(message_id = %message_id, error = %e, "Dropping corrupted outbox entry");
@@ -583,25 +592,14 @@ impl OfflineProtocol {
                 continue;
             }
 
-            // Carrier-relative TTL: don't restore an entry already past the
-            // outbox lifetime — refresh the clock so it survives the first
-            // cleanup tick and gets a fresh chance once a carrier appears.
-            if entry.last_sent_at + lifetime <= Utc::now() {
-                entry.last_sent_at = Utc::now();
-                self.persist_outbox_entry(&entry);
-                info!(
-                    event = "outbox_entry_restored",
-                    message_id = %message_id,
-                    repair_action = "ttl_refreshed_carrier_relative",
-                    "outbox_entry_restored"
-                );
-            }
-
             restored.push(entry);
         }
 
-        // Prune to capacity, keeping the newest by last_sent_at. Delete the
-        // pruned overflow from storage so it can't linger and be re-restored.
+        // Prune to capacity BEFORE refreshing TTLs, keeping the newest by
+        // last_sent_at. Delete the pruned overflow from storage so it can't
+        // linger and be re-restored. Ordering matters: refreshing a lapsed
+        // clock stamps it with `now`, which would otherwise sort it as the
+        // newest and crowd genuinely-fresh entries out of the kept set.
         if restored.len() > MAX_OUTBOX_ENTRIES {
             restored.sort_by_key(|e| std::cmp::Reverse(e.last_sent_at));
             for entry in restored.drain(MAX_OUTBOX_ENTRIES..) {
@@ -609,9 +607,46 @@ impl OfflineProtocol {
             }
         }
 
+        // Carrier-relative TTL: refresh any entry already past the outbox
+        // lifetime so it survives the first cleanup tick and gets a fresh chance
+        // once a carrier appears. Collect the refreshed clones so the repair can
+        // be re-persisted below, once the mutable borrow of `restored` is gone.
+        let now = Utc::now();
+        let mut refreshed: Vec<OutboxEntry> = Vec::new();
+        for entry in &mut restored {
+            if entry.last_sent_at + lifetime <= now {
+                entry.last_sent_at = now;
+                refreshed.push(entry.clone());
+                info!(
+                    event = "outbox_entry_restored",
+                    message_id = %entry.message.id,
+                    repair_action = "ttl_refreshed_carrier_relative",
+                    "outbox_entry_restored"
+                );
+            }
+        }
+
+        // Pre-existing in-memory entries not backed by storage (queued before
+        // persistence was enabled) must be persisted too, so they survive the
+        // next restart and memory/storage stay consistent after restore.
+        let restored_ids: std::collections::HashSet<String> =
+            restored.iter().map(|e| e.message.id.as_str()).collect();
+        let orphans: Vec<OutboxEntry> = self
+            .outbox
+            .values()
+            .filter(|e| !restored_ids.contains(&e.message.id.as_str()))
+            .cloned()
+            .collect();
+
         let count = restored.len();
         for entry in restored {
             self.outbox.insert(entry.message.id.clone(), entry);
+        }
+        for entry in &refreshed {
+            self.persist_outbox_entry(entry);
+        }
+        for entry in &orphans {
+            self.persist_outbox_entry(entry);
         }
         if count > 0 {
             info!(count = count, "Restored outbox entries from storage");

--- a/crates/offline-protocol/src/protocol/storage.rs
+++ b/crates/offline-protocol/src/protocol/storage.rs
@@ -1,13 +1,14 @@
 //! Storage persistence methods for protocol state.
 
 use super::{
-    storage_keys, OfflineProtocol, PendingMessage, ReceivedKeyPackage, SessionState,
+    storage_keys, OfflineProtocol, OutboxEntry, PendingMessage, ReceivedKeyPackage, SessionState,
     WelcomeDeliveryState, WelcomeLifecycleRecord, MAX_PENDING_KEY_PACKAGES,
     WELCOME_LIFECYCLE_TTL_SECS,
 };
+use crate::constants::MAX_OUTBOX_ENTRIES;
 use crate::{Error, Result};
 use chrono::{Duration as ChronoDuration, Utc};
-use offline_protocol_core::LamportClock;
+use offline_protocol_core::{LamportClock, MessageId};
 use offline_protocol_mls::MlsManager;
 use offline_protocol_transport::{NostrKeypair, NostrTransport, TransportType};
 use std::sync::{Arc, RwLock};
@@ -479,6 +480,156 @@ impl OfflineProtocol {
         }
 
         Ok(())
+    }
+
+    // ========================================================================
+    // OUTBOX PERSISTENCE
+    // ========================================================================
+
+    /// Persists a single outbox entry to storage, keyed by message id.
+    ///
+    /// Best-effort and infallible: the send path cannot propagate storage
+    /// errors, so a failed write is logged and swallowed (the message still
+    /// lives in the in-memory outbox and will retry; it just won't survive a
+    /// restart). No-ops when persistence is not configured or when the entry
+    /// belongs to the media outbox — file transfers are not persisted and
+    /// resurrected chunks could never complete, so we never write them.
+    pub(crate) fn persist_outbox_entry(&self, entry: &OutboxEntry) {
+        let Some(storage) = &self.message_storage else {
+            return;
+        };
+        if Self::is_media_outbox_message(&entry.message) {
+            return;
+        }
+        match serde_json::to_vec(entry) {
+            Ok(data) => {
+                if let Err(e) =
+                    storage.store(storage_keys::OUTBOX, &entry.message.id.as_str(), &data)
+                {
+                    warn!(message_id = %entry.message.id, error = %e, "Failed to persist outbox entry");
+                }
+            }
+            Err(e) => {
+                warn!(message_id = %entry.message.id, error = %e, "Failed to serialize outbox entry");
+            }
+        }
+    }
+
+    /// Removes a persisted outbox entry from storage. Best-effort: a media
+    /// message id is never persisted, so deleting it is a harmless no-op.
+    pub(crate) fn clear_outbox_entry_from_storage(&self, message_id: &MessageId) {
+        let Some(storage) = &self.message_storage else {
+            return;
+        };
+        if let Err(e) = storage.delete(storage_keys::OUTBOX, &message_id.as_str()) {
+            warn!(message_id = %message_id, error = %e, "Failed to clear persisted outbox entry");
+        }
+    }
+
+    /// Restores the store-and-forward outbox from storage on startup.
+    ///
+    /// Rebuilds `self.outbox` from persisted entries. The retry queue and ACK
+    /// manager start empty, so every restored entry lands in the "stranded"
+    /// state that [`Self::flush_outbox_all`] already recovers — a flush on
+    /// `start()` re-drives delivery.
+    ///
+    /// Recovery rules, mirroring the other restore paths:
+    /// - corrupted entries are dropped from storage and skipped;
+    /// - any stray media entry is dropped (they must never be resurrected);
+    /// - the TTL clock is carrier-relative: an entry whose `last_sent_at` has
+    ///   already lapsed the outbox lifetime is refreshed rather than restored
+    ///   already-expired, so it gets a fresh delivery window once a carrier
+    ///   reappears (mirrors the Welcome lifecycle repair);
+    /// - the total is pruned to `MAX_OUTBOX_ENTRIES`, keeping the newest by
+    ///   `last_sent_at`.
+    pub(crate) fn restore_outbox(&mut self) -> Result<()> {
+        self.outbox.clear();
+        let Some(storage) = &self.message_storage else {
+            return Ok(());
+        };
+
+        let message_ids = storage
+            .list_keys(storage_keys::OUTBOX)
+            .map_err(|e| Error::Other(format!("Failed to list outbox entries: {}", e)))?;
+
+        let lifetime = ChronoDuration::milliseconds(
+            self.config.reliability.retry.outbox_max_lifetime_ms as i64,
+        );
+
+        let mut restored: Vec<OutboxEntry> = Vec::new();
+        for message_id in message_ids {
+            let loaded = self
+                .message_storage
+                .as_ref()
+                .and_then(|s| s.load(storage_keys::OUTBOX, &message_id).ok().flatten());
+            let Some(data) = loaded else {
+                continue;
+            };
+
+            let mut entry = match serde_json::from_slice::<OutboxEntry>(&data) {
+                Ok(entry) => entry,
+                Err(e) => {
+                    warn!(message_id = %message_id, error = %e, "Dropping corrupted outbox entry");
+                    self.delete_outbox_key(&message_id);
+                    continue;
+                }
+            };
+
+            // A media entry should never have been persisted; drop any that
+            // slipped in (e.g. from an older build) so it can't be resurrected.
+            if Self::is_media_outbox_message(&entry.message) {
+                warn!(message_id = %message_id, "Dropping persisted media outbox entry");
+                self.delete_outbox_key(&message_id);
+                continue;
+            }
+
+            // Carrier-relative TTL: don't restore an entry already past the
+            // outbox lifetime — refresh the clock so it survives the first
+            // cleanup tick and gets a fresh chance once a carrier appears.
+            if entry.last_sent_at + lifetime <= Utc::now() {
+                entry.last_sent_at = Utc::now();
+                self.persist_outbox_entry(&entry);
+                info!(
+                    event = "outbox_entry_restored",
+                    message_id = %message_id,
+                    repair_action = "ttl_refreshed_carrier_relative",
+                    "outbox_entry_restored"
+                );
+            }
+
+            restored.push(entry);
+        }
+
+        // Prune to capacity, keeping the newest by last_sent_at. Delete the
+        // pruned overflow from storage so it can't linger and be re-restored.
+        if restored.len() > MAX_OUTBOX_ENTRIES {
+            restored.sort_by_key(|e| std::cmp::Reverse(e.last_sent_at));
+            for entry in restored.drain(MAX_OUTBOX_ENTRIES..) {
+                self.delete_outbox_key(&entry.message.id.as_str());
+            }
+        }
+
+        let count = restored.len();
+        for entry in restored {
+            self.outbox.insert(entry.message.id.clone(), entry);
+        }
+        if count > 0 {
+            info!(count = count, "Restored outbox entries from storage");
+        }
+
+        Ok(())
+    }
+
+    /// Deletes an outbox key from storage without the media/no-storage guards
+    /// of [`Self::clear_outbox_entry_from_storage`] — used inside
+    /// [`Self::restore_outbox`], which already holds a storage handle and
+    /// operates on raw persisted keys.
+    fn delete_outbox_key(&self, message_id: &str) {
+        if let Some(storage) = &self.message_storage {
+            if let Err(e) = storage.delete(storage_keys::OUTBOX, message_id) {
+                warn!(message_id = %message_id, error = %e, "Failed to delete outbox key");
+            }
+        }
     }
 
     // ========================================================================

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -3004,6 +3004,71 @@ fn test_initialize_mls_restore_failure_does_not_publish_partial_state() {
 }
 
 #[test]
+fn test_initialize_mls_restore_failure_rolls_back_outbox() {
+    // Storage that fails specifically on the outbox restore step, which runs
+    // after restore_outbox has already cleared the in-memory map — the exact
+    // window the rollback snapshot must cover.
+    #[derive(Default)]
+    struct FailingOutboxListStorage {
+        inner: crate::mls::InMemoryStorage,
+    }
+    impl MlsStorage for FailingOutboxListStorage {
+        fn store(
+            &self,
+            key_type: &str,
+            key_id: &str,
+            data: &[u8],
+        ) -> offline_protocol_mls::storage::StorageResult<()> {
+            self.inner.store(key_type, key_id, data)
+        }
+        fn load(
+            &self,
+            key_type: &str,
+            key_id: &str,
+        ) -> offline_protocol_mls::storage::StorageResult<Option<Vec<u8>>> {
+            self.inner.load(key_type, key_id)
+        }
+        fn delete(
+            &self,
+            key_type: &str,
+            key_id: &str,
+        ) -> offline_protocol_mls::storage::StorageResult<()> {
+            self.inner.delete(key_type, key_id)
+        }
+        fn list_keys(
+            &self,
+            key_type: &str,
+        ) -> offline_protocol_mls::storage::StorageResult<Vec<String>> {
+            if key_type == storage_keys::OUTBOX {
+                return Err(offline_protocol_mls::StorageError::LoadFailed(
+                    "forced outbox restore failure".to_string(),
+                ));
+            }
+            self.inner.list_keys(key_type)
+        }
+    }
+
+    let mut config = create_test_config_for_user("alice");
+    config.encryption.enabled = true;
+
+    let mut protocol = OfflineProtocol::new(config).unwrap();
+
+    // Seed an in-memory outbox entry before persistence is wired up.
+    protocol.ensure_outbox_entry(&test_message("bob", "pre-existing"));
+    assert_eq!(protocol.outbox_entry_count(), 1);
+
+    let result = protocol.initialize_mls(Arc::new(FailingOutboxListStorage::default()));
+    assert!(result.is_err());
+    assert!(protocol.mls_manager.is_none());
+    assert!(protocol.message_storage.is_none());
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        1,
+        "Outbox should be rolled back to its pre-initialize state on restore failure"
+    );
+}
+
+#[test]
 fn test_auto_send_and_manual_mls_share_single_state_under_concurrency() {
     let mut config = create_test_config_for_user("alice");
     config.encryption.enabled = true;
@@ -11282,6 +11347,342 @@ fn test_flush_outbox_all_collects_stranded_outbox_entries() {
     assert!(
         !sent.is_empty(),
         "Expected stranded outbox message to be sent"
+    );
+}
+
+// ============================================================================
+// OUTBOX PERSISTENCE
+// ============================================================================
+
+/// Builds a config with long retry delays so a failed send parks the message
+/// in the outbox instead of racing a backoff timer during the test.
+fn outbox_persistence_config() -> ProtocolConfig {
+    let mut config = create_test_config();
+    config.reliability.retry.initial_delay_ms = 60_000;
+    config.reliability.retry.max_delay_ms = 60_000;
+    config
+}
+
+fn test_message(recipient: &str, content: &str) -> Message {
+    Message::new(
+        UserId::new("user123").unwrap(),
+        UserId::new(recipient).unwrap(),
+        AppId::new("test-app").unwrap(),
+        content,
+    )
+}
+
+fn store_outbox_entry(storage: &InMemoryStorage, entry: &OutboxEntry) {
+    storage
+        .store(
+            storage_keys::OUTBOX,
+            &entry.message.id.as_str(),
+            &serde_json::to_vec(entry).unwrap(),
+        )
+        .unwrap();
+}
+
+#[test]
+fn test_outbox_persisted_and_restored_after_restart() {
+    let storage = Arc::new(InMemoryStorage::new());
+
+    let msg_id;
+    {
+        let mut protocol = OfflineProtocol::new(outbox_persistence_config()).unwrap();
+        protocol
+            .enable_message_persistence(storage.clone())
+            .unwrap();
+
+        // Failing transport so the send is deferred into the outbox.
+        let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(flaky));
+        protocol.start().unwrap();
+
+        msg_id = protocol
+            .send_message("bob", "durable", None::<MessagePriority>, None::<String>)
+            .unwrap();
+        assert!(protocol.outbox_entry_count() > 0);
+        assert_eq!(
+            storage.list_keys(storage_keys::OUTBOX).unwrap().len(),
+            1,
+            "Deferred message should be persisted to the outbox"
+        );
+    }
+
+    // New protocol instance, same storage: the outbox should be restored.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        1,
+        "Outbox entry should be restored after restart"
+    );
+    let restored = protocol.outbox_messages().next().unwrap();
+    assert_eq!(restored.id, msg_id);
+    assert_eq!(restored.content, "durable");
+}
+
+#[test]
+fn test_remove_outbox_entry_clears_storage() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(outbox_persistence_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+
+    let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+    protocol.start().unwrap();
+
+    let msg_id = protocol
+        .send_message(
+            "bob",
+            "to-be-acked",
+            None::<MessagePriority>,
+            None::<String>,
+        )
+        .unwrap();
+    assert_eq!(storage.list_keys(storage_keys::OUTBOX).unwrap().len(), 1);
+
+    // Both delivery-ACK and max-retries removal funnel through
+    // remove_outbox_entry, which must also delete the persisted copy.
+    let removed = protocol.remove_outbox_entry(&msg_id);
+    assert!(removed.is_some());
+    assert!(
+        storage.list_keys(storage_keys::OUTBOX).unwrap().is_empty(),
+        "Persisted outbox entry should be deleted on removal"
+    );
+}
+
+#[test]
+fn test_outbox_eviction_deletes_from_storage() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(outbox_persistence_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+
+    let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(flaky));
+    protocol.start().unwrap();
+
+    // One more than capacity: the oldest entry is evicted, and its persisted
+    // copy must be deleted so storage never exceeds the in-memory cap.
+    let total = crate::constants::MAX_OUTBOX_ENTRIES + 1;
+    for i in 0..total {
+        let _ = protocol.send_message(
+            "bob",
+            &format!("msg-{i}"),
+            None::<MessagePriority>,
+            None::<String>,
+        );
+    }
+
+    assert_eq!(
+        storage.list_keys(storage_keys::OUTBOX).unwrap().len(),
+        crate::constants::MAX_OUTBOX_ENTRIES,
+        "Persisted outbox must be pruned to capacity on eviction"
+    );
+}
+
+#[test]
+fn test_restore_outbox_skips_corrupted_entries() {
+    let storage = Arc::new(InMemoryStorage::new());
+
+    let valid = test_message("bob", "valid");
+    let valid_id = valid.id.clone();
+    store_outbox_entry(
+        &storage,
+        &OutboxEntry {
+            message: valid,
+            attempt_count: 2,
+            first_sent_at: chrono::Utc::now(),
+            last_sent_at: chrono::Utc::now(),
+            last_transport: None,
+        },
+    );
+    storage
+        .store(storage_keys::OUTBOX, "corrupt-id", b"not json")
+        .unwrap();
+
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        1,
+        "Only the valid entry should be restored"
+    );
+    assert_eq!(
+        protocol.outbox_messages().next().unwrap().id,
+        valid_id,
+        "The restored entry should be the valid one"
+    );
+    let keys = storage.list_keys(storage_keys::OUTBOX).unwrap();
+    assert_eq!(
+        keys.len(),
+        1,
+        "Corrupted key should be deleted from storage"
+    );
+    assert!(!keys.iter().any(|k| k == "corrupt-id"));
+}
+
+#[test]
+fn test_restore_outbox_prunes_overflow() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let base = chrono::Utc::now();
+
+    // Persist more than capacity, each with a strictly increasing last_sent_at
+    // so "newest kept" is unambiguous.
+    let total = crate::constants::MAX_OUTBOX_ENTRIES + 10;
+    let mut oldest_id = None;
+    for i in 0..total {
+        let entry = OutboxEntry {
+            message: test_message("bob", &format!("m{i}")),
+            attempt_count: 0,
+            first_sent_at: base,
+            last_sent_at: base + ChronoDuration::seconds(i as i64),
+            last_transport: None,
+        };
+        if i == 0 {
+            oldest_id = Some(entry.message.id.as_str());
+        }
+        store_outbox_entry(&storage, &entry);
+    }
+
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        crate::constants::MAX_OUTBOX_ENTRIES,
+        "Restore should prune the in-memory outbox to capacity"
+    );
+    let keys = storage.list_keys(storage_keys::OUTBOX).unwrap();
+    assert_eq!(
+        keys.len(),
+        crate::constants::MAX_OUTBOX_ENTRIES,
+        "Pruned overflow should be deleted from storage, not left to re-restore"
+    );
+    // The oldest (smallest last_sent_at) is what gets dropped.
+    let oldest_id = oldest_id.unwrap();
+    assert!(!keys.iter().any(|k| *k == oldest_id));
+}
+
+#[test]
+fn test_restore_outbox_refreshes_expired_ttl_carrier_relative() {
+    let storage = Arc::new(InMemoryStorage::new());
+
+    // Persist an entry whose last_sent_at is older than the default 1h outbox
+    // lifetime — as if the app was killed and reopened hours later.
+    let old = chrono::Utc::now() - ChronoDuration::hours(2);
+    store_outbox_entry(
+        &storage,
+        &OutboxEntry {
+            message: test_message("bob", "aged"),
+            attempt_count: 1,
+            first_sent_at: old,
+            last_sent_at: old,
+            last_transport: None,
+        },
+    );
+
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        1,
+        "An entry past its wall-clock TTL must still be restored"
+    );
+
+    // A cleanup tick must NOT reap it: the TTL clock is carrier-relative and
+    // was refreshed on restore, so the message keeps its delivery window.
+    protocol.cleanup_outbox();
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        1,
+        "Refreshed entry should survive cleanup (carrier-relative TTL)"
+    );
+}
+
+#[test]
+fn test_media_outbox_entry_not_persisted() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+
+    let mut msg = test_message("bob", "chunk");
+    msg.content_type = ContentType::FileChunk;
+    protocol.ensure_outbox_entry(&msg);
+
+    // The chunk lands in the in-memory media outbox...
+    assert!(protocol.outbox_entry_count() > 0);
+    // ...but is never persisted: file transfers are not durable, so a
+    // resurrected chunk could never complete its transfer.
+    assert!(
+        storage.list_keys(storage_keys::OUTBOX).unwrap().is_empty(),
+        "Media (file-chunk) entries must not be persisted"
+    );
+}
+
+#[test]
+fn test_restored_outbox_entry_flushed_on_start() {
+    let storage = Arc::new(InMemoryStorage::new());
+
+    let msg_id;
+    {
+        let mut protocol = OfflineProtocol::new(outbox_persistence_config()).unwrap();
+        protocol
+            .enable_message_persistence(storage.clone())
+            .unwrap();
+        let flaky = FlakyTransport::fail_first(TransportType::BLE, u32::MAX);
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(flaky));
+        protocol.start().unwrap();
+        msg_id = protocol
+            .send_message("bob", "resend-me", None::<MessagePriority>, None::<String>)
+            .unwrap();
+        assert_eq!(storage.list_keys(storage_keys::OUTBOX).unwrap().len(), 1);
+    }
+
+    // Restart with a working transport; start() should flush the restored
+    // entry and actually deliver it.
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+    assert_eq!(protocol.outbox_entry_count(), 1);
+
+    let mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    let mock_clone = mock.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+
+    protocol.start().unwrap();
+
+    let sent = mock_clone.sent_messages();
+    assert!(
+        sent.iter().any(|m| m.id == msg_id),
+        "Restored outbox entry should be flushed and sent on start()"
     );
 }
 

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -3005,9 +3005,10 @@ fn test_initialize_mls_restore_failure_does_not_publish_partial_state() {
 
 #[test]
 fn test_initialize_mls_restore_failure_rolls_back_outbox() {
-    // Storage that fails specifically on the outbox restore step, which runs
-    // after restore_outbox has already cleared the in-memory map — the exact
-    // window the rollback snapshot must cover.
+    // Storage that fails specifically on the outbox restore step. The failure
+    // propagates out of the transactional initialize_mls closure, and the
+    // rollback snapshot must restore the pre-existing in-memory outbox rather
+    // than leave it half-merged or published under a failed init.
     #[derive(Default)]
     struct FailingOutboxListStorage {
         inner: crate::mls::InMemoryStorage,
@@ -11684,6 +11685,111 @@ fn test_restored_outbox_entry_flushed_on_start() {
         sent.iter().any(|m| m.id == msg_id),
         "Restored outbox entry should be flushed and sent on start()"
     );
+}
+
+#[test]
+fn test_restore_outbox_preserves_preexisting_in_memory_entry() {
+    // An entry queued in memory *before* persistence is enabled is not in
+    // storage. restore_outbox must merge, not clear — otherwise this entry is
+    // silently dropped, and if it was awaiting an ACK (not in the retry queue)
+    // it has no recovery path. Restore must also persist it so it survives the
+    // next restart.
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+    // Populate the in-memory outbox while storage is still None.
+    let msg = test_message("bob", "queued-before-persistence");
+    let msg_id = msg.id.clone();
+    protocol.ensure_outbox_entry(&msg);
+    assert_eq!(protocol.outbox_entry_count(), 1);
+    assert!(
+        storage.list_keys(storage_keys::OUTBOX).unwrap().is_empty(),
+        "Nothing is persisted before persistence is enabled"
+    );
+
+    // Enabling persistence runs restore_outbox. The pre-existing entry must
+    // survive and become durable.
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        1,
+        "Pre-existing in-memory entry must survive restore (merge, not clear)"
+    );
+    assert_eq!(protocol.outbox_messages().next().unwrap().id, msg_id);
+    let keys = storage.list_keys(storage_keys::OUTBOX).unwrap();
+    assert_eq!(
+        keys.len(),
+        1,
+        "Pre-existing entry must be persisted on restore"
+    );
+    assert_eq!(keys[0], msg_id.as_str());
+}
+
+#[test]
+fn test_restore_outbox_prune_keeps_fresh_over_refreshed_stale() {
+    // Prune must run before the carrier-relative TTL refresh. A lapsed entry
+    // refreshed *before* the prune would be stamped `now` and sort as the
+    // newest, crowding genuinely-fresh entries out of the kept set. Here the
+    // lapsed entries are the overflow and must be dropped, not resurrected.
+    let storage = Arc::new(InMemoryStorage::new());
+    let now = chrono::Utc::now();
+
+    // Exactly capacity's worth of fresh entries (well within the 1h lifetime).
+    for i in 0..crate::constants::MAX_OUTBOX_ENTRIES {
+        store_outbox_entry(
+            &storage,
+            &OutboxEntry {
+                message: test_message("bob", &format!("fresh-{i}")),
+                attempt_count: 0,
+                first_sent_at: now,
+                last_sent_at: now - ChronoDuration::seconds((i + 1) as i64),
+                last_transport: None,
+            },
+        );
+    }
+    // A handful of lapsed entries (older than the 1h lifetime) — overflow.
+    let mut lapsed_ids = Vec::new();
+    for i in 0..5 {
+        let entry = OutboxEntry {
+            message: test_message("bob", &format!("lapsed-{i}")),
+            attempt_count: 0,
+            first_sent_at: now - ChronoDuration::hours(2),
+            last_sent_at: now - ChronoDuration::hours(2),
+            last_transport: None,
+        };
+        lapsed_ids.push(entry.message.id.as_str().to_string());
+        store_outbox_entry(&storage, &entry);
+    }
+
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol
+        .enable_message_persistence(storage.clone())
+        .unwrap();
+
+    assert_eq!(
+        protocol.outbox_entry_count(),
+        crate::constants::MAX_OUTBOX_ENTRIES,
+        "Restore should prune to capacity"
+    );
+    // The lapsed (oldest) entries are the pruned overflow — they must NOT have
+    // been refreshed-and-kept, and must be gone from both memory and storage.
+    let restored_ids: std::collections::HashSet<String> = protocol
+        .outbox_messages()
+        .map(|m| m.id.as_str().to_string())
+        .collect();
+    let keys = storage.list_keys(storage_keys::OUTBOX).unwrap();
+    for id in &lapsed_ids {
+        assert!(
+            !restored_ids.contains(id),
+            "Lapsed overflow entry {id} must be pruned, not refreshed-and-kept"
+        );
+        assert!(
+            !keys.iter().any(|k| k == id),
+            "Pruned lapsed entry {id} must be deleted from storage"
+        );
+    }
 }
 
 #[test]

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -499,6 +499,12 @@ pub(crate) mod storage_keys {
     pub const PEER_KEY_PACKAGES: &str = "peer_key_packages";
     /// Key type for persisted per-peer outbound welcome lifecycle state.
     pub const WELCOME_LIFECYCLES: &str = "welcome_lifecycles";
+    /// Key type for persisted store-and-forward outbox entries, keyed by
+    /// message id. Holds only main-outbox (non-media) entries so undelivered
+    /// messages survive app restarts; the media (file-chunk) outbox is
+    /// intentionally excluded because file transfers are not persisted and
+    /// must be re-initiated by the app after a restart.
+    pub const OUTBOX: &str = "outbox";
     /// Key type for the Lamport clock value.
     pub const LAMPORT_CLOCK: &str = "lamport_clock";
     /// Key ID for the single Lamport clock entry.
@@ -610,7 +616,7 @@ pub(crate) fn lock_shared_state(
         .map_err(|_| Error::Other("Shared state mutex poisoned".to_string()))
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct OutboxEntry {
     pub(crate) message: Message,
     pub(crate) attempt_count: u32,


### PR DESCRIPTION
## Summary

The store-and-forward outbox (`outbox: HashMap<MessageId, OutboxEntry>`) lived entirely in memory, so a message queued while offline was lost if the app was killed before a carrier appeared — store-and-forward that doesn't survive a restart is just *store*.

This persists the outbox through the **existing `MlsStorage` KV interface** under a new `"outbox"` key type. No SQLite, no new abstraction, no changes to the reliability/transport/core/mls crates. The insight: the outbox is already the source of truth — `flush_outbox_all` treats "in the outbox, not in the retry queue, not awaiting an ACK" as a *stranded* entry and re-drives it, which is exactly the state every entry lands in after a restart. So persisting the one map lets the existing recovery machinery do the rest.

## What changed

- **`types.rs`** — `OutboxEntry` derives `Serialize`/`Deserialize`; new `storage_keys::OUTBOX`.
- **`storage.rs`** — `persist_outbox_entry` / `clear_outbox_entry_from_storage` (best-effort, infallible; media-gated) and `restore_outbox` (corrupt-skip-and-delete, media-drop, carrier-relative TTL repair, overflow-prune to capacity keeping newest).
- **`send.rs`** — persistence hooked at the four funnel functions (`ensure_outbox_entry` evict + insert, `mark_message_sent`, `remove_outbox_entry`, `cleanup_outbox`), main-outbox only.
- **`mod.rs`** — `restore_outbox()` wired into the `initialize_mls` transactional block (with rollback snapshot) and `enable_message_persistence`; `flush_outbox_all()` added to `start()` to re-drive restored entries once transports are up.

## Design calls

- **Carrier-relative TTL** — the outbox lifetime is *not* wall-clock. A restored entry whose lifetime lapsed while the app was closed gets its clock refreshed on restore, so the first `cleanup` tick doesn't reap it before a carrier can appear. Mirrors the Welcome-lifecycle restart behavior.
- **Media excluded by design** — the file-transfer manager has no persistence, so a resurrected chunk could never complete its transfer. Transfers are re-initiated by the app after a restart.
- **At-least-once** — a delivered-then-crashed-before-delete entry is resent and de-duplicated by the receiver's re-ACK path, matching the existing contract.

## Compatibility

No FFI, UDL, binding, or event changes. The storage contract is additive — older SDKs ignore the unknown `"outbox"` key type. Revert is safe (orphaned records are simply never read).

## Testing

- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test --workspace --lib` — **840 passed** in the protocol crate, all other crates green, 0 failures
- `cargo fmt --all -- --check` — clean

9 new tests: round-trip restore, removal-clears-storage, capacity-eviction-deletes-from-storage, corrupt-skip, overflow-prune, carrier-relative-TTL survival through a cleanup tick, media-not-persisted, restored-entry-flushed-on-start, and restore-failure-rolls-back-outbox.