### PR TITLE
fix(bindings): run mesh teardown to completion and clear the stop slot by identity

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
@@ -71,7 +71,7 @@ class MeshForegroundService : Service() {
 
         /**
          * Callback invoked when the user taps "Stop" on the service
-         * notification. The host module must set this and run the same
+         * notification. The host module must register one and run the same
          * teardown as its JS-facing `stop()`: this service is only a
          * keep-alive, so dropping it alone would leave BLE/WiFi-Direct/Nostr
          * and the process scheduler running with no foreground protection and
@@ -79,11 +79,46 @@ class MeshForegroundService : Service() {
          * radios keep draining until the OS reaps the process.
          *
          * Held in a companion field, so a host that captures itself here must
-         * null it out on teardown or it pins that host for the process
-         * lifetime.
+         * drop it on teardown or it pins that host for the process lifetime.
+         * Mutated only through [registerStopRequestCallback] and
+         * [clearStopRequestCallback] — see the latter for why a host may not
+         * simply null it.
          */
         @Volatile
         var onStopRequestedByUser: (() -> Unit)? = null
+            private set
+
+        /**
+         * Serializes register against clear so the compare-and-clear in
+         * [clearStopRequestCallback] cannot lose a registration that lands
+         * between its read and its write.
+         */
+        private val stopCallbackLock = Any()
+
+        /** Installs [callback] as the host to hand a user-initiated stop to. */
+        fun registerStopRequestCallback(callback: () -> Unit) {
+            synchronized(stopCallbackLock) {
+                onStopRequestedByUser = callback
+            }
+        }
+
+        /**
+         * Drops [callback], but only while it is still the registered one.
+         *
+         * The slot is process-global while hosts are per-ReactContext, and the
+         * two overlap: during a React reload a new module can register before
+         * the old one tears down. An unconditional null there would disarm the
+         * *new* host's Stop action, and the button would then drop the
+         * keep-alive while the mesh it belongs to keeps running — the exact
+         * failure [onStopRequestedByUser] exists to prevent.
+         */
+        fun clearStopRequestCallback(callback: () -> Unit) {
+            synchronized(stopCallbackLock) {
+                if (onStopRequestedByUser === callback) {
+                    onStopRequestedByUser = null
+                }
+            }
+        }
 
         fun start(context: Context) {
             startRequested = true

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -51,6 +51,19 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
     private var reticulumManager: ReticulumManager? = null
     private var nostrManager: NostrManager? = null
     private var processScheduler: ScheduledExecutorService? = null
+
+    /**
+     * Our registration in [MeshForegroundService]'s process-global stop slot,
+     * kept so teardown can clear it by identity rather than unconditionally.
+     * See [releaseForegroundStopCallback].
+     *
+     * Volatile because `start()` writes it from the JS thread while
+     * [invalidate] reads it from React Native's teardown, with no lock between
+     * them: a stale read there would skip the clear and leave this module — and
+     * its ReactContext — pinned by the companion field.
+     */
+    @Volatile
+    private var foregroundStopCallback: (() -> Unit)? = null
     private var listenerCount: Int = 0
     private var currentConfig: ProtocolConfig? = null
     private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
@@ -87,25 +100,68 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
 
     override fun getName(): String = NAME
 
+    /**
+     * Deliberately NOT `@Synchronized`, and deliberately inline rather than
+     * routed through [stopTransportsAndProtocol]: React Native may call this
+     * while holding its own teardown lock, so taking the module monitor here —
+     * and holding it across calls that reach back into RN internals — is a
+     * lock-order inversion. The residual is a double-stop of a transport racing
+     * `stop()`, which every transport tolerates. Please don't "fix" that by
+     * adding the annotation.
+     *
+     * The steps still run through [TeardownSequence] — a plain helper that
+     * takes no locks, so it does not reintroduce that inversion — because a
+     * throwing transport must not skip the ones after it, the keep-alive
+     * service, or the callback clear that unpins this module. Failures only
+     * reach logcat: `invalidate` has no error channel, and reporting through
+     * [emitDiagnostic] would push events into a ReactContext that is already
+     * going down.
+     */
     override fun invalidate() {
         super.invalidate()
-        reactApplicationContext.removeLifecycleEventListener(this)
-        stopProcessScheduler()
-        bleTransport?.stop()
+        val teardown = TeardownSequence()
+
+        teardown.step("lifecycle listener") {
+            reactApplicationContext.removeLifecycleEventListener(this)
+        }
+        teardown.step("process scheduler") { stopProcessScheduler() }
+
+        // The null-outs sit outside their steps so a transport that throws on
+        // stop is still released.
+        teardown.step("BLE manager") { bleTransport?.stop() }
         bleTransport = null
-        internetManager?.stop()
+        teardown.step("Internet manager") { internetManager?.stop() }
         internetManager = null
-        wifiDirectManager?.stop()
+        teardown.step("WiFi Direct manager") { wifiDirectManager?.stop() }
         wifiDirectManager = null
-        reticulumManager?.stop()
+        teardown.step("Reticulum manager") { reticulumManager?.stop() }
         reticulumManager = null
-        nostrManager?.stop()
+        teardown.step("Nostr manager") { nostrManager?.stop() }
         nostrManager = null
         protocol = null
-        stopForegroundService()
-        // Companion field capturing this module — drop it or the module and
-        // its ReactContext outlive teardown.
-        MeshForegroundService.onStopRequestedByUser = null
+
+        teardown.step("mesh foreground service") { stopForegroundService() }
+        releaseForegroundStopCallback()
+
+        for (failure in teardown.failures) {
+            android.util.Log.w(NAME, "Teardown step failed during invalidate: ${failure.step}", failure.cause)
+        }
+    }
+
+    /**
+     * Drops this module's registration from [MeshForegroundService] — a
+     * companion field that captures the module, so leaving it set outlives the
+     * module and its ReactContext for the process lifetime.
+     *
+     * Clears by identity: the slot is process-global while modules are
+     * per-ReactContext, so during a reload this module may be tearing down
+     * *after* its replacement registered, and an unconditional null would
+     * disarm the live host's Stop action.
+     */
+    private fun releaseForegroundStopCallback() {
+        val ours = foregroundStopCallback ?: return
+        foregroundStopCallback = null
+        MeshForegroundService.clearStopRequestCallback(ours)
     }
 
     // MARK: - Host lifecycle (foreground relay heal)
@@ -1012,52 +1068,72 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
      *
      * Synchronized because those two callers run on different threads and can
      * overlap — a notification Stop while the app foregrounds and calls `stop()`.
-     * Interleaved passes double-stop the transports mid-teardown, and a throw on
-     * both leaves every later step unreached while the user-stop path still
-     * reports the mesh down. Serialized, the second entrant re-runs the stops
-     * after a completed first pass, which is their idempotent no-op path.
+     * Interleaved passes double-stop the transports mid-teardown. Serialized,
+     * the second entrant re-runs the stops after a completed first pass, which
+     * is their idempotent no-op path.
      *
-     * The keep-alive and the core come down in `finally`: a transport that
-     * throws must not strand the notification advertising an active mesh, nor
-     * leave the core ticking its outbox against stopped transports. The
-     * exception still propagates, so [stop] rejects as it did before.
+     * Every step runs through [TeardownSequence], so a transport that throws
+     * cannot skip the ones after it, strand the notification advertising an
+     * active mesh, or leave the core ticking its outbox against stopped
+     * transports. A BLE stop reaches `stopScan` on an adapter the user may have
+     * just switched off, which throws `IllegalStateException` back across
+     * `runOnMainSync` — and BLE is the first transport in the sequence. The
+     * first failure is rethrown once the rest are down, so [stop] still rejects
+     * with the same cause it did before.
      */
     @Synchronized
     private fun stopTransportsAndProtocol() {
-        try {
-            stopProcessScheduler()
+        val teardown = TeardownSequence()
 
-            // Stop BLE manager first
+        teardown.step("process scheduler") { stopProcessScheduler() }
+
+        teardown.step("BLE manager") {
             bleTransport?.stop()
             android.util.Log.i(NAME, "BLE Manager stopped")
             emitDiagnostic("info", "BLE manager stopped")
+        }
 
-            // Stop Internet manager
+        teardown.step("Internet manager") {
             internetManager?.stop()
             android.util.Log.i(NAME, "Internet Manager stopped")
             emitDiagnostic("info", "Internet manager stopped")
+        }
 
-            // Stop WiFi Direct manager
+        teardown.step("WiFi Direct manager") {
             wifiDirectManager?.stop()
             android.util.Log.i(NAME, "WiFi Direct Manager stopped")
             emitDiagnostic("info", "WiFi Direct manager stopped")
+        }
 
-            // Stop Reticulum manager
+        teardown.step("Reticulum manager") {
             reticulumManager?.stop()
             android.util.Log.i(NAME, "Reticulum Manager stopped")
             emitDiagnostic("info", "Reticulum manager stopped")
+        }
 
-            // Stop Nostr manager
+        teardown.step("Nostr manager") {
             nostrManager?.stop()
             android.util.Log.i(NAME, "Nostr Manager stopped")
             emitDiagnostic("info", "Nostr manager stopped")
-        } finally {
-            // Stop foreground service
-            stopForegroundService()
+        }
 
+        teardown.step("mesh foreground service") { stopForegroundService() }
+
+        teardown.step("protocol core") {
             protocol?.stop()
             emitDiagnostic("info", "Protocol stopped")
         }
+
+        for (failure in teardown.failures) {
+            android.util.Log.e(NAME, "Teardown step failed: ${failure.step}", failure.cause)
+            emitDiagnostic("error", "Teardown step failed", mapOf(
+                "step" to failure.step,
+                "message" to (failure.cause.message ?: "unknown"),
+                "exception" to failure.cause.javaClass.simpleName
+            ))
+        }
+
+        teardown.firstFailureOrNull()?.let { throw it }
     }
 
     /**
@@ -1508,27 +1584,36 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         promise.resolve(messageJson)
     }
 
+    /**
+     * Tear the protocol down and release it, leaving the module able to
+     * [create] a fresh one.
+     *
+     * Runs the same teardown as [stop] rather than its own copy, which is also
+     * what brings the keep-alive service down: a `destroy` without a preceding
+     * `stop` used to leave a "Mesh Active" notification over a protocol that no
+     * longer existed. Sharing the path serializes it against a notification
+     * Stop running concurrently, too.
+     *
+     * A step that throws is logged, not propagated: the sequence has already
+     * run to completion by then, and `destroy` releasing its references is not
+     * conditional on every transport having stopped cleanly — a caller that
+     * could not destroy would have no way forward.
+     */
     @ReactMethod
     fun destroy(promise: Promise) {
         try {
-            stopProcessScheduler()
-            bleTransport?.stop()
-            bleTransport = null
-            internetManager?.stop()
-            internetManager = null
-            wifiDirectManager?.stop()
-            wifiDirectManager = null
-            reticulumManager?.stop()
-            reticulumManager = null
-            nostrManager?.stop()
-            nostrManager = null
-
             try {
-                protocol?.stop()
-            } catch (_: Exception) {
-                // Ignore stop errors during destroy
+                stopTransportsAndProtocol()
+            } catch (e: Exception) {
+                android.util.Log.w(NAME, "Teardown failed during destroy; releasing anyway", e)
             }
 
+            releaseForegroundStopCallback()
+            bleTransport = null
+            internetManager = null
+            wifiDirectManager = null
+            reticulumManager = null
+            nostrManager = null
             protocol = null
             meshServices = null
             listenerCount = 0
@@ -3884,10 +3969,13 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         try {
             // Register before the service exists, so the notification's Stop
             // action always has a host to defer to. The callback lives in a
-            // companion field and captures this module, so invalidate() must
-            // clear it or the module — and the ReactContext it holds — is
-            // pinned for the process lifetime.
-            MeshForegroundService.onStopRequestedByUser = { handleUserRequestedMeshStop() }
+            // companion field and captures this module, so teardown must clear
+            // it or the module — and the ReactContext it holds — is pinned for
+            // the process lifetime. Kept in a field so that clear can check it
+            // is still ours (see releaseForegroundStopCallback).
+            val stopCallback = { handleUserRequestedMeshStop() }
+            foregroundStopCallback = stopCallback
+            MeshForegroundService.registerStopRequestCallback(stopCallback)
             MeshForegroundService.start(reactApplicationContext)
             emitDiagnostic("info", "Mesh foreground service started")
         } catch (e: Exception) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/TeardownSequence.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/TeardownSequence.kt
@@ -1,0 +1,58 @@
+package com.offlineprotocol
+
+/**
+ * Runs a teardown to completion even when one of its steps throws, then hands
+ * the caller the failures it collected.
+ *
+ * A teardown here stops several independent things — the process scheduler,
+ * five transports, the keep-alive service, the protocol core. Written as a
+ * plain statement list, the first throw skips every step after it: one
+ * transport that fails to stop leaves the rest running, while the paths that
+ * *report* the teardown (the notification coming down, `mesh_stopped_by_user`
+ * reaching JS) still say the mesh is off. That is not hypothetical — a BLE stop
+ * runs `stopScan` on an adapter the user may have just turned off, and the
+ * resulting `IllegalStateException` crosses back to the caller. The steps do
+ * not depend on each other, so a failure in one must not decide whether the
+ * others run.
+ *
+ * Failures are collected rather than reported inline: a reporter that throws
+ * would abort the very sequence it is describing, and a caller usually wants to
+ * report only once everything is actually down. [firstFailureOrNull] is what a
+ * caller rethrows to keep its own error contract — it is the exception that
+ * would have propagated before, so a `stop()` still rejects with the same
+ * cause, just after the remaining steps have run.
+ *
+ * Only [Exception] is caught. An [Error] is not "a step failed", it means the
+ * process is already in trouble, so it propagates immediately and abandons the
+ * rest — which is what it should do.
+ *
+ * Not thread-safe: one sequence belongs to one teardown pass on one thread.
+ */
+class TeardownSequence {
+
+    /** A step that threw, named as the caller named it. */
+    data class Failure(val step: String, val cause: Exception)
+
+    private val collected = mutableListOf<Failure>()
+
+    /** The failures so far, in the order they happened. */
+    val failures: List<Failure> get() = collected
+
+    /**
+     * Runs [action], recording a throw against [step] instead of propagating
+     * it, so the steps that follow still run.
+     */
+    fun step(step: String, action: () -> Unit) {
+        try {
+            action()
+        } catch (e: Exception) {
+            collected.add(Failure(step, e))
+        }
+    }
+
+    /**
+     * The first failure's cause, for callers that must still surface one — a
+     * `stop()` rejecting its promise. Null when every step ran clean.
+     */
+    fun firstFailureOrNull(): Exception? = collected.firstOrNull()?.cause
+}

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
@@ -32,7 +32,10 @@ import org.robolectric.annotation.Config
  * The second is the notification's Stop action, which must reach the host
  * module rather than stopping this service directly. Dropping the keep-alive
  * on its own leaves the transports and the process scheduler running with no
- * foreground protection and nothing told to JS.
+ * foreground protection and nothing told to JS. That includes reaching the
+ * *right* host: the callback slot is process-global while hosts are
+ * per-ReactContext, so clearing it is by identity and a departing host must
+ * leave its replacement armed.
  *
  * Action strings are written out verbatim rather than read from the companion:
  * they cross a process boundary inside a PendingIntent that can outlive the
@@ -56,6 +59,9 @@ class MeshForegroundServiceTest {
 
     private var controller: ServiceController<MeshForegroundService>? = null
 
+    /** Every stop callback this test registered, so tearDown can clear them. */
+    private val registeredStopCallbacks = mutableListOf<() -> Unit>()
+
     /**
      * `isRunning` and the internal start-request flag are companion state, so
      * they outlive an individual test. Destroying the instance clears both
@@ -65,15 +71,25 @@ class MeshForegroundServiceTest {
      * A test that calls `start()` without ever creating an instance leaves the
      * start-request flag set with no `onDestroy` to clear it, so `stop()` runs
      * unconditionally here too — it no-ops once both flags are already down.
+     *
+     * The stop slot is cleared by identity like production does, which means
+     * clearing every callback registered here rather than nulling the field.
      */
     @After
     fun tearDown() {
-        MeshForegroundService.onStopRequestedByUser = null
+        registeredStopCallbacks.forEach { MeshForegroundService.clearStopRequestCallback(it) }
+        registeredStopCallbacks.clear()
         MeshForegroundService.onServiceRestarted = null
         controller?.destroy()
         controller = null
         MeshForegroundService.stop(context)
         drainStartedServices()
+    }
+
+    private fun registerHost(callback: () -> Unit): () -> Unit {
+        registeredStopCallbacks.add(callback)
+        MeshForegroundService.registerStopRequestCallback(callback)
+        return callback
     }
 
     private fun createService(): MeshForegroundService {
@@ -134,7 +150,7 @@ class MeshForegroundServiceTest {
     @Test
     fun `stop action defers to the host and leaves the keep-alive up`() {
         var invoked = 0
-        MeshForegroundService.onStopRequestedByUser = { invoked += 1 }
+        registerHost { invoked += 1 }
 
         createService()
         val service = deliver(ACTION_STOP_FROM_NOTIFICATION)
@@ -151,7 +167,7 @@ class MeshForegroundServiceTest {
 
     @Test
     fun `stop action still drops the keep-alive when no host is registered`() {
-        MeshForegroundService.onStopRequestedByUser = null
+        assertNull(MeshForegroundService.onStopRequestedByUser)
 
         createService()
         val service = deliver(ACTION_STOP_FROM_NOTIFICATION)
@@ -165,13 +181,54 @@ class MeshForegroundServiceTest {
 
     @Test
     fun `stop action falls back to stopping itself when the host callback throws`() {
-        MeshForegroundService.onStopRequestedByUser = { throw IllegalStateException("host is gone") }
+        registerHost { throw IllegalStateException("host is gone") }
 
         createService()
         val service = deliver(ACTION_STOP_FROM_NOTIFICATION)
 
         assertTrue(shadowOf(service).isStoppedBySelf)
         assertFalse(MeshForegroundService.isRunning)
+    }
+
+    @Test
+    fun `a host clearing its own registration disarms the stop action`() {
+        var invoked = 0
+        val callback = registerHost { invoked += 1 }
+
+        MeshForegroundService.clearStopRequestCallback(callback)
+
+        createService()
+        val service = deliver(ACTION_STOP_FROM_NOTIFICATION)
+
+        assertEquals("a cleared host must not be called", 0, invoked)
+        assertNull(MeshForegroundService.onStopRequestedByUser)
+        // Nothing left to defer to, so the button falls back to dropping the
+        // keep-alive rather than doing nothing.
+        assertTrue(shadowOf(service).isStoppedBySelf)
+    }
+
+    @Test
+    fun `a stale host clearing after a newer one registered leaves the newer one armed`() {
+        var staleInvoked = 0
+        var currentInvoked = 0
+        // The slot is process-global while modules are per-ReactContext: during
+        // a React reload the replacement registers before the outgoing module
+        // tears down. An unconditional null there would disarm the live host
+        // and the Stop button would drop the keep-alive over a running mesh.
+        val stale = registerHost { staleInvoked += 1 }
+        registerHost { currentInvoked += 1 }
+
+        MeshForegroundService.clearStopRequestCallback(stale)
+
+        createService()
+        val service = deliver(ACTION_STOP_FROM_NOTIFICATION)
+
+        assertEquals("a stale clear must not disarm the current host", 1, currentInvoked)
+        assertEquals(0, staleInvoked)
+        assertFalse(
+            "the current host owns teardown, so the keep-alive stays up",
+            shadowOf(service).isStoppedBySelf
+        )
     }
 
     @Test

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/TeardownSequenceTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/TeardownSequenceTest.kt
@@ -1,0 +1,96 @@
+package com.offlineprotocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Pins the one property the mesh teardown depends on: a step that throws must
+ * not decide whether the steps after it run.
+ *
+ * The teardown this backs stops five transports, the keep-alive service and the
+ * protocol core. Before this helper the first throw skipped everything after it
+ * — and since BLE is stopped first, and its stop reaches `stopScan` on an
+ * adapter the user may have just switched off, that meant the remaining
+ * transports kept running while the notification came down and JS was told the
+ * mesh was off.
+ */
+class TeardownSequenceTest {
+
+    @Test
+    fun `a throwing step does not stop the ones after it`() {
+        val ran = mutableListOf<String>()
+        val teardown = TeardownSequence()
+
+        teardown.step("scheduler") { ran.add("scheduler") }
+        teardown.step("ble") {
+            ran.add("ble")
+            throw IllegalStateException("BT adapter is off")
+        }
+        teardown.step("internet") { ran.add("internet") }
+        teardown.step("keep-alive") { ran.add("keep-alive") }
+
+        assertEquals(listOf("scheduler", "ble", "internet", "keep-alive"), ran)
+    }
+
+    @Test
+    fun `failures are collected in order and named by their step`() {
+        val teardown = TeardownSequence()
+        val bleFailure = IllegalStateException("BT adapter is off")
+        val nostrFailure = RuntimeException("relay socket already closed")
+
+        teardown.step("ble") { throw bleFailure }
+        teardown.step("internet") { }
+        teardown.step("nostr") { throw nostrFailure }
+
+        assertEquals(2, teardown.failures.size)
+        assertEquals("ble", teardown.failures[0].step)
+        assertSame(bleFailure, teardown.failures[0].cause)
+        assertEquals("nostr", teardown.failures[1].step)
+        assertSame(nostrFailure, teardown.failures[1].cause)
+    }
+
+    @Test
+    fun `the first failure is the one a caller rethrows`() {
+        val teardown = TeardownSequence()
+        val first = IllegalStateException("first")
+
+        teardown.step("ble") { throw first }
+        teardown.step("nostr") { throw RuntimeException("second") }
+
+        // stop() rejects with this, so it must stay the exception that would
+        // have propagated before — later failures must not displace it.
+        assertSame(first, teardown.firstFailureOrNull())
+    }
+
+    @Test
+    fun `a clean sequence reports nothing`() {
+        val teardown = TeardownSequence()
+
+        teardown.step("ble") { }
+        teardown.step("internet") { }
+
+        assertTrue(teardown.failures.isEmpty())
+        assertNull(teardown.firstFailureOrNull())
+    }
+
+    @Test
+    fun `an Error is not treated as a failed step`() {
+        val teardown = TeardownSequence()
+
+        // OutOfMemory/StackOverflow mean the process is already in trouble;
+        // pressing on with teardown would be the wrong call, so Errors are not
+        // swallowed the way a transport's Exception is.
+        try {
+            teardown.step("ble") { throw OutOfMemoryError("heap") }
+            fail("an Error must propagate rather than be recorded")
+        } catch (expected: OutOfMemoryError) {
+            assertEquals("heap", expected.message)
+        }
+
+        assertTrue(teardown.failures.isEmpty())
+    }
+}


### PR DESCRIPTION
Follow-up to #278, from its review. Two fixes on the mesh teardown path, plus the `destroy()` unification that falls out of the first.

## 1. A throwing step no longer skips the rest of the teardown

`stopTransportsAndProtocol()` stopped five transports inside a single `try`, with only the keep-alive service and the protocol core in `finally`. The first throw skipped every step after it.

That is reachable, not theoretical: `BleTransportFacade.stop()` → `runOnMainSync { stopUnsafe() }` **rethrows on the calling thread** (`Result.getOrThrow()`), and `stopUnsafe()` has unguarded throwers — `stopScanning()` catches only `SecurityException`, so the `IllegalStateException` from `stopScan()` with the adapter off (the class #279 targets) propagates out. BLE is stopped *first*, so one such throw left Internet, WiFi Direct, Reticulum and Nostr running while the `finally` tail removed the notification and the notification path emitted `mesh_stopped_by_user`.

That is verbatim the failure the `onStopRequestedByUser` doc comment warns about: *"the user sees 'mesh off' while the radios keep draining until the OS reaps the process."*

Every step now runs through a new `TeardownSequence`:

- each step runs regardless of what the ones before it did;
- failures are collected in order rather than reported inline (a reporter that throws would abort the very sequence it is describing);
- the first failure is rethrown once the rest are down, so `stop()` still rejects with the same cause it did before — just after the mesh is actually down;
- `Error` propagates rather than being collected. An `Error` is not "a step failed", it means the process is already in trouble.

`invalidate()` uses the helper too. It **keeps** its inline, unsynchronized teardown — routing it through the shared `@Synchronized` path would take the module monitor while React Native may hold its own teardown lock, a lock-order inversion — but a throwing transport no longer strands the ones after it, the keep-alive, or the callback clear that unpins the module. `TeardownSequence` takes no locks, so it does not reintroduce that inversion. Failures there go to logcat only: `invalidate` has no error channel, and reporting through `emitDiagnostic` would push events into a ReactContext that is already going down.

## 2. The stop callback is cleared by identity

`MeshForegroundService.onStopRequestedByUser` is process-global while modules are per-ReactContext, and a React reload overlaps them. An outgoing module calling `invalidate()` *after* its replacement registered nulled the **live** host's callback — the Stop button would then drop the keep-alive without stopping the mesh, which is the same failure mode the callback exists to prevent.

Registration and clearing now go through a synchronized `registerStopRequestCallback` / `clearStopRequestCallback` pair (the setter is private, so the compare-and-clear cannot lose a registration landing between its read and its write), and the module clears only its own registration.

## 3. `destroy()` shares the teardown path

`destroy()` was a third copy of the sequence — unserialized against the new `mesh-user-stop` thread, carrying the same first-throw-skips-the-rest bug, and it never stopped the foreground service, so a `destroy` without a preceding `stop` left a "Mesh Active" notification over a protocol that no longer existed.

It now calls the shared path. It logs rather than propagates a teardown failure: the sequence has already run to completion by then, and releasing its references is not conditional on every transport having stopped cleanly — a caller that could not `destroy` would have no way forward (`wipePersistedState` runs after it). The failure is still visible to apps, since `stopTransportsAndProtocol` emits its own `Teardown step failed` diagnostic before throwing.

## Tests

`TeardownSequenceTest` (new, 5 cases) pins the helper: all steps run past a throw, failures are collected in order and named, the first failure is the one a caller rethrows, a clean sequence reports nothing, and an `Error` is not swallowed.

`MeshForegroundServiceTest` gains two cases for the identity guard — clearing your own registration disarms the action, and a stale host clearing after a newer one registered leaves the newer one armed. Verified non-vacuous: reverting the identity check to an unconditional null fails exactly the stale-clear test and nothing else.

Full Android JVM suite green locally (261 tests, 0 failures) via the standalone CI harness.

## Not in this PR

Both remain open from the #278 review and need work outside this path:

- #291 — `MeshForegroundService.onServiceRestarted` is declared and invoked but never assigned, so after a START_STICKY restart the notification advertises a mesh that was never re-initialized. Wiring it needs JS involvement (config to rebuild).
- #292 — `sendEvent` drops events when `listenerCount == 0`, so a user-initiated stop while JS has no listeners loses `mesh_stopped_by_user` permanently. Fixing it needs buffering in the bridge event model.
