### PR TITLE
fix(bindings): honor RN encryption config fields dropped by shape mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Binary wire frames carry base64 content tails raw (ext TLV tag 1).** When a message's `content` ends in a long canonical-base64 run (the compact MLS envelope, Welcome blobs, and similar), wire-v1 frames now carry the decoded bytes in the frame's extension section instead of paying the 4/3 base64 inflation, reconstructing the exact original string on decode. The split is verified byte-for-byte at encode time, so arbitrary content is safe by construction. `WireMessageV1`'s frozen layout is unchanged; tag 1 ships inside wire v1's first release, so advertising v1 implies understanding it.
 
+### Fixed
+
+- **React Native encryption settings now actually reach the protocol core.** The JS wrapper sent `encryption.enabled`, `autoKeyExchange`, `storePending`, and `requireEncryption` as flat top-level keys while the iOS and Android bridges read them only from the nested `encryption` object, so every app-set value was silently discarded and the all-true defaults won. The wrapper now sends the nested shape alongside the flat keys (kept in lockstep), and both bridges accept either shape in camelCase or snake_case, locked by unit tests on both platforms. The sibling flags also now default to the value of `enabled`, so `encryption: { enabled: false }` alone yields the coherent fully-disabled posture (mirroring Rust's `EncryptionConfig::disabled()`) instead of a node whose every send fails with `EncryptFailed`; explicitly combining `enabled: false` with `requireEncryption: true` is rejected loudly at `create()` by the existing core validation.
+
 ## [0.13.1] — 2026-07-14
 
 ### Fixed

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ProtocolConfigParser.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ProtocolConfigParser.kt
@@ -10,9 +10,10 @@ import uniffi.offline_protocol.ProtocolConfig
  *
  * Extracted from [OfflineProtocolModule] so the dual-shape/dual-case field
  * reads are JVM unit testable — a silent parse regression here reverts a
- * field to its default with no error anywhere. The iOS bridge keeps the same
- * logic inline in OfflineProtocolModule.swift `parseConfig`; keep the read
- * order and precedence in sync.
+ * field to its default with no error anywhere. The iOS bridge mirrors the
+ * encryption-section reads in EncryptionConfigReader.swift (covered by the
+ * SwiftPM suite) and keeps the rest inline in OfflineProtocolModule.swift
+ * `parseConfig`; keep the read order and precedence in sync.
  */
 internal object ProtocolConfigParser {
 
@@ -26,25 +27,33 @@ internal object ProtocolConfigParser {
     fun parse(configJson: String): ParsedConfig {
         val json = JSONObject(configJson)
 
-        // Parse encryption config with defaults (enabled by default)
+        // Encryption flags (default on): nested home under `encryption`
+        // first, then top level, in camelCase or snake_case. The JS wrapper
+        // sends both shapes with identical values; direct native callers may
+        // send either. Accepting both is what keeps a sender-side shape
+        // change from silently reverting a flag to its default — these four
+        // were nested-only while the wrapper sent flat, so every app-set
+        // value was dropped.
         val encryptionJson = json.optJSONObject("encryption")
-        val encryptionEnabled = encryptionJson?.optBoolean("enabled", true) ?: true
-        val autoKeyExchange = encryptionJson?.let {
-            it.optBooleanCompat("autoKeyExchange", "auto_key_exchange") ?: true
-        } ?: true
-        val storePending = encryptionJson?.let {
-            it.optBooleanCompat("storePending", "store_pending") ?: true
-        } ?: true
+        val encryptionEnabled = encryptionJson?.optBooleanCompat("enabled")
+            ?: json.optBooleanCompat("encryptionEnabled", "encryption_enabled")
+            ?: true
+        val autoKeyExchange =
+            encryptionJson?.optBooleanCompat("autoKeyExchange", "auto_key_exchange")
+                ?: json.optBooleanCompat("autoKeyExchange", "auto_key_exchange")
+                ?: true
+        val storePending = encryptionJson?.optBooleanCompat("storePending", "store_pending")
+            ?: json.optBooleanCompat("storePending", "store_pending")
+            ?: true
         // Fail-closed default (SEC-M3): plaintext operation is an explicit opt-out.
-        val requireEncryption = encryptionJson?.let {
-            it.optBooleanCompat("requireEncryption", "require_encryption") ?: true
-        } ?: true
-        // Wire-format kill switches (default on), accepted in camelCase or
-        // snake_case. compactEnvelopeEnabled: nested home under `encryption`
-        // first, then top level (the JS wrapper sends the flat shape; direct
-        // native callers may follow the nested config). binaryWireEnabled:
-        // top level only — that IS its home in both the JS config and the
-        // flat UniFFI dictionary.
+        val requireEncryption =
+            encryptionJson?.optBooleanCompat("requireEncryption", "require_encryption")
+                ?: json.optBooleanCompat("requireEncryption", "require_encryption")
+                ?: true
+        // Wire-format kill switches (default on), same shape rules as above
+        // for compactEnvelopeEnabled. binaryWireEnabled: top level only —
+        // that IS its home in both the JS config and the flat UniFFI
+        // dictionary.
         val binaryWireEnabled =
             json.optBooleanCompat("binaryWireEnabled", "binary_wire_enabled") ?: true
         val compactEnvelopeEnabled = encryptionJson?.optBooleanCompat(

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ProtocolConfigParserTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ProtocolConfigParserTest.kt
@@ -5,11 +5,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Locks down the wire-format kill-switch parsing: a silent regression here
- * reverts a switch to its default with no error anywhere, which is exactly
- * how the legacy nested-only encryption fields drifted. Read order under
- * test: compactEnvelopeEnabled nested under `encryption` first then top
- * level, binaryWireEnabled top level only, both in camelCase or snake_case.
+ * Locks down the create()-config parsing: a silent regression here reverts a
+ * field to its default with no error anywhere — exactly what happened to the
+ * four encryption flags, which were read nested-only while the JS wrapper
+ * sent the flat shape, silently discarding every app-set value. Read order
+ * under test: encryption flags and compactEnvelopeEnabled nested under
+ * `encryption` first then top level, binaryWireEnabled top level only, all
+ * in camelCase or snake_case.
  */
 class ProtocolConfigParserTest {
 
@@ -68,5 +70,70 @@ class ProtocolConfigParserTest {
             """{"appId":"app","userId":"alice","compactEnvelopeEnabled":false,"encryption":{"enabled":true}}"""
         )
         assertFalse(config.compactEnvelopeEnabled)
+    }
+
+    @Test
+    fun encryptionFlagsDefaultOnWhenOmitted() {
+        val config = parse("""{"appId":"app","userId":"alice"}""")
+        assertTrue(config.encryptionEnabled)
+        assertTrue(config.autoKeyExchange)
+        assertTrue(config.storePending)
+        assertTrue(config.requireEncryption)
+    }
+
+    @Test
+    fun encryptionFlagsReadTheFlatCamelCaseShapeTheJsWrapperSends() {
+        val config = parse(
+            """{"appId":"app","userId":"alice","encryptionEnabled":false,"autoKeyExchange":false,"storePending":false,"requireEncryption":false}"""
+        )
+        assertFalse(config.encryptionEnabled)
+        assertFalse(config.autoKeyExchange)
+        assertFalse(config.storePending)
+        assertFalse(config.requireEncryption)
+    }
+
+    @Test
+    fun encryptionFlagsReadTheirNestedHome() {
+        val config = parse(
+            """{"appId":"app","userId":"alice","encryption":{"enabled":false,"autoKeyExchange":false,"storePending":false,"requireEncryption":false}}"""
+        )
+        assertFalse(config.encryptionEnabled)
+        assertFalse(config.autoKeyExchange)
+        assertFalse(config.storePending)
+        assertFalse(config.requireEncryption)
+    }
+
+    @Test
+    fun encryptionFlagsReadFlatSnakeCase() {
+        val config = parse(
+            """{"appId":"app","userId":"alice","encryption_enabled":false,"auto_key_exchange":false,"store_pending":false,"require_encryption":false}"""
+        )
+        assertFalse(config.encryptionEnabled)
+        assertFalse(config.autoKeyExchange)
+        assertFalse(config.storePending)
+        assertFalse(config.requireEncryption)
+    }
+
+    @Test
+    fun nestedEncryptionFlagsWinOverFlat() {
+        val config = parse(
+            """{"appId":"app","userId":"alice","encryptionEnabled":true,"autoKeyExchange":true,"storePending":true,"requireEncryption":true,"encryption":{"enabled":false,"autoKeyExchange":false,"storePending":false,"requireEncryption":false}}"""
+        )
+        assertFalse(config.encryptionEnabled)
+        assertFalse(config.autoKeyExchange)
+        assertFalse(config.storePending)
+        assertFalse(config.requireEncryption)
+    }
+
+    @Test
+    fun encryptionSectionWithoutTheFlagsFallsThroughToFlatKeys() {
+        val config = parse(
+            """{"appId":"app","userId":"alice","encryptionEnabled":false,"requireEncryption":false,"encryption":{"compactEnvelopeEnabled":true}}"""
+        )
+        assertFalse(config.encryptionEnabled)
+        assertFalse(config.requireEncryption)
+        assertTrue(config.compactEnvelopeEnabled)
+        assertTrue(config.autoKeyExchange)
+        assertTrue(config.storePending)
     }
 }

--- a/bindings/react-native/ios/EncryptionConfigReader.swift
+++ b/bindings/react-native/ios/EncryptionConfigReader.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// The encryption section of the `create()` config JSON, resolved to
+/// effective values.
+///
+/// Mirrors android/ `ProtocolConfigParser` — keep the read order and
+/// precedence in sync: nested home under `encryption` first, then top level,
+/// camelCase or snake_case, defaults on. Both shapes are accepted so a
+/// sender-side shape change can never silently revert a flag to its default —
+/// the four flags below were read nested-only while the JS wrapper sent the
+/// flat shape, silently discarding every app-set value.
+///
+/// Foundation-only on purpose: the SwiftPM test harness (Package.swift)
+/// compiles this file without React or the Generated UniFFI module, so the
+/// values struct uses plain types and `OfflineProtocolModule` maps them onto
+/// the UniFFI `ProtocolConfig` (including the `OverflowPolicy` enum, which
+/// must not be imported here).
+struct EncryptionConfigValues: Equatable {
+    var enabled: Bool
+    var autoKeyExchange: Bool
+    var storePending: Bool
+    var requireEncryption: Bool
+    var compactEnvelopeEnabled: Bool
+    var maxPendingPerPeer: UInt64
+    var maxPendingGlobal: UInt64
+    var pendingTtlMs: UInt64
+    /// Raw policy string ("drop_oldest" / "drop_newest"); the module maps it
+    /// onto the Generated `OverflowPolicy` enum.
+    var overflowPolicyRaw: String
+}
+
+enum EncryptionConfigReader {
+
+    static func read(_ raw: [String: Any]) -> EncryptionConfigValues {
+        let nested = raw["encryption"] as? [String: Any] ?? [:]
+
+        let enabled = bool(nested, "enabled")
+            ?? bool(raw, "encryptionEnabled", "encryption_enabled")
+            ?? true
+        let autoKeyExchange = bool(nested, "autoKeyExchange", "auto_key_exchange")
+            ?? bool(raw, "autoKeyExchange", "auto_key_exchange")
+            ?? true
+        let storePending = bool(nested, "storePending", "store_pending")
+            ?? bool(raw, "storePending", "store_pending")
+            ?? true
+        // Fail-closed default (SEC-M3): plaintext operation is an explicit opt-out.
+        let requireEncryption = bool(nested, "requireEncryption", "require_encryption")
+            ?? bool(raw, "requireEncryption", "require_encryption")
+            ?? true
+        let compactEnvelopeEnabled = bool(nested, "compactEnvelopeEnabled", "compact_envelope_enabled")
+            ?? bool(raw, "compactEnvelopeEnabled", "compact_envelope_enabled")
+            ?? true
+
+        let pendingQueue = (nested["pendingQueue"] as? [String: Any])
+            ?? (nested["pending_queue"] as? [String: Any])
+            ?? [:]
+        let maxPendingPerPeer = number(pendingQueue, "maxPendingPerPeer", "max_pending_per_peer")
+            ?? number(raw, "maxPendingPerPeer", "max_pending_per_peer")
+            ?? 64
+        let maxPendingGlobal = number(pendingQueue, "maxPendingGlobal", "max_pending_global")
+            ?? number(raw, "maxPendingGlobal", "max_pending_global")
+            ?? 4096
+        let pendingTtlMs = number(pendingQueue, "pendingTtlMs", "pending_ttl_ms")
+            ?? number(raw, "pendingTtlMs", "pending_ttl_ms")
+            ?? 120_000
+        let overflowPolicyRaw = string(pendingQueue, "overflowPolicy", "overflow_policy")
+            ?? string(raw, "overflowPolicy", "overflow_policy")
+            ?? "drop_oldest"
+
+        return EncryptionConfigValues(
+            enabled: enabled,
+            autoKeyExchange: autoKeyExchange,
+            storePending: storePending,
+            requireEncryption: requireEncryption,
+            compactEnvelopeEnabled: compactEnvelopeEnabled,
+            maxPendingPerPeer: maxPendingPerPeer,
+            maxPendingGlobal: maxPendingGlobal,
+            pendingTtlMs: pendingTtlMs,
+            overflowPolicyRaw: overflowPolicyRaw
+        )
+    }
+
+    private static func bool(_ dict: [String: Any], _ keys: String...) -> Bool? {
+        for key in keys {
+            if let value = dict[key] as? Bool {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func number(_ dict: [String: Any], _ keys: String...) -> UInt64? {
+        for key in keys {
+            if let value = dict[key] as? NSNumber {
+                return value.uint64Value
+            }
+        }
+        return nil
+    }
+
+    private static func string(_ dict: [String: Any], _ keys: String...) -> String? {
+        for key in keys {
+            if let value = dict[key] as? String {
+                return value
+            }
+        }
+        return nil
+    }
+}

--- a/bindings/react-native/ios/MeshSdk.podspec
+++ b/bindings/react-native/ios/MeshSdk.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   # Source files
   s.source_files = [
     "OfflineProtocolModule.{m,swift}",
+    "EncryptionConfigReader.swift",
     "ProtocolErrorBridge.swift",
     "TransportManager.swift",
     "BleManager.swift",

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -129,65 +129,24 @@ class OfflineProtocolModule: RCTEventEmitter {
                          userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"])
         }
         
-        // Parse encryption config with defaults (enabled by default)
-        let encryptionDict = raw["encryption"] as? [String: Any] ?? [:]
-        let encryptionEnabled = encryptionDict["enabled"] as? Bool ?? true
-        let autoKeyExchange = encryptionDict["autoKeyExchange"] as? Bool 
-                              ?? encryptionDict["auto_key_exchange"] as? Bool ?? true
-        let storePending = encryptionDict["storePending"] as? Bool 
-                           ?? encryptionDict["store_pending"] as? Bool ?? true
-        // Fail-closed default (SEC-M3): plaintext operation is an explicit opt-out.
-        let requireEncryption = encryptionDict["requireEncryption"] as? Bool
-                                ?? encryptionDict["require_encryption"] as? Bool ?? true
-        // Wire-format kill switches (default on), accepted in camelCase or
-        // snake_case. compactEnvelopeEnabled: nested home under `encryption`
-        // first, then top level (the JS wrapper sends the flat shape; direct
-        // native callers may follow the nested config). binaryWireEnabled:
-        // top level only — that IS its home in both the JS config and the
-        // flat UniFFI dictionary. Mirrors ProtocolConfigParser.kt on Android;
-        // keep the read order and precedence in sync.
-        let binaryWireEnabled = raw["binaryWireEnabled"] as? Bool
-            ?? raw["binary_wire_enabled"] as? Bool ?? true
-        let compactEnvelopeEnabled = encryptionDict["compactEnvelopeEnabled"] as? Bool
-            ?? encryptionDict["compact_envelope_enabled"] as? Bool
-            ?? raw["compactEnvelopeEnabled"] as? Bool
-            ?? raw["compact_envelope_enabled"] as? Bool ?? true
-        let pendingQueueDict = encryptionDict["pendingQueue"] as? [String: Any]
-            ?? encryptionDict["pending_queue"] as? [String: Any]
-        let maxPendingPerPeer = UInt64(
-            (pendingQueueDict?["maxPendingPerPeer"] as? NSNumber)?.uint64Value
-                ?? (pendingQueueDict?["max_pending_per_peer"] as? NSNumber)?.uint64Value
-                ?? (raw["maxPendingPerPeer"] as? NSNumber)?.uint64Value
-                ?? (raw["max_pending_per_peer"] as? NSNumber)?.uint64Value
-                ?? 64
-        )
-        let maxPendingGlobal = UInt64(
-            (pendingQueueDict?["maxPendingGlobal"] as? NSNumber)?.uint64Value
-                ?? (pendingQueueDict?["max_pending_global"] as? NSNumber)?.uint64Value
-                ?? (raw["maxPendingGlobal"] as? NSNumber)?.uint64Value
-                ?? (raw["max_pending_global"] as? NSNumber)?.uint64Value
-                ?? 4096
-        )
-        let pendingTtlMs = UInt64(
-            (pendingQueueDict?["pendingTtlMs"] as? NSNumber)?.uint64Value
-                ?? (pendingQueueDict?["pending_ttl_ms"] as? NSNumber)?.uint64Value
-                ?? (raw["pendingTtlMs"] as? NSNumber)?.uint64Value
-                ?? (raw["pending_ttl_ms"] as? NSNumber)?.uint64Value
-                ?? 120_000
-        )
-        let overflowPolicyRaw = (pendingQueueDict?["overflowPolicy"] as? String)
-            ?? (pendingQueueDict?["overflow_policy"] as? String)
-            ?? (raw["overflowPolicy"] as? String)
-            ?? (raw["overflow_policy"] as? String)
-            ?? "drop_oldest"
+        // Encryption section (four flags, compact-envelope kill switch,
+        // pending queue): read by EncryptionConfigReader — Foundation-only so
+        // the SwiftPM suite covers it; mirrors ProtocolConfigParser.kt on
+        // Android, keep the read order and precedence in sync.
+        let encryption = EncryptionConfigReader.read(raw)
         let overflowPolicy: OverflowPolicy
-        switch overflowPolicyRaw.lowercased() {
+        switch encryption.overflowPolicyRaw.lowercased() {
         case "drop_newest":
             overflowPolicy = .dropNewest
         default:
             overflowPolicy = .dropOldest
         }
-        
+        // binaryWireEnabled (kill switch, default on): top level only — that
+        // IS its home in both the JS config and the flat UniFFI dictionary.
+        // camelCase or snake_case.
+        let binaryWireEnabled = raw["binaryWireEnabled"] as? Bool
+            ?? raw["binary_wire_enabled"] as? Bool ?? true
+
         let config = ProtocolConfig(
             appId: raw["appId"] as? String ?? raw["app_id"] as? String ?? "",
             userId: raw["userId"] as? String ?? raw["user_id"] as? String ?? "",
@@ -198,16 +157,16 @@ class OfflineProtocolModule: RCTEventEmitter {
             nostrEnabled: raw["nostrEnabled"] as? Bool ?? raw["nostr_enabled"] as? Bool ?? false,
             preferOnline: raw["preferOnline"] as? Bool ?? raw["prefer_online"] as? Bool ?? false,
             initialTtl: UInt8(raw["initialTtl"] as? Int ?? raw["initial_ttl"] as? Int ?? 8),
-            encryptionEnabled: encryptionEnabled,
-            autoKeyExchange: autoKeyExchange,
-            storePending: storePending,
-            requireEncryption: requireEncryption,
-            maxPendingPerPeer: maxPendingPerPeer,
-            maxPendingGlobal: maxPendingGlobal,
-            pendingTtlMs: pendingTtlMs,
+            encryptionEnabled: encryption.enabled,
+            autoKeyExchange: encryption.autoKeyExchange,
+            storePending: encryption.storePending,
+            requireEncryption: encryption.requireEncryption,
+            maxPendingPerPeer: encryption.maxPendingPerPeer,
+            maxPendingGlobal: encryption.maxPendingGlobal,
+            pendingTtlMs: encryption.pendingTtlMs,
             overflowPolicy: overflowPolicy,
             binaryWireEnabled: binaryWireEnabled,
-            compactEnvelopeEnabled: compactEnvelopeEnabled
+            compactEnvelopeEnabled: encryption.compactEnvelopeEnabled
         )
 
         return (config, raw)

--- a/bindings/react-native/ios/Package.swift
+++ b/bindings/react-native/ios/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
                 "tests"
             ],
             sources: [
+                "EncryptionConfigReader.swift",
                 "LegacyRelayMessage.swift",
                 "PresenceWatchPolicy.swift",
                 "RecipientInFlightTracker.swift",
@@ -70,6 +71,7 @@ let package = Package(
                 "ProtocolErrorBridgeTests.swift"
             ],
             sources: [
+                "EncryptionConfigReaderTests.swift",
                 "LegacyRelayMessageTests.swift",
                 "PresenceWatchPolicyTests.swift",
                 "RecipientInFlightTrackerTests.swift",

--- a/bindings/react-native/ios/tests/EncryptionConfigReaderTests.swift
+++ b/bindings/react-native/ios/tests/EncryptionConfigReaderTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import OfflineProtocol
+
+/// Mirrors android/ `ProtocolConfigParserTest`'s encryption cases — keep the
+/// two suites in sync. A silent regression here reverts a flag to its
+/// default with no error anywhere, which is exactly how the four encryption
+/// flags drifted (nested-only reads while the JS wrapper sent the flat
+/// shape).
+final class EncryptionConfigReaderTests: XCTestCase {
+
+    private func read(_ json: String) throws -> EncryptionConfigValues {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let raw = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        return EncryptionConfigReader.read(raw)
+    }
+
+    func testEncryptionFlagsDefaultOnWhenOmitted() throws {
+        let values = try read(#"{"appId":"app","userId":"alice"}"#)
+        XCTAssertTrue(values.enabled)
+        XCTAssertTrue(values.autoKeyExchange)
+        XCTAssertTrue(values.storePending)
+        XCTAssertTrue(values.requireEncryption)
+        XCTAssertTrue(values.compactEnvelopeEnabled)
+        XCTAssertEqual(values.maxPendingPerPeer, 64)
+        XCTAssertEqual(values.maxPendingGlobal, 4096)
+        XCTAssertEqual(values.pendingTtlMs, 120_000)
+        XCTAssertEqual(values.overflowPolicyRaw, "drop_oldest")
+    }
+
+    func testEncryptionFlagsReadTheFlatCamelCaseShapeTheJsWrapperSends() throws {
+        let values = try read(
+            #"{"encryptionEnabled":false,"autoKeyExchange":false,"storePending":false,"requireEncryption":false}"#
+        )
+        XCTAssertFalse(values.enabled)
+        XCTAssertFalse(values.autoKeyExchange)
+        XCTAssertFalse(values.storePending)
+        XCTAssertFalse(values.requireEncryption)
+    }
+
+    func testEncryptionFlagsReadTheirNestedHome() throws {
+        let values = try read(
+            #"{"encryption":{"enabled":false,"autoKeyExchange":false,"storePending":false,"requireEncryption":false}}"#
+        )
+        XCTAssertFalse(values.enabled)
+        XCTAssertFalse(values.autoKeyExchange)
+        XCTAssertFalse(values.storePending)
+        XCTAssertFalse(values.requireEncryption)
+    }
+
+    func testEncryptionFlagsReadFlatSnakeCase() throws {
+        let values = try read(
+            #"{"encryption_enabled":false,"auto_key_exchange":false,"store_pending":false,"require_encryption":false}"#
+        )
+        XCTAssertFalse(values.enabled)
+        XCTAssertFalse(values.autoKeyExchange)
+        XCTAssertFalse(values.storePending)
+        XCTAssertFalse(values.requireEncryption)
+    }
+
+    func testNestedEncryptionFlagsWinOverFlat() throws {
+        let values = try read(
+            #"{"encryptionEnabled":true,"autoKeyExchange":true,"storePending":true,"requireEncryption":true,"encryption":{"enabled":false,"autoKeyExchange":false,"storePending":false,"requireEncryption":false}}"#
+        )
+        XCTAssertFalse(values.enabled)
+        XCTAssertFalse(values.autoKeyExchange)
+        XCTAssertFalse(values.storePending)
+        XCTAssertFalse(values.requireEncryption)
+    }
+
+    func testEncryptionSectionWithoutTheFlagsFallsThroughToFlatKeys() throws {
+        let values = try read(
+            #"{"encryptionEnabled":false,"requireEncryption":false,"encryption":{"compactEnvelopeEnabled":true}}"#
+        )
+        XCTAssertFalse(values.enabled)
+        XCTAssertFalse(values.requireEncryption)
+        XCTAssertTrue(values.compactEnvelopeEnabled)
+        XCTAssertTrue(values.autoKeyExchange)
+        XCTAssertTrue(values.storePending)
+    }
+
+    func testCompactEnvelopeReadsItsNestedHomeThenTopLevel() throws {
+        let nested = try read(
+            #"{"compactEnvelopeEnabled":true,"encryption":{"compactEnvelopeEnabled":false}}"#
+        )
+        XCTAssertFalse(nested.compactEnvelopeEnabled)
+
+        let flat = try read(#"{"compactEnvelopeEnabled":false,"encryption":{"enabled":true}}"#)
+        XCTAssertFalse(flat.compactEnvelopeEnabled)
+    }
+
+    func testPendingQueueNestedHomeWinsOverFlat() throws {
+        let values = try read(
+            #"{"maxPendingPerPeer":1,"pendingTtlMs":1,"encryption":{"pendingQueue":{"maxPendingPerPeer":32,"pendingTtlMs":60000,"overflowPolicy":"drop_newest"}}}"#
+        )
+        XCTAssertEqual(values.maxPendingPerPeer, 32)
+        XCTAssertEqual(values.pendingTtlMs, 60_000)
+        XCTAssertEqual(values.overflowPolicyRaw, "drop_newest")
+    }
+
+    func testPendingQueueSnakeCaseAndFlatFallback() throws {
+        let values = try read(
+            #"{"max_pending_per_peer":16,"max_pending_global":256,"pending_ttl_ms":30000,"overflow_policy":"drop_newest"}"#
+        )
+        XCTAssertEqual(values.maxPendingPerPeer, 16)
+        XCTAssertEqual(values.maxPendingGlobal, 256)
+        XCTAssertEqual(values.pendingTtlMs, 30_000)
+        XCTAssertEqual(values.overflowPolicyRaw, "drop_newest")
+    }
+}

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -112,6 +112,19 @@ interface NativeConfig {
   maxPendingGlobal?: number;
   pendingTtlMs?: number;
   overflowPolicy?: 'drop_oldest' | 'drop_newest';
+  encryption: {
+    enabled: boolean;
+    autoKeyExchange: boolean;
+    storePending: boolean;
+    requireEncryption: boolean;
+    compactEnvelopeEnabled: boolean;
+    pendingQueue: {
+      maxPendingPerPeer: number;
+      maxPendingGlobal: number;
+      pendingTtlMs: number;
+      overflowPolicy: 'drop_oldest' | 'drop_newest';
+    };
+  };
   dors?: {
     preferOnline: boolean;
     switchHysteresis: number;
@@ -289,6 +302,30 @@ export class OfflineProtocol {
         : null;
     this.initialRuntimeConfigApplied = false;
 
+    // Effective encryption posture. The sibling flags default to the value
+    // of `enabled` so that `encryption: { enabled: false }` alone yields the
+    // fully-disabled posture (mirroring Rust's EncryptionConfig::disabled());
+    // with unconditional all-true defaults it would instead trip the Rust
+    // create()-time validation that rejects requireEncryption without
+    // enabled. Explicit values always win over these derived defaults.
+    const encryptionSource = this.config.encryption;
+    const encryptionOn = encryptionSource?.enabled ?? true;
+    const encryption = {
+      enabled: encryptionOn,
+      autoKeyExchange: encryptionSource?.autoKeyExchange ?? encryptionOn,
+      storePending: encryptionSource?.storePending ?? encryptionOn,
+      // Fail-closed default (SEC-M3): plaintext operation is an explicit opt-out.
+      requireEncryption: encryptionSource?.requireEncryption ?? encryptionOn,
+      compactEnvelopeEnabled: encryptionSource?.compactEnvelopeEnabled ?? true,
+      pendingQueue: {
+        maxPendingPerPeer: encryptionSource?.pendingQueue?.maxPendingPerPeer ?? 64,
+        maxPendingGlobal: encryptionSource?.pendingQueue?.maxPendingGlobal ?? 4096,
+        pendingTtlMs: encryptionSource?.pendingQueue?.pendingTtlMs ?? 120000,
+        overflowPolicy:
+          encryptionSource?.pendingQueue?.overflowPolicy ?? 'drop_oldest',
+      },
+    };
+
     const nativeConfig: NativeConfig = {
       appId: this.config.appId,
       userId: this.config.userId,
@@ -300,16 +337,20 @@ export class OfflineProtocol {
       preferOnline: dorsSource?.preferOnline ?? false,
       initialTtl: this.config.network?.initialTtl ?? 8,
       binaryWireEnabled: this.config.binaryWireEnabled ?? true,
-      encryptionEnabled: this.config.encryption?.enabled ?? true,
-      autoKeyExchange: this.config.encryption?.autoKeyExchange ?? true,
-      storePending: this.config.encryption?.storePending ?? true,
-      // Fail-closed default (SEC-M3): plaintext operation is an explicit opt-out.
-      requireEncryption: this.config.encryption?.requireEncryption ?? true,
-      compactEnvelopeEnabled: this.config.encryption?.compactEnvelopeEnabled ?? true,
-      maxPendingPerPeer: this.config.encryption?.pendingQueue?.maxPendingPerPeer ?? 64,
-      maxPendingGlobal: this.config.encryption?.pendingQueue?.maxPendingGlobal ?? 4096,
-      pendingTtlMs: this.config.encryption?.pendingQueue?.pendingTtlMs ?? 120000,
-      overflowPolicy: this.config.encryption?.pendingQueue?.overflowPolicy ?? 'drop_oldest',
+      // The nested `encryption` object is the documented home for these
+      // fields (what the native bridges read first); the flat keys carry the
+      // same effective values for readers of the historical flat shape. Keep
+      // the two in lockstep — they must never diverge.
+      encryptionEnabled: encryption.enabled,
+      autoKeyExchange: encryption.autoKeyExchange,
+      storePending: encryption.storePending,
+      requireEncryption: encryption.requireEncryption,
+      compactEnvelopeEnabled: encryption.compactEnvelopeEnabled,
+      maxPendingPerPeer: encryption.pendingQueue.maxPendingPerPeer,
+      maxPendingGlobal: encryption.pendingQueue.maxPendingGlobal,
+      pendingTtlMs: encryption.pendingQueue.pendingTtlMs,
+      overflowPolicy: encryption.pendingQueue.overflowPolicy,
+      encryption,
     };
 
     if (dorsConfig) {


### PR DESCRIPTION
## Summary

- `transformConfigForNative()` sent `encryptionEnabled`/`autoKeyExchange`/`storePending`/`requireEncryption` as flat top-level JSON keys, but both native bridges (`ProtocolConfigParser.kt`, `OfflineProtocolModule.swift`) read them **nested-only** under `encryption`. Every app-set value was silently discarded and the all-`true` defaults always won.
- The JS wrapper now emits the nested `encryption` object alongside the flat keys (kept in lockstep), and both bridges accept either shape — nested-first, then flat, camelCase or snake_case — the same dual-shape pattern `compactEnvelopeEnabled`/`binaryWireEnabled` already use (#190).
- The three sibling flags (`autoKeyExchange`, `storePending`, `requireEncryption`) now default to the value of `enabled` instead of unconditionally `true`, mirroring Rust's `EncryptionConfig::disabled()`. Without this, honoring the flat values as-is would turn `encryption: { enabled: false }` into a `create()`-time `InvalidConfiguration` crash, since Rust's `validate()` rejects `require_encryption` without `enabled`. Today that same config instead silently produces a node whose every send fails `EncryptFailed` — this fix makes it a working plaintext opt-out instead.
- On iOS, the encryption-section parsing was extracted into a new Foundation-only `EncryptionConfigReader.swift` (mirroring `ProtocolConfigParser.kt`) so it's covered by the SwiftPM test harness, which can't compile `OfflineProtocolModule.swift` itself (React/Generated-UniFFI dependents). Registered in `Package.swift` and `MeshSdk.podspec`.

No Rust, UDL, or wire-format changes — this is purely how the two RN native bridges populate the existing `ProtocolConfig` fields.

## Behavior changes

| App config (via JS wrapper) | Before | After |
|---|---|---|
| unset / all-true | defaults | unchanged |
| `{enabled: false}` | create OK; every send fails `EncryptFailed`; inbound plaintext silently rejected | plaintext operation works (with per-peer `PlaintextSend` warnings) |
| `{requireEncryption: false}` | ignored — stays fail-closed | honored |
| `{autoKeyExchange: false}` / `{storePending: false}` | ignored | honored |
| `{enabled: false, requireEncryption: true}` (contradictory) | create OK, everything silently fails | loud `InvalidConfiguration` at create — correct, since this combo can't work |

## Test plan

- [x] `npx tsc --noEmit` clean on `bindings/react-native`
- [x] Android: ran the JVM unit test harness in a clean copy (avoids the `node_modules` react-android resolution gotcha) — `ProtocolConfigParserTest`: 12/12 passing, including 6 new cases (default/flat-camel/nested/flat-snake/nested-wins/section-without-flags-falls-through)
- [x] iOS: `swift test --package-path bindings/react-native/ios` — 73/73 passing (was 64), including 9 new `EncryptionConfigReaderTests` cases mirroring the Android suite
- [x] CHANGELOG updated under `[Unreleased]` → Fixed

Out of scope (separate, pre-existing gap): `maxGroupMembers`/`groupRelayEnabled`/`requireTransportIdentity` remain unreachable from the RN config; JS `preferOnline`/WiFi-Direct/Internet transport default asymmetry between JS and native parsers when keys are omitted.