### PR TITLE
docs: name the NSA recipient in the export notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Offline Protocol SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This changelog covers everything after the **v0.7.1** release.
 
+## [Unreleased]
+
+### Documentation
+
+- **The export notice now names both recipients of the §742.15(b) notification.** [15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15) requires notifying *two* parties of the Internet location of publicly available encryption source code — BIS at `crypt@bis.doc.gov` **and** the ENC Encryption Request Coordinator at the NSA, at `enc@nsa.gov` — and the notice as shipped in 0.19.0 named only BIS. Both were notified; only the document was incomplete. Since the whole "not subject to the EAR under [§734.7(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7)" conclusion is conditioned on that notification, a notice that describes it as half-made understates the basis for the conclusion it draws. The paragraph addressed to app teams whose own application is open source — for whom the notification duty on their own source location is theirs — now says the duty runs to both addresses, since a developer following that sentence would otherwise file with one. No code, packaging, or license-surface change: `EXPORT.md` still ships in the npm package, the Python wheel, and the GitHub release assets, and the three copies stay byte-identical under `scripts/check-license-consistency.sh`.
+
 ## [0.19.0] — 2026-08-04
 
 > **Two receive-side behaviours tighten on first launch.** Cleartext from a peer

--- a/EXPORT.md
+++ b/EXPORT.md
@@ -16,9 +16,11 @@ Classification Number (ECCN) 5D002 of the U.S. Export Administration
 Regulations (EAR, 15 CFR parts 730–774).
 
 The source code of the SDK is publicly available without restriction, and
-Offline Protocol, Inc. has notified the U.S. Bureau of Industry and Security
-(BIS) of its Internet location as described in
-[15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15).
+Offline Protocol, Inc. has notified both recipients named in
+[15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15)
+of its Internet location: the U.S. Bureau of Industry and Security (BIS), at
+crypt@bis.doc.gov, and the ENC Encryption Request Coordinator at the National
+Security Agency (NSA), at enc@nsa.gov.
 Publicly available encryption source code for which that notification has been
 made is not subject to the EAR under
 [15 CFR §734.7(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7),
@@ -51,7 +53,8 @@ specifics with your own counsel:
 
 If your application is itself open source, the publicly-available treatment
 described above may extend to it as well — in which case the §742.15(b)
-notification duty for your own source location is yours.
+notification duty for your own source location is yours, and runs to both
+addresses above.
 
 ## Not legal advice
 

--- a/bindings/python/EXPORT.md
+++ b/bindings/python/EXPORT.md
@@ -16,9 +16,11 @@ Classification Number (ECCN) 5D002 of the U.S. Export Administration
 Regulations (EAR, 15 CFR parts 730–774).
 
 The source code of the SDK is publicly available without restriction, and
-Offline Protocol, Inc. has notified the U.S. Bureau of Industry and Security
-(BIS) of its Internet location as described in
-[15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15).
+Offline Protocol, Inc. has notified both recipients named in
+[15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15)
+of its Internet location: the U.S. Bureau of Industry and Security (BIS), at
+crypt@bis.doc.gov, and the ENC Encryption Request Coordinator at the National
+Security Agency (NSA), at enc@nsa.gov.
 Publicly available encryption source code for which that notification has been
 made is not subject to the EAR under
 [15 CFR §734.7(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7),
@@ -51,7 +53,8 @@ specifics with your own counsel:
 
 If your application is itself open source, the publicly-available treatment
 described above may extend to it as well — in which case the §742.15(b)
-notification duty for your own source location is yours.
+notification duty for your own source location is yours, and runs to both
+addresses above.
 
 ## Not legal advice
 

--- a/bindings/react-native/EXPORT.md
+++ b/bindings/react-native/EXPORT.md
@@ -16,9 +16,11 @@ Classification Number (ECCN) 5D002 of the U.S. Export Administration
 Regulations (EAR, 15 CFR parts 730–774).
 
 The source code of the SDK is publicly available without restriction, and
-Offline Protocol, Inc. has notified the U.S. Bureau of Industry and Security
-(BIS) of its Internet location as described in
-[15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15).
+Offline Protocol, Inc. has notified both recipients named in
+[15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15)
+of its Internet location: the U.S. Bureau of Industry and Security (BIS), at
+crypt@bis.doc.gov, and the ENC Encryption Request Coordinator at the National
+Security Agency (NSA), at enc@nsa.gov.
 Publicly available encryption source code for which that notification has been
 made is not subject to the EAR under
 [15 CFR §734.7(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7),
@@ -51,7 +53,8 @@ specifics with your own counsel:
 
 If your application is itself open source, the publicly-available treatment
 described above may extend to it as well — in which case the §742.15(b)
-notification duty for your own source location is yours.
+notification duty for your own source location is yours, and runs to both
+addresses above.
 
 ## Not legal advice
 


### PR DESCRIPTION
## Summary

`EXPORT.md` (shipped in #276, released in v0.19.0) states that Offline Protocol, Inc. made the [15 CFR §742.15(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-742/section-742.15) notification — and named only BIS as the recipient. That section requires notifying **two** parties: BIS at `crypt@bis.doc.gov` **and** the ENC Encryption Request Coordinator at the NSA, at `enc@nsa.gov`. Both were notified; only the document was incomplete.

It matters where it sits. The document's whole conclusion — that this source and the object code built from it are **not subject to the EAR** under [§734.7(b)](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-734/section-734.7) — is conditioned on that notification having been made. Describing it as half-made understates the basis for the claim the notice exists to make.

The second edit is the one with a downstream victim. The closing paragraph tells app teams whose own application is open source that the §742.15(b) duty for their own source location is theirs. As written, a developer following it would have filed with BIS and stopped — inheriting exactly the gap this PR closes. It now says the duty runs to both addresses.

## Changes

- **`EXPORT.md`** (root + the byte-identical npm and PyPI copies) — the company-status paragraph names both recipients and both addresses; the open-source-app paragraph says the duty runs to both.
- **`CHANGELOG.md`** — `[Unreleased] → Documentation` entry.

The notification email text itself stays out of the repo, per the standing instruction from #276. Naming who you file with is regulatory description, not the filing.

## Related issues

None.

## Type of change

- [x] `docs` — documentation only

## Checklist

- [x] `scripts/check-license-consistency.sh` passes (the three `EXPORT.md` copies are byte-identical)
- [x] Commits follow Conventional Commits
- [x] Docs / `CHANGELOG.md` updated
- [ ] Rust gates (`fmt`/`clippy`/`test`/`cargo-deny`) — no code touched; CI will confirm

## Breaking changes

None.

## Notes for reviewers

- **Citation verified, not recalled.** eCFR blocks automated fetches, so §742.15(b) was confirmed against Cornell LII: recipients are BIS and the ENC Encryption Request Coordinator, at `crypt@bis.doc.gov` and `enc@nsa.gov`. The coordinator sits at NSA (Ft. Meade) per Supplement No. 3 to Part 742, which is what the `enc@nsa.gov` address reflects.
- **No recall needed for the published 0.19.0 artifacts.** With both emails now sent, the shipped text ("has notified BIS") is true — just incomplete. That's an omission, not a misstatement, and it corrects itself with the next release.
- **Open question:** whether to also record the notification date in `EXPORT.md`. Useful as evidence of compliance, but it's a factual claim, so it was left out rather than guessed. Say the date and I'll add it.
- The counsel-review gate from #276 still applies to this document as a whole; this PR doesn't change that.