### PR TITLE
fix(bindings): disambiguate stale relay-4000 by socket generation on iOS

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -838,11 +838,17 @@ class InternetManager(
         // path) latches first. Even absent the notice, the reconnect gets
         // displaced again and the next onClosed(4000) latches. iOS instead marks
         // before its identity guard (so it can't miss the code) but must then
-        // exclude a newer successor socket. Opposite orderings, same end state.
+        // exclude a bygone socket by SOCKET GENERATION (SocketGenerationTracker),
+        // because its pre-mark path also sees a nil reconnect window that object
+        // identity can't classify. Android needs no such generation tracking:
+        // dropping non-current sockets here, before the decision, already makes
+        // it immune to the bygone-generation false-latch iOS's generation guard
+        // fixes. Opposite orderings, same end state.
         //
         // hasNewerSuccessor = false: terminateSocket's identity guard already
         // dropped any close whose socket isn't the current one, so a successor
-        // can never reach here (unlike the iOS didClose funnel).
+        // (or any bygone socket) can never reach here (unlike the iOS didClose
+        // funnel).
         if (supersedeLatch.shouldMark(code, hasNewerSuccessor = false)) {
             markSuperseded(reason)
             if (state != TransportState.STOPPED) updateState(TransportState.STOPPED)

--- a/bindings/react-native/ios/InternetManager.swift
+++ b/bindings/react-native/ios/InternetManager.swift
@@ -123,6 +123,17 @@ public class InternetManager: NSObject, TransportManager {
     // supersedeLatch.
     private let supersedeLatch = SupersededLatchPolicy()
 
+    // Monotonic socket-generation counter. Each socket minted in connect() is
+    // stamped with the next generation (carried on task.taskDescription) so the
+    // close funnel can tell a bygone socket's late close-4000 from the current
+    // one's — the disambiguation object identity can't make while webSocketTask
+    // is momentarily nil during a reconnect backoff window (see the didCloseWith
+    // ORDERING NOTE). Main-owned/single-writer like webSocketTask: minted only
+    // in connect(), read only on the didCloseWith main hop. No Kotlin mirror —
+    // the Android funnel drops non-current sockets before the supersede decision
+    // (see InternetManager.kt's ORDERING NOTE).
+    private var socketGeneration = SocketGenerationTracker()
+
     // State tracking. Lock-guarded (stateLock) like the Kotlin bridge's
     // AtomicBoolean/@Volatile fields: written on main (open/close/lifecycle),
     // read from messageQueue (poll ticks, drains), the URLSession delegate
@@ -699,6 +710,12 @@ public class InternetManager: NSObject, TransportManager {
             request.setValue(deviceId, forHTTPHeaderField: "X-Device-ID")
 
             let task = session.webSocketTask(with: request)
+            // Stamp this socket's generation (this is the sole task-creation
+            // site — start / auto-reconnect / forceReconnect all funnel here).
+            // Read back in didCloseWith to distinguish a bygone generation's
+            // late close-4000 from the current socket's during a nil reconnect
+            // window; the tag rides with the task and dies with it.
+            task.taskDescription = String(socketGeneration.mint())
             webSocketTask = task
             task.resume()
 
@@ -2432,20 +2449,38 @@ extension InternetManager: URLSessionWebSocketDelegate {
             // early-return. markSuperseded cancels any reconnect the losing path
             // scheduled.
             //
-            // But do NOT mark when a *newer* socket has already replaced this
-            // one: a late 4000 for a bygone generation (old socket displaced →
-            // app re-enabled via start() → new socket B up) must not re-latch
-            // and stop B. A live successor is a non-nil `self.webSocketTask`
-            // that differs from this close's task; webSocketTask == nil is the
-            // sibling-race this fix targets — detached with no successor yet, so
-            // this 4000 belongs to the current generation and must latch. NOTE:
-            // the Android bridge guards this ordering differently — its identity
-            // check sits *before* the supersede decision (terminateSocket), so
-            // it cannot mark once detached and instead re-latches on the next
-            // 4000. The two funnels defend against opposite terminal-signal
-            // orderings; don't "unify" them. The decision itself is shared
-            // (SupersededLatchPolicy) so both bridges agree on the rule.
-            let hasNewerSuccessor = self.webSocketTask != nil && webSocketTask !== self.webSocketTask
+            // But do NOT mark when this close belongs to a *bygone* generation:
+            // a late 4000 for an old socket that a newer one has already
+            // superseded (old socket displaced → app re-enabled via start(), or
+            // torn down by forceReconnect → a newer socket minted) must not
+            // re-latch and stop the current generation. We key this on socket
+            // GENERATION, not object identity: identity can only see a live,
+            // non-nil successor, but the systematic case is a nil reconnect
+            // window — forceReconnect (fernweh's foreground recovery) nils
+            // webSocketTask and schedules connect() at a backoff, and on
+            // foreground iOS flushes a background-queued 4000 for the old socket
+            // into that window. Object identity would read webSocketTask == nil
+            // as "current generation, must latch" and wedge the transport;
+            // generation reads the old socket as bygone and lets the reconnect
+            // live. A 4000 whose generation is still the newest (the current
+            // socket genuinely displaced, or detached by a sibling terminal
+            // signal with the reconnect not yet minted) is NOT bygone and still
+            // latches — cancelling any reconnect the losing path scheduled.
+            // (Fallback to object identity only if the generation tag is ever
+            // absent — connect() always sets it, so this is belt-and-suspenders.)
+            //
+            // NOTE: the Android bridge guards this ordering differently — its
+            // identity check sits *before* the supersede decision
+            // (terminateSocket), so a non-current socket's close is dropped
+            // before it can latch and it re-latches on the next 4000 instead.
+            // That makes Android immune to the bygone-generation false-latch by
+            // construction, so it needs no generation tracking. The two funnels
+            // defend against opposite terminal-signal orderings; don't "unify"
+            // them. The core decision is shared (SupersededLatchPolicy) so both
+            // bridges agree on the rule.
+            let closingGeneration = webSocketTask.taskDescription.flatMap { Int($0) }
+            let hasNewerSuccessor = closingGeneration.map { self.socketGeneration.isBygone($0) }
+                ?? (self.webSocketTask != nil && webSocketTask !== self.webSocketTask)
             if self.supersedeLatch.shouldMark(closeCode: code, hasNewerSuccessor: hasNewerSuccessor) {
                 self.markSuperseded(reason: reasonString)
                 if self.state != .stopped { self.updateState(.stopped) }

--- a/bindings/react-native/ios/Package.swift
+++ b/bindings/react-native/ios/Package.swift
@@ -57,6 +57,7 @@ let package = Package(
                 "RelayGroupSnapshotBridge.swift",
                 "RelayRateLimiter.swift",
                 "RelayTimestamps.swift",
+                "SocketGenerationTracker.swift",
                 "SupersededLatchPolicy.swift"
             ]
         ),
@@ -82,6 +83,7 @@ let package = Package(
                 "RelayGroupSnapshotBridgeTests.swift",
                 "RelayRateLimiterTests.swift",
                 "RelayTimestampsTests.swift",
+                "SocketGenerationTrackerTests.swift",
                 "SupersededLatchPolicyTests.swift"
             ]
         )

--- a/bindings/react-native/ios/SocketGenerationTracker.swift
+++ b/bindings/react-native/ios/SocketGenerationTracker.swift
@@ -1,0 +1,55 @@
+//
+// SocketGenerationTracker.swift
+// OfflineProtocol
+//
+// A monotonic socket-generation counter, extracted as a pure, Foundation-only
+// helper so it can be unit-tested without a live WebSocket (see
+// tests/SocketGenerationTrackerTests.swift). InternetManager owns the
+// threading (every call is made on main, the single writer — the same
+// discipline that governs webSocketTask); this type owns only the counter and
+// the bygone-generation decision.
+//
+// Purpose: the relay-displacement latch (see SupersededLatchPolicy) has to
+// answer, in didCloseWith, "does this close-4000 belong to the socket I still
+// intend to run, or to a bygone one?". Object identity against the current
+// webSocketTask cannot answer that during a reconnect backoff window, when
+// webSocketTask is momentarily nil: nil means both "current generation,
+// detached by a sibling terminal signal, reconnect pending" (must latch) and
+// "an old superseded socket while a newer generation is already in flight"
+// (must NOT latch). A per-socket generation disambiguates them: each socket is
+// stamped with mint() at creation (carried on task.taskDescription), and a
+// close whose generation is strictly older than latest is bygone regardless of
+// whether webSocketTask is currently nil or a live successor.
+//
+// There is deliberately NO Kotlin mirror. The Android close funnel runs its
+// socket-identity guard (terminateSocket) BEFORE the supersede decision, so a
+// non-current socket's close — nil-window or successor — is dropped before it
+// can ever latch; Android is immune to the bygone-generation false-latch by
+// construction (see InternetManager.kt's ORDERING NOTE). Only the iOS funnel,
+// which marks on the close code before its identity guard, needs this.
+//
+
+import Foundation
+
+struct SocketGenerationTracker {
+    /// The newest generation minted so far. Starts at 0 (no socket yet); the
+    /// first mint() returns 1. Main-owned like webSocketTask.
+    private(set) var latest: Int = 0
+
+    /// Advances to and returns the next generation. Called once per socket
+    /// creation (InternetManager.connect), which stamps the returned value on
+    /// the task so didCloseWith can recover it.
+    mutating func mint() -> Int {
+        latest += 1
+        return latest
+    }
+
+    /// True when `generation` belongs to a socket older than the newest one
+    /// minted — a bygone generation whose late close must not re-latch a
+    /// transport that has since moved on. The current generation (== latest)
+    /// is not bygone, so a genuine displacement of the live socket still
+    /// latches.
+    func isBygone(_ generation: Int) -> Bool {
+        generation < latest
+    }
+}

--- a/bindings/react-native/ios/tests/SocketGenerationTrackerTests.swift
+++ b/bindings/react-native/ios/tests/SocketGenerationTrackerTests.swift
@@ -1,0 +1,52 @@
+//
+// SocketGenerationTrackerTests.swift
+//
+// iOS-only: there is no Kotlin mirror for SocketGenerationTracker (the Android
+// close funnel drops non-current sockets before the supersede decision, so it
+// needs no generation tracking — see SocketGenerationTracker.swift).
+//
+
+import XCTest
+@testable import OfflineProtocol
+
+final class SocketGenerationTrackerTests: XCTestCase {
+
+    func testFreshTrackerHasNoGeneration() {
+        let tracker = SocketGenerationTracker()
+        XCTAssertEqual(tracker.latest, 0)
+    }
+
+    func testMintIsMonotonicAndAdvancesLatest() {
+        var tracker = SocketGenerationTracker()
+        XCTAssertEqual(tracker.mint(), 1)
+        XCTAssertEqual(tracker.latest, 1)
+        XCTAssertEqual(tracker.mint(), 2)
+        XCTAssertEqual(tracker.mint(), 3)
+        XCTAssertEqual(tracker.latest, 3)
+    }
+
+    func testCurrentGenerationIsNotBygone() {
+        // A 4000 for the current generation must still latch: the live socket
+        // was genuinely displaced (case a).
+        var tracker = SocketGenerationTracker()
+        let gen = tracker.mint()
+        XCTAssertFalse(tracker.isBygone(gen))
+    }
+
+    func testOlderGenerationIsBygone() {
+        // A 4000 for a socket minted before the newest one is stale and must
+        // NOT re-latch (case b — the nil reconnect window).
+        var tracker = SocketGenerationTracker()
+        let first = tracker.mint()
+        _ = tracker.mint()
+        XCTAssertTrue(tracker.isBygone(first))
+    }
+
+    func testBygoneHoldsAcrossManyGenerations() {
+        var tracker = SocketGenerationTracker()
+        let first = tracker.mint()
+        for _ in 0..<5 { _ = tracker.mint() }
+        XCTAssertTrue(tracker.isBygone(first))
+        XCTAssertFalse(tracker.isBygone(tracker.latest))
+    }
+}


### PR DESCRIPTION
## Problem

The iOS internet transport permanently wedges after foreground when a stale relay close-4000 lands during a reconnect window. `didCloseWith` decided whether a 4000 latches `supersedeLatch` using object identity (`hasNewerSuccessor = self.webSocketTask != nil && webSocketTask !== self.webSocketTask`). That guard is blind while `webSocketTask == nil` (the reconnect backoff window): it cannot distinguish

- **(a)** a 4000 for the **current** generation whose task a sibling terminal signal already detached + scheduled a reconnect for → **must latch** (to cancel that blind reconnect — the deliberate cd9fa39 ordering), from
- **(b)** a stale 4000 for a **bygone** generation while a legitimately newer socket is in flight → **must not latch**.

**fernweh triggers (b) systematically:** `internetForceReconnect()` → `forceReconnect()` → `teardownSocket()` nils `webSocketTask` and schedules `connect()` at a backoff, and on foreground iOS flushes a background-queued 4000 for the old socket into that nil window. Object identity read `nil` as "current generation → latch" and stopped the transport for good — recoverable only by an explicit `start()` (`forceReconnect` no-ops once latched, via `connect()`'s `isSuperseded` guard).

The app-team's suggested "move the identity guard before the mark" (Android ordering) was rejected: it regresses case (a) — the sibling-signal 4000 would fail the identity guard and never cancel the blind reconnect, reintroducing the ~1s re-displacement loop (see the `didCloseWith` ORDERING NOTE / cd9fa39).

## Fix

Stamp each socket minted in `connect()` (the sole task-creation site) with a monotonic generation, carried on `task.taskDescription`, via a new Foundation-only `SocketGenerationTracker`. Compute `hasNewerSuccessor` as `closingGeneration < latest`:

- A **bygone** socket's late 4000 is ignored even while `webSocketTask == nil` → no false latch, the reconnect lives (fixes fernweh).
- A **current-generation** 4000 is *not* bygone → still latches and cancels the losing path's reconnect (case (a) preserved).

Generation strictly subsumes the old object-identity guard (a live successor is always a newer generation); object identity remains only as a fallback if the tag is ever absent.

## Sync / blast radius

- Shared decision (`SupersededLatchPolicy.swift`/`.kt`) **unchanged** → the ios/android mirror stays byte-identical.
- **Android needs no generation tracking** and gets a **comment-only** update: its `terminateSocket` identity guard drops non-current sockets *before* the supersede decision, so it is immune to the bygone-generation false-latch by construction (documented in its ORDERING NOTE). Deferred as a non-bug; its only cost is one self-healing extra re-displacement cycle on case (a).
- No UniFFI/UDL regen, no wire/contract/JS changes, no Rust touched.

## Test

`swift test --package-path bindings/react-native/ios` → **91 passed, 0 failures**, including the 8 unchanged `SupersededLatchPolicy` tests (mirror intact) and 5 new `SocketGenerationTracker` tests.