### PR TITLE
fix(bindings): declare 7 missing RN event types + Rust↔TS drift guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **React Native `MessageReceivedEvent` type was missing `reply_to_msg`.** The Rust event has always carried the replied-to message id; the TypeScript mirror now declares it (alongside the new `reply_context`).
 
+- **React Native: seven runtime events had no TypeScript declaration.** `group_renamed`, `message_decryption_failed`, `ack_evicted`, `fragment_assembly_evicted`, `relay_demoted_battery`, `user_blocked`, and `user_unblocked` have always been emitted at runtime (events cross the FFI as tagged JSON, and the dispatcher applies no filter) but were absent from `types.ts` — outside the `ProtocolEvent` union, `.on('<type>')` didn't type-check and payloads were untyped. All seven interfaces are now declared (plus a `DecryptionFailureCode` string union), and a Rust drift-guard test pins every core `Event` variant to a `types.ts` declaration so an event can no longer ship without its TypeScript mirror. Purely a typing change — no runtime behavior differs.
+
 ### Removed
 
 - **React Native: `src/types-uniffi.ts` (and its compiled `lib/types-uniffi.*`) removed from the package.** A pre-UniFFI-migration relic that was never exported from the package root and whose declarations contradicted the shipped API (a 3-argument `sendMessage`, a `ProtocolError` class the SDK never throws). Anyone deep-importing it should switch to the package root exports: `EstablishmentState` is exported from the root, and error codes arrive at runtime as plain `err.code` strings on native promise rejections, mirroring the UDL `ProtocolError` variant names — no runtime behavior changes.

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -735,6 +735,32 @@ export interface MessageFailedEvent extends BaseEvent {
 }
 
 /**
+ * Machine-readable decryption failure codes. `PENDING_QUEUE_DROPPED` means the
+ * message was dropped from the pending-decryption queue (overflow or TTL
+ * expiry) before the sender's session became ready; it was ACKed on receipt,
+ * so the sender will not retransmit it.
+ */
+export type DecryptionFailureCode =
+  | 'INVALID_PAYLOAD'
+  | 'NOT_INITIALIZED'
+  | 'INVALID_CIPHERTEXT'
+  | 'IDENTITY_MISMATCH'
+  | 'CRYPTO_FAILURE'
+  | 'PENDING_QUEUE_DROPPED'
+  | 'UNKNOWN';
+
+/**
+ * Failed to decrypt an inbound encrypted message.
+ */
+export interface MessageDecryptionFailedEvent extends BaseEvent {
+  type: 'message_decryption_failed';
+  message_id: string;
+  sender: string;
+  code: DecryptionFailureCode;
+  reason: string;
+}
+
+/**
  * Transport switched event
  */
 export interface TransportSwitchedEvent extends BaseEvent {
@@ -759,6 +785,15 @@ export interface RelayPromotedEvent extends BaseEvent {
 export interface RelayDemotedEvent extends BaseEvent {
   type: 'relay_demoted';
   reason: string;
+}
+
+/**
+ * Relay role was demoted due to battery constraints.
+ */
+export interface RelayDemotedBatteryEvent extends BaseEvent {
+  type: 'relay_demoted_battery';
+  battery_level: number;
+  min_required: number;
 }
 
 /**
@@ -880,6 +915,27 @@ export interface MediaSendFailedEvent extends BaseEvent {
   type: 'media_send_failed';
   file_id: string;
   recipient: string;
+  reason: string;
+}
+
+/**
+ * A pending ACK was evicted due to capacity constraints.
+ */
+export interface AckEvictedEvent extends BaseEvent {
+  type: 'ack_evicted';
+  message_id: string;
+  priority: string;
+  reason: string;
+}
+
+/**
+ * A fragment assembly was evicted to make room for new fragments.
+ */
+export interface FragmentAssemblyEvictedEvent extends BaseEvent {
+  type: 'fragment_assembly_evicted';
+  message_id: string;
+  /** Completion percentage (0-100) when evicted. */
+  completion_percent: number;
   reason: string;
 }
 
@@ -1276,6 +1332,20 @@ export interface GroupRoleChangedEvent extends BaseEvent {
   changed_by: string;
 }
 
+/**
+ * Group renamed — emitted when a rename is performed or received via
+ * `meshRenameGroup`. Renames observed only as relay-native `GroupRenamed`
+ * frames surface through `internet_server_message` instead.
+ */
+export interface GroupRenamedEvent extends BaseEvent {
+  type: 'group_renamed';
+  group_id: string;
+  new_name: string;
+  /** Previous group name, if known. */
+  old_name: string | null;
+  renamed_by: string;
+}
+
 // ============================================================================
 // SERVICE DISCOVERY & REQUEST/RESPONSE EVENTS
 // ============================================================================
@@ -1576,6 +1646,22 @@ export interface TofuResetEvent extends BaseEvent {
 }
 
 /**
+ * A user was blocked. Emitted for local UI notification only.
+ */
+export interface UserBlockedEvent extends BaseEvent {
+  type: 'user_blocked';
+  user_id: string;
+}
+
+/**
+ * A user was unblocked. Emitted for local UI notification only.
+ */
+export interface UserUnblockedEvent extends BaseEvent {
+  type: 'user_unblocked';
+  user_id: string;
+}
+
+/**
  * A raw relay server frame that apps need outside or in addition to
  * SDK-owned processing — invite-link lifecycle responses (`GroupInviteLinkCreated`,
  * `GroupJoinedViaInvite`, `GroupInviteJoinPending`, …), `GroupRoleChanged`,
@@ -1623,9 +1709,11 @@ export type ProtocolEvent =
   | MessageReceivedEvent
   | MessageDeliveredEvent
   | MessageFailedEvent
+  | MessageDecryptionFailedEvent
   | TransportSwitchedEvent
   | RelayPromotedEvent
   | RelayDemotedEvent
+  | RelayDemotedBatteryEvent
   | NeighborDiscoveredEvent
   | NeighborLostEvent
   | NetworkMetricsEvent
@@ -1634,6 +1722,8 @@ export type ProtocolEvent =
   | FileReceiveFailedEvent
   | MediaSentEvent
   | MediaSendFailedEvent
+  | AckEvictedEvent
+  | FragmentAssemblyEvictedEvent
   | DiagnosticEvent
   | SecureSessionEstablishedEvent
   | SecureSessionFailedEvent
@@ -1661,6 +1751,7 @@ export type ProtocolEvent =
   | GroupEpochForkDetectedEvent
   | GroupEpochForkResolvedEvent
   | GroupRoleChangedEvent
+  | GroupRenamedEvent
   | DorsScoreUpdatedEvent
   | DorsTransportSelectedEvent
   | DorsTransportSwitchedEvent
@@ -1679,7 +1770,9 @@ export type ProtocolEvent =
   | MessageUndeliverableEvent
   | MediaResendRequiredEvent
   | SecurityWarningEvent
-  | TofuResetEvent;
+  | TofuResetEvent
+  | UserBlockedEvent
+  | UserUnblockedEvent;
 
 /**
  * Event listener type

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -3259,4 +3259,114 @@ mod tests {
             }
         }
     }
+
+    /// Mirrors serde's `rename_all = "snake_case"` rule.
+    fn serde_snake_case(name: &str) -> String {
+        let mut out = String::new();
+        for (i, ch) in name.chars().enumerate() {
+            if ch.is_ascii_uppercase() {
+                if i > 0 {
+                    out.push('_');
+                }
+                out.push(ch.to_ascii_lowercase());
+            } else {
+                out.push(ch);
+            }
+        }
+        out
+    }
+
+    /// Drift guard: every `Event` variant must have a typed declaration in the
+    /// React Native bindings. Events cross UniFFI as tagged JSON, so nothing
+    /// else fails when `types.ts` lags — the event just arrives untyped and
+    /// invisible to the `ProtocolEvent` union (7 variants had silently drifted
+    /// before this guard existed).
+    #[test]
+    fn react_native_types_cover_all_event_variants() {
+        use std::collections::BTreeSet;
+
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let events_rs = std::fs::read_to_string(manifest_dir.join("src/events.rs")).unwrap();
+        let types_ts_path = manifest_dir.join("../../bindings/react-native/src/types.ts");
+        let types_ts = std::fs::read_to_string(&types_ts_path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", types_ts_path.display()));
+
+        // Collect each `Event` variant's serde tag by scanning the enum block:
+        // variant names sit at 4-space indent, brace depth 1.
+        let mut rust_tags = BTreeSet::new();
+        let mut in_enum = false;
+        let mut depth = 0usize;
+        for line in events_rs.lines() {
+            if !in_enum {
+                if line.starts_with("pub enum Event {") {
+                    in_enum = true;
+                    depth = 1;
+                }
+                continue;
+            }
+            let trimmed = line.trim();
+            if trimmed.starts_with("//") || trimmed.starts_with("#[") {
+                continue;
+            }
+            if depth == 1
+                && line.starts_with("    ")
+                && !line.starts_with("     ")
+                && trimmed
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_uppercase())
+            {
+                let name: String = trimmed
+                    .chars()
+                    .take_while(|c| c.is_ascii_alphanumeric())
+                    .collect();
+                rust_tags.insert(serde_snake_case(&name));
+            }
+            depth += line.matches('{').count();
+            depth = depth.saturating_sub(line.matches('}').count());
+            if depth == 0 {
+                break;
+            }
+        }
+        assert!(
+            rust_tags.len() >= 60,
+            "enum scan looks broken: only {} variants found",
+            rust_tags.len()
+        );
+
+        // Event interface discriminants in types.ts: `  type: '<tag>';` at
+        // exactly 2-space indent (nested object fields sit deeper).
+        let ts_tags: BTreeSet<String> = types_ts
+            .lines()
+            .filter_map(|l| l.strip_prefix("  type: '"))
+            .filter_map(|rest| rest.strip_suffix("';"))
+            .map(str::to_string)
+            .collect();
+
+        // Emitted by the native iOS/Android bridges, not the core enum.
+        let bridge_only: BTreeSet<String> = [
+            "diagnostic",
+            "internet_server_message",
+            "internet_status_changed",
+        ]
+        .map(str::to_string)
+        .into();
+
+        let missing: Vec<_> = rust_tags.difference(&ts_tags).collect();
+        assert!(
+            missing.is_empty(),
+            "Event variants missing a typed declaration in bindings/react-native/src/types.ts \
+             (add the interface AND its ProtocolEvent union entry): {missing:?}"
+        );
+
+        let stale: Vec<_> = ts_tags
+            .difference(&rust_tags)
+            .filter(|t| !bridge_only.contains(*t))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "types.ts declares event tags with no core Event variant \
+             (stale, or a new bridge-only event that needs allowlisting here): {stale:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Prompted by fernweh's report that `group_renamed` is absent from the installed 0.15.0 tarball: the event has always fired at runtime (events cross UniFFI as tagged JSON, and the RN dispatcher applies no per-type filter), but its TypeScript declaration never existed. An audit against the core `Event` enum found **seven** variants in that state:

`group_renamed`, `message_decryption_failed`, `ack_evicted`, `fragment_assembly_evicted`, `relay_demoted_battery`, `user_blocked`, `user_unblocked`

Outside the `ProtocolEvent` union, these tags aren't in `EventType`, so `.on('group_renamed', …)` doesn't type-check and payloads are untyped.

## Changes

- **`bindings/react-native/src/types.ts`**: declares all seven interfaces following existing conventions (snake_case fields verbatim, JSDoc lifted from the Rust doc comments, placed in matching sections) and adds them to the `ProtocolEvent` union (`EventType`/`EventListener` derive automatically). Adds an exported `DecryptionFailureCode` string union mirroring the SCREAMING_SNAKE_CASE serde enum. `GroupRenamedEvent.old_name` is `string | null` (no `skip_serializing_if` on the Rust side, so `None` serializes as `null` — same precedent as `TransportSwitchedEvent.from`).
- **`crates/offline-protocol/src/events.rs`**: new drift-guard test `react_native_types_cover_all_event_variants` — derives every `Event` variant's serde tag from the enum source and asserts each appears as a `type: '<tag>'` literal in `types.ts`, plus the reverse check (stale TS tags), with an allowlist for the three bridge-emitted events (`diagnostic`, `internet_server_message`, `internet_status_changed`) that have no core variant. Runs in the normal `cargo test --lib` loop, so this class of drift can't ship silently again.
- **`CHANGELOG.md`**: entry under Unreleased → Fixed.

Purely a typing change — no runtime behavior differs, no UDL/bindings regen needed.

## Testing

- `cargo test --package offline-protocol --lib` — 993 passed (guard included)
- Negative-tested the guard: renaming one tag in types.ts makes it fail with the exact missing tag named
- `npx tsc --noEmit` in `bindings/react-native` — clean
- `cargo clippy --workspace -- -D warnings` + `cargo fmt --all` — clean