### PR TITLE
ci: typecheck the RN package in CI and put a 7-day cooldown on Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,54 @@
 version: 2
+
+# Every ecosystem below carries a 7-day cooldown: a release must have been
+# public for a week before Dependabot proposes it. Without this we were being
+# offered releases 2-3 days old (taiki-e/install-action v2.85.3 was superseded
+# by v2.85.4 the day after its PR opened), which is exactly the window in which
+# a bad release gets yanked or hot-fixed.
+#
+# Cooldown applies to *version* updates only — Dependabot still raises security
+# updates immediately, which is the behavior we want.
 updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: pip
     directory: /bindings/python
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directory: /bindings/react-native
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gradle
     directory: /bindings/react-native/android
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+    ignore:
+      # ci.yml pins `dtolnay/rust-toolchain@1.87.0` for the MSRV job. That ref is
+      # not a stale action version — it encodes the workspace's
+      # `rust-version = "1.87"`, and bumping it silently stops testing MSRV
+      # rather than upgrading anything. Dependabot read it as a version pin and
+      # proposed 1.100.0, a Rust release that does not exist (#184).
+      # Our four other uses of this action are `@stable`, which Dependabot does
+      # not version-bump, so ignoring the action outright costs us nothing.
+      - dependency-name: dtolnay/rust-toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,35 @@ jobs:
       - name: Run pytest
         run: pytest bindings/python/tests/ -v
 
+  react-native-typecheck:
+    name: React Native Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Node version and the install/build pair below deliberately mirror the
+      # npm-publish job in release.yml. `npm run build` (tsc) had been reachable
+      # *only* from that job, which runs immediately before `npm publish` — so a
+      # type error or a tsconfig incompatibility surfaced during a release
+      # instead of on the PR that caused it. A dependabot bump to TypeScript 7
+      # (#178) passed all of CI for exactly this reason while failing to build.
+      #
+      # This job does not run scripts/prepare-npm.sh: that validates pre-built
+      # iOS .a and Android .so binaries, which don't exist outside a release run.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: bindings/react-native/package-lock.json
+
+      - name: Install dependencies
+        working-directory: bindings/react-native
+        run: npm ci
+
+      - name: Typecheck TypeScript
+        working-directory: bindings/react-native
+        run: npm run build
+
   android-unit-tests:
     name: Android Unit Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to the Dependabot audit that merged #233, #235, #236 and closed #170, #171, #174, #175, #178, #184, #232, #237. Two gaps that audit exposed.

## 1. Nothing in CI typechecks `bindings/react-native`

`npm run build` (i.e. `tsc`) was reachable **only** from the npm-publish job in `release.yml`, which runs it immediately before `npm publish`. So a type error or a tsconfig incompatibility surfaced during a release rather than on the PR that introduced it.

This is not hypothetical — it is why the TypeScript 7 bump (#178) passed **every** CI job while being unbuildable:

```
tsconfig.json(17,25): error TS5108: Option 'moduleResolution=node10' has been removed. Please remove it from your configuration.
```

`tsconfig.json` still uses `moduleResolution: "node"`, which TypeScript 7 removed. Had that merged, the break would have appeared during a release.

The new `react-native-typecheck` job mirrors the publish job's Node version and its `npm ci` + `npm run build` pair, so the same failure now lands on the PR. It deliberately stops short of `scripts/prepare-npm.sh`, which validates pre-built iOS `.a` and Android `.so` binaries that don't exist outside a release run.

Verified locally:

| | result |
|---|---|
| this branch (TypeScript 5.9.3) | `npm ci` + `npm run build` exit **0** |
| #178's branch (TypeScript 7.0.2) | fails with `TS5108` |

`lib/` and `node_modules/` are gitignored, so the job leaves no diff behind.

## 2. `dependabot.yml` had no cooldown

We were being offered releases 2-3 days old. taiki-e/install-action v2.85.3 (#234) was already superseded by v2.85.4 the day after its PR opened — that early window is exactly when a bad release gets yanked or hot-fixed.

All five ecosystems now carry `cooldown: default-days: 7`. Cooldown applies to **version** updates only, so security updates still arrive immediately.

### Also: ignore `dtolnay/rust-toolchain`

Called out separately because it is a third change rather than one of the two gaps above, but it is the direct consequence of closing #184.

`ci.yml` pins `dtolnay/rust-toolchain@1.87.0` for the MSRV job. That ref is not a stale action pin — it encodes the workspace's `rust-version = "1.87"`. Bumping it doesn't upgrade anything; it silently stops testing MSRV. Dependabot read it as a version and proposed `1.100.0`, a Rust release that does not exist:

```
error: could not download nonexistent rust version `1.100.0-x86_64-unknown-linux-gnu`
```

Without an ignore rule that PR returns every week. The four other uses of this action are `@stable`, which Dependabot does not version-bump, so ignoring it outright costs nothing.

## Notes for review

- `dependabot.yml` changes can only be fully validated once merged — GitHub parses the file on its own schedule. Both files were checked for YAML validity and the `cooldown` schema matches the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) (`default-days` is supported on all five ecosystems here; the `semver-*-days` variants are deliberately not used).
- The new job adds ~1 min to CI and runs in parallel with the existing jobs.