### PR TITLE
docs: correct the AGPL section-13 blurb and remove the dangling Corporate CLA reference

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,15 +37,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
-          # Pinned to the immutable tag `cla-v1.0`, which freezes the agreed CLA
+          # Pinned to the immutable tag `cla-v1.1`, which freezes the agreed CLA
           # text at a specific revision. A bare commit SHA is unsafe here: PRs are
           # squash-merged, so a feature-branch commit is orphaned from main and
           # 404s once its branch is pruned (exactly what happened to the previous
           # c1193863 pin). A tag stays reachable regardless of merge strategy or
-          # branch cleanup. If you amend CLA.md, cut a NEW tag (cla-v1.1) on the
+          # branch cleanup. If you amend CLA.md, cut a NEW tag (cla-v1.2) on the
           # amending commit and bump this ref in the same commit — never move an
           # existing CLA tag; contributors have signed against it.
-          path-to-document: "https://github.com/Offline-Protocol/offline-protocol-sdk/blob/cla-v1.0/CLA.md"
+          path-to-document: "https://github.com/Offline-Protocol/offline-protocol-sdk/blob/cla-v1.1/CLA.md"
           # Signatures are committed to this branch — leave it unprotected.
           branch: "cla-signatures"
           # Allowlist GitHub App bot accounts (they have a "[bot]" suffix on the

--- a/CLA.md
+++ b/CLA.md
@@ -97,9 +97,8 @@ litigation is filed.
 license. If your employer(s) has rights to intellectual property
 that you create that includes your Contributions, you represent
 that you have received permission to make Contributions on behalf
-of that employer, that your employer has waived such rights for
-your Contributions to the Project, or that your employer has
-executed a separate Corporate CLA with the Project.
+of that employer, or that your employer has waived such rights
+for your Contributions to the Project.
 
 5. You represent that each of Your Contributions is Your original
 creation (see section 7 for submissions on behalf of others). You

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0--only%20or%20Commercial-blue.svg)](#license)
 [![Platforms](https://img.shields.io/badge/platforms-iOS%20%7C%20Android%20%7C%20macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)](#building-the-sdk)
 
-**Dual-licensed:** use it under [AGPL-3.0-only](LICENSE), or buy a [commercial license](LICENSE-COMMERCIAL.md), your call. The AGPL requires you to publish your source whenever you distribute the SDK or expose it over a network (section 13); the commercial license lifts that requirement for closed-source mobile apps, embedded firmware, and SaaS deployments. See the [License](#license) section for the full breakdown.
+**Dual-licensed:** use it under [AGPL-3.0-only](LICENSE), or buy a [commercial license](LICENSE-COMMERCIAL.md), your call — see the [License](#license) section for the full breakdown.
 
 ## Features
 

--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -2,7 +2,7 @@
 
 Offline-first mesh networking SDK for React Native. Enables peer-to-peer messaging over BLE, WiFi Direct, Internet, Reticulum, and Nostr relays with intelligent transport switching.
 
-**Dual-licensed:** use it under [AGPL-3.0-only](./LICENSE), or buy a [commercial license](./LICENSE-COMMERCIAL.md), your call. The AGPL requires you to publish your source whenever you distribute the SDK or expose it over a network (section 13); the commercial license lifts that requirement for closed-source apps. The npm manifest can only name `AGPL-3.0-only` because SPDX has no identifier for the commercial offer — see [License](#license) for the full breakdown.
+**Dual-licensed:** use it under [AGPL-3.0-only](./LICENSE), or buy a [commercial license](./LICENSE-COMMERCIAL.md), your call. The npm manifest can only name `AGPL-3.0-only` because SPDX has no identifier for the commercial offer — see [License](#license) for the full breakdown.
 
 > **Upgrading an existing app?** Read [docs/UPGRADING.md](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/UPGRADING.md)
 > first — this release changes storage, adds new input rejections, and is not


### PR DESCRIPTION
## What

Two documentation-accuracy fixes, no code changes.

### 1. README license blurbs overstated AGPL section 13

`README.md:10` and `bindings/react-native/README.md:5` claimed the AGPL "requires you to publish your source whenever you distribute the SDK or expose it over a network (section 13)". Wrong on both halves:

- **Section 13** attaches only to **modified** versions that users interact with remotely over a network.
- Source obligations for **plain distribution** come from **sections 4–6**, not 13.
- Unmodified network use imposes no publication obligation at all.

The RN copy has shipped on the npm package page since PR #255. Both blurbs now match the Python README's approach — state the dual license and point at the License section, which (along with `LICENSE-COMMERCIAL.md`) already describes section 13 accurately as the network-use clause. The correct deeper descriptions (`README.md` License section, RN `README.md` License section, all `LICENSE-COMMERCIAL.md` copies) are untouched, and `scripts/check-license-consistency.sh` still passes.

### 2. CLA clause 4 referenced a Corporate CLA that doesn't exist

`CLA.md` told employed contributors their employer could have "executed a separate Corporate CLA with the Project" — no such document exists anywhere in the repo, so the first corporate contributor hits a dead end. The alternative is removed; employer **permission** or **waiver** remain the two live paths. If a real CCLA is authored later, the clause can be restored under a new tag.

Per the amendment convention documented in `cla.yml`, `path-to-document` moves to the new immutable tag `cla-v1.1` in the same commit as the `CLA.md` edit. Signatures stay on `signatures/version1`: the change removes an unusable option and imposes nothing new on prior signers, so re-signing is not forced.

## ⚠️ Required post-merge step

Immediately after squash-merging, cut the tag on the squash commit and push it:

```bash
git fetch origin main
git tag cla-v1.1 origin/main
git push origin cla-v1.1
```

Until the tag exists, the CLA bot's document link on newly opened PRs 404s (`pull_request_target` uses main's workflow). Never move `cla-v1.0` — the existing signature references it.