### PR TITLE
fix(protocol): replicate the group creator to joiners

### DIFF
--- a/crates/offline-protocol-mls/src/manager.rs
+++ b/crates/offline-protocol-mls/src/manager.rs
@@ -829,6 +829,31 @@ impl MlsManager {
         self.save_group_metadata(group_id, &metadata)
     }
 
+    /// Records the group's creator, **only if none is on record yet**.
+    ///
+    /// `created_by` is the fallback [`GroupMetadata`] consults when no admin
+    /// role is stored (see the protocol layer's `check_is_admin`), so it must
+    /// behave monotonically: a device that created the group, or already
+    /// adopted a creator from the Welcome that admitted it, keeps what it has.
+    /// Only the "no information" state is fillable. That makes the write
+    /// idempotent under duplicate Welcomes and stops a later invite — from an
+    /// inviter whose own metadata disagrees — from rewriting an established
+    /// admin fallback.
+    ///
+    /// Returns `Ok(())` whether or not the value was adopted; use
+    /// [`Self::get_group_metadata`] to observe the result.
+    pub fn set_group_creator(&self, group_id: &GroupId, creator_id: &str) -> Result<()> {
+        let mut metadata = self
+            .load_group_metadata(group_id)?
+            .unwrap_or_else(|| GroupMetadata::new(None));
+        if metadata.created_by.is_some() {
+            return Ok(());
+        }
+        metadata.created_by = Some(creator_id.to_string());
+        metadata.touch();
+        self.save_group_metadata(group_id, &metadata)
+    }
+
     /// Removes a member's role metadata from a group.
     pub fn remove_member_role(&self, group_id: &GroupId, user_id: &str) -> Result<()> {
         let mut metadata = self

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -435,6 +435,26 @@ pub(crate) struct GroupMlsWelcomePayload {
     /// overrides its attested entry.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub(crate) member_rich: HashMap<String, Vec<u8>>,
+    /// The group creator the inviter has on record (additive; absent from
+    /// old SDKs and from inviters whose own metadata never learned it).
+    ///
+    /// Without this, a joiner's metadata is materialized by `set_member_role`
+    /// via `GroupMetadata::new(None)`, leaving `created_by` permanently
+    /// `None` — so `check_is_admin`'s creator fallback is dead code for
+    /// every joiner, and a group whose role snapshot arrived incomplete
+    /// resolves to deny-by-default. Propagating it makes the fallback
+    /// reachable.
+    ///
+    /// Trust bounds mirror [`Self::member_roles`]: this is the inviter's
+    /// unauthenticated claim, adopted only when the joiner has no creator on
+    /// record (first write wins, see `MlsManager::set_group_creator`), and
+    /// deliberately **not** bounded to the joined MLS roster — the creator of
+    /// record may have already left the group. It feeds only the admin
+    /// *fallback* used for send-side gating and the authorization report; it
+    /// is never consulted by receive-side commit enforcement, which fails
+    /// open on an unknown admin set rather than trusting a single claim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) created_by: Option<String>,
 }
 
 /// Type of group membership commit operation.
@@ -1225,12 +1245,25 @@ impl OfflineProtocol {
 
             self.group_mesh.members.insert(group_id.clone(), members);
 
-            // Store member roles from welcome payload
-            if !payload.member_roles.is_empty() {
+            // Store member roles and the creator of record from the welcome
+            // payload. The creator is what makes `check_is_admin`'s fallback
+            // reachable for a joiner: without it our metadata is materialized
+            // by `set_member_role` via `GroupMetadata::new(None)`, so a group
+            // whose role snapshot arrived incomplete would resolve to
+            // deny-by-default with no way back. Deliberately not bounded to
+            // the roster we just joined — the creator of record may already
+            // have left. `set_group_creator` is first-write-wins, so a
+            // duplicate or later Welcome cannot rewrite it.
+            if !payload.member_roles.is_empty() || payload.created_by.is_some() {
                 if let Ok(mls_guard) = self.read_mls_guard() {
                     for (user_id, role) in &payload.member_roles {
                         if let Err(e) = mls_guard.set_member_role(&gid, user_id, *role) {
                             warn!(user_id = %user_id, error = %e, "Failed to store member role from welcome");
+                        }
+                    }
+                    if let Some(creator) = &payload.created_by {
+                        if let Err(e) = mls_guard.set_group_creator(&gid, creator) {
+                            warn!(creator = %creator, error = %e, "Failed to store group creator from welcome");
                         }
                     }
                 }
@@ -2623,8 +2656,10 @@ impl OfflineProtocol {
         // Refresh member list after add
         let members = self.refresh_group_members(group_id)?;
 
-        // Store invitee as member role and load all roles for the welcome payload
-        let member_roles = {
+        // Store invitee as member role, then read back both role-overlay
+        // fields the Welcome carries (roles and the creator of record) from a
+        // single metadata load.
+        let (member_roles, created_by) = {
             let mls_guard = self.read_mls_guard()?;
             let gid = offline_protocol_mls::GroupId::new(group_id)?;
             if let Err(e) = mls_guard.set_member_role(&gid, invitee_user_id, GroupRole::Member) {
@@ -2634,7 +2669,7 @@ impl OfflineProtocol {
                 .get_group_metadata(&gid)
                 .ok()
                 .flatten()
-                .map(|m| m.get_all_roles())
+                .map(|m| (m.get_all_roles(), m.created_by.clone()))
                 .unwrap_or_default()
         };
 
@@ -2671,6 +2706,11 @@ impl OfflineProtocol {
             member_list: members.clone(),
             member_roles,
             member_rich,
+            // Carries our creator of record so the joiner's `check_is_admin`
+            // has a fallback when the role snapshot above is incomplete.
+            // Absent when we never learned it ourselves (joined via an older
+            // SDK's Welcome) — absence is "no information", not a downgrade.
+            created_by,
         };
         let welcome_content = format!(
             "{}{}",

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -131,6 +131,7 @@ fn test_group_welcome_cannot_squat_session_slot() {
     // 1:1 session slot.
     let squat = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        created_by: None,
         group_id: "session:alice:bob".to_string(),
         group_name: None,
         welcome_data: base64_encode(&welcome.welcome_data),
@@ -514,6 +515,7 @@ fn test_group_mls_payload_serialization_roundtrip() {
 
     let welcome_payload = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        created_by: None,
         group_id: "group:def".to_string(),
         group_name: Some("Test Group".to_string()),
         welcome_data: "d2VsY29tZQ==".to_string(),
@@ -1127,6 +1129,7 @@ fn test_group_mls_welcome_bad_data_no_panic() {
     // Send a Welcome with invalid base64 welcome_data
     let welcome_payload = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        created_by: None,
         group_id: "group:bad-welcome".to_string(),
         group_name: Some("Bad Group".to_string()),
         welcome_data: "not-valid-base64!!!".to_string(),
@@ -1161,6 +1164,7 @@ fn test_group_mls_welcome_valid_base64_bad_mls_no_panic() {
     // Send a Welcome with valid base64 but garbage MLS data
     let welcome_payload = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        created_by: None,
         group_id: "group:garbage-mls".to_string(),
         group_name: Some("Garbage MLS".to_string()),
         welcome_data: base64_encode(b"this is not valid MLS data"),
@@ -7118,6 +7122,7 @@ fn test_welcome_payload_carries_roles() {
 
     let payload = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        created_by: None,
         group_id: "group:test".to_string(),
         group_name: Some("Test".to_string()),
         welcome_data: "d2VsY29tZQ==".to_string(),
@@ -11505,12 +11510,21 @@ fn non_admin_commit_attestation_is_ignored() {
     let members = vec!["alice".to_string(), "bob".to_string(), "carol".to_string()];
 
     // Strip alice's admin role in bob's local metadata before the commit
-    // arrives, so the sender fails bob's admin check.
+    // arrives, so the sender fails bob's admin check. Promote bob in the same
+    // breath: `check_is_admin` falls back to the group *creator* when no admin
+    // role is stored at all, and bob now learns that creator from the Welcome
+    // — so demoting alice alone would leave her resolving as admin through
+    // that fallback rather than failing the check. Leaving one real admin
+    // makes the stored roles authoritative, which is the state this test
+    // means to exercise.
     {
         let bob_mls = bob.mls_manager_for_testing().read().unwrap();
         let gid = offline_protocol_mls::GroupId::new(&group_id).unwrap();
         bob_mls
             .set_member_role(&gid, "alice", GroupRole::Member)
+            .unwrap();
+        bob_mls
+            .set_member_role(&gid, "bob", GroupRole::Admin)
             .unwrap();
     }
 
@@ -12326,5 +12340,196 @@ fn test_failed_roster_read_skips_delta_and_judgment_but_merges_commit() {
     assert!(
         !members.iter().any(|m| m == "charlie"),
         "the roster must converge to MLS state once reads succeed again"
+    );
+}
+
+// ============================================================================
+// GROUP CREATOR REPLICATION (Stage 2 — makes the admin fallback reachable)
+// ============================================================================
+
+/// Builds a `__GRP_MLS_WELCOME__` frame body, letting a test control the
+/// role-overlay fields (`member_roles`, `created_by`) independently of the
+/// real MLS Welcome they wrap.
+fn group_welcome_frame(
+    welcome: &offline_protocol_mls::WelcomeMessage,
+    group_id: &str,
+    member_list: &[&str],
+    member_roles: serde_json::Value,
+    created_by: Option<&str>,
+) -> String {
+    let mut body = serde_json::json!({
+        "group_id": group_id,
+        "group_name": "Creator Group",
+        "welcome_data": base64_encode(&welcome.welcome_data),
+        "member_list": member_list,
+        "member_roles": member_roles,
+    });
+    if let Some(creator) = created_by {
+        body["created_by"] = serde_json::json!(creator);
+    }
+    body.to_string()
+}
+
+/// Alice creates a group and stages a real Welcome for Bob without sending it.
+fn stage_welcome_for_bob(
+    group_name: &str,
+) -> (
+    OfflineProtocol,
+    OfflineProtocol,
+    String,
+    offline_protocol_mls::WelcomeMessage,
+) {
+    let storage_a = Arc::new(crate::mls::InMemoryStorage::default());
+    let storage_b = Arc::new(crate::mls::InMemoryStorage::default());
+    let mut alice = OfflineProtocol::new(create_test_config_for_user("alice")).unwrap();
+    let mut bob = OfflineProtocol::new(create_test_config_for_user("bob")).unwrap();
+    alice.initialize_mls_for_test(storage_a).unwrap();
+    bob.initialize_mls_for_test(storage_b).unwrap();
+    alice.start().unwrap();
+    bob.start().unwrap();
+
+    let group_info = alice.create_group(group_name).unwrap();
+    let group_id = group_info.group_id.as_str().to_string();
+
+    let bob_kp = {
+        let bob_mls = bob.mls_manager_for_testing().read().unwrap();
+        bob_mls.generate_key_package().unwrap()
+    };
+    let welcome = {
+        let alice_mls = alice.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id).unwrap();
+        let (welcome, _commit) = alice_mls
+            .add_group_member(&gid, &bob_kp.key_package_data)
+            .unwrap();
+        welcome
+    };
+    alice.refresh_group_members(&group_id).unwrap();
+
+    (alice, bob, group_id, welcome)
+}
+
+fn creator_of(protocol: &OfflineProtocol, group_id: &str) -> Option<String> {
+    let mls = protocol.mls_manager_for_testing().read().unwrap();
+    let gid = offline_protocol_mls::GroupId::new(group_id).unwrap();
+    mls.get_group_metadata(&gid)
+        .unwrap()
+        .and_then(|m| m.created_by)
+}
+
+#[test]
+fn test_welcome_propagates_group_creator_to_joiner() {
+    // The inviter's `invite_to_group` reads `created_by` out of its own
+    // metadata and puts it on the wire; the joiner adopts it. Before this,
+    // a joiner's metadata was materialized by `set_member_role` via
+    // `GroupMetadata::new(None)` and `created_by` stayed permanently absent.
+    let (_alice, mut bob, group_id, welcome) = stage_welcome_for_bob("Creator Group");
+
+    assert_eq!(
+        creator_of(&bob, &group_id),
+        None,
+        "precondition: Bob has no metadata for a group he has not joined"
+    );
+
+    let frame = group_welcome_frame(
+        &welcome,
+        &group_id,
+        &["alice", "bob"],
+        serde_json::json!({"alice": "admin", "bob": "member"}),
+        Some("alice"),
+    );
+    bob.handle_group_mls_welcome("welcome-creator-1", "alice", &frame);
+
+    assert_eq!(
+        creator_of(&bob, &group_id),
+        Some("alice".to_string()),
+        "the joiner must adopt the creator the Welcome carried"
+    );
+}
+
+#[test]
+fn test_joiner_without_role_snapshot_resolves_admin_via_created_by() {
+    // The whole point of replicating the creator: an inviter whose
+    // `get_all_roles()` was incomplete used to leave the joiner with an
+    // empty role map, `has_any_admin() == false`, an absent `created_by`,
+    // and therefore deny-by-default for *every* member — including the real
+    // admin. With the creator replicated, the fallback resolves.
+    let (_alice, mut bob, group_id, welcome) = stage_welcome_for_bob("Creator Group");
+
+    let frame = group_welcome_frame(
+        &welcome,
+        &group_id,
+        &["alice", "bob"],
+        // Empty role snapshot — the degenerate case the fallback exists for.
+        serde_json::json!({}),
+        Some("alice"),
+    );
+    bob.handle_group_mls_welcome("welcome-creator-2", "alice", &frame);
+
+    assert!(
+        bob.check_is_admin(&group_id, "alice").unwrap(),
+        "with no roles stored, the creator fallback must resolve the creator as admin"
+    );
+    assert!(
+        !bob.check_is_admin(&group_id, "bob").unwrap(),
+        "the fallback must not promote anyone but the creator"
+    );
+}
+
+#[test]
+fn test_welcome_created_by_does_not_overwrite_existing() {
+    // `created_by` is the admin fallback, so the write is monotone:
+    // first-write-wins. A device that created the group — or already adopted
+    // a creator — keeps it, so a later invite from an inviter with a
+    // different view cannot rewrite an established admin fallback, and a
+    // duplicate Welcome is idempotent.
+    let (alice, _bob, group_id, _welcome) = stage_welcome_for_bob("Creator Group");
+
+    assert_eq!(
+        creator_of(&alice, &group_id),
+        Some("alice".to_string()),
+        "precondition: the creator has itself on record"
+    );
+
+    {
+        let alice_mls = alice.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id).unwrap();
+        alice_mls.set_group_creator(&gid, "mallory").unwrap();
+    }
+
+    assert_eq!(
+        creator_of(&alice, &group_id),
+        Some("alice".to_string()),
+        "an established creator must never be rewritten"
+    );
+}
+
+#[test]
+fn test_welcome_without_created_by_leaves_metadata_unchanged() {
+    // Additive field: a Welcome from an older SDK (no `created_by`) must
+    // still join cleanly, and absence must read as "no information" rather
+    // than clearing or fabricating a creator.
+    let (_alice, mut bob, group_id, welcome) = stage_welcome_for_bob("Creator Group");
+
+    let frame = group_welcome_frame(
+        &welcome,
+        &group_id,
+        &["alice", "bob"],
+        serde_json::json!({"alice": "admin"}),
+        None,
+    );
+    bob.handle_group_mls_welcome("welcome-creator-3", "alice", &frame);
+
+    assert!(
+        bob.group_mesh.members.contains_key(&group_id),
+        "a Welcome without the additive field must still join"
+    );
+    assert_eq!(
+        creator_of(&bob, &group_id),
+        None,
+        "absence means no information — never a fabricated creator"
+    );
+    assert!(
+        bob.check_is_admin(&group_id, "alice").unwrap(),
+        "the role snapshot still resolves admin without the fallback"
     );
 }

--- a/docs/mls-integration.md
+++ b/docs/mls-integration.md
@@ -716,6 +716,19 @@ window does not re-emit `group_unauthorized_membership_change` (divergent
 role metadata would otherwise re-fire it on every commit), but every
 affected roster event still carries `authorized: false`.
 
+**How the local replica is built.** A member's view of who is an admin comes
+from two sources, in order: the per-member roles it has stored, and — only when
+it has *no* admin role stored at all — the group creator, who is always an
+admin. A joiner receives both in its Welcome: a point-in-time snapshot of the
+inviter's roles, and the inviter's record of the group creator. The creator
+field is what keeps an incomplete snapshot from collapsing to
+deny-everyone: without it, a joiner whose snapshot arrived empty would judge
+*every* member — including the real admin — unauthorized. It is adopted only
+when the joiner has no creator on record already (first write wins), so a later
+invite cannot rewrite an established admin fallback, and it is absent from
+Welcomes sent by SDKs older than this field, where absence means "no
+information" rather than "no creator".
+
 **The signal can false-positive.** "Unauthorized" is judged against the
 receiving member's *local replica* of role state — the same best-effort
 metadata that makes receive-side enforcement unsafe. A member whose role map


### PR DESCRIPTION
Stage 2 of the group commit authorization work (Stage 1 was #267).

## The problem

`check_is_admin` falls back to the group creator when no admin role is stored — the state an incomplete role snapshot leaves a member in. That fallback was **dead code for every joiner**.

`GroupMlsWelcomePayload` carried a point-in-time `member_roles` snapshot and nothing else, so a joiner's group metadata was materialized by `set_member_role` via `GroupMetadata::new(None)` and its `created_by` stayed permanently `None`. A joiner whose snapshot arrived empty therefore had **no admin at all** in its replica, and judged *every* member unauthorized — including the real admin.

## The change

The Welcome now carries the inviter's creator of record, and the joiner adopts it.

- `GroupMlsWelcomePayload::created_by` — additive, `skip_serializing_if = "Option::is_none"`. Absent from older SDKs, where absence means "no information", never a downgrade.
- `MlsManager::set_group_creator` — **first-write-wins**. A device that created the group, or already adopted a creator, keeps what it has. Duplicate Welcomes are idempotent, and a later invite from an inviter whose metadata disagrees cannot rewrite an established admin fallback.
- Deliberately **not** bounded to the joined roster: the creator of record may already have left the group. Same trust class as `member_roles`, which is also unbounded.

Single construct site (`invite_to_group`) and single parse site (`handle_group_mls_welcome`), so every Welcome flow is covered.

## Scope note

Stage 3's receive-side commit enforcement deliberately never consults `created_by` — one unauthenticated claim is too thin to fork a group over. This field feeds only send-side gating and the authorization report.

## Test change worth reviewing

`non_admin_commit_attestation_is_ignored` demoted alice to make her fail bob's admin check. That only worked *because* the fallback was dead — with the creator now replicated, alice correctly resolves as admin through it (the fallback fires only when no admin role is stored at all). The test now leaves one real admin so the stored roles stay authoritative, which is the state it means to exercise.

## Tests

- `test_welcome_propagates_group_creator_to_joiner`
- `test_joiner_without_role_snapshot_resolves_admin_via_created_by` — the degenerate case the fallback exists for
- `test_welcome_created_by_does_not_overwrite_existing` — monotonicity
- `test_welcome_without_created_by_leaves_metadata_unchanged` — additive-field compatibility

## Verification

```
cargo clippy --workspace -- -D warnings   # clean
cargo test --workspace                    # all green
cargo fmt --all -- --check                # clean
```