### PR TITLE
feat(bindings): handle relay close 4000 as session-superseded (no auto-reconnect)

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -833,6 +833,15 @@ class InternetManager(
         // a ~1s eviction loop, so stop for good and let the app decide when to
         // reconnect (explicit user action / foreground with long jitter).
         // Recovery is an explicit start(), which clears isSuperseded.
+        //
+        // ORDERING NOTE (differs from InternetManager.swift — don't "unify"):
+        // this supersede check sits *after* terminateSocket's identity guard,
+        // so a 4000 that loses the terminal-signal race to a concurrent local
+        // teardown (ping/auth/send-failure, code -1) arrives stale and does not
+        // latch this cycle — it self-heals because the reconnect gets displaced
+        // again and the next onClosed(4000) latches. iOS instead marks before
+        // its identity guard (so it can't miss the code) but must then exclude a
+        // newer successor socket. Opposite orderings, same end state.
         if (isSuperseded || code == SUPERSEDED_CLOSE_CODE) {
             markSuperseded(reason)
             updateState(TransportState.STOPPED)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -49,13 +49,6 @@ class InternetManager(
         private const val CONNECTION_TIMEOUT_MS = 10000L
         private const val MAX_CONSECUTIVE_FAILURES = 2  // Trigger disconnect after 2 consecutive failures
         private const val AUTH_RESPONSE_TIMEOUT_MS = 10_000L
-        // WebSocket close code the relay uses to signal this connection was
-        // displaced by a newer registration for the same identity ("session
-        // superseded"). A blind reconnect would just re-displace the peer
-        // socket in a ~1s loop (the fleet-wide eviction storm the
-        // relay-displacement rollout guards against), so on this code we stop
-        // and let the app decide when to reconnect. Mirrors InternetManager.swift.
-        private const val SUPERSEDED_CLOSE_CODE = 4000
         // Forced presence checks: how long a checkPresence(force = true)
         // may park waiting for authenticated + rate-admitted, and how often
         // the parked queue re-attempts. Mirror the iOS bridge's
@@ -123,13 +116,13 @@ class InternetManager(
     // True between pause() and resume(): a background reconnect must not
     // restart the poll/ping/presence timers the app paused.
     @Volatile private var isPaused = false
-    // Set when the relay displaced this connection (close 4000, or a
-    // SessionSuperseded notice on the current socket). Suppresses auto- AND
-    // force-reconnect until an explicit start() — a blind reconnect just
-    // re-displaces the peer socket in a tight loop. Written/read on main like
-    // autoReconnect; @Volatile for the same defensive cross-thread safety.
-    // Mirrors InternetManager.swift's isSuperseded.
-    @Volatile private var isSuperseded = false
+    // The relay-displacement latch (close 4000, or a SessionSuperseded notice
+    // on the current socket). While latched, auto- AND force-reconnect refuse
+    // until an explicit start() — a blind reconnect just re-displaces the peer
+    // socket in a tight loop. Owns the boolean + decision; this manager owns
+    // the threading (every call on main, the single writer). Mirrors
+    // InternetManager.swift's supersedeLatch.
+    private val supersedeLatch = SupersededLatchPolicy()
     private var reconnectAttempts = AtomicInteger(0)
     // Atomic for cross-thread reads; written only on main (scheduleReconnect
     // grows it, handleAuthenticated's posted reaction resets it).
@@ -385,7 +378,7 @@ class InternetManager(
         // relay-superseded latch: the app has resolved the "connected
         // elsewhere" condition (e.g. signed the other session out) and now
         // wants this device connected again.
-        isSuperseded = false
+        supersedeLatch.clear()
         reconnectAttempts.set(0)
         currentReconnectDelay.set(RECONNECT_INITIAL_DELAY_MS)
 
@@ -571,7 +564,7 @@ class InternetManager(
             "is_connected" to isConnected.get(),
             "is_authenticated" to isAuthenticated.get(),
             "reconnect_attempts" to reconnectAttempts.get(),
-            "is_superseded" to isSuperseded
+            "is_superseded" to supersedeLatch.isSuperseded
         )
     }
     
@@ -581,7 +574,7 @@ class InternetManager(
         val url = serverUrl ?: return
         // A relay-superseded transport must not reconnect until an explicit
         // start() clears the latch (see markSuperseded).
-        if (isSuperseded) return
+        if (supersedeLatch.isSuperseded) return
         if (isConnecting.get() || isConnected.get()) return
         // stop() may have run between a reconnect being scheduled and firing.
         // The client null-check must precede the isConnecting latch: with no
@@ -838,13 +831,21 @@ class InternetManager(
         // this supersede check sits *after* terminateSocket's identity guard,
         // so a 4000 that loses the terminal-signal race to a concurrent local
         // teardown (ping/auth/send-failure, code -1) arrives stale and does not
-        // latch this cycle — it self-heals because the reconnect gets displaced
-        // again and the next onClosed(4000) latches. iOS instead marks before
-        // its identity guard (so it can't miss the code) but must then exclude a
-        // newer successor socket. Opposite orderings, same end state.
-        if (isSuperseded || code == SUPERSEDED_CLOSE_CODE) {
+        // latch this cycle. It self-heals via the relay's *other* displacement
+        // signal: the relay always sends an application-level SessionSuperseded
+        // notice on the live socket BEFORE close 4000, and that notice (handled
+        // race-free while the socket is still current — see the message-dispatch
+        // path) latches first. Even absent the notice, the reconnect gets
+        // displaced again and the next onClosed(4000) latches. iOS instead marks
+        // before its identity guard (so it can't miss the code) but must then
+        // exclude a newer successor socket. Opposite orderings, same end state.
+        //
+        // hasNewerSuccessor = false: terminateSocket's identity guard already
+        // dropped any close whose socket isn't the current one, so a successor
+        // can never reach here (unlike the iOS didClose funnel).
+        if (supersedeLatch.shouldMark(code, hasNewerSuccessor = false)) {
             markSuperseded(reason)
-            updateState(TransportState.STOPPED)
+            if (state != TransportState.STOPPED) updateState(TransportState.STOPPED)
             return
         }
 
@@ -859,15 +860,14 @@ class InternetManager(
 
     /**
      * Marks the connection displaced by the relay and latches it stopped:
-     * cancels any pending reconnect, sets [isSuperseded] so auto- and
+     * cancels any pending reconnect, sets [supersedeLatch] so auto- and
      * force-reconnect refuse until the next start(), and fires the one-shot
-     * superseded event. Idempotent — the relay emits both a SessionSuperseded
-     * notice and close 4000, so several paths reach here for one displacement.
-     * Main-thread only.
+     * superseded event. Idempotent (via [SupersededLatchPolicy.mark]) — the
+     * relay emits both a SessionSuperseded notice and close 4000, so several
+     * paths reach here for one displacement. Main-thread only.
      */
     private fun markSuperseded(reason: String?) {
-        if (isSuperseded) return
-        isSuperseded = true
+        if (!supersedeLatch.mark()) return
         reconnectRunnable?.let { mainHandler.removeCallbacks(it) }
         reconnectRunnable = null
         emitDiagnostic("warning", "Relay superseded this session; not auto-reconnecting", mapOf(
@@ -880,7 +880,7 @@ class InternetManager(
         if (!autoReconnect) return
         // Defense in depth: handleConnectionClosed already returns before here
         // on a superseded connection, but never schedule a reconnect for one.
-        if (isSuperseded) return
+        if (supersedeLatch.isSuperseded) return
         // A close can race stop(): its posted scheduleReconnect must not
         // revive a transport the app already stopped (the delayed connect()
         // would find okHttpClient nulled and leave the transport wedged).

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -49,6 +49,13 @@ class InternetManager(
         private const val CONNECTION_TIMEOUT_MS = 10000L
         private const val MAX_CONSECUTIVE_FAILURES = 2  // Trigger disconnect after 2 consecutive failures
         private const val AUTH_RESPONSE_TIMEOUT_MS = 10_000L
+        // WebSocket close code the relay uses to signal this connection was
+        // displaced by a newer registration for the same identity ("session
+        // superseded"). A blind reconnect would just re-displace the peer
+        // socket in a ~1s loop (the fleet-wide eviction storm the
+        // relay-displacement rollout guards against), so on this code we stop
+        // and let the app decide when to reconnect. Mirrors InternetManager.swift.
+        private const val SUPERSEDED_CLOSE_CODE = 4000
         // Forced presence checks: how long a checkPresence(force = true)
         // may park waiting for authenticated + rate-admitted, and how often
         // the parked queue re-attempts. Mirror the iOS bridge's
@@ -116,6 +123,13 @@ class InternetManager(
     // True between pause() and resume(): a background reconnect must not
     // restart the poll/ping/presence timers the app paused.
     @Volatile private var isPaused = false
+    // Set when the relay displaced this connection (close 4000, or a
+    // SessionSuperseded notice on the current socket). Suppresses auto- AND
+    // force-reconnect until an explicit start() — a blind reconnect just
+    // re-displaces the peer socket in a tight loop. Written/read on main like
+    // autoReconnect; @Volatile for the same defensive cross-thread safety.
+    // Mirrors InternetManager.swift's isSuperseded.
+    @Volatile private var isSuperseded = false
     private var reconnectAttempts = AtomicInteger(0)
     // Atomic for cross-thread reads; written only on main (scheduleReconnect
     // grows it, handleAuthenticated's posted reaction resets it).
@@ -209,6 +223,16 @@ class InternetManager(
      * through it, so the pair is only ever published on actual change.
      */
     var connectionStatusEmitter: ((connected: Boolean, authenticated: Boolean) -> Unit)? = null
+
+    /**
+     * Fires once when the relay displaces this connection (close 4000 or a
+     * SessionSuperseded notice) — the module forwards it as the
+     * `internet_session_superseded` event. The SDK will not auto-reconnect;
+     * the app surfaces "connected elsewhere" and reconnects only on explicit
+     * user action (re-enabling the transport). Reason is the close/notice
+     * reason, if any. Mirrors InternetManager.swift.
+     */
+    var supersededEmitter: ((reason: String?) -> Unit)? = null
 
     /**
      * Last (connected, authenticated) pair published, or null before the
@@ -357,6 +381,11 @@ class InternetManager(
         // The reconnect backoff is likewise per-session state: a stale 30s
         // delay must not slow the first retry of a brand-new start.
         isPaused = false
+        // A fresh start() is the deliberate re-enable that clears a prior
+        // relay-superseded latch: the app has resolved the "connected
+        // elsewhere" condition (e.g. signed the other session out) and now
+        // wants this device connected again.
+        isSuperseded = false
         reconnectAttempts.set(0)
         currentReconnectDelay.set(RECONNECT_INITIAL_DELAY_MS)
 
@@ -541,7 +570,8 @@ class InternetManager(
             "messages_received" to messagesReceived.get(),
             "is_connected" to isConnected.get(),
             "is_authenticated" to isAuthenticated.get(),
-            "reconnect_attempts" to reconnectAttempts.get()
+            "reconnect_attempts" to reconnectAttempts.get(),
+            "is_superseded" to isSuperseded
         )
     }
     
@@ -549,6 +579,9 @@ class InternetManager(
     
     private fun connect() {
         val url = serverUrl ?: return
+        // A relay-superseded transport must not reconnect until an explicit
+        // start() clears the latch (see markSuperseded).
+        if (isSuperseded) return
         if (isConnecting.get() || isConnected.get()) return
         // stop() may have run between a reconnect being scheduled and firing.
         // The client null-check must precede the isConnecting latch: with no
@@ -794,6 +827,18 @@ class InternetManager(
             "wasAuthenticated" to wasAuthenticated
         ))
 
+        // The relay displaced this connection (close 4000, or a
+        // SessionSuperseded notice already flipped the flag on the live
+        // socket). A blind reconnect would just re-displace the peer socket in
+        // a ~1s eviction loop, so stop for good and let the app decide when to
+        // reconnect (explicit user action / foreground with long jitter).
+        // Recovery is an explicit start(), which clears isSuperseded.
+        if (isSuperseded || code == SUPERSEDED_CLOSE_CODE) {
+            markSuperseded(reason)
+            updateState(TransportState.STOPPED)
+            return
+        }
+
         // Attempt reconnection if enabled
         // Messages in outbox will be flushed on successful reconnection
         if (autoReconnect && state != TransportState.STOPPING && state != TransportState.STOPPED) {
@@ -802,9 +847,31 @@ class InternetManager(
             updateState(TransportState.STOPPED)
         }
     }
-    
+
+    /**
+     * Marks the connection displaced by the relay and latches it stopped:
+     * cancels any pending reconnect, sets [isSuperseded] so auto- and
+     * force-reconnect refuse until the next start(), and fires the one-shot
+     * superseded event. Idempotent — the relay emits both a SessionSuperseded
+     * notice and close 4000, so several paths reach here for one displacement.
+     * Main-thread only.
+     */
+    private fun markSuperseded(reason: String?) {
+        if (isSuperseded) return
+        isSuperseded = true
+        reconnectRunnable?.let { mainHandler.removeCallbacks(it) }
+        reconnectRunnable = null
+        emitDiagnostic("warning", "Relay superseded this session; not auto-reconnecting", mapOf(
+            "reason" to (reason ?: "none")
+        ))
+        supersededEmitter?.invoke(reason)
+    }
+
     private fun scheduleReconnect() {
         if (!autoReconnect) return
+        // Defense in depth: handleConnectionClosed already returns before here
+        // on a superseded connection, but never schedule a reconnect for one.
+        if (isSuperseded) return
         // A close can race stop(): its posted scheduleReconnect must not
         // revive a transport the app already stopped (the delayed connect()
         // would find okHttpClient nulled and leave the transport wedged).
@@ -1008,7 +1075,25 @@ class InternetManager(
                 // cancel-triggered callbacks are ignored as stale).
                 teardownSocket(ws, reason)
             }
-            
+
+            "SessionSuperseded" -> {
+                // The relay is displacing this connection — a newer
+                // registration for the same identity took the slot. It also
+                // closes with code 4000, but honor the notice too so we never
+                // blind-reconnect even if the close code is lost. Run the mark
+                // + teardown on main like the other lifecycle funnels; the
+                // ws-identity re-check there scopes it to the current socket.
+                val supersedeReason = json.optNullableString("reason")
+                mainHandler.post {
+                    if (ws !== webSocket) return@post
+                    markSuperseded(supersedeReason)
+                    // Close the live socket through the shared funnel;
+                    // handleConnectionClosed sees isSuperseded and stops
+                    // without reconnecting (markSuperseded already emitted).
+                    teardownSocket(ws, supersedeReason ?: "Session superseded")
+                }
+            }
+
             "MessageSent" -> {
                 // Handle MessageSent event from WebSocket server
                 // This contains the server-generated message_id that we should use

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -302,6 +302,7 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
                     manager.connectionStatusEmitter = { connected, authenticated ->
                         emitInternetStatusEvent(connected, authenticated)
                     }
+                    manager.supersededEmitter = { reason -> emitInternetSupersededEvent(reason) }
                     manager.listener = object : TransportManagerListener {
                         override fun onTransportStateChanged(manager: TransportManager, state: TransportState) {
                             emitDiagnostic("info", "Internet transport state changed", mapOf(
@@ -449,6 +450,27 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
             sendEvent(EVENT_NAME, params)
         } catch (e: Exception) {
             android.util.Log.e(NAME, "Failed to emit internet status event", e)
+        }
+    }
+
+    /**
+     * Forwards a relay session displacement ("superseded") as the
+     * `internet_session_superseded` event. The relay closed this socket with
+     * code 4000 because a newer registration for the same identity took over;
+     * the SDK will NOT auto-reconnect. The app surfaces "connected elsewhere"
+     * and reconnects only on explicit user action (re-enabling the transport).
+     */
+    private fun emitInternetSupersededEvent(reason: String?) {
+        try {
+            val json = JSONObject()
+            json.put("type", "internet_session_superseded")
+            if (reason != null) json.put("reason", reason)
+            val params = Arguments.createMap().apply {
+                putString("eventJson", json.toString())
+            }
+            sendEvent(EVENT_NAME, params)
+        } catch (e: Exception) {
+            android.util.Log.e(NAME, "Failed to emit internet superseded event", e)
         }
     }
 
@@ -1409,6 +1431,7 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
                             manager.connectionStatusEmitter = { connected, authenticated ->
                                 emitInternetStatusEvent(connected, authenticated)
                             }
+                            manager.supersededEmitter = { reason -> emitInternetSupersededEvent(reason) }
                         }
                         emitDiagnostic("info", "Internet manager created on demand")
                     }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/SupersededLatchPolicy.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/SupersededLatchPolicy.kt
@@ -1,0 +1,73 @@
+package com.offlineprotocol
+
+/**
+ * The relay-displacement ("session superseded") latch, extracted as a pure
+ * state machine so it can be unit-tested without a live WebSocket (see
+ * SupersededLatchPolicyTest). InternetManager owns the threading (every call
+ * is made on main, the single writer); this class owns only the decision and
+ * the boolean.
+ *
+ * The relay closes a displaced connection with WebSocket close code 4000 (a
+ * newer registration for the same identity took the slot) and, redundantly,
+ * sends an application-level SessionSuperseded notice on the live socket
+ * first. Either signal must latch the transport stopped: a blind reconnect
+ * would just re-displace the peer socket in a ~1s loop — the fleet-wide
+ * eviction storm the relay-displacement rollout guards against. The latch is
+ * cleared only by an explicit start() (the app resolved "connected
+ * elsewhere" and re-enabled the transport).
+ *
+ * Mirrors ios/SupersededLatchPolicy.swift — keep in sync.
+ */
+class SupersededLatchPolicy {
+    companion object {
+        /** WebSocket close code the relay uses to signal displacement. */
+        const val SUPERSEDED_CLOSE_CODE = 4000
+    }
+
+    // Main-owned like the InternetManager flags it replaces (autoReconnect):
+    // written on main, read best-effort off-main (getMetrics). @Volatile for
+    // the same defensive cross-thread visibility the field it replaced had.
+    @Volatile
+    private var latched = false
+
+    val isSuperseded: Boolean get() = latched
+
+    /**
+     * Pure decision: does a close on some socket displace the transport?
+     *
+     * @param closeCode the WebSocket close code, or null for a local / error
+     *   terminal (ping/auth/send-failure teardown) that carries none.
+     * @param hasNewerSuccessor a *different*, live socket has already replaced
+     *   the one this close belongs to. A late 4000 for a bygone generation
+     *   (old socket displaced → app re-enabled via start() → new socket B up)
+     *   must NOT re-latch and stop B — the sibling-race the cd9fa39 fix
+     *   targets. The Android close funnel's identity guard runs before the
+     *   decision, so a successor never reaches it: callers there pass false.
+     *   (The parameter exists so the iOS bridge, which keys on the close code
+     *   before its identity guard, shares this exact decision.)
+     *
+     * An already-latched connection stays latched regardless of close code (a
+     * non-4000 close after a SessionSuperseded notice still stops).
+     */
+    fun shouldMark(closeCode: Int?, hasNewerSuccessor: Boolean): Boolean {
+        if (hasNewerSuccessor) return false
+        return latched || closeCode == SUPERSEDED_CLOSE_CODE
+    }
+
+    /**
+     * Latches superseded. Returns true only on the false→true transition, so
+     * the caller fires the one-shot event exactly once even though the relay
+     * emits both a notice and a close (each of which fans into several
+     * terminal signals) for a single displacement.
+     */
+    fun mark(): Boolean {
+        if (latched) return false
+        latched = true
+        return true
+    }
+
+    /** Cleared by an explicit start() — the deliberate re-enable. */
+    fun clear() {
+        latched = false
+    }
+}

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/SupersededLatchPolicyTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/SupersededLatchPolicyTest.kt
@@ -1,0 +1,80 @@
+package com.offlineprotocol
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SupersededLatchPolicyTest {
+
+    @Test
+    fun close4000LatchesWhenSocketIsCurrent() {
+        val policy = SupersededLatchPolicy()
+        // The Android close funnel's identity guard already dropped stale
+        // sockets, so hasNewerSuccessor is always false there.
+        assertTrue(policy.shouldMark(closeCode = 4000, hasNewerSuccessor = false))
+    }
+
+    @Test
+    fun nonSupersedeCloseDoesNotLatch() {
+        val policy = SupersededLatchPolicy()
+        assertFalse(policy.shouldMark(closeCode = 1000, hasNewerSuccessor = false))
+        assertFalse(policy.shouldMark(closeCode = -1, hasNewerSuccessor = false))
+        assertFalse(policy.shouldMark(closeCode = null, hasNewerSuccessor = false))
+    }
+
+    @Test
+    fun newerSuccessorSocketIsNeverLatchedByAStale4000() {
+        // The cd9fa39 regression: old socket displaced → app re-enabled via
+        // start() → new socket B up → a LATE 4000 for the bygone generation
+        // must not re-latch and stop B.
+        val policy = SupersededLatchPolicy()
+        assertFalse(policy.shouldMark(closeCode = 4000, hasNewerSuccessor = true))
+    }
+
+    @Test
+    fun successorGuardWinsEvenWhenAlreadyLatched() {
+        val policy = SupersededLatchPolicy()
+        policy.mark()
+        // A stale latch bit must still never stop a live successor socket.
+        assertFalse(policy.shouldMark(closeCode = 1000, hasNewerSuccessor = true))
+    }
+
+    @Test
+    fun onceLatchedAnyCloseKeepsLatching() {
+        // A non-4000 close arriving after a SessionSuperseded notice already
+        // latched (on the live socket) must still stop, not reconnect.
+        val policy = SupersededLatchPolicy()
+        policy.mark()
+        assertTrue(policy.shouldMark(closeCode = 1000, hasNewerSuccessor = false))
+        assertTrue(policy.shouldMark(closeCode = null, hasNewerSuccessor = false))
+    }
+
+    @Test
+    fun markIsIdempotentAndReportsOnlyTheFirstTransition() {
+        // The relay emits a notice AND close 4000 (each fanning into several
+        // terminal signals); the one-shot event must fire exactly once.
+        val policy = SupersededLatchPolicy()
+        assertTrue(policy.mark())   // false -> true: fire the event
+        assertFalse(policy.mark())  // already latched: no re-fire
+        assertFalse(policy.mark())
+        assertTrue(policy.isSuperseded)
+    }
+
+    @Test
+    fun startClearsTheLatchAndReArmsMark() {
+        val policy = SupersededLatchPolicy()
+        policy.mark()
+        assertTrue(policy.isSuperseded)
+
+        // A fresh start() clears it; a subsequent displacement fires again.
+        policy.clear()
+        assertFalse(policy.isSuperseded)
+        assertFalse(policy.shouldMark(closeCode = 1000, hasNewerSuccessor = false))
+        assertTrue(policy.mark())
+    }
+
+    @Test
+    fun closeCodeConstantMatchesRelayContract() {
+        assertTrue(SupersededLatchPolicy.SUPERSEDED_CLOSE_CODE == 4000)
+    }
+}

--- a/bindings/react-native/ios/InternetManager.swift
+++ b/bindings/react-native/ios/InternetManager.swift
@@ -35,6 +35,13 @@ public class InternetManager: NSObject, TransportManager {
     private let PING_INTERVAL: TimeInterval = 10.0  // Reduced from 30s for faster failure detection
     private let CONNECTION_TIMEOUT: TimeInterval = 10.0
     private let AUTH_RESPONSE_TIMEOUT: TimeInterval = 10.0
+    // WebSocket close code the relay uses to signal this connection was
+    // displaced by a newer registration for the same identity ("session
+    // superseded"). A blind reconnect would just re-displace the peer socket
+    // in a ~1s loop (the fleet-wide eviction storm the relay-displacement
+    // rollout guards against), so on this code we stop and let the app decide
+    // when to reconnect. Mirrors InternetManager.kt.
+    private static let SUPERSEDED_CLOSE_CODE = 4000
     // Tracker ids for app-authored raw SendMessage frames (sendRawCommand):
     // recorded to keep the per-recipient FIFO honest, never reported to the
     // core. Mirrors InternetManager.kt — keep in sync.
@@ -112,6 +119,15 @@ public class InternetManager: NSObject, TransportManager {
     private var authTimeoutWorkItem: DispatchWorkItem?
     private var maxReconnectAttempts: Int = 0 // 0 = infinite
     private var autoReconnect: Bool = true
+
+    // Set when the relay displaced this connection (close 4000, or a
+    // SessionSuperseded notice on the current socket). Suppresses auto- AND
+    // force-reconnect until an explicit start() — a blind reconnect just
+    // re-displaces the peer socket in a tight loop. Main-owned (touched only
+    // on main: the close funnel, the message-dispatch main hop, and the
+    // lifecycle entry points), like autoReconnect/currentReconnectDelay.
+    // Mirrors InternetManager.kt's isSuperseded.
+    private var isSuperseded = false
 
     // State tracking. Lock-guarded (stateLock) like the Kotlin bridge's
     // AtomicBoolean/@Volatile fields: written on main (open/close/lifecycle),
@@ -278,6 +294,14 @@ public class InternetManager: NSObject, TransportManager {
     /// InternetManager.kt.
     public var connectionStatusEmitter: ((Bool, Bool) -> Void)?
 
+    /// Fires once when the relay displaces this connection (close 4000 or a
+    /// SessionSuperseded notice) — the module forwards it as the
+    /// `internet_session_superseded` event. The SDK will not auto-reconnect; the
+    /// app surfaces "connected elsewhere" and reconnects only on explicit user
+    /// action (re-enabling the transport). Reason is the close/notice reason,
+    /// if any. Mirrors InternetManager.kt.
+    public var supersededEmitter: ((String?) -> Void)?
+
     /// Last (connected, authenticated) pair published, or nil before the
     /// first. Lock-guarded like the flags themselves: flips happen on main,
     /// but the guard keeps the read-compare-store atomic against any future
@@ -442,6 +466,11 @@ public class InternetManager: NSObject, TransportManager {
         // The reconnect backoff is likewise per-session state: a stale 30s
         // delay must not slow the first retry of a brand-new start.
         isPaused = false
+        // A fresh start() is the deliberate re-enable that clears a prior
+        // relay-superseded latch: the app has resolved the "connected
+        // elsewhere" condition (e.g. signed the other session out) and now
+        // wants this device connected again.
+        isSuperseded = false
         reconnectAttempts = 0
         currentReconnectDelay = RECONNECT_INITIAL_DELAY
 
@@ -633,7 +662,8 @@ public class InternetManager: NSObject, TransportManager {
             "messages_received": messagesReceived.get(),
             "is_connected": isConnected,
             "is_authenticated": isAuthenticated,
-            "reconnect_attempts": reconnectAttempts
+            "reconnect_attempts": reconnectAttempts,
+            "is_superseded": isSuperseded
         ]
     }
     
@@ -655,6 +685,9 @@ public class InternetManager: NSObject, TransportManager {
     private func connect() {
         runOnMainSync {
             guard let url = serverUrl else { return }
+            // A relay-superseded transport must not reconnect until an
+            // explicit start() clears the latch (see markSuperseded).
+            guard !isSuperseded else { return }
             guard !isConnecting && !isConnected else { return }
             // stop() may have run between a reconnect being scheduled and
             // firing. The session null-check must precede the isConnecting
@@ -897,7 +930,24 @@ public class InternetManager: NSObject, TransportManager {
         ])
     }
     
-    private func handleConnectionClosed(error: Error?) {
+    /// Marks the connection displaced by the relay and latches it stopped:
+    /// cancels any pending reconnect, sets [isSuperseded] so auto- and
+    /// force-reconnect refuse until the next start(), and fires the one-shot
+    /// superseded event. Idempotent — the relay emits both a SessionSuperseded
+    /// notice and close 4000, and the close itself fires 2-3 terminal signals,
+    /// so several paths reach here for one displacement. Main-thread only.
+    private func markSuperseded(reason: String?) {
+        guard !isSuperseded else { return }
+        isSuperseded = true
+        reconnectWorkItem?.cancel()
+        reconnectWorkItem = nil
+        emitDiagnostic("warning", "Relay superseded this session; not auto-reconnecting", context: [
+            "reason": reason ?? "none"
+        ])
+        supersededEmitter?(reason)
+    }
+
+    private func handleConnectionClosed(error: Error?, closeCode: Int? = nil, closeReason: String? = nil) {
         let wasConnected = isConnected
         let wasAuthenticated = isAuthenticated
         isConnected = false
@@ -943,6 +993,18 @@ public class InternetManager: NSObject, TransportManager {
             "wasAuthenticated": wasAuthenticated
         ])
         
+        // The relay displaced this connection (close 4000, or a
+        // SessionSuperseded notice already flipped the flag on the live
+        // socket). A blind reconnect would just re-displace the peer socket in
+        // a ~1s eviction loop, so stop for good and let the app decide when to
+        // reconnect (explicit user action / foreground with long jitter).
+        // Recovery is an explicit start(), which clears isSuperseded.
+        if isSuperseded || closeCode == Self.SUPERSEDED_CLOSE_CODE {
+            markSuperseded(reason: closeReason ?? error?.localizedDescription)
+            updateState(.stopped)
+            return
+        }
+
         // Attempt reconnection if enabled
         // Messages in outbox will be flushed on successful reconnection
         if autoReconnect && state != .stopping && state != .stopped {
@@ -951,9 +1013,12 @@ public class InternetManager: NSObject, TransportManager {
             updateState(.stopped)
         }
     }
-    
+
     private func scheduleReconnect() {
         guard autoReconnect else { return }
+        // Defense in depth: handleConnectionClosed already returns before here
+        // on a superseded connection, but never schedule a reconnect for one.
+        guard !isSuperseded else { return }
         // A close can race stop(): its scheduled reconnect must not revive a
         // transport the app already stopped (the delayed connect() would
         // find urlSession nilled and leave the transport wedged).
@@ -1105,7 +1170,23 @@ public class InternetManager: NSObject, TransportManager {
             // connection (the teardown detaches it first, so the
             // cancel-triggered callbacks are ignored as stale).
             teardownSocket(ifCurrent: task, reason: reason)
-            
+
+        case "SessionSuperseded":
+            // The relay is displacing this connection — a newer registration
+            // for the same identity took the slot. It also closes with code
+            // 4000, but honor the notice too so we never blind-reconnect even
+            // if the close code is lost to a funnel race. Current socket only.
+            guard !isStale(task) else { break }
+            let supersedeReason = json["reason"] as? String
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self, task === self.webSocketTask else { return }
+                self.markSuperseded(reason: supersedeReason)
+                // Close the live socket through the shared funnel;
+                // handleConnectionClosed sees isSuperseded and stops without
+                // reconnecting (markSuperseded already emitted the event).
+                self.teardownSocket(ifCurrent: task, reason: supersedeReason ?? "Session superseded")
+            }
+
         case "MessageSent":
             // Handle MessageSent event from WebSocket server
             // This contains the server-generated message_id that we should use
@@ -2340,15 +2421,27 @@ extension InternetManager: URLSessionWebSocketDelegate {
         // funnel into the single task-scoped close: main hop, identity
         // check, detach FIRST, then handleConnectionClosed — whichever
         // signal lands first wins and the rest become stale no-ops.
+        let code = closeCode.rawValue
         DispatchQueue.main.async { [weak self] in
-            guard let self = self, webSocketTask === self.webSocketTask else { return }
-            self.webSocketTask = nil
+            guard let self = self else { return }
             let reasonString = reason.flatMap { String(data: $0, encoding: .utf8) }
+            // Displacement is authoritative regardless of which terminal signal
+            // won the funnel race: the receive-loop failure / didCompleteWithError
+            // may already have detached this task and scheduled a reconnect, so
+            // key the decision on the code — not task identity — and mark before
+            // the identity guard below can early-return. markSuperseded cancels
+            // any reconnect the losing path scheduled.
+            if code == Self.SUPERSEDED_CLOSE_CODE {
+                self.markSuperseded(reason: reasonString)
+                if self.state != .stopped { self.updateState(.stopped) }
+            }
+            guard webSocketTask === self.webSocketTask else { return }
+            self.webSocketTask = nil
             self.emitDiagnostic("info", "WebSocket closed", context: [
-                "closeCode": closeCode.rawValue,
+                "closeCode": code,
                 "reason": reasonString ?? "none"
             ])
-            self.handleConnectionClosed(error: nil)
+            self.handleConnectionClosed(error: nil, closeCode: code, closeReason: reasonString)
         }
     }
 

--- a/bindings/react-native/ios/InternetManager.swift
+++ b/bindings/react-native/ios/InternetManager.swift
@@ -35,13 +35,6 @@ public class InternetManager: NSObject, TransportManager {
     private let PING_INTERVAL: TimeInterval = 10.0  // Reduced from 30s for faster failure detection
     private let CONNECTION_TIMEOUT: TimeInterval = 10.0
     private let AUTH_RESPONSE_TIMEOUT: TimeInterval = 10.0
-    // WebSocket close code the relay uses to signal this connection was
-    // displaced by a newer registration for the same identity ("session
-    // superseded"). A blind reconnect would just re-displace the peer socket
-    // in a ~1s loop (the fleet-wide eviction storm the relay-displacement
-    // rollout guards against), so on this code we stop and let the app decide
-    // when to reconnect. Mirrors InternetManager.kt.
-    private static let SUPERSEDED_CLOSE_CODE = 4000
     // Tracker ids for app-authored raw SendMessage frames (sendRawCommand):
     // recorded to keep the per-recipient FIFO honest, never reported to the
     // core. Mirrors InternetManager.kt — keep in sync.
@@ -120,14 +113,15 @@ public class InternetManager: NSObject, TransportManager {
     private var maxReconnectAttempts: Int = 0 // 0 = infinite
     private var autoReconnect: Bool = true
 
-    // Set when the relay displaced this connection (close 4000, or a
-    // SessionSuperseded notice on the current socket). Suppresses auto- AND
-    // force-reconnect until an explicit start() — a blind reconnect just
-    // re-displaces the peer socket in a tight loop. Main-owned (touched only
-    // on main: the close funnel, the message-dispatch main hop, and the
-    // lifecycle entry points), like autoReconnect/currentReconnectDelay.
-    // Mirrors InternetManager.kt's isSuperseded.
-    private var isSuperseded = false
+    // The relay-displacement latch (close 4000, or a SessionSuperseded notice
+    // on the current socket). While latched, auto- AND force-reconnect refuse
+    // until an explicit start() — a blind reconnect just re-displaces the peer
+    // socket in a tight loop. Owns the boolean + decision; this manager owns
+    // the threading (touched only on main: the close funnel, the
+    // message-dispatch main hop, and the lifecycle entry points), like
+    // autoReconnect/currentReconnectDelay. Mirrors InternetManager.kt's
+    // supersedeLatch.
+    private let supersedeLatch = SupersededLatchPolicy()
 
     // State tracking. Lock-guarded (stateLock) like the Kotlin bridge's
     // AtomicBoolean/@Volatile fields: written on main (open/close/lifecycle),
@@ -470,7 +464,7 @@ public class InternetManager: NSObject, TransportManager {
         // relay-superseded latch: the app has resolved the "connected
         // elsewhere" condition (e.g. signed the other session out) and now
         // wants this device connected again.
-        isSuperseded = false
+        supersedeLatch.clear()
         reconnectAttempts = 0
         currentReconnectDelay = RECONNECT_INITIAL_DELAY
 
@@ -663,7 +657,7 @@ public class InternetManager: NSObject, TransportManager {
             "is_connected": isConnected,
             "is_authenticated": isAuthenticated,
             "reconnect_attempts": reconnectAttempts,
-            "is_superseded": isSuperseded
+            "is_superseded": supersedeLatch.isSuperseded
         ]
     }
     
@@ -687,7 +681,7 @@ public class InternetManager: NSObject, TransportManager {
             guard let url = serverUrl else { return }
             // A relay-superseded transport must not reconnect until an
             // explicit start() clears the latch (see markSuperseded).
-            guard !isSuperseded else { return }
+            guard !supersedeLatch.isSuperseded else { return }
             guard !isConnecting && !isConnected else { return }
             // stop() may have run between a reconnect being scheduled and
             // firing. The session null-check must precede the isConnecting
@@ -931,14 +925,14 @@ public class InternetManager: NSObject, TransportManager {
     }
     
     /// Marks the connection displaced by the relay and latches it stopped:
-    /// cancels any pending reconnect, sets [isSuperseded] so auto- and
+    /// cancels any pending reconnect, latches `supersedeLatch` so auto- and
     /// force-reconnect refuse until the next start(), and fires the one-shot
-    /// superseded event. Idempotent — the relay emits both a SessionSuperseded
-    /// notice and close 4000, and the close itself fires 2-3 terminal signals,
-    /// so several paths reach here for one displacement. Main-thread only.
+    /// superseded event. Idempotent (via SupersededLatchPolicy.mark) — the
+    /// relay emits both a SessionSuperseded notice and close 4000, and the
+    /// close itself fires 2-3 terminal signals, so several paths reach here
+    /// for one displacement. Main-thread only.
     private func markSuperseded(reason: String?) {
-        guard !isSuperseded else { return }
-        isSuperseded = true
+        guard supersedeLatch.mark() else { return }
         reconnectWorkItem?.cancel()
         reconnectWorkItem = nil
         emitDiagnostic("warning", "Relay superseded this session; not auto-reconnecting", context: [
@@ -998,10 +992,15 @@ public class InternetManager: NSObject, TransportManager {
         // socket). A blind reconnect would just re-displace the peer socket in
         // a ~1s eviction loop, so stop for good and let the app decide when to
         // reconnect (explicit user action / foreground with long jitter).
-        // Recovery is an explicit start(), which clears isSuperseded.
-        if isSuperseded || closeCode == Self.SUPERSEDED_CLOSE_CODE {
+        // Recovery is an explicit start(), which clears the latch.
+        //
+        // hasNewerSuccessor = false: this runs only after handleSocketTerminated
+        // / the didClose funnel detached the current task, so there is no live
+        // successor to guard against here (didCloseWith does that guarding
+        // itself, before it ever reaches this path).
+        if supersedeLatch.shouldMark(closeCode: closeCode, hasNewerSuccessor: false) {
             markSuperseded(reason: closeReason ?? error?.localizedDescription)
-            updateState(.stopped)
+            if state != .stopped { updateState(.stopped) }
             return
         }
 
@@ -1018,7 +1017,7 @@ public class InternetManager: NSObject, TransportManager {
         guard autoReconnect else { return }
         // Defense in depth: handleConnectionClosed already returns before here
         // on a superseded connection, but never schedule a reconnect for one.
-        guard !isSuperseded else { return }
+        guard !supersedeLatch.isSuperseded else { return }
         // A close can race stop(): its scheduled reconnect must not revive a
         // transport the app already stopped (the delayed connect() would
         // find urlSession nilled and leave the transport wedged).
@@ -2436,16 +2435,18 @@ extension InternetManager: URLSessionWebSocketDelegate {
             // But do NOT mark when a *newer* socket has already replaced this
             // one: a late 4000 for a bygone generation (old socket displaced →
             // app re-enabled via start() → new socket B up) must not re-latch
-            // isSuperseded and stop B. webSocketTask == nil is the sibling-race
-            // this fix targets (detached, no successor yet); a non-nil task that
-            // differs from `webSocketTask` is a live successor and the stale
-            // close is ignored. NOTE: the Android bridge guards this ordering
-            // differently — its identity check sits *before* the supersede
-            // decision (terminateSocket), so it cannot mark once detached and
-            // instead re-latches on the next 4000. The two funnels defend
-            // against opposite terminal-signal orderings; don't "unify" them.
-            if code == Self.SUPERSEDED_CLOSE_CODE,
-               self.webSocketTask == nil || webSocketTask === self.webSocketTask {
+            // and stop B. A live successor is a non-nil `self.webSocketTask`
+            // that differs from this close's task; webSocketTask == nil is the
+            // sibling-race this fix targets — detached with no successor yet, so
+            // this 4000 belongs to the current generation and must latch. NOTE:
+            // the Android bridge guards this ordering differently — its identity
+            // check sits *before* the supersede decision (terminateSocket), so
+            // it cannot mark once detached and instead re-latches on the next
+            // 4000. The two funnels defend against opposite terminal-signal
+            // orderings; don't "unify" them. The decision itself is shared
+            // (SupersededLatchPolicy) so both bridges agree on the rule.
+            let hasNewerSuccessor = self.webSocketTask != nil && webSocketTask !== self.webSocketTask
+            if self.supersedeLatch.shouldMark(closeCode: code, hasNewerSuccessor: hasNewerSuccessor) {
                 self.markSuperseded(reason: reasonString)
                 if self.state != .stopped { self.updateState(.stopped) }
             }

--- a/bindings/react-native/ios/InternetManager.swift
+++ b/bindings/react-native/ios/InternetManager.swift
@@ -2427,11 +2427,25 @@ extension InternetManager: URLSessionWebSocketDelegate {
             let reasonString = reason.flatMap { String(data: $0, encoding: .utf8) }
             // Displacement is authoritative regardless of which terminal signal
             // won the funnel race: the receive-loop failure / didCompleteWithError
-            // may already have detached this task and scheduled a reconnect, so
-            // key the decision on the code — not task identity — and mark before
-            // the identity guard below can early-return. markSuperseded cancels
-            // any reconnect the losing path scheduled.
-            if code == Self.SUPERSEDED_CLOSE_CODE {
+            // may already have detached this task (nilling webSocketTask) and
+            // scheduled a reconnect, so key the decision on the code — not task
+            // identity — and mark before the identity guard below can
+            // early-return. markSuperseded cancels any reconnect the losing path
+            // scheduled.
+            //
+            // But do NOT mark when a *newer* socket has already replaced this
+            // one: a late 4000 for a bygone generation (old socket displaced →
+            // app re-enabled via start() → new socket B up) must not re-latch
+            // isSuperseded and stop B. webSocketTask == nil is the sibling-race
+            // this fix targets (detached, no successor yet); a non-nil task that
+            // differs from `webSocketTask` is a live successor and the stale
+            // close is ignored. NOTE: the Android bridge guards this ordering
+            // differently — its identity check sits *before* the supersede
+            // decision (terminateSocket), so it cannot mark once detached and
+            // instead re-latches on the next 4000. The two funnels defend
+            // against opposite terminal-signal orderings; don't "unify" them.
+            if code == Self.SUPERSEDED_CLOSE_CODE,
+               self.webSocketTask == nil || webSocketTask === self.webSocketTask {
                 self.markSuperseded(reason: reasonString)
                 if self.state != .stopped { self.updateState(.stopped) }
             }

--- a/bindings/react-native/ios/MeshSdk.podspec
+++ b/bindings/react-native/ios/MeshSdk.podspec
@@ -29,6 +29,7 @@ Pod::Spec.new do |s|
     "PresenceWatchPolicy.swift",
     "RecipientInFlightTracker.swift",
     "RelayTimestamps.swift",
+    "SupersededLatchPolicy.swift",
     "WifiDirectManager.swift",
     "NostrManager.swift",
     "ReticulumManager.swift",

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -374,6 +374,9 @@ class OfflineProtocolModule: RCTEventEmitter {
                 internetManager?.connectionStatusEmitter = { [weak self] connected, authenticated in
                     self?.emitInternetStatusEvent(connected: connected, authenticated: authenticated)
                 }
+                internetManager?.supersededEmitter = { [weak self] reason in
+                    self?.emitInternetSupersededEvent(reason: reason)
+                }
                 print("[OfflineProtocolModule] Internet Manager initialized for user: \(config.userId)")
                 
                 // Extract and store internet config for use during start()
@@ -519,6 +522,23 @@ class OfflineProtocolModule: RCTEventEmitter {
             "connected": connected,
             "authenticated": authenticated
         ]
+        if let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
+           let jsonString = String(data: data, encoding: .utf8) {
+            sendEventToJS(Events.onEvent, body: ["eventJson": jsonString])
+        }
+    }
+
+    /// Forwards a relay session displacement ("superseded") as the
+    /// `internet_session_superseded` event. The relay closed this socket with
+    /// code 4000 because a newer registration for the same identity took over;
+    /// the SDK will NOT auto-reconnect. The app surfaces "connected elsewhere"
+    /// and reconnects only on explicit user action (re-enabling the transport).
+    fileprivate func emitInternetSupersededEvent(reason: String?) {
+        guard hasListeners else { return }
+        var payload: [String: Any] = [
+            "type": "internet_session_superseded"
+        ]
+        if let reason = reason { payload["reason"] = reason }
         if let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
            let jsonString = String(data: data, encoding: .utf8) {
             sendEventToJS(Events.onEvent, body: ["eventJson": jsonString])
@@ -1351,6 +1371,9 @@ class OfflineProtocolModule: RCTEventEmitter {
                     }
                     newManager.connectionStatusEmitter = { [weak self] connected, authenticated in
                         self?.emitInternetStatusEvent(connected: connected, authenticated: authenticated)
+                    }
+                    newManager.supersededEmitter = { [weak self] reason in
+                        self?.emitInternetSupersededEvent(reason: reason)
                     }
                     internetManager = newManager
                     emitDiagnostic(level: "info", message: "Internet manager created on demand")

--- a/bindings/react-native/ios/Package.swift
+++ b/bindings/react-native/ios/Package.swift
@@ -56,7 +56,8 @@ let package = Package(
                 "RelayControlOpTranslator.swift",
                 "RelayGroupSnapshotBridge.swift",
                 "RelayRateLimiter.swift",
-                "RelayTimestamps.swift"
+                "RelayTimestamps.swift",
+                "SupersededLatchPolicy.swift"
             ]
         ),
         .testTarget(
@@ -80,7 +81,8 @@ let package = Package(
                 "RelayControlOpTranslatorTests.swift",
                 "RelayGroupSnapshotBridgeTests.swift",
                 "RelayRateLimiterTests.swift",
-                "RelayTimestampsTests.swift"
+                "RelayTimestampsTests.swift",
+                "SupersededLatchPolicyTests.swift"
             ]
         )
     ]

--- a/bindings/react-native/ios/SupersededLatchPolicy.swift
+++ b/bindings/react-native/ios/SupersededLatchPolicy.swift
@@ -1,0 +1,71 @@
+//
+// SupersededLatchPolicy.swift
+// OfflineProtocol
+//
+// The relay-displacement ("session superseded") latch, extracted as a pure,
+// Foundation-only state machine so it can be unit-tested without a live
+// WebSocket (see tests/SupersededLatchPolicyTests.swift). InternetManager
+// owns the threading (every call is made on main, the single writer); this
+// type owns only the decision and the boolean.
+//
+// The relay closes a displaced connection with WebSocket close code 4000 (a
+// newer registration for the same identity took the slot) and, redundantly,
+// sends an application-level SessionSuperseded notice on the live socket
+// first. Either signal must latch the transport stopped: a blind reconnect
+// would just re-displace the peer socket in a ~1s loop — the fleet-wide
+// eviction storm the relay-displacement rollout guards against. The latch is
+// cleared only by an explicit start() (the app resolved "connected
+// elsewhere" and re-enabled the transport).
+//
+// Mirrors android/src/main/java/com/offlineprotocol/SupersededLatchPolicy.kt
+// — keep in sync.
+//
+
+import Foundation
+
+final class SupersededLatchPolicy {
+    /// WebSocket close code the relay uses to signal displacement.
+    static let SUPERSEDED_CLOSE_CODE = 4000
+
+    // Main-owned like the InternetManager flags it replaces (autoReconnect,
+    // the connection bools): written on main, read best-effort off-main
+    // (getMetrics). A plain Bool matches that established pattern.
+    private var latched = false
+
+    var isSuperseded: Bool { latched }
+
+    /// Pure decision: does a close on some socket displace the transport?
+    ///
+    /// - Parameter closeCode: the WebSocket close code, or nil for a local /
+    ///   error terminal (ping/auth/send-failure teardown) that carries none.
+    /// - Parameter hasNewerSuccessor: a *different*, live socket has already
+    ///   replaced the one this close belongs to. A late 4000 for a bygone
+    ///   generation (old socket displaced → app re-enabled via start() → new
+    ///   socket B up) must NOT re-latch and stop B. This is the sibling-race
+    ///   the cd9fa39 fix targets. Callers whose socket-identity guard already
+    ///   ran before reaching the decision (the Android close funnel) pass
+    ///   false — a successor can never reach that point.
+    ///
+    /// An already-latched connection stays latched regardless of close code
+    /// (a non-4000 close after a SessionSuperseded notice still stops).
+    func shouldMark(closeCode: Int?, hasNewerSuccessor: Bool) -> Bool {
+        if hasNewerSuccessor { return false }
+        return latched || closeCode == Self.SUPERSEDED_CLOSE_CODE
+    }
+
+    /// Latches superseded. Returns true only on the false→true transition, so
+    /// the caller fires the one-shot event exactly once even though the relay
+    /// emits both a notice and a close (each of which fans into 2-3 terminal
+    /// signals) for a single displacement.
+    @discardableResult
+    func mark() -> Bool {
+        if latched { return false }
+        latched = true
+        return true
+    }
+
+    /// Cleared by an explicit start() — the deliberate re-enable.
+    func clear() {
+        latched = false
+    }
+}

--- a/bindings/react-native/ios/tests/SupersededLatchPolicyTests.swift
+++ b/bindings/react-native/ios/tests/SupersededLatchPolicyTests.swift
@@ -1,0 +1,74 @@
+//
+// SupersededLatchPolicyTests.swift
+// Mirrors android/src/test/java/com/offlineprotocol/SupersededLatchPolicyTest.kt
+//
+
+import XCTest
+@testable import OfflineProtocol
+
+final class SupersededLatchPolicyTests: XCTestCase {
+
+    func testClose4000LatchesWhenSocketIsCurrent() {
+        let policy = SupersededLatchPolicy()
+        // handleConnectionClosed reaches the decision only after the task was
+        // detached, so hasNewerSuccessor is false there.
+        XCTAssertTrue(policy.shouldMark(closeCode: 4000, hasNewerSuccessor: false))
+    }
+
+    func testNonSupersedeCloseDoesNotLatch() {
+        let policy = SupersededLatchPolicy()
+        XCTAssertFalse(policy.shouldMark(closeCode: 1000, hasNewerSuccessor: false))
+        XCTAssertFalse(policy.shouldMark(closeCode: -1, hasNewerSuccessor: false))
+        XCTAssertFalse(policy.shouldMark(closeCode: nil, hasNewerSuccessor: false))
+    }
+
+    func testNewerSuccessorSocketIsNeverLatchedByAStale4000() {
+        // The cd9fa39 regression: old socket displaced → app re-enabled via
+        // start() → new socket B up → a LATE 4000 for the bygone generation
+        // must not re-latch and stop B.
+        let policy = SupersededLatchPolicy()
+        XCTAssertFalse(policy.shouldMark(closeCode: 4000, hasNewerSuccessor: true))
+    }
+
+    func testSuccessorGuardWinsEvenWhenAlreadyLatched() {
+        let policy = SupersededLatchPolicy()
+        policy.mark()
+        // A stale latch bit must still never stop a live successor socket.
+        XCTAssertFalse(policy.shouldMark(closeCode: 1000, hasNewerSuccessor: true))
+    }
+
+    func testOnceLatchedAnyCloseKeepsLatching() {
+        // A non-4000 close arriving after a SessionSuperseded notice already
+        // latched (on the live socket) must still stop, not reconnect.
+        let policy = SupersededLatchPolicy()
+        policy.mark()
+        XCTAssertTrue(policy.shouldMark(closeCode: 1000, hasNewerSuccessor: false))
+        XCTAssertTrue(policy.shouldMark(closeCode: nil, hasNewerSuccessor: false))
+    }
+
+    func testMarkIsIdempotentAndReportsOnlyTheFirstTransition() {
+        // The relay emits a notice AND close 4000 (each fanning into several
+        // terminal signals); the one-shot event must fire exactly once.
+        let policy = SupersededLatchPolicy()
+        XCTAssertTrue(policy.mark())   // false -> true: fire the event
+        XCTAssertFalse(policy.mark())  // already latched: no re-fire
+        XCTAssertFalse(policy.mark())
+        XCTAssertTrue(policy.isSuperseded)
+    }
+
+    func testStartClearsTheLatchAndReArmsMark() {
+        let policy = SupersededLatchPolicy()
+        policy.mark()
+        XCTAssertTrue(policy.isSuperseded)
+
+        // A fresh start() clears it; a subsequent displacement fires again.
+        policy.clear()
+        XCTAssertFalse(policy.isSuperseded)
+        XCTAssertFalse(policy.shouldMark(closeCode: 1000, hasNewerSuccessor: false))
+        XCTAssertTrue(policy.mark())
+    }
+
+    func testCloseCodeConstantMatchesRelayContract() {
+        XCTAssertEqual(SupersededLatchPolicy.SUPERSEDED_CLOSE_CODE, 4000)
+    }
+}

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -1697,6 +1697,23 @@ export interface InternetStatusChangedEvent extends BaseEvent {
 }
 
 /**
+ * The relay displaced this device's internet connection: a newer
+ * registration for the same identity took over the relay slot, and the relay
+ * closed this socket with code 4000 (optionally preceded by a
+ * `SessionSuperseded` notice). The SDK does **not** auto-reconnect after this
+ * — a blind reconnect would just re-displace the other socket in a tight loop
+ * (the fleet-wide eviction storm the relay-displacement rollout guards
+ * against). The transport is left stopped; the app should surface a
+ * "connected elsewhere" state and reconnect only on explicit user action
+ * (re-enabling the internet transport), or on foreground with long jitter.
+ * `reason` is the relay-supplied close/notice reason when present.
+ */
+export interface InternetSessionSupersededEvent extends BaseEvent {
+  type: 'internet_session_superseded';
+  reason?: string;
+}
+
+/**
  * Relay-side registration state of a group (`groupRelaySyncState`).
  */
 export type RelaySyncState = 'synced' | 'pending' | 'unsynced';
@@ -1762,6 +1779,7 @@ export type ProtocolEvent =
   | PresenceUpdatedEvent
   | InternetServerMessageEvent
   | InternetStatusChangedEvent
+  | InternetSessionSupersededEvent
   | TypingIndicatorReceivedEvent
   | ReadReceiptReceivedEvent
   | MessageRelayedEvent

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -3348,6 +3348,7 @@ mod tests {
             "diagnostic",
             "internet_server_message",
             "internet_status_changed",
+            "internet_session_superseded",
         ]
         .map(str::to_string)
         .into();


### PR DESCRIPTION
## Why

The relay displaces a stale connection by closing the WebSocket with code **4000** (optionally preceded by a `SessionSuperseded` notice) when a newer registration for the same identity takes over the relay slot. Per the [relay-displacement rollout audit](../fernweh_v2/docs/relay-displacement-rollout-audit.md), **no deployed client generation reacts to close 4000 — all blind-auto-reconnect.** Combined with an undamped displacement server, every legacy dual-socket device becomes a self-sustaining ~1–2s eviction loop (presence flapping, message-routing lottery, JWT verify + register/unregister churn) across the entire fleet.

This is the **mesh-sdk (next release), defense-in-depth** recommendation from that audit.

## What

The WebSocket lives entirely in the native bridges (the Rust `InternetTransport` is only a queue engine), so the change is in the RN bindings, mirrored across iOS (`URLSessionWebSocketTask`) and Android (OkHttp):

- **Plumb the close code through** to `handleConnectionClosed`. iOS previously read `closeCode` in `didCloseWith` and discarded it; Android carried `code` but never consulted it.
- **On close 4000 → superseded state**: latch `isSuperseded`, cancel any pending reconnect, transition to `stopped`, and **do not auto-reconnect**. `connect()` / `scheduleReconnect()` refuse while latched.
- **Also honor a `SessionSuperseded` notice** on the current socket (the audit's "or a SessionSuperseded observed on the current connection") — same latch, torn down through the shared funnel. On iOS this also makes the decision robust against the URLSession terminal-signal funnel race by keying on the code rather than task identity (cancelling any reconnect a losing signal scheduled).
- **Recovery** = an explicit `start()` / re-enable clears the latch (the app has resolved "connected elsewhere"). `forceReconnect()` no-ops while superseded (state is `stopped`), matching what fernweh needs.
- **New event `internet_session_superseded`** (`{ type, reason? }`) via a new `supersededEmitter`, wired in both module-init paths; declared in `types.ts` (interface + `ProtocolEvent` union) and added to the Rust↔TS drift-guard `bridge_only` allow-list. `is_superseded` also exposed in `getMetrics()`.

## Verification

- ✅ Rust drift-guard test `react_native_types_cover_all_event_variants`
- ✅ `tsc --noEmit`
- ✅ `cargo fmt --all -- --check`

Native Swift/Kotlin were not compiled (no Xcode/Gradle in this environment); every edited native region was re-read for syntax/scope correctness.

## Note / assumption

The relay notice message `type` is assumed to be `"SessionSuperseded"` (per the audit doc). If the relay names it differently that case is a no-op — **close 4000 remains the guaranteed, required trigger**, so behavior degrades safely.

## Follow-up (not in this PR)

- fernweh subscribes to `internet_session_superseded`, surfaces the UX, and suppresses its foreground force-reconnect for a superseded session.
- relay-server ships per-username displacement damping (the required guardrail for the *deployed* legacy fleet, which this SDK change cannot protect).