### PR TITLE
fix(bindings): null-guard BluetoothDevice.connectGatt return in connectToDevice

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -2072,6 +2072,26 @@ class BleTransportFacade(
                 }
                 
                 val gatt = device.connectGatt(context, false, centralClient.callback, BluetoothDevice.TRANSPORT_LE)
+                if (gatt == null) {
+                    // BluetoothDevice.connectGatt is declared @Nullable in the
+                    // Android framework — Kotlin treats it as a platform type,
+                    // but MeshConnectionRegistry.registerGatt takes a non-null
+                    // BluetoothGatt, so a null return trips the compiler-
+                    // inserted Intrinsics.checkNotNullParameter and crashes
+                    // with NullPointerException. connectGatt returns null when
+                    // the adapter has just turned off, the underlying hardware
+                    // handle is stale, or the device unbonded between scan and
+                    // connect — the same adapter-race conditions that motivate
+                    // the SecurityException handler below. Release the pending
+                    // role reserved for this address (mirroring the RSSI and
+                    // connection-cap skip paths above) so state does not hang
+                    // half-set-up, and emit a diagnostic so callers can see
+                    // how often the race fires in the field.
+                    Log.i(TAG, "connectGatt returned null for ${device.address} — adapter unavailable")
+                    emitDiagnostic("info", "Skipping connectGatt — adapter unavailable", mapOf("address" to device.address))
+                    connections.consumePendingRole(device.address)
+                    return
+                }
                 connections.registerGatt(device.address, gatt)
             }
             


### PR DESCRIPTION
## Problem

`BluetoothDevice.connectGatt` is declared `@Nullable` in the Android framework. Kotlin treats the return as a platform type, but `MeshConnectionRegistry.registerGatt` takes a non-null `BluetoothGatt`, so a null return trips the compiler-inserted `Intrinsics.checkNotNullParameter` and crashes with `NullPointerException`.

`connectGatt` returns null when the adapter has just turned off, when the underlying hardware handle is stale, or when the device unbonded between scan and connect — the same adapter-race conditions that already motivate the `SecurityException` handler at the tail of `connectToDevice`.

## Fix

Guard the `connectGatt` return before it reaches `registerGatt`. On null:

- Log at info and emit an info-level diagnostic (adapter-off is a user action, not an SDK error).
- Call `connections.consumePendingRole(device.address)` to release the pending role reserved for this address. This mirrors the RSSI-skip, connection-cap, and `SecurityException` paths — without it, the pending-role reservation leaks and blocks future connection attempts to that address.
- `return` out of the `synchronized(connectionLock) { ... }` block, matching the early-return convention used by the existing skip paths in the same block.

## Why this is a real crash and not theoretical

Same adapter-off race as the `IllegalStateException` scan-site crashes filed as a sibling PR. Three users, three events on the pre-patch version of the MINE app before this shipped as a `patch-package` override.

## Notes

- Diff is purely additive.
- Comments describe the invariant in plain language — no Linear or Sentry IDs in source per MINE's style guide.
- Retires [Linear OFF-1985](https://linear.app/offlineprotocol/issue/OFF-1985) on the MINE side.
- Part of a 3-PR patch-elimination series against #278 (foreground-service promotion + Stop action) and #279 (BLE scan-site `IllegalStateException` catch). All three retire the same MINE-side `mesh-sdk` patch.