### PR TITLE
docs: export-control notice and App Store × AGPL licensing FAQ

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -585,7 +585,9 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           body_path: RELEASE_NOTES.md
-          files: THIRD-PARTY-NOTICES.md
+          files: |
+            THIRD-PARTY-NOTICES.md
+            EXPORT.md
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
         env:

--- a/EXPORT.md
+++ b/EXPORT.md
@@ -1,0 +1,63 @@
+# Export Control Notice
+
+This distribution includes cryptographic software. The country in which you
+currently reside may have restrictions on the import, possession, use, and/or
+re-export to another country, of encryption software. Before using any
+encryption software, please check your country's laws, regulations, and
+policies concerning the import, possession, use, and re-export of encryption
+software, to see if this is permitted.
+
+## U.S. export status of this repository
+
+The Offline Protocol SDK implements end-to-end encryption (MLS, RFC 9420) and
+uses cryptographic primitives including ChaCha20-Poly1305, AES-GCM, HPKE, and
+Ed25519. Encryption software of this kind falls under Export Control
+Classification Number (ECCN) 5D002 of the U.S. Export Administration
+Regulations (EAR, 15 CFR parts 730–774).
+
+The source code of the SDK is publicly available without restriction, and
+Offline Protocol, Inc. has notified the U.S. Bureau of Industry and Security
+(BIS) of its Internet location as described in
+[15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15).
+Publicly available encryption source code for which that notification has been
+made is not subject to the EAR under
+[15 CFR §734.7(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7),
+and publicly available object code compiled from it — the npm packages, Python
+wheels, and GitHub release artifacts built from this source and published
+without charge — receives the same treatment.
+
+## If you ship an application that embeds this SDK
+
+The treatment above covers the SDK's public source code and the public builds
+of it — not your application. You, not Offline Protocol, Inc., are the
+exporter of your application, and an application embedding this SDK contains
+encryption functionality. Expect at least the following, and confirm the
+specifics with your own counsel:
+
+- **Apple App Store.** App Store Connect asks export-compliance questions on
+  every submission (the `ITSAppUsesNonExemptEncryption` Info.plist key). An
+  app whose messaging is end-to-end encrypted by this SDK generally does not
+  qualify for the "exempt" answers. Proprietary apps in this position
+  typically self-classify as mass-market encryption under License Exception
+  ENC
+  ([15 CFR §740.17(b)(1)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-740/section-740.17))
+  and file the associated annual self-classification report with BIS, due
+  each February 1.
+- **Google Play** asks for a comparable export-compliance declaration.
+- **France** requires a declaration to ANSSI for supplying or importing means
+  of cryptology.
+- Other jurisdictions impose their own import, use, or supply restrictions on
+  encryption software.
+
+If your application is itself open source, the publicly-available treatment
+described above may extend to it as well — in which case the §742.15(b)
+notification duty for your own source location is yours.
+
+## Not legal advice
+
+This notice reflects Offline Protocol, Inc.'s good-faith understanding of the
+rules that apply to this repository and its published artifacts. It is
+informational only, is not legal advice, and does not modify the SDK's
+licenses (see [LICENSE](LICENSE) and
+[LICENSE-COMMERCIAL.md](LICENSE-COMMERCIAL.md)). Questions:
+legal@offlineprotocol.com.

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -23,6 +23,13 @@ following licenses, at your option:
 
 You only need **one** of the two licenses, not both.
 
+One distribution channel deserves a specific call-out: Apple's standard App
+Store terms are widely regarded as incompatible with the AGPL-3.0's
+prohibition on further restrictions, so the commercial license is the
+supported option for apps distributed through the Apple App Store — the
+reasoning is laid out in the
+[Licensing FAQ](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/licensing-faq.md).
+
 ## Obtaining a Commercial License
 
 Commercial licenses are offered by **Offline Protocol, Inc.** To request a quote

--- a/README.md
+++ b/README.md
@@ -228,5 +228,10 @@ The Offline Protocol SDK is **dual-licensed**:
 You may use the SDK under **either** license; you do not need both. Contributions
 are accepted under the terms described in [CONTRIBUTING.md](CONTRIBUTING.md).
 
+App-store distribution has consequences under the AGPL — see the
+[Licensing FAQ](docs/licensing-faq.md). And this software contains encryption:
+[EXPORT.md](EXPORT.md) describes its export-control status and what app teams
+must handle themselves.
+
 Neither license grants rights to the "Offline Protocol" name or logo — see
 [TRADEMARKS.md](TRADEMARKS.md).

--- a/bindings/python/EXPORT.md
+++ b/bindings/python/EXPORT.md
@@ -1,0 +1,63 @@
+# Export Control Notice
+
+This distribution includes cryptographic software. The country in which you
+currently reside may have restrictions on the import, possession, use, and/or
+re-export to another country, of encryption software. Before using any
+encryption software, please check your country's laws, regulations, and
+policies concerning the import, possession, use, and re-export of encryption
+software, to see if this is permitted.
+
+## U.S. export status of this repository
+
+The Offline Protocol SDK implements end-to-end encryption (MLS, RFC 9420) and
+uses cryptographic primitives including ChaCha20-Poly1305, AES-GCM, HPKE, and
+Ed25519. Encryption software of this kind falls under Export Control
+Classification Number (ECCN) 5D002 of the U.S. Export Administration
+Regulations (EAR, 15 CFR parts 730–774).
+
+The source code of the SDK is publicly available without restriction, and
+Offline Protocol, Inc. has notified the U.S. Bureau of Industry and Security
+(BIS) of its Internet location as described in
+[15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15).
+Publicly available encryption source code for which that notification has been
+made is not subject to the EAR under
+[15 CFR §734.7(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7),
+and publicly available object code compiled from it — the npm packages, Python
+wheels, and GitHub release artifacts built from this source and published
+without charge — receives the same treatment.
+
+## If you ship an application that embeds this SDK
+
+The treatment above covers the SDK's public source code and the public builds
+of it — not your application. You, not Offline Protocol, Inc., are the
+exporter of your application, and an application embedding this SDK contains
+encryption functionality. Expect at least the following, and confirm the
+specifics with your own counsel:
+
+- **Apple App Store.** App Store Connect asks export-compliance questions on
+  every submission (the `ITSAppUsesNonExemptEncryption` Info.plist key). An
+  app whose messaging is end-to-end encrypted by this SDK generally does not
+  qualify for the "exempt" answers. Proprietary apps in this position
+  typically self-classify as mass-market encryption under License Exception
+  ENC
+  ([15 CFR §740.17(b)(1)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-740/section-740.17))
+  and file the associated annual self-classification report with BIS, due
+  each February 1.
+- **Google Play** asks for a comparable export-compliance declaration.
+- **France** requires a declaration to ANSSI for supplying or importing means
+  of cryptology.
+- Other jurisdictions impose their own import, use, or supply restrictions on
+  encryption software.
+
+If your application is itself open source, the publicly-available treatment
+described above may extend to it as well — in which case the §742.15(b)
+notification duty for your own source location is yours.
+
+## Not legal advice
+
+This notice reflects Offline Protocol, Inc.'s good-faith understanding of the
+rules that apply to this repository and its published artifacts. It is
+informational only, is not legal advice, and does not modify the SDK's
+licenses (see [LICENSE](LICENSE) and
+[LICENSE-COMMERCIAL.md](LICENSE-COMMERCIAL.md)). Questions:
+legal@offlineprotocol.com.

--- a/bindings/python/LICENSE-COMMERCIAL.md
+++ b/bindings/python/LICENSE-COMMERCIAL.md
@@ -23,6 +23,13 @@ following licenses, at your option:
 
 You only need **one** of the two licenses, not both.
 
+One distribution channel deserves a specific call-out: Apple's standard App
+Store terms are widely regarded as incompatible with the AGPL-3.0's
+prohibition on further restrictions, so the commercial license is the
+supported option for apps distributed through the Apple App Store — the
+reasoning is laid out in the
+[Licensing FAQ](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/licensing-faq.md).
+
 ## Obtaining a Commercial License
 
 Commercial licenses are offered by **Offline Protocol, Inc.** To request a quote

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.2.0"
 description = "Python bindings for the Offline Protocol SDK — offline-first mesh networking with MLS encryption"
 readme = "README.md"
 license = "AGPL-3.0-only"
-license-files = ["LICENSE", "LICENSE-COMMERCIAL.md", "THIRD-PARTY-NOTICES.md"]
+license-files = ["LICENSE", "LICENSE-COMMERCIAL.md", "THIRD-PARTY-NOTICES.md", "EXPORT.md"]
 requires-python = ">=3.10"
 authors = [{ name = "Offline Protocol, Inc." }]
 keywords = ["offline", "messaging", "p2p", "mesh", "ble", "mls", "encryption"]

--- a/bindings/react-native/EXPORT.md
+++ b/bindings/react-native/EXPORT.md
@@ -1,0 +1,63 @@
+# Export Control Notice
+
+This distribution includes cryptographic software. The country in which you
+currently reside may have restrictions on the import, possession, use, and/or
+re-export to another country, of encryption software. Before using any
+encryption software, please check your country's laws, regulations, and
+policies concerning the import, possession, use, and re-export of encryption
+software, to see if this is permitted.
+
+## U.S. export status of this repository
+
+The Offline Protocol SDK implements end-to-end encryption (MLS, RFC 9420) and
+uses cryptographic primitives including ChaCha20-Poly1305, AES-GCM, HPKE, and
+Ed25519. Encryption software of this kind falls under Export Control
+Classification Number (ECCN) 5D002 of the U.S. Export Administration
+Regulations (EAR, 15 CFR parts 730–774).
+
+The source code of the SDK is publicly available without restriction, and
+Offline Protocol, Inc. has notified the U.S. Bureau of Industry and Security
+(BIS) of its Internet location as described in
+[15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15).
+Publicly available encryption source code for which that notification has been
+made is not subject to the EAR under
+[15 CFR §734.7(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7),
+and publicly available object code compiled from it — the npm packages, Python
+wheels, and GitHub release artifacts built from this source and published
+without charge — receives the same treatment.
+
+## If you ship an application that embeds this SDK
+
+The treatment above covers the SDK's public source code and the public builds
+of it — not your application. You, not Offline Protocol, Inc., are the
+exporter of your application, and an application embedding this SDK contains
+encryption functionality. Expect at least the following, and confirm the
+specifics with your own counsel:
+
+- **Apple App Store.** App Store Connect asks export-compliance questions on
+  every submission (the `ITSAppUsesNonExemptEncryption` Info.plist key). An
+  app whose messaging is end-to-end encrypted by this SDK generally does not
+  qualify for the "exempt" answers. Proprietary apps in this position
+  typically self-classify as mass-market encryption under License Exception
+  ENC
+  ([15 CFR §740.17(b)(1)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-740/section-740.17))
+  and file the associated annual self-classification report with BIS, due
+  each February 1.
+- **Google Play** asks for a comparable export-compliance declaration.
+- **France** requires a declaration to ANSSI for supplying or importing means
+  of cryptology.
+- Other jurisdictions impose their own import, use, or supply restrictions on
+  encryption software.
+
+If your application is itself open source, the publicly-available treatment
+described above may extend to it as well — in which case the §742.15(b)
+notification duty for your own source location is yours.
+
+## Not legal advice
+
+This notice reflects Offline Protocol, Inc.'s good-faith understanding of the
+rules that apply to this repository and its published artifacts. It is
+informational only, is not legal advice, and does not modify the SDK's
+licenses (see [LICENSE](LICENSE) and
+[LICENSE-COMMERCIAL.md](LICENSE-COMMERCIAL.md)). Questions:
+legal@offlineprotocol.com.

--- a/bindings/react-native/LICENSE-COMMERCIAL.md
+++ b/bindings/react-native/LICENSE-COMMERCIAL.md
@@ -23,6 +23,13 @@ following licenses, at your option:
 
 You only need **one** of the two licenses, not both.
 
+One distribution channel deserves a specific call-out: Apple's standard App
+Store terms are widely regarded as incompatible with the AGPL-3.0's
+prohibition on further restrictions, so the commercial license is the
+supported option for apps distributed through the Apple App Store — the
+reasoning is laid out in the
+[Licensing FAQ](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/licensing-faq.md).
+
 ## Obtaining a Commercial License
 
 Commercial licenses are offered by **Offline Protocol, Inc.** To request a quote

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -22,7 +22,8 @@
     "README.md",
     "LICENSE",
     "LICENSE-COMMERCIAL.md",
-    "THIRD-PARTY-NOTICES.md"
+    "THIRD-PARTY-NOTICES.md",
+    "EXPORT.md"
   ],
   "scripts": {
     "prepare": "tsc",

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,3 +47,10 @@
 |----------|-------------|
 | [Contributing Guide](../CONTRIBUTING.md) | Development setup, code quality standards, and PR process |
 | [Security Policy](../SECURITY.md) | Vulnerability reporting and security design |
+
+## Licensing
+
+| Resource | Description |
+|----------|-------------|
+| [Licensing FAQ](licensing-faq.md) | The dual license in practice — app stores, the AGPL's reach, commercial licensing |
+| [Export Control Notice](../EXPORT.md) | Encryption export status of the SDK and what app teams must handle themselves |

--- a/docs/licensing-faq.md
+++ b/docs/licensing-faq.md
@@ -1,0 +1,85 @@
+# Licensing FAQ
+
+How the SDK's dual license plays out in practice, especially for mobile apps
+and app-store distribution. This page is informational — it is not legal
+advice, and nothing here modifies either license. The licenses themselves are
+[LICENSE](../LICENSE) (AGPL-3.0-only) and
+[LICENSE-COMMERCIAL.md](../LICENSE-COMMERCIAL.md); the trademark policy is
+[TRADEMARKS.md](../TRADEMARKS.md), and the SDK's export-control status is
+covered in [EXPORT.md](../EXPORT.md).
+
+## Which license am I using?
+
+Either one, at your option — AGPL-3.0-only free of charge, or a commercial
+license from Offline Protocol, Inc. You need one of the two, never both. If
+you have not obtained a commercial license, the AGPL is the only permission
+you have.
+
+## My app links the SDK. Does the AGPL cover my whole app?
+
+Under the AGPL option, yes. An application that incorporates the SDK is a
+covered work (AGPL-3.0 §5), so distributing the app means distributing the
+whole of it under the AGPL-3.0 and offering every recipient its corresponding
+source (§6). If that does not fit your product, that is exactly what the
+[commercial license](../LICENSE-COMMERCIAL.md) is for.
+
+## Does the network clause (§13) matter for a mesh app?
+
+§13 adds an obligation the plain GPL does not have: if you **modify** the SDK
+and users interact with your modified version "remotely through a computer
+network", you must offer those users the corresponding source too — even if
+you never ship them a binary. In a peer-to-peer mesh messaging app, the
+remote peers your modified app exchanges messages with are plausibly such
+users. If you modify the SDK under the AGPL option, plan on offering source
+to everyone your app talks to, not only to the people you distribute the app
+to.
+
+## Can I ship an AGPL-licensed app on the Apple App Store?
+
+We do not consider that a supported combination, for two independent reasons —
+neither of which an app developer can cure on their own:
+
+1. **Apple's terms add restrictions the AGPL forbids.** Apps distributed
+   through the App Store are subject to Apple's standard license terms and
+   usage rules. The Free Software Foundation's position — established in the
+   GNU Go and VLC App Store takedowns — is that those terms impose "further
+   restrictions" that GPL-family licenses prohibit (AGPL-3.0 §10), making App
+   Store distribution of a covered work itself a license violation.
+2. **iOS code signing collides with §6.** For software conveyed in or for a
+   consumer device, AGPL-3.0 §6 requires "Installation Information" —
+   whatever a user needs to install and run a modified version on their own
+   device. App Store distribution cannot provide that: users cannot install
+   modified builds of your app on their iPhones.
+
+The supported path for App Store distribution is the
+[commercial license](../LICENSE-COMMERCIAL.md), which carries neither
+obligation.
+
+## Is there an "App Store exception"?
+
+Not at present: Offline Protocol, Inc. has not granted any additional
+permission under AGPL-3.0 §7 for app-store distribution. Because contributors
+license their work through the [CLA](../CLA.md), Offline Protocol, Inc. does
+hold the rights needed to grant one in the future. If an app-store exception
+would matter to your open-source project, contact legal@offlineprotocol.com.
+
+## What about Google Play?
+
+Google Play's terms have not drawn the same incompatibility objections, and
+GPL-family apps are distributed there. But everything above about combined
+works still applies in full: a Play app using the SDK under the AGPL option
+must itself be AGPL-3.0, with source offered to every recipient. A
+proprietary Play app needs the commercial license, the same as on iOS.
+
+## Does either license handle export compliance for me?
+
+No. The licenses govern copyright; export control is separate law. The SDK's
+own status is described in [EXPORT.md](../EXPORT.md); the export-compliance
+declarations an app store asks for when you submit your app are yours to
+make.
+
+## How do I get a commercial license?
+
+See [LICENSE-COMMERCIAL.md](../LICENSE-COMMERCIAL.md) — in short, email
+legal@offlineprotocol.com with a brief description of your product, its
+distribution model, and expected scale.

--- a/scripts/check-license-consistency.sh
+++ b/scripts/check-license-consistency.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Guards the hand-maintained license surface against drift.
 #
-# Three license documents are triplicated into each package that redistributes
-# the binaries (root, react-native, python) -- LICENSE and LICENSE-COMMERCIAL.md
-# by hand, THIRD-PARTY-NOTICES.md by generate-third-party-notices.sh. Nothing
+# Four license documents are triplicated into each package that redistributes
+# the binaries (root, react-native, python) -- LICENSE, LICENSE-COMMERCIAL.md,
+# and EXPORT.md by hand, THIRD-PARTY-NOTICES.md by
+# generate-third-party-notices.sh. Nothing
 # else stops an edit from landing in one copy and not the others, and a
 # divergent license text in a published artifact is not a bug you find by
 # testing. This asserts the copies are byte-identical, that every notice-bearing
@@ -15,7 +16,7 @@ cd "$(dirname "$0")/.."
 status=0
 
 # Documents copied verbatim into each redistributing package.
-for doc in LICENSE LICENSE-COMMERCIAL.md THIRD-PARTY-NOTICES.md; do
+for doc in LICENSE LICENSE-COMMERCIAL.md THIRD-PARTY-NOTICES.md EXPORT.md; do
   for pkg in bindings/react-native bindings/python; do
     if ! cmp -s "$doc" "$pkg/$doc"; then
       echo "error: $pkg/$doc has drifted from $doc" >&2


### PR DESCRIPTION
Closes the two remaining gaps from the licensing/compliance audit: the repo distributes encryption software with no export-control notice anywhere, and nothing warned App Store developers about the AGPL conflict that is the headline commercial-license use case.

## What's in here

**`EXPORT.md`** (root, + copies in the npm and PyPI packages)
- Standard cryptographic-software notice, ECCN 5D002 classification, and the publicly-available treatment of 15 CFR §734.7(b) in reliance on the §742.15(b) notification (eCFR links verified).
- A checklist of what remains with app teams embedding the SDK: App Store Connect export questions / `ITSAppUsesNonExemptEncryption`, the §740.17(b)(1) mass-market self-classification and annual BIS report, ANSSI declaration, Play declarations.
- Ships like the other license documents: npm `files`, pyproject `license-files`, attached to GitHub releases, and added to `check-license-consistency.sh`'s triplication guard (negative-tested: a drifted copy fails the script).

**`docs/licensing-faq.md`**
- Combined-work reach of the AGPL option (§5/§6) and the §13 network clause read against a mesh app.
- Why AGPL + Apple App Store is not a supported combination (Apple's terms as forbidden further restrictions per the FSF's GNU Go/VLC position; iOS code signing vs §6 Installation Information) — the supported App Store path is the commercial license.
- Explicit statement that **no §7 app-store exception is currently granted** (descriptive of today's posture; granting one later stays open, since the CLA aggregates the rights).
- Play Store and export-compliance entries.
- Pointed at from the README License section, `LICENSE-COMMERCIAL.md` (all three copies, absolute URL since docs/ doesn't ship in packages), and the docs index.

## Before merging

- [ ] **Send the §742.15(b) notification** (internal action, deliberately not in this repo). `EXPORT.md` states the notification has been made, so it must be true by merge time.
- [ ] **Counsel review.** Both documents make regulatory/legal characterizations and join the existing counsel track (safe-harbor wording, trademark clearance). Neither has been through counsel.

## Verification

- `scripts/check-license-consistency.sh` passes; breaking any `EXPORT.md` copy makes it fail.
- All eCFR citation links return 200.