### PR TITLE
fix(cla): pin CLA doc to immutable tag + name Offline Protocol, Inc. as the contracting entity

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,12 +37,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
-          # Pinned to the SHA of the commit that introduced CLA.md so signatures
-          # always reference an immutable copy of the agreed text. If you
-          # intentionally amend CLA.md, update this SHA in the same commit so
-          # new signatures sign against the new revision; existing signatures
-          # remain tied to whatever URL the bot showed them at signing time.
-          path-to-document: "https://github.com/Offline-Protocol/offline-protocol-sdk/blob/c11938638e3a505e13cde810355d06ac15eeb02e/CLA.md"
+          # Pinned to the immutable tag `cla-v1.0`, which freezes the agreed CLA
+          # text at a specific revision. A bare commit SHA is unsafe here: PRs are
+          # squash-merged, so a feature-branch commit is orphaned from main and
+          # 404s once its branch is pruned (exactly what happened to the previous
+          # c1193863 pin). A tag stays reachable regardless of merge strategy or
+          # branch cleanup. If you amend CLA.md, cut a NEW tag (cla-v1.1) on the
+          # amending commit and bump this ref in the same commit — never move an
+          # existing CLA tag; contributors have signed against it.
+          path-to-document: "https://github.com/Offline-Protocol/offline-protocol-sdk/blob/cla-v1.0/CLA.md"
           # Signatures are committed to this branch — leave it unprotected.
           branch: "cla-signatures"
           # Allowlist GitHub App bot accounts (they have a "[bot]" suffix on the

--- a/CLA.md
+++ b/CLA.md
@@ -32,7 +32,7 @@ Original text found [here](https://www.apache.org/licenses/icla.pdf)
 
 By commenting **“I have read the CLA Document and I hereby sign the CLA”**
 on a Pull Request, **you (“Contributor”) agree to the following terms** for any
-past and future “Contributions” submitted to **Offline Protocol SDK (the “Project”)**.
+past and future “Contributions” submitted to **Offline Protocol, Inc. (the “Project”)**, the company that maintains the Offline Protocol SDK.
 
 ---
 

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -15,14 +15,16 @@ following licenses, at your option:
 2. **Commercial License** — for organizations that cannot or do not wish to comply
    with the AGPL-3.0 (for example, shipping the SDK inside a proprietary mobile
    application, embedding it in closed-source firmware, or operating a SaaS without
-   releasing source). A separate commercial license grants the right to use,
-   modify, and distribute the SDK without the AGPL-3.0 obligations.
+   releasing source). A separate commercial license from **Offline Protocol, Inc.**
+   grants the right to use, modify, and distribute the SDK without the AGPL-3.0
+   obligations.
 
 You only need **one** of the two licenses, not both.
 
 ## Obtaining a Commercial License
 
-To request a quote or discuss commercial terms, contact:
+Commercial licenses are offered by **Offline Protocol, Inc.** To request a quote
+or discuss commercial terms, contact:
 
 - **Email:** legal@offlineprotocol.com
 
@@ -31,8 +33,8 @@ model, expected scale) so we can scope the license appropriately.
 
 ## Contributions
 
-Contributors grant the project the right to sublicense their contributions under
-this Commercial License alongside the AGPL-3.0. The full terms are in
+Contributors grant **Offline Protocol, Inc.** the right to sublicense their
+contributions under this Commercial License alongside the AGPL-3.0. The full terms are in
 [`CLA.md`](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/CLA.md);
 see [`CONTRIBUTING.md`](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/CONTRIBUTING.md)
 for the signing flow.

--- a/bindings/python/LICENSE-COMMERCIAL.md
+++ b/bindings/python/LICENSE-COMMERCIAL.md
@@ -15,14 +15,16 @@ following licenses, at your option:
 2. **Commercial License** — for organizations that cannot or do not wish to comply
    with the AGPL-3.0 (for example, shipping the SDK inside a proprietary mobile
    application, embedding it in closed-source firmware, or operating a SaaS without
-   releasing source). A separate commercial license grants the right to use,
-   modify, and distribute the SDK without the AGPL-3.0 obligations.
+   releasing source). A separate commercial license from **Offline Protocol, Inc.**
+   grants the right to use, modify, and distribute the SDK without the AGPL-3.0
+   obligations.
 
 You only need **one** of the two licenses, not both.
 
 ## Obtaining a Commercial License
 
-To request a quote or discuss commercial terms, contact:
+Commercial licenses are offered by **Offline Protocol, Inc.** To request a quote
+or discuss commercial terms, contact:
 
 - **Email:** legal@offlineprotocol.com
 
@@ -31,8 +33,8 @@ model, expected scale) so we can scope the license appropriately.
 
 ## Contributions
 
-Contributors grant the project the right to sublicense their contributions under
-this Commercial License alongside the AGPL-3.0. The full terms are in
+Contributors grant **Offline Protocol, Inc.** the right to sublicense their
+contributions under this Commercial License alongside the AGPL-3.0. The full terms are in
 [`CLA.md`](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/CLA.md);
 see [`CONTRIBUTING.md`](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/CONTRIBUTING.md)
 for the signing flow.

--- a/bindings/react-native/LICENSE-COMMERCIAL.md
+++ b/bindings/react-native/LICENSE-COMMERCIAL.md
@@ -15,14 +15,16 @@ following licenses, at your option:
 2. **Commercial License** — for organizations that cannot or do not wish to comply
    with the AGPL-3.0 (for example, shipping the SDK inside a proprietary mobile
    application, embedding it in closed-source firmware, or operating a SaaS without
-   releasing source). A separate commercial license grants the right to use,
-   modify, and distribute the SDK without the AGPL-3.0 obligations.
+   releasing source). A separate commercial license from **Offline Protocol, Inc.**
+   grants the right to use, modify, and distribute the SDK without the AGPL-3.0
+   obligations.
 
 You only need **one** of the two licenses, not both.
 
 ## Obtaining a Commercial License
 
-To request a quote or discuss commercial terms, contact:
+Commercial licenses are offered by **Offline Protocol, Inc.** To request a quote
+or discuss commercial terms, contact:
 
 - **Email:** legal@offlineprotocol.com
 
@@ -31,8 +33,8 @@ model, expected scale) so we can scope the license appropriately.
 
 ## Contributions
 
-Contributors grant the project the right to sublicense their contributions under
-this Commercial License alongside the AGPL-3.0. The full terms are in
+Contributors grant **Offline Protocol, Inc.** the right to sublicense their
+contributions under this Commercial License alongside the AGPL-3.0. The full terms are in
 [`CLA.md`](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/CLA.md);
 see [`CONTRIBUTING.md`](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/CONTRIBUTING.md)
 for the signing flow.


### PR DESCRIPTION
## What & why

Two defects made the CLA legally unwired. Both are fixed here.

### 1. Broken document pin (latent 404)
`cla.yml` pinned the signing document to commit `c1193863`, which was **squash-merged** in #107 and is **not an ancestor of `main`** (on `main`, `CLA.md` was introduced by `d93a5a5`).

Ground truth, verified against GitHub: the old URL returns **HTTP 200 today** — *not* a live 404 — but only because the already-merged feature branch `chore/relicense-agpl-commercial` still lingers on the remote and keeps the orphaned commit reachable. The day that branch is pruned, the commit is unreachable and **every contributor is sent to a 404 as the document they're "signing."** It's a time-bomb, not a corpse.

**Fix:** repin to an immutable tag **`cla-v1.0`** (pushed with this PR) that stays reachable regardless of merge strategy or branch cleanup. A bare feature-branch SHA would just reproduce this bug. The `cla.yml` comment now documents the tag convention: amend → cut a new tag (`cla-v1.1`) and bump the ref in the same commit; never move an existing CLA tag.

### 2. Grant made to a non-entity
- `CLA.md` granted the copyright / patent / **sublicense** rights to *"Offline Protocol SDK (the Project)"* — a project name, not a legal person.
- `LICENSE-COMMERCIAL.md` never named the **licensor** that sells commercial licenses or receives the sublicense right.

A grant to a non-entity is of doubtful enforceability, and the whole dual-license model depends on an entity that can exercise the sublicense grant and sell commercial licenses.

**Fix:** name **Offline Protocol, Inc.** as the grantee in `CLA.md` and as the licensor in `LICENSE-COMMERCIAL.md`.

## Blast radius
- CLA **text** is byte-identical to the previously agreed revision apart from naming the entity.
- Only recorded signer is the repo owner (`bahdotsh`, 3 entries on PR #108) — no external contributor is affected by the grantee rename.

## ⚖️ Still needs counsel before this is relied upon
- [ ] Confirm the **exact clause wording** naming the entity (I inserted the name into the definitional slots, mirroring how the ASF ICLA names "the Foundation" — I did not draft new legal language).
- [ ] Confirm the entity's **legal form and state of incorporation** ("Offline Protocol, Inc." as written).
- [ ] Decide whether naming the grantee is material enough to require **re-signing**. If so: bump the doc header to v1.1, cut `cla-v1.1`, and bump `path-to-signatures` to `signatures/version2/cla.json` to invalidate the (owner-only) existing signatures.

## Note
If counsel revises the wording before merge, the `cla-v1.0` tag must be re-cut on the amended commit (safe pre-signing — only the owner has signed).