### PR TITLE
feat(bindings): add forceInternetReconnect() for deterministic foreground recovery

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -515,8 +515,20 @@ class InternetManager(
                 teardownSocket(ws, "Force reconnect")
             } else {
                 // No live socket (e.g. mid-backoff, its pending reconnect just
-                // cancelled above): connect immediately.
-                connect()
+                // cancelled above): connect immediately. connect() throws on a
+                // malformed server URL (reachable if configure() changed it
+                // mid-session); a throw here would escape to the RN bridge and
+                // reject the promise, so — like scheduleReconnect's posted
+                // runnable — a reconnect that cannot even build its request
+                // stops the transport instead of surfacing as a rejection.
+                try {
+                    connect()
+                } catch (e: Exception) {
+                    emitDiagnostic("error", "Force reconnect failed", mapOf(
+                        "error" to (e.message ?: "unknown")
+                    ))
+                    updateState(TransportState.STOPPED)
+                }
             }
         }
     }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -476,6 +476,51 @@ class InternetManager(
         }
     }
     
+    /**
+     * Forces an immediate teardown + reconnect + re-authenticate of the
+     * internet socket, bypassing the exponential backoff. The app calls this
+     * on foreground-after-background when the cached ready flags may be stale:
+     * a suspend can kill the TCP connection before a clean WS close, leaving
+     * [isReady] reporting true against a dead (or relay-deregistered) socket.
+     * A liveness probe cannot distinguish either case reliably — only a full
+     * reconnect, which re-runs the relay's authenticate/register handshake,
+     * heals both — so this is the honest recovery primitive.
+     *
+     * No-op unless the transport is running/starting (respects the app's
+     * enable/disable lifecycle). The actual reconnect honors [autoReconnect];
+     * with it disabled this tears the socket down without rebuilding it.
+     * Emits a transient `internet_status_changed` down→up.
+     */
+    fun forceReconnect() {
+        runOnMainSync {
+            if (state != TransportState.RUNNING && state != TransportState.STARTING) return@runOnMainSync
+
+            // A forced reconnect is a fresh attempt: cancel any pending
+            // backoff-scheduled reconnect and reset the backoff so this
+            // reconnect (and any that follow it) starts from the initial delay
+            // instead of a stale 30s ceiling.
+            reconnectRunnable?.let { mainHandler.removeCallbacks(it) }
+            reconnectRunnable = null
+            currentReconnectDelay.set(RECONNECT_INITIAL_DELAY_MS)
+            reconnectAttempts.set(0)
+
+            emitDiagnostic("info", "Force reconnect requested")
+
+            val ws = webSocket
+            if (ws != null) {
+                // teardownSocket runs the full per-connection cleanup exactly
+                // once (stale-socket guarded); with autoReconnect,
+                // handleConnectionClosed schedules the reconnect at the reset
+                // (initial) delay.
+                teardownSocket(ws, "Force reconnect")
+            } else {
+                // No live socket (e.g. mid-backoff, its pending reconnect just
+                // cancelled above): connect immediately.
+                connect()
+            }
+        }
+    }
+
     override fun getMetrics(): Map<String, Any> {
         return mapOf(
             "bytes_sent" to bytesSent.get(),

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -3535,8 +3535,10 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
      * internet socket, bypassing the exponential backoff — the deterministic
      * recovery for a foreground-after-background where the cached ready flags
      * may be stale (see InternetManager.forceReconnect). Resolves true when
-     * the request was issued, false (never rejects) when the internet
-     * transport isn't initialized.
+     * the request reached a live internet transport ("accepted", not
+     * "reconnected" — also true when the transport is initialized but not
+     * running, where forceReconnect is a deliberate no-op); false (never
+     * rejects) only when the internet transport isn't initialized.
      */
     @ReactMethod
     fun internetForceReconnect(promise: Promise) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -3531,6 +3531,25 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
     }
 
     /**
+     * Forces an immediate teardown + reconnect + re-authenticate of the
+     * internet socket, bypassing the exponential backoff — the deterministic
+     * recovery for a foreground-after-background where the cached ready flags
+     * may be stale (see InternetManager.forceReconnect). Resolves true when
+     * the request was issued, false (never rejects) when the internet
+     * transport isn't initialized.
+     */
+    @ReactMethod
+    fun internetForceReconnect(promise: Promise) {
+        val manager = internetManager
+        if (manager == null) {
+            promise.resolve(false)
+            return
+        }
+        manager.forceReconnect()
+        promise.resolve(true)
+    }
+
+    /**
      * Wire event-driven transport callbacks using direct typed UniFFI calls.
      * Each callback fires when Rust enqueues outgoing data, replacing timer-based polling.
      * Falls back to polling if bindings are stale (logged as warning).

--- a/bindings/react-native/ios/InternetManager.swift
+++ b/bindings/react-native/ios/InternetManager.swift
@@ -579,6 +579,56 @@ public class InternetManager: NSObject, TransportManager {
         }
     }
 
+    /// Forces an immediate teardown + reconnect + re-authenticate of the
+    /// internet socket, bypassing the exponential backoff. The app calls this
+    /// on foreground-after-background when the cached ready flags may be
+    /// stale: an iOS suspend can kill the TCP connection before a clean WS
+    /// close, leaving `isReady()` reporting true against a dead (or
+    /// relay-deregistered) socket. A liveness probe cannot distinguish either
+    /// case reliably — only a full reconnect, which re-runs the relay's
+    /// authenticate/register handshake, heals both — so this is the honest
+    /// recovery primitive.
+    ///
+    /// No-op unless the transport is running/starting (respects the app's
+    /// enable/disable lifecycle). The actual reconnect honors `autoReconnect`;
+    /// with it disabled this tears the socket down without rebuilding it.
+    /// Emits a transient `internet_status_changed` down→up.
+    public func forceReconnect() {
+        runOnMainSync {
+            guard state == .running || state == .starting else { return }
+
+            // A forced reconnect is a fresh attempt: cancel any pending
+            // backoff-scheduled reconnect and reset the backoff so this
+            // reconnect (and any that follow it) starts from the initial
+            // delay instead of a stale 30s ceiling.
+            reconnectWorkItem?.cancel()
+            reconnectWorkItem = nil
+            currentReconnectDelay = RECONNECT_INITIAL_DELAY
+            reconnectAttempts = 0
+
+            emitDiagnostic("info", "Force reconnect requested")
+
+            if let task = webSocketTask {
+                // Detach before cancel so the cancel-triggered delegate/receive
+                // callbacks see a stale task and no-op (see isStale), then run
+                // the full per-connection cleanup exactly once. With
+                // autoReconnect, handleConnectionClosed schedules the reconnect
+                // at the reset (initial) delay.
+                webSocketTask = nil
+                task.cancel(with: .goingAway, reason: nil)
+                handleConnectionClosed(error: NSError(
+                    domain: "OfflineProtocol.InternetManager",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Force reconnect"]
+                ))
+            } else {
+                // No live socket (e.g. mid-backoff, its pending reconnect just
+                // cancelled above): connect immediately.
+                connect()
+            }
+        }
+    }
+
     public func getMetrics() -> [String: Any] {
         return [
             "bytes_sent": bytesSent.get(),

--- a/bindings/react-native/ios/InternetManager.swift
+++ b/bindings/react-native/ios/InternetManager.swift
@@ -609,18 +609,14 @@ public class InternetManager: NSObject, TransportManager {
             emitDiagnostic("info", "Force reconnect requested")
 
             if let task = webSocketTask {
-                // Detach before cancel so the cancel-triggered delegate/receive
-                // callbacks see a stale task and no-op (see isStale), then run
-                // the full per-connection cleanup exactly once. With
-                // autoReconnect, handleConnectionClosed schedules the reconnect
-                // at the reset (initial) delay.
-                webSocketTask = nil
-                task.cancel(with: .goingAway, reason: nil)
-                handleConnectionClosed(error: NSError(
-                    domain: "OfflineProtocol.InternetManager",
-                    code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "Force reconnect"]
-                ))
+                // Reuse the shared teardown funnel: it detaches before cancel
+                // (so the cancel-triggered delegate/receive callbacks see a
+                // stale task and no-op, see isStale) then runs the full
+                // per-connection cleanup exactly once. With autoReconnect,
+                // handleConnectionClosed schedules the reconnect at the reset
+                // (initial) delay. The guard (task === webSocketTask) holds —
+                // we're on main and have not nilled it yet.
+                teardownSocket(ifCurrent: task, reason: "Force reconnect")
             } else {
                 // No live socket (e.g. mid-backoff, its pending reconnect just
                 // cancelled above): connect immediately.

--- a/bindings/react-native/ios/OfflineProtocolModule.m
+++ b/bindings/react-native/ios/OfflineProtocolModule.m
@@ -549,6 +549,9 @@ RCT_EXTERN_METHOD(internetSendRawCommand:(NSString *)json
 RCT_EXTERN_METHOD(internetIsReady:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(internetForceReconnect:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 // Presence, Typing, Read Receipts
 RCT_EXTERN_METHOD(sendPresenceUpdate:(NSString *)recipient
                   status:(nonnull NSNumber *)status

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -3534,8 +3534,10 @@ class OfflineProtocolModule: RCTEventEmitter {
     /// internet socket, bypassing the exponential backoff — the deterministic
     /// recovery for a foreground-after-background where the cached ready flags
     /// may be stale (see InternetManager.forceReconnect). Resolves true when
-    /// the request was issued, false (never rejects) when the internet
-    /// transport isn't initialized.
+    /// the request reached a live internet transport ("accepted", not
+    /// "reconnected" — also true when the transport is initialized but not
+    /// running, where forceReconnect is a deliberate no-op); false (never
+    /// rejects) only when the internet transport isn't initialized.
     @objc func internetForceReconnect(_ resolver: @escaping RCTPromiseResolveBlock,
                                       rejecter: @escaping RCTPromiseRejectBlock) {
         guard let manager = internetManager else {

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -3530,6 +3530,22 @@ class OfflineProtocolModule: RCTEventEmitter {
         resolver(internetManager?.isReady() ?? false)
     }
 
+    /// Forces an immediate teardown + reconnect + re-authenticate of the
+    /// internet socket, bypassing the exponential backoff — the deterministic
+    /// recovery for a foreground-after-background where the cached ready flags
+    /// may be stale (see InternetManager.forceReconnect). Resolves true when
+    /// the request was issued, false (never rejects) when the internet
+    /// transport isn't initialized.
+    @objc func internetForceReconnect(_ resolver: @escaping RCTPromiseResolveBlock,
+                                      rejecter: @escaping RCTPromiseRejectBlock) {
+        guard let manager = internetManager else {
+            resolver(false)
+            return
+        }
+        manager.forceReconnect()
+        resolver(true)
+    }
+
     // MARK: - Helpers
     
     private func parseInternetConfig(_ config: NSDictionary?) throws -> (String, UInt16) {

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -3004,8 +3004,11 @@ export class OfflineProtocol {
    * Emits a transient `internet_status_changed` down→up. No-op unless the
    * internet transport is running (respects the enable/disable lifecycle).
    *
-   * @returns true once the reconnect was issued; false when the internet
-   *          transport was never initialized (never throws)
+   * @returns true once the request reached a live internet transport — this
+   *          means "accepted", not "reconnected": it is also true when the
+   *          transport is initialized but not currently running/starting, in
+   *          which case the call is a deliberate no-op. false only when the
+   *          internet transport was never initialized. Never throws.
    */
   async forceInternetReconnect(): Promise<boolean> {
     return await OfflineProtocolNativeModule.internetForceReconnect();

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -2983,6 +2983,35 @@ export class OfflineProtocol {
   }
 
   /**
+   * Forces an immediate teardown + reconnect + re-authenticate of the SDK's
+   * internet socket, bypassing the exponential reconnect backoff.
+   *
+   * `isInternetReady()` is a point-in-time cached flag, not a liveness probe:
+   * an OS suspend can kill the TCP connection before a clean WebSocket close,
+   * so after a background→foreground transition the socket may be a zombie
+   * (dead but still reported ready) or alive-but-deregistered by the relay.
+   * Neither is detectable by a ping, and both are healed by the same action —
+   * a full reconnect that re-runs the relay authenticate/register handshake.
+   * Call this on foreground when a stale socket is suspected, instead of
+   * relying on `isInternetReady()` to gate a disable→enable toggle (which
+   * no-ops precisely when the flag is stale-true).
+   *
+   * Recovery lands in ~1s rather than waiting ~20-30s for zombie ping
+   * detection. Prefer to debounce and gate on background duration rather than
+   * calling this on every foreground — it drops a genuinely-healthy socket if
+   * called needlessly, forcing a group re-registration round-trip.
+   *
+   * Emits a transient `internet_status_changed` down→up. No-op unless the
+   * internet transport is running (respects the enable/disable lifecycle).
+   *
+   * @returns true once the reconnect was issued; false when the internet
+   *          transport was never initialized (never throws)
+   */
+  async forceInternetReconnect(): Promise<boolean> {
+    return await OfflineProtocolNativeModule.internetForceReconnect();
+  }
+
+  /**
    * Sends a typing indicator to a peer.
    *
    * @param recipient - Recipient's user ID


### PR DESCRIPTION
## Problem

`isInternetReady()` / the native `InternetManager.isReady()` returns a **cached** `_isConnected && _isAuthenticated` flag, not a liveness probe:

- iOS `InternetManager.swift`: `return _isConnected && _isAuthenticated`
- Android `InternetManager.kt`: `isConnected.get() && isAuthenticated.get()`

On an OS suspend that kills TCP **before** a clean WebSocket close, both flags stay `true`. So an app's foreground *"if not ready, disable→enable transport"* reconnect gate **no-ops precisely when it's needed**, and recovery falls back to zombie detection: `PING_INTERVAL` 10s × `MAX_CONSECUTIVE_FAILURES` 2 ≈ **20–30s** just to notice the socket is dead. There was also no primitive to force a reconnect faster than the hardcoded 1s→×2→30s backoff.

## Why a probe is the wrong fix

A liveness probe cannot heal the case that matters. After a background→foreground, the socket is either:
1. a **zombie** — dead, but the flag reads stale-`true`, or
2. **alive but deregistered by the relay** (separate server-side generational-registration bug).

A ping/pong would return *"alive"* for case 2 — false confidence in exactly the target scenario. Only a full **teardown + reconnect + re-authenticate** repairs both, because re-auth re-runs the relay's authenticate/register handshake. (OkHttp has no app-triggered ping either, so a probe couldn't even be implemented symmetrically.)

## Change

Adds a symmetric `forceInternetReconnect()` primitive:

- **iOS/Android `InternetManager.forceReconnect()`** — cancels any pending backoff, resets the delay to initial, then drives the **existing** `teardownSocket → handleConnectionClosed → scheduleReconnect` funnel (or `connect()` when there's no live socket). Recovery lands in **~1s**. No-op unless the transport is running (respects the enable/disable lifecycle); honors `autoReconnect`.
- Exposed via the module method + `.m` bridge / `@ReactMethod`, and a TS `forceInternetReconnect(): Promise<boolean>`.

Because it reuses the tested close funnel, every `isStale` guard, the single close funnel, and the `internet_status_changed` / `internetStatusChanged` emission chokepoint are honored. **Purely additive** (+162 lines, 6 files) — no Rust/core, wire, schema, or event change; no existing caller affected.

## Files

| File | Change |
|------|--------|
| `ios/InternetManager.swift` | `public func forceReconnect()` |
| `ios/OfflineProtocolModule.swift` | `@objc func internetForceReconnect(...)` |
| `ios/OfflineProtocolModule.m` | `RCT_EXTERN_METHOD` bridge entry |
| `android/.../InternetManager.kt` | `fun forceReconnect()` |
| `android/.../OfflineProtocolModule.kt` | `@ReactMethod fun internetForceReconnect(promise)` |
| `src/index.ts` | `async forceInternetReconnect(): Promise<boolean>` + JSDoc |

## Scope / context

This is the **SDK/client half** of a broader issue. The relay server has a separate generational-registration root-cause bug (kicks live clients out of routing on late cleanup) that is **out of scope** here — this PR reduces the client-side recovery delay from ~20–30s to ~1s but is not expected to be the complete end-to-end fix on its own.

Deliberately **not** included (deferred): threading the app-passed `reconnectDelay` (declared at `types.ts:131` but never read natively — a latent silent-drop gap), an iOS probe-first fast-path, and starting a stopped transport from this call.

## Verification

- `tsc --noEmit` passes.
- Rust workspace untouched (no `.rs` changes).
- Native symbols/signatures confirmed against existing code by inspection.
- **Remaining (needs native toolchain / device):** Xcode + Gradle compile, and the on-device functional test — background past the suspend window → foreground → `forceInternetReconnect()` → confirm `internet_status_changed` cycles down→up in ~1s and a send delivers without the stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)