### PR TITLE
chore: assert project copyright notice on distributed copies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,15 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
+  licenses:
+    name: License Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: License consistency check
+        run: ./scripts/check-license-consistency.sh
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-authors = ["Offline Protocol Contributors"]
+authors = ["Offline Protocol, Inc."]
 # Dual-licensed: AGPL-3.0-only for open-source use, with a separate commercial
 # license offered out-of-band (see LICENSE-COMMERCIAL.md). The SPDX field carries
 # only the open-source identifier because the commercial offer is not an

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -1,5 +1,7 @@
 # Commercial License
 
+Copyright © 2025-2026 Offline Protocol, Inc.
+
 The Offline Protocol SDK is **dual-licensed**. You may use it under **either** of the
 following licenses, at your option:
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and [QUICKSTAR
 
 ## License
 
+Copyright © 2025-2026 Offline Protocol, Inc.
+
 The Offline Protocol SDK is **dual-licensed**:
 
 - **GNU Affero General Public License v3.0** (AGPL-3.0-only) — see [LICENSE](LICENSE).

--- a/bindings/python/LICENSE-COMMERCIAL.md
+++ b/bindings/python/LICENSE-COMMERCIAL.md
@@ -1,5 +1,7 @@
 # Commercial License
 
+Copyright © 2025-2026 Offline Protocol, Inc.
+
 The Offline Protocol SDK is **dual-licensed**. You may use it under **either** of the
 following licenses, at your option:
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -2,7 +2,7 @@
 
 Python bindings for the Offline Protocol SDK: offline-first mesh networking with MLS end-to-end encryption. Supports macOS, Linux, and Windows.
 
-> **Upgrading an existing install?** Read [docs/UPGRADING.md](../../docs/UPGRADING.md)
+> **Upgrading an existing install?** Read [docs/UPGRADING.md](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/UPGRADING.md)
 > first — `ProtocolManager` now requires an explicit `state_root`, and this
 > release is not safely downgradable.
 
@@ -231,3 +231,23 @@ pip-audit --strict
 | Linux | x86_64 | `.so` |
 | Linux | aarch64 | `.so` |
 | Windows | x86_64 | `.dll` |
+
+## License
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+The Offline Protocol SDK is **dual-licensed**:
+
+- **AGPL-3.0-only** — see [LICENSE](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE).
+  Free for use in projects that comply with AGPL-3.0, including its network-use
+  source-disclosure requirement (section 13).
+- **Commercial License** — for proprietary applications that cannot or do not wish to
+  comply with the AGPL. See [LICENSE-COMMERCIAL.md](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE-COMMERCIAL.md)
+  (contact legal@offlineprotocol.com).
+
+You may use the SDK under **either** license; you do not need both.
+
+Both license texts, along with `THIRD-PARTY-NOTICES.md`, are also installed with the
+package under `offline_protocol_sdk-<version>.dist-info/licenses/`. The links above are
+absolute because this file is the PyPI long description, and PyPI does not resolve
+repository-relative links.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "AGPL-3.0-only"
 license-files = ["LICENSE", "LICENSE-COMMERCIAL.md", "THIRD-PARTY-NOTICES.md"]
 requires-python = ">=3.10"
-authors = [{ name = "Offline Protocol Contributors" }]
+authors = [{ name = "Offline Protocol, Inc." }]
 keywords = ["offline", "messaging", "p2p", "mesh", "ble", "mls", "encryption"]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/bindings/react-native/LICENSE-COMMERCIAL.md
+++ b/bindings/react-native/LICENSE-COMMERCIAL.md
@@ -1,5 +1,7 @@
 # Commercial License
 
+Copyright © 2025-2026 Offline Protocol, Inc.
+
 The Offline Protocol SDK is **dual-licensed**. You may use it under **either** of the
 following licenses, at your option:
 

--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -1396,9 +1396,11 @@ If you see the linking error message:
 
 ## License
 
+Copyright © 2025-2026 Offline Protocol, Inc.
+
 The Offline Protocol SDK is **dual-licensed**:
 
-- **AGPL-3.0-only** — see [LICENSE](../../LICENSE). Free for use in projects that comply
+- **AGPL-3.0-only** — see [LICENSE](./LICENSE). Free for use in projects that comply
   with AGPL-3.0, including its network-use source-disclosure requirement (section 13).
 - **Commercial License** — for proprietary apps that cannot or do not wish to comply with
   the AGPL. See [LICENSE-COMMERCIAL.md](./LICENSE-COMMERCIAL.md) (contact legal@offlineprotocol.com).

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -49,7 +49,7 @@
     "relay",
     "offline-first"
   ],
-  "author": "Offline Protocol Team",
+  "author": "Offline Protocol, Inc.",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/scripts/check-license-consistency.sh
+++ b/scripts/check-license-consistency.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Guards the hand-maintained license surface against drift.
+#
+# Three license documents are triplicated into each package that redistributes
+# the binaries (root, react-native, python) -- LICENSE and LICENSE-COMMERCIAL.md
+# by hand, THIRD-PARTY-NOTICES.md by generate-third-party-notices.sh. Nothing
+# else stops an edit from landing in one copy and not the others, and a
+# divergent license text in a published artifact is not a bug you find by
+# testing. This asserts the copies are byte-identical and that every
+# notice-bearing file carries the same copyright line.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+status=0
+
+# Documents copied verbatim into each redistributing package.
+for doc in LICENSE LICENSE-COMMERCIAL.md THIRD-PARTY-NOTICES.md; do
+  for pkg in bindings/react-native bindings/python; do
+    if ! cmp -s "$doc" "$pkg/$doc"; then
+      echo "error: $pkg/$doc has drifted from $doc" >&2
+      if [ "$doc" = "THIRD-PARTY-NOTICES.md" ]; then
+        echo "       run scripts/generate-third-party-notices.sh to resync" >&2
+      else
+        echo "       copy the root file over it -- all three must match" >&2
+      fi
+      status=1
+    fi
+  done
+done
+
+# The copyright notice AGPL-3.0 section 4 obliges downstream copies to
+# reproduce. Lives beside the license terms rather than inside LICENSE, which
+# is the verbatim GPL document and must not be modified.
+NOTICE="Copyright © 2025-2026 Offline Protocol, Inc."
+for f in \
+  README.md \
+  LICENSE-COMMERCIAL.md \
+  bindings/react-native/README.md \
+  bindings/react-native/LICENSE-COMMERCIAL.md \
+  bindings/python/README.md \
+  bindings/python/LICENSE-COMMERCIAL.md
+do
+  if ! grep -qF "$NOTICE" "$f"; then
+    echo "error: $f is missing the copyright notice: $NOTICE" >&2
+    status=1
+  fi
+done
+
+if [ "$status" -eq 0 ]; then
+  echo "License documents are consistent across root, react-native, and python."
+fi
+exit "$status"


### PR DESCRIPTION
## Summary

The tree carried license *terms* but never a copyright *notice* of its own. `LICENSE` is the verbatim AGPL-3.0 text with its "How to Apply These Terms" appendix left as the unfilled `Copyright (C) <year>  <name of author>` template; `THIRD-PARTY-NOTICES.md` (#253) preserves every incorporated crate's notice but none of ours; and `Offline Protocol, Inc.` appeared only as the CLA grantee and the commercial licensor — never in the copyright-owner role. Grepping the tree for `©` or `(c) <year>` outside the vendored Gradle wrappers returned nothing.

That is not a *protection* gap — Berne is automatic and US notice has been optional since 1989. It is a licensing-mechanics gap: GPLv3 §4 (`LICENSE:187`) requires anyone conveying copies to "conspicuously and appropriately publish on each copy an appropriate copyright notice," and §5(a) requires modified works carry notices. Downstream AGPL compliers had no project notice to reproduce or keep intact — an obligation we made impossible to discharge.

This PR adds the notice, makes the distributed manifests name the entity that can sublicense the work, and puts a CI guard under the whole hand-maintained license surface.

### Copyright notice

`Copyright © 2025-2026 Offline Protocol, Inc.` now heads the license section of:

- `README.md`, `bindings/react-native/README.md`, `bindings/python/README.md`
- all three copies of `LICENSE-COMMERCIAL.md` (root, `bindings/python/`, `bindings/react-native/`)

`LICENSE` is deliberately untouched. The AGPL text states that changing the license document is not allowed, so the unfilled `<year> <name of author>` at `LICENSE:633` is part of the verbatim document rather than a blank to fill. The notice belongs beside the license, not inside it.

The Python README is the PyPI long description and previously had **no** license section at all; it gains one.

### Package metadata

The three distributed manifests attributed the work to two different non-corporate names — `Offline Protocol Contributors` (Cargo, PyPI) and `Offline Protocol Team` (npm) — so the published copies credited a diffuse authorship while only `LICENSE-COMMERCIAL.md` named the party claiming the right to sublicense. All three now name `Offline Protocol, Inc.`

All nine workspace crates inherit this via `authors.workspace = true`. Nothing reads `CARGO_PKG_AUTHORS`, and there is no `cargo publish` in CI, so the Cargo change is metadata-only. `MeshSdk.podspec` feeds `package["author"]` into `s.authors`, which CocoaPods accepts as a String.

### README link fixes

Both bindings had broken license links, in opposite directions:

- **React Native** linked the AGPL as `../../LICENSE`. npm *does* rewrite repository-relative links on npmjs.com, so that resolved on the web — but it escapes the tarball, where the file sits at `./LICENSE`. Repointed to `./LICENSE`, which the `files` array actually ships (verified: `files` lists `LICENSE`, `LICENSE-COMMERCIAL.md`, and `THIRD-PARTY-NOTICES.md`, so `.npmignore`'s `*.md` rule does not strip them).
- **Python** is the reverse. PyPI renders the long description standalone and does **not** resolve repository-relative links, so `./LICENSE` would 404 against `pypi.org/project/…`. The new license section uses absolute URLs, and the pre-existing `[docs/UPGRADING.md](../../docs/UPGRADING.md)` link — already broken that way, and absent from the sdist besides — is fixed the same way.

### Drift guard (was flagged as follow-up; now in scope)

`LICENSE`, `LICENSE-COMMERCIAL.md`, and `THIRD-PARTY-NOTICES.md` are triplicated into every package that redistributes the binaries. `THIRD-PARTY-NOTICES.md` has a generator; the other two are hand-copied, and nothing stopped an edit from landing in one copy and not the others. A divergent license text in a published artifact is not the kind of bug you find by running the tests.

`scripts/check-license-consistency.sh` asserts:

1. all three documents are byte-identical across root / react-native / python (`cmp -s`), with a fix hint that points at the generator for the generated one;
2. all six notice-bearing files carry the same copyright line.

Wired into CI as a new `License Consistency` job (checkout + one script, no toolchain). Both failure modes were verified to actually fail before shipping.

## Related issues

None.

## Type of change

- [x] `docs` — documentation only
- [x] `chore` — build, tooling, or dependency changes
- [x] `ci` — CI configuration changes

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test --workspace` — not run locally; no Rust source is touched (the only manifest change is the `authors` field, and `cargo metadata --no-deps` parses clean). CI covers it.
- [x] `cargo-deny` is satisfied — no dependency or license-expression changes; `license = "AGPL-3.0-only"` is untouched
- [x] Commits follow Conventional Commits
- [ ] `CHANGELOG.md` — intentionally not updated. No user-facing behavior, API, or license-terms change.
- [x] No new `unsafe`
- [x] UDL unchanged

## Breaking changes

None. No code, API, wire format, or license *terms* change — `license = "AGPL-3.0-only"` and the AGPL/commercial dual-license structure are exactly as before.

## Notes for reviewers

Two judgment calls worth a look:

1. **The notice is the bare corporate form.** `CLA.md` is Apache-ICLA-derived and says *"You retain copyright on your contributions"* — it is a sublicensable license-back, not an assignment. An earlier revision of this PR read `… Offline Protocol, Inc. and the Offline Protocol SDK contributors.` for that reason. The bare form is the deliberate choice: a notice identifies the party asserting copyright and need not enumerate every owner, and Offline Protocol, Inc. holds copyright in its own contributions plus a sublicensable license in everyone else's. **If counsel prefers the joint form, it is a one-line change in six files plus the `NOTICE` constant in the guard script.**

2. **`2025-2026`, not `2025`.** 2025 is first publication (first commit `2025-10-30`); the work has been substantially revised and published through 2026. The annual bump is the cost, and the guard makes a partial bump a CI failure rather than a silent inconsistency.

**No `NOTICE` file.** `NOTICE` is an Apache-2.0 §4(d) convention with no defined role under the AGPL, and a second notice-shaped file next to `THIRD-PARTY-NOTICES.md` would invite confusion about which is which. A copyright line in the README + commercial license is the GPL-family-idiomatic placement.
