### PR TITLE
fix(bindings): promote MeshForegroundService to foreground in onCreate + add Stop action

### DIFF
--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -86,6 +86,12 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.16'
+    // NotificationCompat reaches the production classpath transitively through
+    // react-android, which is compileOnly in the standalone/CI harness — so the
+    // JVM tests have to bring it themselves. Test-only: consumers keep getting
+    // it from the host app. Hold at 1.13.x, the last line that builds against
+    // compileSdk 34.
+    testImplementation 'androidx.core:core:1.13.1'
     // Real org.json for JVM unit tests (the android.jar org.json is a stub
     // that throws) — needed by RelayControlOpTranslatorTest.
     testImplementation 'org.json:json:20260719'

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
@@ -3,6 +3,7 @@ package com.offlineprotocol
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
@@ -79,6 +80,22 @@ class MeshForegroundService : Service() {
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
+        // Enter the foreground here rather than waiting for onStartCommand.
+        // Android gives an app 5 seconds after startForegroundService() to
+        // call startForeground(); if onStartCommand is delayed past that
+        // window (JS-thread initialization on cold start, main-thread work
+        // during app resume on mid-range devices), the OS terminates the
+        // process with a fatal RemoteServiceException. Promoting in
+        // onCreate — which runs before any onStartCommand dispatch — makes
+        // the deadline unreachable. Subsequent startForeground() calls in
+        // onStartCommand are idempotent on the same service instance and
+        // remain safe re-promotes.
+        try {
+            startForeground(NOTIFICATION_ID, buildNotification())
+            isRunning = true
+        } catch (e: Exception) {
+            Log.w(TAG, "startForeground in onCreate failed: ${e.message}", e)
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -129,6 +146,22 @@ class MeshForegroundService : Service() {
     }
 
     private fun buildNotification(): Notification {
+        // Route the notification's stop action back through this service's
+        // own ACTION_STOP handler. Using PendingIntent.getForegroundService
+        // on O+ keeps the delivery legal under the background service-start
+        // restrictions that apply when the user taps the action from the
+        // notification shade while the app itself is in the background;
+        // pre-O falls back to getService which has no such restriction.
+        val stopIntent = Intent(this, MeshForegroundService::class.java).apply {
+            action = ACTION_STOP
+        }
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val stopPendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            PendingIntent.getForegroundService(this, 0, stopIntent, flags)
+        } else {
+            PendingIntent.getService(this, 0, stopIntent, flags)
+        }
+
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("Mesh Active")
             .setContentText("Offline mesh networking is running")
@@ -136,6 +169,7 @@ class MeshForegroundService : Service() {
             .setOngoing(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .addAction(android.R.drawable.ic_media_pause, "Stop", stopPendingIntent)
             .build()
     }
 }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
@@ -25,7 +25,8 @@ import androidx.core.app.NotificationCompat
  * The service itself does NOT own the protocol or transport instances.
  * It exists solely to prevent the OS from killing the process while mesh
  * networking is active. Protocol and transport lifecycle remains in
- * OfflineProtocolModule.
+ * OfflineProtocolModule — including the notification's Stop action, which
+ * hands off to [onStopRequestedByUser] instead of tearing down here.
  */
 class MeshForegroundService : Service() {
 
@@ -38,9 +39,27 @@ class MeshForegroundService : Service() {
         private const val ACTION_START = "com.offlineprotocol.action.START_MESH"
         private const val ACTION_STOP = "com.offlineprotocol.action.STOP_MESH"
 
+        /**
+         * Delivered by the notification's Stop action. Deliberately distinct
+         * from [ACTION_STOP]: that one is the host telling the service that
+         * mesh is *already* going down, while this one is the user asking for
+         * a teardown the host has not started yet and must run itself.
+         */
+        private const val ACTION_STOP_FROM_NOTIFICATION =
+            "com.offlineprotocol.action.STOP_MESH_FROM_NOTIFICATION"
+
         @Volatile
         var isRunning: Boolean = false
             private set
+
+        /**
+         * Set by [start], cleared by [stop] and [onDestroy]. Tracks intent
+         * rather than state: the service is created asynchronously, so a
+         * `stop()` racing a just-issued `start()` sees [isRunning] still false
+         * while a service is on its way up.
+         */
+        @Volatile
+        private var startRequested: Boolean = false
 
         /**
          * Callback invoked when the service is restarted after a process kill
@@ -50,7 +69,24 @@ class MeshForegroundService : Service() {
         @Volatile
         var onServiceRestarted: (() -> Unit)? = null
 
+        /**
+         * Callback invoked when the user taps "Stop" on the service
+         * notification. The host module must set this and run the same
+         * teardown as its JS-facing `stop()`: this service is only a
+         * keep-alive, so dropping it alone would leave BLE/WiFi-Direct/Nostr
+         * and the process scheduler running with no foreground protection and
+         * no JS-visible state change — the user sees "mesh off" while the
+         * radios keep draining until the OS reaps the process.
+         *
+         * Held in a companion field, so a host that captures itself here must
+         * null it out on teardown or it pins that host for the process
+         * lifetime.
+         */
+        @Volatile
+        var onStopRequestedByUser: (() -> Unit)? = null
+
         fun start(context: Context) {
+            startRequested = true
             val intent = Intent(context, MeshForegroundService::class.java).apply {
                 action = ACTION_START
             }
@@ -62,6 +98,18 @@ class MeshForegroundService : Service() {
         }
 
         fun stop(context: Context) {
+            // Skip when there is nothing to stop. Callers invoke this from
+            // both stop() and invalidate(), so a stop-after-stop would
+            // otherwise create an instance purely to tear it down — and since
+            // onCreate now promotes to the foreground, that means a visible
+            // notification flash during app teardown.
+            //
+            // Both flags are needed: startRequested covers a stop racing a
+            // service that is still coming up (isRunning not yet set), and
+            // isRunning covers an instance we never requested — a START_STICKY
+            // restart after process death, which resets the statics.
+            if (!startRequested && !isRunning) return
+            startRequested = false
             val intent = Intent(context, MeshForegroundService::class.java).apply {
                 action = ACTION_STOP
             }
@@ -90,34 +138,29 @@ class MeshForegroundService : Service() {
         // the deadline unreachable. Subsequent startForeground() calls in
         // onStartCommand are idempotent on the same service instance and
         // remain safe re-promotes.
-        try {
-            startForeground(NOTIFICATION_ID, buildNotification())
-            isRunning = true
-        } catch (e: Exception) {
-            Log.w(TAG, "startForeground in onCreate failed: ${e.message}", e)
-        }
+        promoteToForeground()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_STOP -> {
                 Log.i(TAG, "Stopping mesh foreground service")
-                isRunning = false
-                stopForeground(STOP_FOREGROUND_REMOVE)
-                stopSelf()
+                stopForegroundAndSelf()
                 return START_NOT_STICKY
+            }
+            ACTION_STOP_FROM_NOTIFICATION -> {
+                Log.i(TAG, "User requested mesh stop from the notification")
+                return handleUserStopRequest()
             }
             ACTION_START -> {
                 Log.i(TAG, "Starting mesh foreground service")
-                startForeground(NOTIFICATION_ID, buildNotification())
-                isRunning = true
+                promoteToForeground()
             }
             null -> {
                 // Service restarted by the system after process kill (START_STICKY).
                 // Re-enter foreground immediately to prevent ANR, then notify host.
                 Log.i(TAG, "Service restarted after process kill")
-                startForeground(NOTIFICATION_ID, buildNotification())
-                isRunning = true
+                promoteToForeground()
                 onServiceRestarted?.invoke()
             }
         }
@@ -126,8 +169,67 @@ class MeshForegroundService : Service() {
 
     override fun onDestroy() {
         isRunning = false
+        startRequested = false
         Log.i(TAG, "Mesh foreground service destroyed")
         super.onDestroy()
+    }
+
+    /**
+     * Enter (or re-enter) the foreground with the mesh notification.
+     *
+     * Shared by all three promotion sites so none of them can throw where the
+     * caller does not expect it. A `connectedDevice`-typed promotion is not
+     * failure-free on targetSdk 34: it raises SecurityException once the
+     * Nearby-Devices runtime permissions are revoked, and a START_STICKY
+     * restart while the app is backgrounded raises
+     * ForegroundServiceStartNotAllowedException on Android 12+. Neither is
+     * worth taking the process down for by itself, and the ACTION_START path
+     * re-promotes afterwards.
+     *
+     * The residual is worth stating plainly: when the instance was created by
+     * startForegroundService() and promotion genuinely fails, swallowing here
+     * only defers the kill — the system still raises its own 5-second-timeout
+     * RemoteServiceException. This buys survival for transient OEM failures,
+     * not immunity.
+     */
+    private fun promoteToForeground() {
+        try {
+            startForeground(NOTIFICATION_ID, buildNotification())
+            isRunning = true
+        } catch (e: Exception) {
+            Log.w(TAG, "startForeground failed: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Hand a user-initiated stop to the host, which owns protocol and
+     * transport lifecycle. Its teardown ends in [stop], so this service comes
+     * down through the ACTION_STOP branch once the mesh is actually off —
+     * keeping the notification truthful rather than clearing it while the
+     * radios still run.
+     */
+    private fun handleUserStopRequest(): Int {
+        val callback = onStopRequestedByUser
+        if (callback != null) {
+            try {
+                callback.invoke()
+                return START_NOT_STICKY
+            } catch (e: Exception) {
+                Log.w(TAG, "Host stop callback failed; stopping the service directly: ${e.message}", e)
+            }
+        } else {
+            Log.w(TAG, "No host stop callback registered; stopping the service only — transports may still be running")
+        }
+        // Fallback: nothing to defer to, so at least honour the button by
+        // dropping the keep-alive.
+        stopForegroundAndSelf()
+        return START_NOT_STICKY
+    }
+
+    private fun stopForegroundAndSelf() {
+        isRunning = false
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
     }
 
     private fun createNotificationChannel() {
@@ -147,19 +249,27 @@ class MeshForegroundService : Service() {
 
     private fun buildNotification(): Notification {
         // Route the notification's stop action back through this service's
-        // own ACTION_STOP handler. Using PendingIntent.getForegroundService
-        // on O+ keeps the delivery legal under the background service-start
-        // restrictions that apply when the user taps the action from the
-        // notification shade while the app itself is in the background;
-        // pre-O falls back to getService which has no such restriction.
+        // own ACTION_STOP_FROM_NOTIFICATION handler. Using
+        // PendingIntent.getForegroundService on O+ keeps the delivery legal
+        // under the background service-start restrictions that apply when the
+        // user taps the action from the notification shade while the app
+        // itself is in the background; pre-O falls back to getService which
+        // has no such restriction.
+        //
+        // Note the coupling with the onCreate promotion: if this fires against
+        // a dead service instance (a stale notification during a sticky-restart
+        // gap), startForegroundService() re-creates the service, and that
+        // promotion is the only thing satisfying the 5-second startForeground
+        // obligation before the stop is handled. Do not remove one without
+        // the other.
         val stopIntent = Intent(this, MeshForegroundService::class.java).apply {
-            action = ACTION_STOP
+            action = ACTION_STOP_FROM_NOTIFICATION
         }
-        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         val stopPendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            PendingIntent.getForegroundService(this, 0, stopIntent, flags)
+            PendingIntent.getForegroundService(this, 0, stopIntent, pendingIntentFlags)
         } else {
-            PendingIntent.getService(this, 0, stopIntent, flags)
+            PendingIntent.getService(this, 0, stopIntent, pendingIntentFlags)
         }
 
         return NotificationCompat.Builder(this, CHANNEL_ID)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -103,6 +103,9 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         nostrManager = null
         protocol = null
         stopForegroundService()
+        // Companion field capturing this module — drop it or the module and
+        // its ReactContext outlive teardown.
+        MeshForegroundService.onStopRequestedByUser = null
     }
 
     // MARK: - Host lifecycle (foreground relay heal)
@@ -988,13 +991,33 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun stop(promise: Promise) {
+        try {
+            stopTransportsAndProtocol()
+            promise.resolve(null)
+        } catch (e: Exception) {
+            emitDiagnostic("error", "Failed to stop protocol", mapOf(
+                "message" to (e.message ?: "unknown"),
+                "exception" to e.javaClass.simpleName
+            ))
+            promise.reject("ERROR_STOP", "Failed to stop protocol: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Stop every transport, the process scheduler, the keep-alive service and
+     * the protocol core. Shared by the JS-facing [stop] and the mesh
+     * notification's Stop action so both tear down identically: the foreground
+     * service is only a keep-alive, and dropping it on its own would leave the
+     * transports and the scheduler running with no process protection.
+     */
+    private fun stopTransportsAndProtocol() {
         stopProcessScheduler()
-        
+
         // Stop BLE manager first
         bleTransport?.stop()
         android.util.Log.i(NAME, "BLE Manager stopped")
         emitDiagnostic("info", "BLE manager stopped")
-        
+
         // Stop Internet manager
         internetManager?.stop()
         android.util.Log.i(NAME, "Internet Manager stopped")
@@ -1017,17 +1040,54 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
 
         // Stop foreground service
         stopForegroundService()
-        
+
+        protocol?.stop()
+        emitDiagnostic("info", "Protocol stopped")
+    }
+
+    /**
+     * The user tapped "Stop" on the mesh notification. Runs the same teardown
+     * as the JS-facing [stop], then tells JS — without the event, the app would
+     * keep reporting mesh as active against transports that are now down.
+     *
+     * The service invokes this from its main-thread `onStartCommand`, so the
+     * work moves off that thread: [stopProcessScheduler] blocks for up to
+     * [PROCESS_SHUTDOWN_TIMEOUT_MS] waiting for an in-flight process tick.
+     * The keep-alive stop is repeated in `finally` (it is idempotent) so a
+     * throwing transport cannot strand the notification on screen.
+     */
+    private fun handleUserRequestedMeshStop() {
+        Thread({
+            try {
+                stopTransportsAndProtocol()
+            } catch (e: Exception) {
+                android.util.Log.e(NAME, "User-requested mesh stop failed", e)
+                emitDiagnostic("error", "User-requested mesh stop failed", mapOf(
+                    "message" to (e.message ?: "unknown"),
+                    "exception" to e.javaClass.simpleName
+                ))
+            } finally {
+                stopForegroundService()
+                emitMeshStoppedByUserEvent()
+            }
+        }, "mesh-user-stop").start()
+    }
+
+    /**
+     * Reports that the mesh was stopped from the notification's Stop action
+     * rather than through a JS `stop()` call, so the app can reconcile its own
+     * "mesh active" state with a teardown it did not initiate.
+     */
+    private fun emitMeshStoppedByUserEvent() {
         try {
-            protocol?.stop()
-            emitDiagnostic("info", "Protocol stopped")
-            promise.resolve(null)
+            val json = JSONObject()
+            json.put("type", "mesh_stopped_by_user")
+            val params = Arguments.createMap().apply {
+                putString("eventJson", json.toString())
+            }
+            sendEvent(EVENT_NAME, params)
         } catch (e: Exception) {
-            emitDiagnostic("error", "Failed to stop protocol", mapOf(
-                "message" to (e.message ?: "unknown"),
-                "exception" to e.javaClass.simpleName
-            ))
-            promise.reject("ERROR_STOP", "Failed to stop protocol: ${e.message}", e)
+            android.util.Log.e(NAME, "Failed to emit mesh stopped event", e)
         }
     }
 
@@ -3804,6 +3864,12 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
      */
     private fun startForegroundService() {
         try {
+            // Register before the service exists, so the notification's Stop
+            // action always has a host to defer to. The callback lives in a
+            // companion field and captures this module, so invalidate() must
+            // clear it or the module — and the ReactContext it holds — is
+            // pinned for the process lifetime.
+            MeshForegroundService.onStopRequestedByUser = { handleUserRequestedMeshStop() }
             MeshForegroundService.start(reactApplicationContext)
             emitDiagnostic("info", "Mesh foreground service started")
         } catch (e: Exception) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -1009,40 +1009,55 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
      * notification's Stop action so both tear down identically: the foreground
      * service is only a keep-alive, and dropping it on its own would leave the
      * transports and the scheduler running with no process protection.
+     *
+     * Synchronized because those two callers run on different threads and can
+     * overlap — a notification Stop while the app foregrounds and calls `stop()`.
+     * Interleaved passes double-stop the transports mid-teardown, and a throw on
+     * both leaves every later step unreached while the user-stop path still
+     * reports the mesh down. Serialized, the second entrant re-runs the stops
+     * after a completed first pass, which is their idempotent no-op path.
+     *
+     * The keep-alive and the core come down in `finally`: a transport that
+     * throws must not strand the notification advertising an active mesh, nor
+     * leave the core ticking its outbox against stopped transports. The
+     * exception still propagates, so [stop] rejects as it did before.
      */
+    @Synchronized
     private fun stopTransportsAndProtocol() {
-        stopProcessScheduler()
+        try {
+            stopProcessScheduler()
 
-        // Stop BLE manager first
-        bleTransport?.stop()
-        android.util.Log.i(NAME, "BLE Manager stopped")
-        emitDiagnostic("info", "BLE manager stopped")
+            // Stop BLE manager first
+            bleTransport?.stop()
+            android.util.Log.i(NAME, "BLE Manager stopped")
+            emitDiagnostic("info", "BLE manager stopped")
 
-        // Stop Internet manager
-        internetManager?.stop()
-        android.util.Log.i(NAME, "Internet Manager stopped")
-        emitDiagnostic("info", "Internet manager stopped")
+            // Stop Internet manager
+            internetManager?.stop()
+            android.util.Log.i(NAME, "Internet Manager stopped")
+            emitDiagnostic("info", "Internet manager stopped")
 
-        // Stop WiFi Direct manager
-        wifiDirectManager?.stop()
-        android.util.Log.i(NAME, "WiFi Direct Manager stopped")
-        emitDiagnostic("info", "WiFi Direct manager stopped")
+            // Stop WiFi Direct manager
+            wifiDirectManager?.stop()
+            android.util.Log.i(NAME, "WiFi Direct Manager stopped")
+            emitDiagnostic("info", "WiFi Direct manager stopped")
 
-        // Stop Reticulum manager
-        reticulumManager?.stop()
-        android.util.Log.i(NAME, "Reticulum Manager stopped")
-        emitDiagnostic("info", "Reticulum manager stopped")
+            // Stop Reticulum manager
+            reticulumManager?.stop()
+            android.util.Log.i(NAME, "Reticulum Manager stopped")
+            emitDiagnostic("info", "Reticulum manager stopped")
 
-        // Stop Nostr manager
-        nostrManager?.stop()
-        android.util.Log.i(NAME, "Nostr Manager stopped")
-        emitDiagnostic("info", "Nostr manager stopped")
+            // Stop Nostr manager
+            nostrManager?.stop()
+            android.util.Log.i(NAME, "Nostr Manager stopped")
+            emitDiagnostic("info", "Nostr manager stopped")
+        } finally {
+            // Stop foreground service
+            stopForegroundService()
 
-        // Stop foreground service
-        stopForegroundService()
-
-        protocol?.stop()
-        emitDiagnostic("info", "Protocol stopped")
+            protocol?.stop()
+            emitDiagnostic("info", "Protocol stopped")
+        }
     }
 
     /**
@@ -1052,9 +1067,12 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
      *
      * The service invokes this from its main-thread `onStartCommand`, so the
      * work moves off that thread: [stopProcessScheduler] blocks for up to
-     * [PROCESS_SHUTDOWN_TIMEOUT_MS] waiting for an in-flight process tick.
-     * The keep-alive stop is repeated in `finally` (it is idempotent) so a
-     * throwing transport cannot strand the notification on screen.
+     * [PROCESS_SHUTDOWN_TIMEOUT_MS] waiting for an in-flight process tick, and
+     * it waits again for any overlapping teardown to release the lock.
+     *
+     * The event fires in `finally` so a throwing transport cannot leave JS
+     * believing the mesh is still up; [stopTransportsAndProtocol] already
+     * guarantees the keep-alive came down on that path.
      */
     private fun handleUserRequestedMeshStop() {
         Thread({
@@ -1067,7 +1085,6 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
                     "exception" to e.javaClass.simpleName
                 ))
             } finally {
-                stopForegroundService()
                 emitMeshStoppedByUserEvent()
             }
         }, "mesh-user-stop").start()

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
@@ -1,0 +1,240 @@
+package com.offlineprotocol
+
+import android.content.Context
+import android.content.Intent
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ServiceController
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the two invariants that keep [MeshForegroundService] from taking the
+ * process down with it.
+ *
+ * The first is the reason this class exists at all: Android gives an app five
+ * seconds after `startForegroundService()` to call `startForeground()`, and
+ * missing it is a fatal `RemoteServiceException`, not a degraded service. The
+ * promotion therefore has to happen in `onCreate` — before any `onStartCommand`
+ * dispatch, and so before whatever main-thread work is queued ahead of it. That
+ * is invisible in the source once written; only a test that creates the service
+ * *without* delivering a start command can tell the two placements apart.
+ *
+ * The second is the notification's Stop action, which must reach the host
+ * module rather than stopping this service directly. Dropping the keep-alive
+ * on its own leaves the transports and the process scheduler running with no
+ * foreground protection and nothing told to JS.
+ *
+ * Action strings are written out verbatim rather than read from the companion:
+ * they cross a process boundary inside a PendingIntent that can outlive the
+ * process that built it, so a rename is a compatibility question, not a
+ * refactor, and the test should notice.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class MeshForegroundServiceTest {
+
+    private companion object {
+        const val NOTIFICATION_ID = 9001
+        const val ACTION_STOP = "com.offlineprotocol.action.STOP_MESH"
+        const val ACTION_STOP_FROM_NOTIFICATION =
+            "com.offlineprotocol.action.STOP_MESH_FROM_NOTIFICATION"
+        const val ACTION_START = "com.offlineprotocol.action.START_MESH"
+    }
+
+    private val context: Context
+        get() = RuntimeEnvironment.getApplication()
+
+    private var controller: ServiceController<MeshForegroundService>? = null
+
+    /**
+     * `isRunning` and the internal start-request flag are companion state, so
+     * they outlive an individual test. Destroying the instance clears both
+     * through `onDestroy`, which keeps the no-op assertions in
+     * [stop_does_not_create_a_service_when_none_was_started] honest.
+     */
+    @After
+    fun tearDown() {
+        MeshForegroundService.onStopRequestedByUser = null
+        MeshForegroundService.onServiceRestarted = null
+        controller?.destroy()
+        controller = null
+        drainStartedServices()
+    }
+
+    private fun createService(): MeshForegroundService {
+        val created = Robolectric.buildService(MeshForegroundService::class.java)
+        controller = created
+        return created.create().get()
+    }
+
+    private fun deliver(action: String?): MeshForegroundService {
+        val started = controller ?: error("createService() first")
+        val intent = action?.let {
+            Intent(context, MeshForegroundService::class.java).apply { this.action = it }
+        }
+        return started.withIntent(intent).startCommand(0, 1).get()
+    }
+
+    private fun drainStartedServices() {
+        while (shadowOf(RuntimeEnvironment.getApplication()).nextStartedService != null) {
+            // discard
+        }
+    }
+
+    @Test
+    fun `service is in the foreground by the end of onCreate`() {
+        val service = createService()
+
+        // Deliberately no startCommand: this is the whole point. If the
+        // promotion ever moves back into onStartCommand, the notification is
+        // still absent here and the 5-second deadline becomes reachable again.
+        val shadow = shadowOf(service)
+        assertNotNull(
+            "startForeground must run in onCreate, before any onStartCommand dispatch",
+            shadow.lastForegroundNotification
+        )
+        assertEquals(NOTIFICATION_ID, shadow.lastForegroundNotificationId)
+        assertTrue(MeshForegroundService.isRunning)
+    }
+
+    @Test
+    fun `notification carries a stop action pointing back at this service`() {
+        val service = createService()
+
+        val notification = shadowOf(service).lastForegroundNotification
+        val actions = notification.actions
+        assertEquals("expected exactly one notification action", 1, actions.size)
+
+        val pending = shadowOf(actions[0].actionIntent)
+        assertTrue(
+            "O+ must use getForegroundService so the tap is legal while backgrounded",
+            pending.isForegroundServiceIntent
+        )
+
+        val routed = pending.savedIntent
+        assertEquals(ACTION_STOP_FROM_NOTIFICATION, routed.action)
+        assertEquals(MeshForegroundService::class.java.name, routed.component?.className)
+    }
+
+    @Test
+    fun `stop action defers to the host and leaves the keep-alive up`() {
+        var invoked = 0
+        MeshForegroundService.onStopRequestedByUser = { invoked += 1 }
+
+        createService()
+        val service = deliver(ACTION_STOP_FROM_NOTIFICATION)
+
+        assertEquals("the host owns transport teardown and must be called", 1, invoked)
+        // The host's own teardown ends in MeshForegroundService.stop(), which
+        // comes back through ACTION_STOP. Clearing the notification here would
+        // report "mesh off" while the radios are still running.
+        assertFalse(
+            "service must stay up until the host has actually stopped the mesh",
+            shadowOf(service).isStoppedBySelf
+        )
+    }
+
+    @Test
+    fun `stop action still drops the keep-alive when no host is registered`() {
+        MeshForegroundService.onStopRequestedByUser = null
+
+        createService()
+        val service = deliver(ACTION_STOP_FROM_NOTIFICATION)
+
+        // Nothing to defer to (process restarted, module never re-registered).
+        // The button must not be dead.
+        assertTrue(shadowOf(service).isStoppedBySelf)
+        assertTrue(shadowOf(service).isForegroundStopped)
+        assertFalse(MeshForegroundService.isRunning)
+    }
+
+    @Test
+    fun `stop action falls back to stopping itself when the host callback throws`() {
+        MeshForegroundService.onStopRequestedByUser = { throw IllegalStateException("host is gone") }
+
+        createService()
+        val service = deliver(ACTION_STOP_FROM_NOTIFICATION)
+
+        assertTrue(shadowOf(service).isStoppedBySelf)
+        assertFalse(MeshForegroundService.isRunning)
+    }
+
+    @Test
+    fun `host-initiated stop tears down foreground and self`() {
+        createService()
+        val service = deliver(ACTION_STOP)
+
+        assertTrue(shadowOf(service).isForegroundStopped)
+        assertTrue(shadowOf(service).isStoppedBySelf)
+        assertFalse(MeshForegroundService.isRunning)
+    }
+
+    @Test
+    fun `sticky restart re-promotes and notifies the host`() {
+        var restarted = 0
+        MeshForegroundService.onServiceRestarted = { restarted += 1 }
+
+        createService()
+        // A null intent is how the system re-delivers after a process kill.
+        val service = deliver(null)
+
+        assertEquals(1, restarted)
+        assertEquals(NOTIFICATION_ID, shadowOf(service).lastForegroundNotificationId)
+        assertTrue(MeshForegroundService.isRunning)
+    }
+
+    @Test
+    fun `stop does not create a service when none was started`() {
+        // Establish the precondition explicitly: onDestroy clears both the
+        // running flag and the start-request flag that survive between tests.
+        createService()
+        controller?.destroy()
+        controller = null
+        drainStartedServices()
+
+        MeshForegroundService.stop(context)
+
+        // Without the guard this would start the service just to stop it —
+        // and since onCreate now promotes, that is a notification flash on a
+        // teardown path the app runs twice (stop() and invalidate()).
+        assertNull(
+            "stop() must not create a service instance when nothing is running",
+            shadowOf(RuntimeEnvironment.getApplication()).nextStartedService
+        )
+    }
+
+    @Test
+    fun `stop reaches a service that is still coming up`() {
+        // start() sets the request flag synchronously; the service itself is
+        // created asynchronously, so isRunning is still false at this point.
+        // Gating stop() on isRunning alone would strand the instance.
+        MeshForegroundService.start(context)
+        drainStartedServices()
+
+        MeshForegroundService.stop(context)
+
+        val stopIntent = shadowOf(RuntimeEnvironment.getApplication()).nextStartedService
+        assertNotNull("stop() must reach a service that start() already requested", stopIntent)
+        assertEquals(ACTION_STOP, stopIntent.action)
+    }
+
+    @Test
+    fun `start requests the service with the start action`() {
+        MeshForegroundService.start(context)
+
+        val intent = shadowOf(RuntimeEnvironment.getApplication()).nextStartedService
+        assertNotNull(intent)
+        assertEquals(ACTION_START, intent.action)
+        assertEquals(MeshForegroundService::class.java.name, intent.component?.className)
+    }
+}

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
@@ -61,6 +61,10 @@ class MeshForegroundServiceTest {
      * they outlive an individual test. Destroying the instance clears both
      * through `onDestroy`, which keeps the no-op assertions in
      * [stop_does_not_create_a_service_when_none_was_started] honest.
+     *
+     * A test that calls `start()` without ever creating an instance leaves the
+     * start-request flag set with no `onDestroy` to clear it, so `stop()` runs
+     * unconditionally here too — it no-ops once both flags are already down.
      */
     @After
     fun tearDown() {
@@ -68,6 +72,7 @@ class MeshForegroundServiceTest {
         MeshForegroundService.onServiceRestarted = null
         controller?.destroy()
         controller = null
+        MeshForegroundService.stop(context)
         drainStartedServices()
     }
 

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -1910,6 +1910,20 @@ export interface InternetSessionSupersededEvent extends BaseEvent {
 }
 
 /**
+ * The user stopped the mesh from the Android foreground-service notification's
+ * "Stop" action rather than through a `stop()` call. The SDK has already torn
+ * down the transports, the process scheduler, the keep-alive service and the
+ * protocol core by the time this arrives — it is a notification, not a request
+ * to act. Apps that track mesh state themselves must reconcile it here, or
+ * they will keep reporting an active mesh against stopped transports.
+ *
+ * Android only; iOS has no equivalent notification affordance.
+ */
+export interface MeshStoppedByUserEvent extends BaseEvent {
+  type: 'mesh_stopped_by_user';
+}
+
+/**
  * Relay-side registration state of a group (`groupRelaySyncState`).
  */
 export type RelaySyncState = 'synced' | 'pending' | 'unsynced';
@@ -1978,6 +1992,7 @@ export type ProtocolEvent =
   | InternetServerMessageEvent
   | InternetStatusChangedEvent
   | InternetSessionSupersededEvent
+  | MeshStoppedByUserEvent
   | TypingIndicatorReceivedEvent
   | ReadReceiptReceivedEvent
   | MessageRelayedEvent

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -3591,6 +3591,9 @@ mod tests {
             "internet_server_message",
             "internet_status_changed",
             "internet_session_superseded",
+            // Android only: the mesh foreground service's notification has no
+            // iOS counterpart.
+            "mesh_stopped_by_user",
         ]
         .map(str::to_string)
         .into();


### PR DESCRIPTION
## Problem

`MeshForegroundService` currently calls `startForeground()` inside `onStartCommand`. When the enclosing app has JS-thread initialisation or main-thread work queued in front of the service dispatch — cold start on mid-range Android devices, or app resume with any noticeable JS work — the OS misses the 5-second `startForegroundService()` → `startForeground()` deadline and terminates the process with a fatal `RemoteServiceException`.

We observed this as the top ANR-adjacent fatal on Redmi Note 8 Pro / Android 11 in the MINE app, fingerprinted by Sentry as `REACT-NATIVE-5Z`.

## Fix

1. **Promote `startForeground()` into `onCreate`.** `onCreate` runs before any `onStartCommand` dispatch, so the deadline becomes unreachable regardless of what runs on the main thread afterwards. `startForeground()` is idempotent on the same service instance, so the subsequent calls in `onStartCommand` remain safe re-promotes.

2. **Add a "Stop" notification action.** The service already exposes `ACTION_STOP` through `onStartCommand`. The new action routes back through that handler via `PendingIntent.getForegroundService` on Android O+ (`getService` on older releases), so no separate `BroadcastReceiver` is required and the delivery stays legal under the background service-start restrictions that apply when the user taps the action from the notification shade while the app is backgrounded.

## Why the promotion is safe

- `onCreate` runs on the main thread, exactly once per service instance, before `onStartCommand`.
- The notification channel is created in `onCreate` before the `startForeground` call, so the channel always exists first.
- The `try / catch (Exception)` guards against transient permission or notification-manager failures on unusual OEM builds; the existing `onStartCommand` path continues to re-promote afterwards.
- The `ACTION_STOP` handler still cleans up via `stopForeground(STOP_FOREGROUND_REMOVE)` + `stopSelf()` — the promoted state is torn down correctly.

## Impact

This fix has been shipping in-app in MINE via a `patch-package` override since v67. Filing upstream so MINE can drop the patch on the next `mesh-sdk` release.

## Notes

- Comments in the new code describe the invariant in plain language — no Linear or Sentry IDs in source per MINE's style guide.
- Retires [Linear OFF-1801](https://linear.app/offlineprotocol/issue/OFF-1801) on the MINE side.
- Part of a 3-PR patch-elimination series against #279 (BLE scan-site `IllegalStateException` catch) and #280 (`connectGatt` null-guard). All three retire the same MINE-side `mesh-sdk` patch.