### PR TITLE
fix(bindings): catch IllegalStateException from BluetoothLeScanner scan sites

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -1412,6 +1412,15 @@ class BleTransportFacade(
             Log.e(TAG, "Permission denied while starting scan", e)
             emitDiagnostic("error", "Permission denied while starting scan", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
             throw e
+        } catch (e: IllegalStateException) {
+            // The BT adapter can transition off between the isScanning check
+            // above and BluetoothLeScanner.startScan below. When that races,
+            // the framework throws IllegalStateException("BT Adapter is not
+            // turned ON") from the scanner. Log and swallow so the scan
+            // watchdog's restart path does not crash the app the moment the
+            // user toggles Bluetooth off mid-session.
+            Log.i(TAG, "Skipping startScan — BT adapter not on: ${e.message}")
+            emitDiagnostic("info", "Skipping startScan — BT adapter not on", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
         }
     }
     
@@ -1455,6 +1464,21 @@ class BleTransportFacade(
         } catch (e: SecurityException) {
             Log.e(TAG, "Permission denied while stopping scan", e)
             emitDiagnostic("error", "Permission denied while stopping scan", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
+        } catch (e: IllegalStateException) {
+            // The BT adapter can transition off between the isScanning check
+            // above and BluetoothLeScanner.stopScan below. When that races,
+            // the framework throws IllegalStateException("BT Adapter is not
+            // turned ON") from the scanner. Log and swallow, and mirror the
+            // post-stopScan cleanup here so state does not hang half-torn-
+            // down — leaving isScanning true would block the next start.
+            Log.i(TAG, "Skipping stopScan — BT adapter not on: ${e.message}")
+            scanCallback = null
+            isScanning = false
+            cancelScanWatchdog()
+            cancelConnectionMonitor()
+            lastDiscoveryAt = 0L
+            discoveryLogTimestamps.clear()
+            emitDiagnostic("info", "Skipping stopScan — BT adapter not on", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
         }
     }
     


### PR DESCRIPTION
## Problem

`BleTransportFacade.startScanning` and `stopScanning` currently catch `SecurityException` around their `BluetoothLeScanner.startScan` / `stopScan` calls. The framework also throws `IllegalStateException("BT Adapter is not turned ON")` from both when the adapter transitions off between the facade's `isScanning` check and the scanner call.

The scan watchdog restart path is a straight `stopScanning("restart_...")` followed by `startScanning("restart_...")` on a fixed cadence, so the watchdog fires the adapter-off race the moment the user toggles Bluetooth off mid-session and crashes the host app.

## Fix

Add `catch (IllegalStateException)` handlers next to the existing `SecurityException` handlers on both scan sites.

- `startScanning`: log at info, emit an info-level diagnostic, and return normally so the watchdog's retry cadence continues without escalating.
- `stopScanning`: log at info, emit the diagnostic, **and mirror the post-`stopScan` cleanup** — clear `scanCallback`, `isScanning`, cancel the scan watchdog and the connection monitor, reset `lastDiscoveryAt` and `discoveryLogTimestamps`. Without the cleanup, `isScanning` stays true and the next `startScanning` call short-circuits at its guard.

## Why info-level

The adapter-off race is a user action, not an SDK error. Emitting at info lets integrators track its frequency without polluting their error dashboards.

## Impact

Four users crashed on the pre-patch version of the MINE app before this shipped as a `patch-package` override. Filing upstream so MINE can drop the patch on the next `mesh-sdk` release.

## Notes

- Diff is purely additive.
- Comments describe the invariant in plain language — no Linear or Sentry IDs in source per MINE's style guide.
- Retires [Linear OFF-1896](https://linear.app/offlineprotocol/issue/OFF-1896) on the MINE side.
- Part of a 3-PR patch-elimination series against #278 (foreground-service promotion + Stop action) and #280 (`connectGatt` null-guard). All three retire the same MINE-side `mesh-sdk` patch.