### PR TITLE
docs: document the per-member group fan-out default and GroupConfig

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -542,8 +542,12 @@ anything accepted can actually be delivered.
 **Large payloads belong on `send_media` / `sendMedia`**, which chunks and is not
 subject to this limit.
 
-**Group sends are exempt** — a group send has no durable pre-session queue, so
-it stays bounded by the transport alone. That is unchanged behaviour.
+**Group sends are exempt from this cap** — a group send encrypts to group state
+that already exists, so it has no durable pre-session queue behind it and the
+boundary check does not run. That is unchanged behaviour. (It is exempt from the
+*cap*, not from delivery tracking: as of the per-member fan-out default, each
+recipient's copy of a group message carries its own outbox entry, ACK, and retry
+ladder. See [Group sends](message-delivery.md#group-sends).)
 
 **What to do:** if your app can produce large text bodies (pasted logs, embedded
 data URIs, JSON blobs in message content), add a length check at your composer

--- a/docs/android-integration.md
+++ b/docs/android-integration.md
@@ -78,8 +78,11 @@ class MainActivity : AppCompatActivity() {
             maxPendingGlobal = 1_000.toULong(),
             pendingTtlMs = 1_800_000.toULong(),  // 30 min (the SDK default)
             overflowPolicy = OverflowPolicy.DROP_OLDEST,
-            // These 8 use their defaults: requireEncryption (true),
+            // These 9 use their defaults: requireEncryption (true),
             // maxGroupMembers (256u), groupRelayEnabled (true),
+            // groupRelayBroadcastEnabled (false — group sends fan out per
+            // member so each copy gets the full delivery ladder; see
+            // docs/configuration.md#group-configuration),
             // requireTransportIdentity (false), binaryWireEnabled (true),
             // compactEnvelopeEnabled (true), richPayloadEnabled (true),
             // cryptoRecoveryEnabled (true).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -385,6 +385,11 @@ inviter); otherwise the text still sends but the extras drop, surfaced via the
 `GroupRichExtrasDropped` event — the SDK then probes the unknown members'
 capability once so a later retry can succeed.
 
+Both group send methods return **one `MessageId` per recipient**, not one per
+send. By default each is a real frame with its own outbox entry, ACK, and retry
+ladder, so an app can track them individually — see
+[Group sends](message-delivery.md#group-sends).
+
 ```rust
 pub fn group_rich_readiness(&self, group_id: &str) -> Result<GroupRichReadiness>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -477,9 +477,12 @@ surface as errors or as `message_failed` events:
 | Single protocol-state record | 4 MiB | refused on write, dropped on read |
 
 Group sends have no durable pre-session queue and are exempt from the queue
-bounds and the content cap; they remain bounded by the transport alone. See
-[Message Delivery](message-delivery.md#reliability-parameters) for the
-reasoning behind each.
+bounds and the content cap. They are **not** otherwise unbounded: by default a
+group send over the Internet transport is one ordinary message frame per member,
+so each member's copy carries its own outbox entry, ACK, and retry ladder. See
+[Message Delivery](message-delivery.md#reliability-parameters) for the reasoning
+behind each bound, and [Group sends](message-delivery.md#group-sends) for the
+per-member delivery path.
 
 **Dedup Config**:
 | Parameter | Type | Default | Description |
@@ -494,6 +497,42 @@ off for a configuration the SDK used to accept in silence;
 `retentionTimeSecs: 0` expires every entry immediately for the same result. This
 refuses only the degenerate value, not an unwise one: sizing the window for your
 deployment is still your call.
+
+### Group Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `maxGroupMembers` | number | 256 | Maximum members in a single group (must be > 0) |
+| `relayEnabled` | boolean | `true` | Register groups with the relay server |
+| `relayBroadcastEnabled` | boolean | `false` | Allow a relay-synced group to send via one O(1) relay broadcast instead of per-member fan-out |
+
+**These two flags are not the same switch, and only one of them is off.**
+
+`relayEnabled` gates *registration*. The relay's group registry is what invite
+links resolve against, so turning it off breaks invite links. Leave it on.
+
+`relayBroadcastEnabled` gates the *send path*, and defaults to **off** because
+the broadcast is an uplink optimization with no delivery contract. The relay
+fans a broadcast out fire-and-forget — no per-recipient presence check, no push
+fallback, no persistence — and answers "sent" before delivery is known, so a
+member who is backgrounded, offline, or on a socket that has quietly died misses
+the message permanently and *undetectably*: MLS application messages do not
+advance the group epoch, so the receiver never learns one existed.
+
+With it off, a group send is one ordinary message frame per member and inherits
+the full direct-message ladder — outbox, ACK, retry, relay write-ack, offline
+push carrying the ciphertext, and park-on-unreachable with presence-driven
+flush. The cost is O(N) frames, which does not risk the relay's rate limiter at
+any group size (the bridge's own token bucket is tighter and defers rather than
+drops), but does mean drain latency and, past roughly 118 members, duplicate
+sends from the ACK timer starting at local enqueue. **Groups near that size are
+the case for turning the broadcast back on** and accepting the delivery gap. See
+[Group sends](message-delivery.md#group-sends) for the full analysis.
+
+> **React Native:** the entire `group` config section is currently unreachable
+> from JS — the bridges do not read it, so these three fields take their Rust
+> defaults and cannot be overridden. The defaults are what an RN app wants
+> today; this is a known gap, tracked alongside `requireTransportIdentity`.
 
 ### Network Configuration
 

--- a/docs/ios-integration.md
+++ b/docs/ios-integration.md
@@ -106,8 +106,11 @@ final class MeshController {
             maxPendingGlobal: 1000,
             pendingTtlMs: 1_800_000,   // 30 min (the SDK default)
             overflowPolicy: .dropOldest
-            // These 8 use their defaults: requireEncryption (true),
+            // These 9 use their defaults: requireEncryption (true),
             // maxGroupMembers (256), groupRelayEnabled (true),
+            // groupRelayBroadcastEnabled (false — group sends fan out per
+            // member so each copy gets the full delivery ladder; see
+            // docs/configuration.md#group-configuration),
             // requireTransportIdentity (false), binaryWireEnabled (true),
             // compactEnvelopeEnabled (true), richPayloadEnabled (true),
             // cryptoRecoveryEnabled (true).

--- a/docs/message-delivery.md
+++ b/docs/message-delivery.md
@@ -175,6 +175,47 @@ The outbox lifetime bounds the entry itself, with one caveat worth knowing: each
 
 **Contract**: `MessageUndeliverable` is the "recipient is offline" signal and may fire repeatedly for the same message while the peer stays offline. Terminal settlement happens only at delivery (`MessageDelivered`) or outbox-lifetime expiry (`MessageFailed`). Apps that previously keyed "recipient offline" UX off the ~15-minute terminal `message_failed` should key it off `message_undeliverable` instead.
 
+## Group sends
+
+A group send returns a `Vec<MessageId>` — **one id per recipient**, not one id
+per send. By default each of those ids is a real `SendMessage` frame carrying
+the same MLS group ciphertext, addressed to one member, and therefore gets
+everything described on this page independently: its own outbox entry, ACK,
+retry ladder, relay write-ack, offline push carrying the ciphertext, and
+park-on-unreachable with presence-driven flush. A member who is backgrounded,
+offline, or on a socket that has quietly died is recovered the same way a direct
+message's recipient is.
+
+This is what `group.relayBroadcastEnabled: false` (the default) buys. The
+alternative is the relay's O(1) broadcast — one frame the relay fans out to the
+group — which saves sender uplink but has **no per-recipient delivery contract
+at any layer**: no presence check, no push fallback, no persistence, and the
+"sent" answer comes back before delivery is known. Missing a group message is
+also undetectable, because MLS application messages do not advance the group
+epoch, so a receiver never learns that one existed. See
+[Group Configuration](configuration.md#group-configuration) for when opting back
+in is the right trade.
+
+**Cost of the default.** Sends are O(N) frames. This does *not* risk tripping
+the relay's rate limiter at any group size: the platform bridge meters every
+relay-bound frame through a client-side token bucket (28 capacity, 9/s refill)
+deliberately tighter than the relay's own (30 burst, 10/s), and defers a frame
+it cannot fund to a later poll tick rather than dropping it — so the fan-out
+self-paces below the server's budget regardless of member count.
+
+What large groups cost instead is **drain latency**, and past roughly 118
+members, self-inflicted duplicate sends. The core enqueues all N frames at once
+and the bridge writes them at about 9/s after an initial burst of ~28, so frame
+N reaches the wire at roughly `(N - 28) / 9` seconds. The ACK timer starts when
+a frame is enqueued locally, not when it reaches the wire, so beyond that size
+the tail of a single fan-out exceeds the 10s ACK timeout and is retransmitted
+before it was ever written. Those duplicates are absorbed by receiver and push
+dedup via the stable outbox id, so they cost bandwidth rather than correctness.
+Presence checks, typing indicators, and read receipts draw on the same bucket
+and lower the threshold. Groups near that size should enable the broadcast and
+accept the delivery gap until the relay can report per-recipient delivery back
+to the sender.
+
 ## ACK Cleanup
 
 When an ACK is received for a message:
@@ -240,8 +281,16 @@ ceiling to leave room for MLS ciphertext expansion, base64, and the JSON wire
 envelope, so anything accepted here can actually be delivered. **Large payloads
 belong on `sendMedia`**, which chunks them and is not subject to this limit.
 
-Group sends are deliberately exempt from all of the above: a group send has no
-durable pre-session queue behind it, so it stays bounded by the transport alone.
+**Group sends are exempt from the pre-session queue bounds and from the content
+cap** — and only from those. A group send encrypts to group state that already
+exists, so there is nothing to wait on and no durable pre-session queue behind
+it, and neither `sendGroupMessage` nor `sendGroupMessageWith` runs the 256 KiB
+check (they reject reserved internal prefixes, `FileChunk`, and oversized rich
+extras instead). Everything else on this page applies: over the Internet
+transport a group send is, by default, one ordinary `SendMessage` frame per
+member, so each member's copy gets its own outbox entry, ACK, retry ladder, and
+park-on-unreachable handling exactly like a direct message. See
+[Group sends](#group-sends) for what that means per member.
 
 Expiry work is scheduled from the earliest queued deadline rather than scanning
 the queue on every `process()` tick.

--- a/docs/mls-integration.md
+++ b/docs/mls-integration.md
@@ -264,7 +264,9 @@ let group = try mesh.createGroup(groupName: "Project Team")
 // Invite members (admin only — handles key exchange + Welcome automatically)
 try mesh.inviteToGroup(groupId: group.groupId, inviteeUserId: "alice")
 
-// Send encrypted group message (MLS encryption + mesh fan-out)
+// Send encrypted group message. Returns one id per recipient: the same MLS
+// ciphertext is fanned out per member, so each copy carries its own outbox
+// entry, ACK, and retry ladder.
 let messageIds = try mesh.sendGroupMessage(
     groupId: group.groupId,
     content: "Hello team!",

--- a/docs/react-native-integration.md
+++ b/docs/react-native-integration.md
@@ -1,6 +1,6 @@
 # Offline Protocol SDK Integration Guide (React Native)
 
-This guide covers integrating the Offline Protocol SDK into React Native applications: installation, configuration, transports (BLE, Wi‑Fi Direct, Internet), Dynamic Offline Relay Switch (DORS), **group management (relay-based) via SDK group methods**, and a **complete API reference** for every function.
+This guide covers integrating the Offline Protocol SDK into React Native applications: installation, configuration, transports (BLE, Wi‑Fi Direct, Internet), Dynamic Offline Relay Switch (DORS), **MLS-encrypted group messaging via SDK group methods**, and a **complete API reference** for every function.
 
 ---
 
@@ -146,7 +146,11 @@ See `docs/dors-configuration.md` and `docs/configuration.md` for full parameters
 
 ## 7. Group Messaging (MLS-Encrypted Mesh Groups)
 
-Group features (create groups, send messages, manage members) are provided directly by the SDK's **mesh group methods**. The SDK handles MLS end-to-end encryption and mesh fan-out automatically — there is **no relay server** to run or connect to. Each method runs against your `OfflineProtocol` instance and delivers over whatever transports DORS has selected.
+Group features (create groups, send messages, manage members) are provided directly by the SDK's **mesh group methods**. Membership and message encryption are MLS, end to end, and handled entirely by the SDK — **there is no group server that can read your messages**, and no separate service for your app to run. Each method runs against your `OfflineProtocol` instance and delivers over whatever transports DORS has selected.
+
+The relay does play two roles over the Internet transport, neither of which can see plaintext. Groups are **registered** with it so invite links resolve (`groupRelayEnabled`, on by default). And a group send is, by default, **one ordinary message frame per member** — the same MLS ciphertext addressed individually — so every member's copy gets the full direct-message delivery ladder: outbox, ACK, retry, offline push, and park-on-unreachable with presence-driven flush. The relay's O(1) broadcast alternative is off by default because it has no per-recipient delivery contract; see [Group sends](message-delivery.md#group-sends) and [Group Configuration](configuration.md#group-configuration).
+
+> **Config gap:** the `group` config section is not readable from JS today — the bridges do not parse it, so `maxGroupMembers`, `groupRelayEnabled`, and `groupRelayBroadcastEnabled` take their Rust defaults and cannot be overridden from React Native. The defaults are what an RN app wants; this is a known gap.
 
 ### 7.1 Prerequisites
 
@@ -427,7 +431,7 @@ Parse the raw event and check the server frame's `type` before consuming extensi
 
 ### 11.13 Mesh Group Messaging (MLS-Encrypted)
 
-High-level group methods that handle MLS encryption and mesh fan-out automatically.
+High-level group methods that handle MLS encryption and per-member fan-out automatically. `meshSendGroupMessage` resolves to **one message id per recipient** — each is a separately tracked frame with its own outbox entry, ACK, and retry ladder ([Group sends](message-delivery.md#group-sends)).
 
 | Method | Signature | Description |
 |--------|-----------|-------------|


### PR DESCRIPTION
PR #257 made per-member fan-out the default group send path. The docs still describe the world before it — this catches them up, and fixes one claim that had become actively wrong.

## The "bounded by the transport alone" claim

`message-delivery.md` and `configuration.md` both said group sends are "exempt from all of the above… bounded by the transport alone." Half of that sentence survived #257 and half became the opposite of the shipped behaviour, which is the interesting part.

Still true: a group send encrypts to group state that already exists, so there is no durable pre-session queue behind it, and neither `send_group_message` nor `send_group_message_with` runs the 256 KiB content check — I verified this rather than assuming, since a stale-looking doc sometimes means the code is what drifted. They reject reserved internal prefixes, `FileChunk`, and oversized rich extras; the content cap lives on the `send_message` boundary only.

No longer true: the delivery half. Per-member fan-out goes through `send_internal_message` → `handle_send_success` → `mark_message_sent`, which creates an outbox entry and registers the ACK for every frame, so each recipient's copy carries the full ladder. The exemption is now scoped to what it actually covers, in all three places that asserted it — including `UPGRADING.md`, whose historical note made the same present-tense claim.

## GroupConfig was undocumented

There was no GroupConfig table anywhere in `docs/`. `relayBroadcastEnabled` (new in #257) appeared nowhere at all; `relayEnabled` and `maxGroupMembers` appeared only as inline comments in the native integration guides.

`configuration.md` gains a **Group Configuration** section documenting all three against the Rust `Default` impl (256 / `true` / `false`). The part worth reviewing is the framing: `relayEnabled` and `relayBroadcastEnabled` are easy to read as the same switch, only one of them is off, and turning off the wrong one silently breaks invite links.

## New "Group sends" section in message-delivery.md

The delivery analysis needed somewhere to live: what the per-member default buys, why the broadcast is off by default (no per-recipient contract at any layer, and loss is undetectable because MLS application messages don't advance the epoch), and the two real costs of the default.

It states explicitly that the fan-out **cannot** trip the relay's rate limiter at any group size — the bridge's client-side bucket is 28/9 against the relay's 30/10 and defers rather than drops, so it self-paces. What large groups actually cost is drain latency and, past roughly 118 members, duplicate sends, because the ACK timer starts at local enqueue rather than wire-confirm. Those duplicates are absorbed by dedup via the stable outbox id, so they cost bandwidth rather than correctness — and groups near that size are the case for turning the broadcast back on.

## React Native guide contradicted itself

Line 3 called group management "relay-based"; line 149 said there is "**no relay server** to run or connect to." Both are now accurate: no group server can read messages (the MLS point the original sentence was reaching for), and the relay does register groups and carry the per-member frames.

That guide and `configuration.md` now also state a pre-existing gap I confirmed while writing them: the entire `group` config section is unreachable from JS — the bridges don't parse it, so all three fields take their Rust defaults and cannot be overridden from React Native. The defaults are what an RN app wants today, so this is a note, not a regression.

## Smaller items

- The native guides' `// These 8 use their defaults` comment blocks were a counted claim that #257 made 9.
- `api-reference.md` and the two group-send examples now state that a group send returns **one id per recipient**, which matters more now that each id is separately tracked.

## Verification

Docs-only; no code changes. Ran a relative-link and anchor checker over all of `docs/` plus `README.md` — everything resolves, including the four new cross-references added here. Every default and behavioural claim was traced to its constant or call site rather than to the CHANGELOG.

## Not covered here

`fernweh_v2/docs/group-offline-delivery-remediation-plan.md` still reads "PLAN — not yet implemented" and carries the superseded ~30/~40 rate-limit bound. That is a separate repo and a separate change.