### PR TITLE
chore: THIRD-PARTY-NOTICES drift gate in CI + trademark policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,61 @@ jobs:
       - name: License consistency check
         run: ./scripts/check-license-consistency.sh
 
+  # The License Consistency job catches the three THIRD-PARTY-NOTICES.md copies
+  # drifting from each other, but a dependency bump leaves all three identical
+  # and uniformly stale — regenerating after Cargo.lock changes was manual
+  # discipline with nothing to catch a miss. Mirror the python-bindings job's
+  # regenerate-and-diff pattern: rerun cargo-about and fail on any diff.
+  #
+  # cargo-about consults clearlydefined.io for license texts, so in rare cases
+  # an upstream data change can surface here as drift with no Cargo.lock change;
+  # the fix is the same either way — regenerate and commit.
+  notices:
+    name: Third-Party Notices Drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # The cargo-about version is pinned in the regeneration script (output
+      # formatting changes across releases would read as false drift); read it
+      # from there so this job can never disagree with local regeneration.
+      - name: Read pinned cargo-about version
+        id: pin
+        run: |
+          version="$(sed -n 's/^CARGO_ABOUT_VERSION="\(.*\)"$/\1/p' scripts/generate-third-party-notices.sh)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache cargo-about binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-about
+          key: cargo-about-${{ steps.pin.outputs.version }}-${{ runner.os }}
+
+      # `--features cli` is required: without it the install exits 0 but ships
+      # no binary.
+      - name: Install cargo-about
+        run: |
+          if ! cargo about --version 2>/dev/null | grep -qFx "cargo-about ${{ steps.pin.outputs.version }}"; then
+            cargo install cargo-about --version "${{ steps.pin.outputs.version }}" --features cli --locked --force
+          fi
+
+      - name: Regenerate third-party notices
+        run: ./scripts/generate-third-party-notices.sh
+
+      - name: Fail on stale THIRD-PARTY-NOTICES.md
+        run: |
+          if ! git diff --exit-code -- \
+            THIRD-PARTY-NOTICES.md \
+            bindings/react-native/THIRD-PARTY-NOTICES.md \
+            bindings/python/THIRD-PARTY-NOTICES.md; then
+            echo "::error::THIRD-PARTY-NOTICES.md is stale — the shipped-binary dependency graph changed without regenerating attribution."
+            echo "Run scripts/generate-third-party-notices.sh and commit the result."
+            exit 1
+          fi
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -227,3 +227,6 @@ The Offline Protocol SDK is **dual-licensed**:
 
 You may use the SDK under **either** license; you do not need both. Contributions
 are accepted under the terms described in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Neither license grants rights to the "Offline Protocol" name or logo — see
+[TRADEMARKS.md](TRADEMARKS.md).

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,39 @@
+# Trademark Policy
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+The name **"Offline Protocol"**, the Offline Protocol logo, and the names of
+Offline Protocol, Inc.'s products and services (together, "the marks") are
+trademarks of Offline Protocol, Inc., whether or not they appear with a ™
+symbol.
+
+The SDK's software licenses — both the [AGPL-3.0-only](LICENSE) option and the
+[commercial license](LICENSE-COMMERCIAL.md) — grant rights to the *code only*.
+Neither one grants any right to use the marks.
+
+## Uses that do not need permission
+
+- Truthfully referring to the project: "built with the Offline Protocol SDK",
+  "compatible with Offline Protocol", linking to this repository or to
+  offlineprotocol.com.
+- Installing or depending on the official packages under their published names
+  (the `@offline-protocol` npm scope, the `offline-protocol*` crates, the
+  Python package).
+- Unmodified redistribution of official release artifacts with their notices
+  intact, as the software licenses already provide.
+
+## Uses that need written permission
+
+- Using the marks (or confusingly similar names) in the name of your own
+  product, company, service, domain, or published package.
+- Distributing a modified version of the SDK under the marks. The AGPL grants
+  every right to fork — please give the fork its own name, and describe its
+  origin nominatively ("a fork of the Offline Protocol SDK").
+- Using the marks in a way that states or implies endorsement, sponsorship, or
+  affiliation that does not exist.
+- Altering the logo or combining the marks with other marks.
+
+## Contact
+
+Questions about the marks, or permission requests:
+**legal@offlineprotocol.com**

--- a/scripts/generate-third-party-notices.sh
+++ b/scripts/generate-third-party-notices.sh
@@ -3,13 +3,26 @@
 # (the offline-protocol-uniffi crate — what actually links into the iOS/Android
 # libraries and the Python wheel's native library) and copies it to every
 # package that redistributes those binaries. Run after dependency changes.
-#
-# Requires: cargo install cargo-about --features cli --locked
+# The notices job in ci.yml reruns this and fails on any diff, so a missed
+# regeneration no longer ships.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# Pinned because output formatting can change across cargo-about releases,
+# which the CI drift gate would misread as stale attribution. ci.yml reads
+# this assignment with sed; keep the NAME="value" shape on its own line.
+CARGO_ABOUT_VERSION="0.9.1"
+
+installed="$(cargo about --version 2>/dev/null || true)"
+if [ "$installed" != "cargo-about $CARGO_ABOUT_VERSION" ]; then
+  echo "error: cargo-about $CARGO_ABOUT_VERSION required (found: ${installed:-none})" >&2
+  echo "       cargo install cargo-about --version $CARGO_ABOUT_VERSION --features cli --locked" >&2
+  exit 1
+fi
+
 cargo about generate \
   --manifest-path crates/offline-protocol-uniffi/Cargo.toml \
+  --locked \
   -o THIRD-PARTY-NOTICES.md \
   about.hbs
 


### PR DESCRIPTION
Closes out the two remaining items from the docs/licensing audit that are fixable in-repo.

## 1. Generate-and-diff CI gate for THIRD-PARTY-NOTICES.md

The `License Consistency` job only asserts the three NOTICES copies (root, react-native, python) match **each other** — a dependency bump that stales all three uniformly passed CI, silently falsifying the file's "exact versions listed" MPL-2.0 §3.2 claim. Regeneration after `Cargo.lock` changes was manual discipline.

- New `notices` CI job: installs cargo-about (binary cached via `actions/cache`), reruns `scripts/generate-third-party-notices.sh`, and fails on `git diff` against the committed trio — same pattern as the python-bindings stale-bindings check.
- The cargo-about version is **pinned in the script** (`CARGO_ABOUT_VERSION="0.9.1"`) and CI reads it from there with `sed`, so local regeneration and the gate can never disagree on a version whose output formatting differs. The script now enforces the pin (and keeps the `--features cli` install hint — without that flag the install exits 0 with no binary).
- `cargo about generate` now passes `--locked`.
- Known soft spot, documented in the job comment: cargo-about consults clearlydefined.io for license texts, so a rare upstream data change can surface as drift with no `Cargo.lock` change. The remedy is identical (regenerate, commit), so it fails safe.

Verified locally: fresh regeneration is byte-identical to the committed trio, so the gate lands green.

## 2. TRADEMARKS.md

Adds a standard trademark policy: the "Offline Protocol" name/logo are marks of Offline Protocol, Inc.; neither the AGPL nor the commercial license grants trademark rights; nominative use and official-package consumption are fine without asking; forks must rename; contact is legal@offlineprotocol.com (matching LICENSE-COMMERCIAL.md). The README license section now points at it.

The file is deliberately silent on registration status — trademark **clearance/registration and the founder IP assignment remain counsel-track items** and are not addressed by this PR.