### PR TITLE
docs: correct cipher, transport, and toolchain claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ npm run build:uniffi:android      # Android only
 npm run generate:bindings         # regenerate after UDL changes
 ```
 
-Prerequisites: `cargo install uniffi --features="cli"`, `cargo install cargo-ndk`, Android NDK, Xcode.
+Prerequisites: `cargo install uniffi --version 0.30.0 --features cli --locked` (must match the workspace `uniffi = "0.30"` pin), Android NDK (`ANDROID_NDK_HOME`), Xcode.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Thank you for your interest in contributing! This document provides guidelines f
 ### Prerequisites
 
 - Rust 1.87+ (`rustup default stable`)
-- For mobile: Android NDK, Xcode
-- For web: wasm-pack
+- For mobile bindings: Android NDK, Xcode
+- For regenerating UniFFI bindings: `cargo install uniffi --features="cli"` and `cargo install cargo-ndk`
 
 ### Clone and Build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing! This document provides guidelines f
 
 - Rust 1.87+ (`rustup default stable`)
 - For mobile bindings: Android NDK, Xcode
-- For regenerating UniFFI bindings: `cargo install uniffi --features="cli"` and `cargo install cargo-ndk`
+- For regenerating UniFFI bindings: `cargo install uniffi --version 0.30.0 --features cli --locked` (the CLI version must match the workspace `uniffi = "0.30"` pin; CI uses this exact command)
 
 ### Clone and Build
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ each plaintext send then emits a `security_warning` event with the
 
 ### Prerequisites
 - Rust (via rustup)
-- uniffi-bindgen: `cargo install uniffi --features="cli"`
-- ndk: `cargo install cargo-ndk`
+- uniffi-bindgen: `cargo install uniffi --version 0.30.0 --features cli --locked` (must match the workspace `uniffi = "0.30"` pin)
+- For Android: the Android NDK (set `ANDROID_NDK_HOME`); for iOS: Xcode
 
 ### Build Mobile UniFFI Libraries
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@
 
 ## Features
 
-- **Multi-Transport**: Seamlessly switches between BLE, WiFi Direct, Internet, Reticulum, and Nostr relays
+- **Multi-Transport**: Automatically switches between BLE, WiFi Direct, Internet, Reticulum, and Nostr relays
 - **Mesh Networking**: Automatic peer discovery and message relay
 - **End-to-End Encryption**: Automatic MLS encryption with forward secrecy (RFC 9420)
 - **Group Roles**: Admin/member role management with last-admin safety invariants
 - **DORS**: Dynamic Offline Relay Switch for optimal transport selection
 - **Reliability**: ACKs, retries, and deduplication built-in
 - **Cross-Platform Bindings**: React Native for iOS/Android and Python for macOS/Linux/Windows
+
+> **What you must implement:** the Rust crates are I/O-free protocol engines — they queue, route, encrypt, and select transports, but never open a socket or touch a radio. A *platform bridge* does the actual I/O: it drains each transport's outbound queue, performs the send, reports the outcome, and injects inbound bytes. The React Native binding ships these bridges for iOS and Android (BLE, WiFi Direct, Internet, Nostr, Reticulum), and the Python binding ships BLE and Internet bridges. If you consume the Rust crates directly via `cargo add`, you write the bridge yourself — the contract is documented in the [`offline-protocol-transport`](crates/offline-protocol-transport/src/lib.rs) crate docs.
 
 ## Quick Start
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,4 +50,4 @@ The following are in scope for security reports:
 
 The SDK enforces `#![deny(unsafe_code)]` in all core crates. Only the UniFFI FFI boundary (`offline-protocol-uniffi`) allows unsafe code, limited to generated scaffolding.
 
-Cryptographic operations use audited RustCrypto primitives (Ed25519-dalek, SHA-256, AES-256-GCM) via the OpenMLS (RFC 9420) implementation.
+Cryptographic operations use the OpenMLS (RFC 9420) implementation with its `openmls_rust_crypto` provider. The default ciphersuite is `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519`: X25519 key agreement, AES-128-GCM authenticated encryption, SHA-256 hashing, and Ed25519 signatures. The underlying primitives come from `ed25519-dalek`/`x25519-dalek` (dalek-cryptography) and the RustCrypto project's AES-GCM and SHA-2 crates.


### PR DESCRIPTION
## Summary

Three documentation claims didn't survive contact with the code. This PR makes the docs say what the SDK actually does.

### SECURITY.md — wrong AEAD strength
Claimed AES-256-GCM; the actual default ciphersuite is `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` (`crates/offline-protocol-mls/src/group.rs:18`) → **AES-128-GCM**. Also fixed the crate attribution: `ed25519-dalek`/`x25519-dalek` are dalek-cryptography crates, not RustCrypto; the RustCrypto contribution is the AES-GCM and SHA-2 crates pulled in by `openmls_rust_crypto`.

### README — oversold transports
The features list said the SDK "seamlessly switches" between BLE, WiFi Direct, Internet, Reticulum, and Nostr, while the transport crate's rustdoc states it performs **no network or radio I/O**. Added a "What you must implement" note up top: the switching/selection logic is real Rust; the actual I/O lives in a platform bridge. The React Native binding ships bridges for all five transports on iOS/Android (verified — including WiFi Direct via MultipeerConnectivity on iOS), the Python binding ships BLE (central + peripheral) and Internet bridges, and a plain `cargo add` consumer writes the bridge themselves per the transport crate docs.

### CONTRIBUTING.md / README / CLAUDE.md — nonexistent toolchain
Listed `wasm-pack` "for web"; there is no web binding (`bindings/` contains only `python` and `react-native`). Replaced with the actual bindings prerequisite: `cargo install uniffi --version 0.30.0 --features cli --locked`, pinned because UniFFI's generated scaffolding must match the workspace `uniffi = "0.30"` pin (CI already installs exactly this). Review of this branch caught that the first draft swapped one phantom tool for another — `cargo-ndk` appears nowhere in the build scripts or CI (`build-uniffi-android.sh` wires the NDK linkers manually via `CARGO_TARGET_*_LINKER`); the follow-up commit removes it from all three docs that claimed it (CONTRIBUTING.md, README.md, CLAUDE.md).

Deliberately untouched: `docs/reticulum.md`'s AES-256-CBC (that's the external Reticulum stack's own crypto), and SECURITY.md's 0.13.x supported-versions table (latest tag is v0.13.1; bump it when v0.14.0 is tagged).

## Test plan

Docs-only change — no runtime surface. Verified every corrected claim against the source: `DEFAULT_CIPHERSUITE` in `group.rs`, the transport crate's no-I/O rustdoc, the bridge implementations in both bindings, and the `bindings/` directory contents.
