### PR TITLE
fix(bindings): recover BLE scanning after the adapter comes back on

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleRecoveryScheduler.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleRecoveryScheduler.kt
@@ -26,6 +26,17 @@ internal class BleRecoveryScheduler(
         nextDelayMs = (nextDelayMs * 2).coerceAtMost(maxDelayMs)
     }
 
+    /**
+     * A lifecycle resume can get scanning going after [cancel] removed the
+     * pending adapter-recovery task. Keep the peripheral repair alive until
+     * the caller clears its adapter-off latch.
+     */
+    fun onScanStarted(adapterRecoveryPending: Boolean) {
+        if (adapterRecoveryPending) {
+            schedule()
+        }
+    }
+
     fun cancel(resetBackoff: Boolean = true) {
         handler.removeCallbacks(task)
         if (resetBackoff) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleRecoveryScheduler.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleRecoveryScheduler.kt
@@ -1,0 +1,39 @@
+package com.offlineprotocol.ble
+
+import android.os.Handler
+
+/**
+ * Owns the single pending BLE-recovery task and its capped backoff ladder.
+ * Cancelling deliberate lifecycle work resets the ladder; transient teardown
+ * can remove the pending task while preserving the next retry rung.
+ */
+internal class BleRecoveryScheduler(
+    private val handler: Handler,
+    private val task: Runnable,
+    private val minDelayMs: Long,
+    private val maxDelayMs: Long,
+) {
+    init {
+        require(minDelayMs > 0) { "minDelayMs must be positive" }
+        require(maxDelayMs >= minDelayMs) { "maxDelayMs must be at least minDelayMs" }
+    }
+
+    private var nextDelayMs = minDelayMs
+
+    fun schedule() {
+        handler.removeCallbacks(task)
+        handler.postDelayed(task, nextDelayMs)
+        nextDelayMs = (nextDelayMs * 2).coerceAtMost(maxDelayMs)
+    }
+
+    fun cancel(resetBackoff: Boolean = true) {
+        handler.removeCallbacks(task)
+        if (resetBackoff) {
+            nextDelayMs = minDelayMs
+        }
+    }
+
+    fun resetBackoff() {
+        nextDelayMs = minDelayMs
+    }
+}

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -246,6 +246,8 @@ class BleTransportFacade(
         private const val CONNECTION_TIMEOUT_MS = 10000L
         private const val SCAN_WATCHDOG_INTERVAL_MS = 30000L // Match iOS timing
         private const val SCAN_WATCHDOG_HEARTBEAT_MS = 10000L
+        /** Retry cadence for re-arming BLE after the adapter was found off (ms) */
+        private const val BLE_RECOVERY_RETRY_MS = 10000L
         private const val MAX_CONNECTIONS_PER_DEVICE = 4
         /** Min interval between connection-monitor reconnect attempts per
          *  device. Reconnect backoff on disconnect is owned by
@@ -773,7 +775,47 @@ class BleTransportFacade(
             mainHandler.postDelayed(this, SCAN_WATCHDOG_HEARTBEAT_MS)
         }
     }
-    
+
+    /**
+     * The one path back to a live BLE session after a start was refused because
+     * the adapter was off.
+     *
+     * Every other self-healing mechanism in this class — the scan watchdog, the
+     * connection monitor, the proactive and forced refreshes, and the adapter
+     * reset they escalate to — hangs off an active scan. So a start that cannot
+     * proceed leaves nothing on the handler to try again: the transport keeps
+     * reporting RUNNING while the mesh is deaf, until the app happens to call
+     * resume() or restart the transport. Re-arming the scan is what puts that
+     * whole chain back in motion, which is why this runnable only has to get
+     * scanning going again rather than rebuild the stack itself.
+     *
+     * Rescheduled from [startScanning] for as long as the adapter stays off, and
+     * cancelled by [stopScanning] so a paused or stopped transport cannot bring
+     * scanning back behind the app's back.
+     */
+    private val bleRecoveryRunnable = object : Runnable {
+        override fun run() {
+            if (state != TransportState.RUNNING || isScanning) {
+                return
+            }
+            // Re-acquire the scanner before retrying: getBluetoothLeScanner()
+            // yields null while the adapter is off, so the instance cached at
+            // start (or nulled by an adapter reset that ran while it was off)
+            // can belong to a dead adapter session. Only overwrite on a
+            // non-null read, so a still-working cached scanner is never lost.
+            bluetoothAdapter?.bluetoothLeScanner?.let { bluetoothLeScanner = it }
+            // Same for the advertiser, which the adapter-reset path re-attaches
+            // from the same nullable read and so can have left detached.
+            bluetoothAdapter?.bluetoothLeAdvertiser?.let { leAdvertiser.attachAdvertiser(it) }
+            // Best-effort: advertising dies with the adapter too, and start()
+            // is gated on its own in-flight flag and on GATT-service readiness,
+            // so this is a no-op when advertising is already healthy or the
+            // service has not come back yet.
+            startAdvertising("adapter_recovery")
+            startScanning("adapter_recovery")
+        }
+    }
+
     /**
      * Evaluates BLE stack health after consecutive restarts and resets adapter if needed.
      * This mirrors iOS's evaluateCentralHealthAfterRestart mechanism.
@@ -1323,7 +1365,23 @@ class BleTransportFacade(
             }
             return
         }
-        
+
+        // Check the adapter before touching the scanner. The framework refuses
+        // startScan while the adapter is off by throwing, and the watchdog
+        // restart path reaches it on every heartbeat for as long as the user
+        // leaves Bluetooth off — so without this, the steady state is a fixed
+        // cadence of exceptions and diagnostics. Deferring here keeps the catch
+        // below for the genuine race (the adapter can still go off between this
+        // check and the call).
+        if (bluetoothAdapter?.isEnabled != true) {
+            if (logThrottler.shouldLog("scan_adapter_off", intervalMs = 60_000L)) {
+                Log.i(TAG, "Deferring scan start — BT adapter is off (reason: $reason)")
+                emitDiagnostic("info", "Deferring BLE scan start — adapter off", mapOf("reason" to reason))
+            }
+            scheduleBleRecovery()
+            return
+        }
+
         try {
             val scanner = bluetoothLeScanner
             if (scanner == null) {
@@ -1331,6 +1389,10 @@ class BleTransportFacade(
                     Log.w(TAG, "BluetoothLeScanner unavailable; cannot start scan")
                     emitDiagnostic("error", "BLE scanner unavailable", mapOf("reason" to reason))
                 }
+                // Recoverable: the adapter reset path nulls this out when it
+                // re-reads the scanner while the adapter is down, and only
+                // [bleRecoveryRunnable] re-reads it afterwards.
+                scheduleBleRecovery()
                 return
             }
             val scanSettings = ScanSettings.Builder()
@@ -1387,7 +1449,24 @@ class BleTransportFacade(
             }
             
             // Scan without filter - we'll filter in software for cross-platform compatibility
-            scanner.startScan(null, scanSettings, scanCallback)
+            try {
+                scanner.startScan(null, scanSettings, scanCallback)
+            } catch (e: IllegalStateException) {
+                // Lost the race against the adapter check above: the framework
+                // throws IllegalStateException("BT Adapter is not turned ON")
+                // from the scanner. Swallow so the watchdog's restart path
+                // cannot crash the host app, and hand the retry to
+                // [bleRecoveryRunnable] — none of the scan-health timers survive
+                // a failed start. Scoped to this one call so an
+                // IllegalStateException raised anywhere else in this function —
+                // a main-thread `check`, a throwing diagnostic emitter — still
+                // fails loud instead of being reported as an adapter-off.
+                Log.i(TAG, "Skipping startScan — BT adapter not on: ${e.message}")
+                emitDiagnostic("info", "Skipping startScan — BT adapter not on", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
+                scanCallback = null
+                scheduleBleRecovery()
+                return
+            }
             isScanning = true
             val now = System.currentTimeMillis()
             lastDiscoveryAt = now
@@ -1412,15 +1491,6 @@ class BleTransportFacade(
             Log.e(TAG, "Permission denied while starting scan", e)
             emitDiagnostic("error", "Permission denied while starting scan", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
             throw e
-        } catch (e: IllegalStateException) {
-            // The BT adapter can transition off between the isScanning check
-            // above and BluetoothLeScanner.startScan below. When that races,
-            // the framework throws IllegalStateException("BT Adapter is not
-            // turned ON") from the scanner. Log and swallow so the scan
-            // watchdog's restart path does not crash the app the moment the
-            // user toggles Bluetooth off mid-session.
-            Log.i(TAG, "Skipping startScan — BT adapter not on: ${e.message}")
-            emitDiagnostic("info", "Skipping startScan — BT adapter not on", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
         }
     }
     
@@ -1447,39 +1517,44 @@ class BleTransportFacade(
     }
     
     private fun stopScanning(reason: String = "manual") {
+        // Cancel ahead of the isScanning guard: a pending recovery exists
+        // precisely when isScanning is false, and every caller that gets here —
+        // stop, pause, restart, the refresh paths — means "do not be scanning
+        // right now". Leaving it armed would let a paused transport put itself
+        // back on air behind the app's back.
+        cancelBleRecovery()
         if (!isScanning) return
-        
+
         try {
             scanCallback?.let { bluetoothLeScanner?.stopScan(it) }
-            scanCallback = null
-            isScanning = false
-            cancelScanWatchdog()
-            cancelConnectionMonitor()
-            lastDiscoveryAt = 0L
-            discoveryLogTimestamps.clear()
-            if (logThrottler.shouldLog("scan_stopped")) {
-                Log.i(TAG, "Stopped scanning (reason: $reason)")
-            }
-            emitDiagnostic("info", "Stopped BLE scanning", mapOf("reason" to reason))
         } catch (e: SecurityException) {
             Log.e(TAG, "Permission denied while stopping scan", e)
             emitDiagnostic("error", "Permission denied while stopping scan", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
         } catch (e: IllegalStateException) {
-            // The BT adapter can transition off between the isScanning check
-            // above and BluetoothLeScanner.stopScan below. When that races,
-            // the framework throws IllegalStateException("BT Adapter is not
-            // turned ON") from the scanner. Log and swallow, and mirror the
-            // post-stopScan cleanup here so state does not hang half-torn-
-            // down — leaving isScanning true would block the next start.
+            // The adapter can transition off between the guard above and the
+            // call, and the framework then throws IllegalStateException("BT
+            // Adapter is not turned ON").
             Log.i(TAG, "Skipping stopScan — BT adapter not on: ${e.message}")
-            scanCallback = null
-            isScanning = false
-            cancelScanWatchdog()
-            cancelConnectionMonitor()
-            lastDiscoveryAt = 0L
-            discoveryLogTimestamps.clear()
             emitDiagnostic("info", "Skipping stopScan — BT adapter not on", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
         }
+
+        // Teardown runs on every outcome, which is why it sits outside the try.
+        // A stopScan that threw leaves the framework-side scan just as dead as
+        // one that returned, so local state has to come down either way: a
+        // lingering isScanning short-circuits the next startScanning at its
+        // guard, and the watchdog and connection monitor would keep firing
+        // against a scanner that is gone.
+        scanCallback = null
+        isScanning = false
+        cancelScanWatchdog()
+        cancelConnectionMonitor()
+        lastDiscoveryAt = 0L
+        discoveryLogTimestamps.clear()
+
+        if (logThrottler.shouldLog("scan_stopped")) {
+            Log.i(TAG, "Stopped scanning (reason: $reason)")
+        }
+        emitDiagnostic("info", "Stopped BLE scanning", mapOf("reason" to reason))
     }
     
     private fun restartScanning(reason: String) {
@@ -1494,6 +1569,15 @@ class BleTransportFacade(
     
     private fun cancelScanWatchdog() {
         mainHandler.removeCallbacks(scanWatchdogRunnable)
+    }
+
+    private fun scheduleBleRecovery() {
+        cancelBleRecovery()
+        mainHandler.postDelayed(bleRecoveryRunnable, BLE_RECOVERY_RETRY_MS)
+    }
+
+    private fun cancelBleRecovery() {
+        mainHandler.removeCallbacks(bleRecoveryRunnable)
     }
     
     /**

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -246,8 +246,17 @@ class BleTransportFacade(
         private const val CONNECTION_TIMEOUT_MS = 10000L
         private const val SCAN_WATCHDOG_INTERVAL_MS = 30000L // Match iOS timing
         private const val SCAN_WATCHDOG_HEARTBEAT_MS = 10000L
-        /** Retry cadence for re-arming BLE after the adapter was found off (ms) */
-        private const val BLE_RECOVERY_RETRY_MS = 10000L
+        /**
+         * Retry cadence for re-arming BLE after a start could not get a scan
+         * going. Doubles per consecutive failure and caps, so leaving Bluetooth
+         * off overnight settles at a wakeup a minute rather than 8,600 of them,
+         * while the first few retries stay fast enough that a quick toggle is
+         * barely noticed. The cap is deliberately low: nothing else re-arms the
+         * scan, so it is also the worst-case time this device stays deaf after
+         * the user switches Bluetooth back on.
+         */
+        private const val BLE_RECOVERY_RETRY_MIN_MS = 10000L
+        private const val BLE_RECOVERY_RETRY_MAX_MS = 30000L
         private const val MAX_CONNECTIONS_PER_DEVICE = 4
         /** Min interval between connection-monitor reconnect attempts per
          *  device. Reconnect backoff on disconnect is owned by
@@ -322,10 +331,12 @@ class BleTransportFacade(
     // Scanner components
     private var bluetoothLeScanner: BluetoothLeScanner? = null
     private var scanCallback: ScanCallback? = null
-    // @Volatile because onScanFailed (binder thread) clears it while the
-    // scan watchdog and stopScanning read it on the main thread. Without
-    // this, a JMM visibility gap can leave the watchdog polling against a
-    // dead scanner.
+    // Main-thread only today: every reader and writer runs on mainHandler,
+    // onScanFailed included — it reposts before touching this. @Volatile is
+    // kept deliberately rather than as a live requirement; this flag has been
+    // written from a binder thread before, and a volatile read on a field
+    // touched a few times a minute costs nothing next to re-deriving the
+    // threading argument the next time a callback path grows.
     @Volatile
     private var isScanning = false
     
@@ -776,6 +787,10 @@ class BleTransportFacade(
         }
     }
 
+    // Current rung of the recovery backoff ladder. Main-thread only, like the
+    // handler it schedules against.
+    private var bleRecoveryDelayMs: Long = BLE_RECOVERY_RETRY_MIN_MS
+
     /**
      * The one path back to a live BLE session after a start was refused because
      * the adapter was off.
@@ -792,6 +807,13 @@ class BleTransportFacade(
      * Rescheduled from [startScanning] for as long as the adapter stays off, and
      * cancelled by [stopScanning] so a paused or stopped transport cannot bring
      * scanning back behind the app's back.
+     *
+     * Known limit: this heals advertising only as a passenger on a scan
+     * recovery. A device whose scan is healthy while advertising alone is dead
+     * — an adapter reset that re-attached a null advertiser, or a terminal
+     * `onStartFailure` — returns at the [isScanning] guard below and stays
+     * discoverable-to-nobody. Closing that needs its own advertising-side
+     * retry; it is not covered here.
      */
     private val bleRecoveryRunnable = object : Runnable {
         override fun run() {
@@ -807,12 +829,19 @@ class BleTransportFacade(
             // Same for the advertiser, which the adapter-reset path re-attaches
             // from the same nullable read and so can have left detached.
             bluetoothAdapter?.bluetoothLeAdvertiser?.let { leAdvertiser.attachAdvertiser(it) }
-            // Best-effort: advertising dies with the adapter too, and start()
-            // is gated on its own in-flight flag and on GATT-service readiness,
-            // so this is a no-op when advertising is already healthy or the
-            // service has not come back yet.
-            startAdvertising("adapter_recovery")
+            // Scan first. startScanning is what re-arms this runnable when the
+            // adapter is still off, so nothing that can throw may sit upstream
+            // of it: run() is a bare handler post, and an escape here would
+            // leave nothing pending — the exact terminal state this runnable
+            // exists to prevent.
             startScanning("adapter_recovery")
+            // Best-effort, and explicitly non-fatal: LeAdvertiser.start
+            // rethrows SecurityException by design so the synchronous start()
+            // path can surface it to its caller, but there is no caller on a
+            // handler post. start() is also gated on its own in-flight flag and
+            // on GATT-service readiness, so this is a no-op when advertising is
+            // already healthy or the service has not come back yet.
+            runCatching { startAdvertising("adapter_recovery") }
         }
     }
 
@@ -1423,6 +1452,9 @@ class BleTransportFacade(
                 }
 
                 override fun onScanFailed(errorCode: Int) {
+                    // Bind the callback identity explicitly rather than leaning
+                    // on `this` resolving through the posted lambda below.
+                    val self = this
                     val errorMsg = when(errorCode) {
                         SCAN_FAILED_ALREADY_STARTED -> "Scan already started"
                         SCAN_FAILED_APPLICATION_REGISTRATION_FAILED -> "Application registration failed"
@@ -1433,17 +1465,39 @@ class BleTransportFacade(
                     Log.e(TAG, "BLE scan failed: $errorMsg (code=$errorCode)")
                     // Repost to main so the state mutation and the runnable
                     // teardown match the threading contract the rest of the
-                    // facade follows. Without cancelling the watchdog and
-                    // connection monitor here, they keep firing against a
-                    // dead scanner.
+                    // facade follows.
                     mainHandler.post {
-                        isScanning = false
-                        cancelScanWatchdog()
-                        cancelConnectionMonitor()
                         emitDiagnostic("error", "BLE scan failed", mapOf(
                             "errorCode" to errorCode,
                             "errorMessage" to errorMsg
                         ))
+                        // Ignore a failure belonging to a callback we have
+                        // already replaced or torn down — the scan we would
+                        // stop is a newer, possibly healthy one, and a
+                        // deliberate stop/pause must not be undone. Same
+                        // identity check LeAdvertiser.onStartFailure uses.
+                        if (scanCallback !== self) return@post
+                        // Route through stopScanning instead of clearing the
+                        // flags inline. Reaching this callback means startScan
+                        // returned normally — the refusal is asynchronous — so
+                        // isScanning is still true and the framework may yet
+                        // hold a scanner registration for this callback
+                        // (SCAN_FAILED_ALREADY_STARTED is precisely that case).
+                        // stopScanning releases it and runs the one shared
+                        // teardown; leaving it registered and re-entering
+                        // startScanning with a fresh callback would strand one
+                        // registration per attempt against a per-app cap of 5.
+                        stopScanning("scan_failed")
+                        // Arm recovery after the teardown, since stopScanning
+                        // cancels a pending one by design. Without this an
+                        // async scan failure lands in exactly the state
+                        // [bleRecoveryRunnable] exists to prevent: RUNNING, not
+                        // scanning, nothing left on the handler. Reached by the
+                        // ordinary transient failures (internal error,
+                        // registration failed) and — on builds that report an
+                        // adapter caught mid-transition here rather than by
+                        // throwing — by the adapter-off case itself.
+                        scheduleBleRecovery()
                     }
                 }
             }
@@ -1468,6 +1522,11 @@ class BleTransportFacade(
                 return
             }
             isScanning = true
+            // A live scan ends the recovery episode. stopScanning already
+            // resets the ladder on the paths that go through it, but the
+            // recovery runnable reaches a successful start without one, so
+            // reset here too or the next adapter-off inherits a stale rung.
+            bleRecoveryDelayMs = BLE_RECOVERY_RETRY_MIN_MS
             val now = System.currentTimeMillis()
             lastDiscoveryAt = now
             lastProactiveScanRefresh = now
@@ -1539,10 +1598,15 @@ class BleTransportFacade(
         }
 
         // Teardown runs on every outcome, which is why it sits outside the try.
-        // A stopScan that threw leaves the framework-side scan just as dead as
-        // one that returned, so local state has to come down either way: a
-        // lingering isScanning short-circuits the next startScanning at its
-        // guard, and the watchdog and connection monitor would keep firing
+        // For the adapter-off throw the framework-side scan is already dead and
+        // local state simply has to follow. For a SecurityException it is not:
+        // the call was refused, so the scan may well still be registered, and
+        // dropping scanCallback below discards the only reference that could
+        // ever stop it. That is accepted rather than equivalent — Android kills
+        // the process on a runtime permission revocation, so the stranded
+        // registration dies with it — and the alternative is worse in both
+        // cases: a lingering isScanning short-circuits the next startScanning
+        // at its guard, and the watchdog and connection monitor keep firing
         // against a scanner that is gone.
         scanCallback = null
         isScanning = false
@@ -1572,12 +1636,18 @@ class BleTransportFacade(
     }
 
     private fun scheduleBleRecovery() {
-        cancelBleRecovery()
-        mainHandler.postDelayed(bleRecoveryRunnable, BLE_RECOVERY_RETRY_MS)
+        // Deliberately not cancelBleRecovery(): that resets the ladder, and a
+        // re-arm from a failed retry is a continuation of the same episode.
+        mainHandler.removeCallbacks(bleRecoveryRunnable)
+        mainHandler.postDelayed(bleRecoveryRunnable, bleRecoveryDelayMs)
+        bleRecoveryDelayMs = (bleRecoveryDelayMs * 2).coerceAtMost(BLE_RECOVERY_RETRY_MAX_MS)
     }
 
     private fun cancelBleRecovery() {
         mainHandler.removeCallbacks(bleRecoveryRunnable)
+        // Reset the ladder with the cancellation: whatever arms recovery next
+        // is a fresh episode, not a resumption of the one being dropped here.
+        bleRecoveryDelayMs = BLE_RECOVERY_RETRY_MIN_MS
     }
     
     /**

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -999,17 +999,19 @@ class BleTransportFacade(
             reportedBleAvailable = isAvailable
             Log.i(TAG, "Reported BLE availability=$isAvailable (reason=$reason)")
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to report BLE availability=$isAvailable", e)
-            emitDiagnostic(
-                "error",
-                "Failed to report BLE availability",
-                mapOf(
-                    "available" to isAvailable,
-                    "reason" to reason,
-                    "exception" to e.javaClass.simpleName,
-                    "message" to (e.message ?: "unknown"),
-                ),
-            )
+            if (logThrottler.shouldLog("ble_status_report_failed", intervalMs = 60_000L)) {
+                Log.e(TAG, "Failed to report BLE availability=$isAvailable", e)
+                emitDiagnostic(
+                    "error",
+                    "Failed to report BLE availability",
+                    mapOf(
+                        "available" to isAvailable,
+                        "reason" to reason,
+                        "exception" to e.javaClass.simpleName,
+                        "message" to (e.message ?: "unknown"),
+                    ),
+                )
+            }
         }
     }
 
@@ -1094,7 +1096,10 @@ class BleTransportFacade(
             
             // Setup GATT server
             Log.i(TAG, "Setting up GATT server...")
-            check(setupGattServer()) { "GATT server setup did not start" }
+            // Keep the working central role when peripheral setup fails.
+            // setupGattServer reports the failure, and advertising remains
+            // deferred behind the service-ready gate.
+            setupGattServer()
 
             transportStartAt = System.currentTimeMillis()
             meshController.markPeerActive(deviceId)
@@ -1642,6 +1647,10 @@ class BleTransportFacade(
                 return
             }
             isScanning = true
+            // pause() deliberately cancels pending recovery. If this scan was
+            // started by a later resume() while the adapter-off latch is still
+            // raised, re-arm the task that repairs GATT and advertising.
+            bleRecoveryScheduler.onScanStarted(adapterWasOff)
             // Deliberately no ladder reset here. Reaching this line proves only
             // that startScan *returned*; the refusal can still arrive
             // asynchronously at onScanFailed, and resetting on the synchronous

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -249,7 +249,7 @@ class BleTransportFacade(
         /**
          * Retry cadence for re-arming BLE after a start could not get a scan
          * going. Doubles per consecutive failure and caps, so leaving Bluetooth
-         * off overnight settles at a wakeup a minute rather than 8,600 of them,
+         * off overnight settles at two wakeups a minute rather than 8,600 of them,
          * while the first few retries stay fast enough that a quick toggle is
          * barely noticed. The cap is deliberately low: nothing else re-arms the
          * scan, so it is also the worst-case time this device stays deaf after
@@ -339,6 +339,12 @@ class BleTransportFacade(
     // threading argument the next time a callback path grows.
     @Volatile
     private var isScanning = false
+    // Set only when scan startup observes the adapter off. Generic scan
+    // failures must not rebuild the peripheral or churn a healthy advertiser.
+    private var adapterWasOff = false
+    // Last availability state successfully delivered to the Rust core. Null
+    // means this facade has not reported a state in its current lifetime.
+    private var reportedBleAvailable: Boolean? = null
     
     // Advertiser component (delegates to LeAdvertiser).
     // Lazy so its construction sees mainHandler / logThrottler / peripheralGattServer
@@ -787,13 +793,8 @@ class BleTransportFacade(
         }
     }
 
-    // Current rung of the recovery backoff ladder. Main-thread only, like the
-    // handler it schedules against.
-    private var bleRecoveryDelayMs: Long = BLE_RECOVERY_RETRY_MIN_MS
-
     /**
-     * The one path back to a live BLE session after a start was refused because
-     * the adapter was off.
+     * The one path back to a live scan after the platform refuses a start.
      *
      * Every other self-healing mechanism in this class — the scan watchdog, the
      * connection monitor, the proactive and forced refreshes, and the adapter
@@ -804,25 +805,23 @@ class BleTransportFacade(
      * whole chain back in motion, which is why this runnable only has to get
      * scanning going again rather than rebuild the stack itself.
      *
-     * Rescheduled from [startScanning] for as long as the adapter stays off, and
+     * Rescheduled from [startScanning] for as long as the refusal persists, and
      * cancelled by [stopScanning] so a paused or stopped transport cannot bring
-     * scanning back behind the app's back.
+     * scanning back behind the app's back. When [adapterWasOff] is set, the
+     * first successful scan start also rebuilds the platform-owned GATT server;
+     * advertising remains deferred until that service is registered again.
      *
-     * Known limits. First, advertising is healed only as a passenger on a scan
-     * recovery: a device whose scan is healthy while advertising alone is dead
-     * — an adapter reset that re-attached a null advertiser, or a terminal
-     * `onStartFailure` — returns at the [isScanning] guard below and stays
-     * discoverable-to-nobody. Second, this does not escalate:
+     * This does not escalate:
      * [evaluateBleHealthAfterRestart], the stack rebuild that repeated scan
      * stalls climb to, hangs off the scan watchdog and so is unreachable while
      * there is no live scan to watch. That is the right trade for an adapter
      * that is simply off — there is nothing to rebuild until it comes back —
      * but it does mean a genuinely wedged stack is retried at the cap rather
-     * than escalated. Both need their own retry paths and are not covered here.
-     */
+     * than escalated.
+    */
     private val bleRecoveryRunnable = object : Runnable {
         override fun run() {
-            if (state != TransportState.RUNNING || isScanning) {
+            if (state != TransportState.RUNNING || (isScanning && !adapterWasOff)) {
                 return
             }
             // Re-acquire the scanner before retrying. Not because the cached
@@ -835,49 +834,94 @@ class BleTransportFacade(
             bluetoothAdapter?.bluetoothLeScanner?.let { bluetoothLeScanner = it }
             // Same for the advertiser, which that path re-attaches from the
             // same nullable read and so can have left detached.
-            bluetoothAdapter?.bluetoothLeAdvertiser?.let { leAdvertiser.attachAdvertiser(it) }
-            // Scan first, and let nothing that can throw sit upstream of it:
-            // run() is a bare handler post, so an escape both takes the host app
-            // down and leaves nothing pending — the exact terminal state this
-            // runnable exists to prevent. startScanning re-arms us on every exit
-            // it handles itself, but it rethrows SecurityException by design so
-            // startUnsafe can surface it to its caller, and there is no caller
-            // here to receive it. Re-arm by hand on that one path.
-            try {
-                startScanning("adapter_recovery")
-            } catch (e: Exception) {
-                Log.e(TAG, "BLE recovery scan attempt failed", e)
-                emitDiagnostic("error", "BLE recovery scan attempt failed", mapOf(
-                    "exception" to e.javaClass.simpleName,
-                    "message" to (e.message ?: "unknown"),
-                ))
-                scheduleBleRecovery()
+            val recoveredAdvertiser = bluetoothAdapter?.bluetoothLeAdvertiser
+            recoveredAdvertiser?.let { leAdvertiser.attachAdvertiser(it) }
+            var scanStartFailure: Exception? = null
+            if (!isScanning) {
+                // Scan first, and let nothing that can throw sit upstream of it:
+                // run() is a bare handler post, so an escape both takes the host
+                // app down and leaves nothing pending. startScanning re-arms
+                // every handled refusal but rethrows SecurityException.
+                try {
+                    startScanning("adapter_recovery")
+                } catch (e: Exception) {
+                    scanStartFailure = e
+                    if (!isScanning) {
+                        // Arm first: a diagnostic emitter is app code and may
+                        // throw. There is no caller above this handler post.
+                        scheduleBleRecovery()
+                        Log.e(TAG, "BLE recovery scan attempt failed", e)
+                        emitDiagnostic("error", "BLE recovery scan attempt failed", mapOf(
+                            "exception" to e.javaClass.simpleName,
+                            "message" to (e.message ?: "unknown"),
+                        ))
+                        return
+                    }
+                }
             }
-            // Tear advertising down before retrying it, or the retry is a no-op
-            // in the very scenario this runnable exists for. The platform stops
-            // advertising on adapter-off *without* delivering onStartFailure,
-            // and nothing between the watchdog restart and here calls
-            // stopAdvertising — so LeAdvertiser's in-flight gate is still raised
-            // from the pre-outage session and start() would return at it on
-            // every tick, leaving the device scanning but discoverable to
-            // nobody. stop() is throw-safe (it catches both platform refusals)
-            // and returns immediately when there is no callback to release, so
-            // the cost when advertising is genuinely live is one re-registration.
-            stopAdvertising()
-            // Best-effort, and explicitly non-fatal: LeAdvertiser.start rethrows
-            // SecurityException for the same reason startScanning does. start()
-            // is still gated on GATT-service readiness, so this defers itself
-            // when the service registration has not come back yet.
-            try {
-                startAdvertising("adapter_recovery")
-            } catch (e: Exception) {
-                Log.w(TAG, "BLE recovery advertising attempt failed", e)
-                emitDiagnostic("warning", "BLE recovery advertising attempt failed", mapOf(
+            if (!isScanning) return
+
+            if (adapterWasOff) {
+                // Scanner and advertiser availability do not become visible
+                // atomically on every stack. Keep the adapter-recovery episode
+                // alive until there is an advertiser to attach; otherwise a
+                // successful scan would make the active-scan guard swallow the
+                // only remaining path that can restore discoverability.
+                if (recoveredAdvertiser == null) {
+                    scheduleBleRecovery()
+                    return
+                }
+                try {
+                    // Android destroys both registrations while the adapter is
+                    // off without updating either wrapper's local state. Drop
+                    // the stale advertising gate, replace the GATT server, and
+                    // latch advertising behind the new service-ready callback.
+                    stopAdvertising()
+                    check(setupGattServer()) { "GATT server setup did not start" }
+                    startAdvertising("adapter_recovery")
+                    adapterWasOff = false
+                } catch (e: Exception) {
+                    // Keep the adapter-off latch raised and turn the scan back
+                    // into a recovery episode so the peripheral repair is not
+                    // silently abandoned after a partial restart.
+                    try {
+                        stopScanning("adapter_recovery_failed", preserveRecoveryBackoff = true)
+                    } finally {
+                        // stopScanning emits through an app-owned callback;
+                        // even if that throws, the next repair must be armed.
+                        scheduleBleRecovery()
+                    }
+                    Log.e(TAG, "BLE adapter recovery failed", e)
+                    emitDiagnostic("error", "BLE adapter recovery failed", mapOf(
+                        "exception" to e.javaClass.simpleName,
+                        "message" to (e.message ?: "unknown"),
+                    ))
+                    return
+                }
+            }
+
+            reportBleAvailability(true, "recovery")
+            scanStartFailure?.let { e ->
+                // startScanning can throw from app diagnostics after the
+                // framework accepted the scan. Finish adapter repair first;
+                // otherwise the next retry returns at the active-scan guard and
+                // leaves the dead peripheral registration untouched.
+                Log.e(TAG, "BLE recovery scan startup reported an error", e)
+                emitDiagnostic("error", "BLE recovery scan startup reported an error", mapOf(
                     "exception" to e.javaClass.simpleName,
                     "message" to (e.message ?: "unknown"),
                 ))
             }
         }
+    }
+
+    private val bleRecoveryScheduler by lazy(LazyThreadSafetyMode.NONE) {
+        BleRecoveryScheduler(
+            handler = mainHandler,
+            task = bleRecoveryRunnable,
+            minDelayMs = BLE_RECOVERY_RETRY_MIN_MS,
+            maxDelayMs = BLE_RECOVERY_RETRY_MAX_MS,
+        )
     }
 
     /**
@@ -947,6 +991,28 @@ class BleTransportFacade(
         diagnosticEmitter?.invoke(level, message, context)
     }
 
+    private fun reportBleAvailability(isAvailable: Boolean, reason: String) {
+        if (reportedBleAvailable == isAvailable) return
+
+        try {
+            protocol.bleStatusChanged(isAvailable)
+            reportedBleAvailable = isAvailable
+            Log.i(TAG, "Reported BLE availability=$isAvailable (reason=$reason)")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to report BLE availability=$isAvailable", e)
+            emitDiagnostic(
+                "error",
+                "Failed to report BLE availability",
+                mapOf(
+                    "available" to isAvailable,
+                    "reason" to reason,
+                    "exception" to e.javaClass.simpleName,
+                    "message" to (e.message ?: "unknown"),
+                ),
+            )
+        }
+    }
+
     override fun isAvailable(): Boolean {
         if (bluetoothAdapter == null) {
             Log.w(TAG, "Bluetooth adapter not available")
@@ -982,6 +1048,7 @@ class BleTransportFacade(
         // it raised so late binder callbacks from the previous session keep
         // early-returning; a fresh start must explicitly re-open the gate.
         shuttingDown = false
+        adapterWasOff = false
         
         // Check permissions with detailed logging
         Log.i(TAG, "Checking Bluetooth permissions (Android ${Build.VERSION.SDK_INT})...")
@@ -1027,7 +1094,7 @@ class BleTransportFacade(
             
             // Setup GATT server
             Log.i(TAG, "Setting up GATT server...")
-            setupGattServer()
+            check(setupGattServer()) { "GATT server setup did not start" }
 
             transportStartAt = System.currentTimeMillis()
             meshController.markPeerActive(deviceId)
@@ -1048,19 +1115,8 @@ class BleTransportFacade(
             mainHandler.postDelayed(routingCleanupRunnable, ROUTING_CLEANUP_INTERVAL_MS)
             
             updateState(TransportState.RUNNING)
-            Log.i(TAG, "BLE Manager started successfully - calling bleStatusChanged(true)")
-            emitDiagnostic("info", "About to call protocol.bleStatusChanged(true)")
-            
-            try {
-                protocol.bleStatusChanged(true)
-                Log.i(TAG, "Successfully called protocol.bleStatusChanged(true)")
-                emitDiagnostic("info", "Successfully called protocol.bleStatusChanged(true)")
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to call protocol.bleStatusChanged(true): ${e.message}", e)
-                emitDiagnostic("error", "Failed to call protocol.bleStatusChanged(true)", mapOf(
-                    "error" to (e.message ?: "unknown"),
-                    "exception" to e.javaClass.simpleName
-                ))
+            if (isScanning) {
+                reportBleAvailability(true, "start")
             }
             
             Log.i(TAG, "BLE transport ready - scanning and advertising active")
@@ -1165,6 +1221,7 @@ class BleTransportFacade(
         recentAdvertisementHashes.clear()
         scanRestartCount = 0
         lastAdapterReset = 0L
+        adapterWasOff = false
         transportStartAt = 0L
         lastProactiveScanRefresh = 0L
         lastForcedBleRefresh = 0L
@@ -1182,7 +1239,7 @@ class BleTransportFacade(
         cachedSignedIdentity = null
 
         updateState(TransportState.STOPPED)
-        protocol.bleStatusChanged(false)
+        reportBleAvailability(false, "stop")
 
         // Leave [shuttingDown] raised until [startUnsafe] explicitly lowers
         // it. Any late binder callbacks from the previous session that
@@ -1279,7 +1336,7 @@ class BleTransportFacade(
         return true
     }
     
-    private fun setupGattServer() {
+    private fun setupGattServer(): Boolean {
         try {
             // Dispose any previous server before starting a new one.
             peripheralGattServer?.stop()
@@ -1312,6 +1369,7 @@ class BleTransportFacade(
 
             Log.i(TAG, "GATT server setup initiated, waiting for service registration callback...")
             emitDiagnostic("info", "GATT server setup initiated")
+            return true
         } catch (e: SecurityException) {
             Log.e(TAG, "Permission denied while setting up GATT server", e)
             emitDiagnostic("error", "Permission denied in GATT server setup", mapOf("exception" to e.javaClass.simpleName))
@@ -1322,6 +1380,7 @@ class BleTransportFacade(
                 "exception" to e.javaClass.simpleName,
                 "message" to (e.message ?: "unknown")
             ))
+            return false
         }
     }
     
@@ -1438,25 +1497,28 @@ class BleTransportFacade(
         // below for the genuine race (the adapter can still go off between this
         // check and the call).
         if (bluetoothAdapter?.isEnabled != true) {
+            adapterWasOff = true
+            scheduleBleRecovery()
+            reportBleAvailability(false, "adapter_off")
             if (logThrottler.shouldLog("scan_adapter_off", intervalMs = 60_000L)) {
                 Log.i(TAG, "Deferring scan start — BT adapter is off (reason: $reason)")
                 emitDiagnostic("info", "Deferring BLE scan start — adapter off", mapOf("reason" to reason))
             }
-            scheduleBleRecovery()
             return
         }
 
         try {
             val scanner = bluetoothLeScanner
             if (scanner == null) {
+                // Recoverable: the adapter reset path nulls this out when it
+                // re-reads the scanner while the adapter is down, and only
+                // [bleRecoveryRunnable] re-reads it afterwards. Arm before the
+                // app-supplied diagnostic emitter runs.
+                scheduleBleRecovery()
                 if (logThrottler.shouldLog("scanner_unavailable")) {
                     Log.w(TAG, "BluetoothLeScanner unavailable; cannot start scan")
                     emitDiagnostic("error", "BLE scanner unavailable", mapOf("reason" to reason))
                 }
-                // Recoverable: the adapter reset path nulls this out when it
-                // re-reads the scanner while the adapter is down, and only
-                // [bleRecoveryRunnable] re-reads it afterwards.
-                scheduleBleRecovery()
                 return
             }
             val scanSettings = ScanSettings.Builder()
@@ -1509,17 +1571,6 @@ class BleTransportFacade(
                         // silent as well as inert. Same identity check
                         // LeAdvertiser.onStartFailure uses.
                         if (scanCallback !== self) return@post
-                        // Throttled, because the retry armed below re-enters
-                        // startScan on a ladder: a stack that keeps refusing
-                        // asynchronously would otherwise emit an error at the
-                        // retry cadence for as long as the transport runs.
-                        if (logThrottler.shouldLog("scan_failed", intervalMs = 60_000L)) {
-                            Log.e(TAG, "BLE scan failed: $errorMsg (code=$errorCode)")
-                            emitDiagnostic("error", "BLE scan failed", mapOf(
-                                "errorCode" to errorCode,
-                                "errorMessage" to errorMsg
-                            ))
-                        }
                         // Route through stopScanning instead of clearing the
                         // flags inline. Reaching this callback means startScan
                         // returned normally — the refusal is asynchronous — so
@@ -1531,23 +1582,40 @@ class BleTransportFacade(
                         // it and re-entering startScanning with a fresh callback
                         // would strand one entry per attempt against a per-app
                         // cap of 5.
-                        stopScanning("scan_failed")
-                        // Terminal — the hardware cannot do what we are asking,
-                        // so a retry only burns wakeups for the life of the
-                        // process. isAvailable() screens most such devices out
-                        // at start via FEATURE_BLUETOOTH_LE, but not every OEM
-                        // reports the capability consistently.
-                        if (errorCode == SCAN_FAILED_FEATURE_UNSUPPORTED) return@post
-                        // Arm recovery after the teardown, since stopScanning
-                        // cancels a pending one by design. Without this an
-                        // async scan failure lands in exactly the state
-                        // [bleRecoveryRunnable] exists to prevent: RUNNING, not
-                        // scanning, nothing left on the handler. Reached by the
-                        // ordinary transient failures (internal error,
-                        // registration failed) and — on builds that report an
-                        // adapter caught mid-transition here rather than by
-                        // throwing — by the adapter-off case itself.
-                        scheduleBleRecovery()
+                        val isTerminal = errorCode == SCAN_FAILED_FEATURE_UNSUPPORTED
+                        try {
+                            stopScanning(
+                                "scan_failed",
+                                preserveRecoveryBackoff = !isTerminal,
+                            )
+                        } finally {
+                            // stopScanning emits through app code after its
+                            // teardown. The terminal status update or transient
+                            // retry must happen even if that emitter throws.
+                            if (isTerminal) {
+                                // The hardware cannot do what we are asking, so
+                                // retrying only burns wakeups for the process
+                                // lifetime. Remove BLE from DORS instead.
+                                reportBleAvailability(false, "scan_feature_unsupported")
+                            } else {
+                                // This is the same recovery episode. Teardown
+                                // preserved the next rung, so persistent async
+                                // refusals climb 10s -> 20s -> 30s rather than
+                                // resetting to 10s on every callback.
+                                scheduleBleRecovery()
+                            }
+                        }
+
+                        // Log only after the state is coherent and any retry is
+                        // armed. The diagnostic emitter crosses into app code
+                        // and must not be able to strand the facade mid-failure.
+                        if (logThrottler.shouldLog("scan_failed", intervalMs = 60_000L)) {
+                            Log.e(TAG, "BLE scan failed: $errorMsg (code=$errorCode)")
+                            emitDiagnostic("error", "BLE scan failed", mapOf(
+                                "errorCode" to errorCode,
+                                "errorMessage" to errorMsg
+                            ))
+                        }
                     }
                 }
             }
@@ -1565,10 +1633,12 @@ class BleTransportFacade(
                 // IllegalStateException raised anywhere else in this function —
                 // a main-thread `check`, a throwing diagnostic emitter — still
                 // fails loud instead of being reported as an adapter-off.
+                scanCallback = null
+                adapterWasOff = true
+                scheduleBleRecovery()
+                reportBleAvailability(false, "adapter_off_race")
                 Log.i(TAG, "Skipping startScan — BT adapter not on: ${e.message}")
                 emitDiagnostic("info", "Skipping startScan — BT adapter not on", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
-                scanCallback = null
-                scheduleBleRecovery()
                 return
             }
             isScanning = true
@@ -1627,26 +1697,31 @@ class BleTransportFacade(
         }
     }
     
-    private fun stopScanning(reason: String = "manual") {
+    private fun stopScanning(
+        reason: String = "manual",
+        preserveRecoveryBackoff: Boolean = false,
+    ) {
         // Cancel ahead of the isScanning guard: a pending recovery exists
         // precisely when isScanning is false, and every caller that gets here —
         // stop, pause, restart, the refresh paths — means "do not be scanning
-        // right now". Leaving it armed would let a paused transport put itself
-        // back on air behind the app's back.
-        cancelBleRecovery()
+        // right now". Async scan failure is the sole exception: it still
+        // removes the pending callback, but preserves the next backoff rung for
+        // the retry that follows this teardown.
+        cancelBleRecovery(resetBackoff = !preserveRecoveryBackoff)
         if (!isScanning) return
 
-        try {
+        val stopFailure: Exception? = try {
             scanCallback?.let { bluetoothLeScanner?.stopScan(it) }
+            null
         } catch (e: SecurityException) {
             Log.e(TAG, "Permission denied while stopping scan", e)
-            emitDiagnostic("error", "Permission denied while stopping scan", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
+            e
         } catch (e: IllegalStateException) {
             // The adapter can transition off between the guard above and the
             // call, and the framework then throws IllegalStateException("BT
             // Adapter is not turned ON").
             Log.i(TAG, "Skipping stopScan — BT adapter not on: ${e.message}")
-            emitDiagnostic("info", "Skipping stopScan — BT adapter not on", mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")))
+            e
         }
 
         // Teardown runs on every outcome, which is why it sits outside the try.
@@ -1666,6 +1741,25 @@ class BleTransportFacade(
         cancelConnectionMonitor()
         lastDiscoveryAt = 0L
         discoveryLogTimestamps.clear()
+
+        when (stopFailure) {
+            is SecurityException -> emitDiagnostic(
+                "error",
+                "Permission denied while stopping scan",
+                mapOf(
+                    "exception" to stopFailure.javaClass.simpleName,
+                    "message" to (stopFailure.message ?: "unknown"),
+                ),
+            )
+            is IllegalStateException -> emitDiagnostic(
+                "info",
+                "Skipping stopScan — BT adapter not on",
+                mapOf(
+                    "exception" to stopFailure.javaClass.simpleName,
+                    "message" to (stopFailure.message ?: "unknown"),
+                ),
+            )
+        }
 
         if (logThrottler.shouldLog("scan_stopped")) {
             Log.i(TAG, "Stopped scanning (reason: $reason)")
@@ -1688,18 +1782,11 @@ class BleTransportFacade(
     }
 
     private fun scheduleBleRecovery() {
-        // Deliberately not cancelBleRecovery(): that resets the ladder, and a
-        // re-arm from a failed retry is a continuation of the same episode.
-        mainHandler.removeCallbacks(bleRecoveryRunnable)
-        mainHandler.postDelayed(bleRecoveryRunnable, bleRecoveryDelayMs)
-        bleRecoveryDelayMs = (bleRecoveryDelayMs * 2).coerceAtMost(BLE_RECOVERY_RETRY_MAX_MS)
+        bleRecoveryScheduler.schedule()
     }
 
-    private fun cancelBleRecovery() {
-        mainHandler.removeCallbacks(bleRecoveryRunnable)
-        // Reset the ladder with the cancellation: whatever arms recovery next
-        // is a fresh episode, not a resumption of the one being dropped here.
-        bleRecoveryDelayMs = BLE_RECOVERY_RETRY_MIN_MS
+    private fun cancelBleRecovery(resetBackoff: Boolean = true) {
+        bleRecoveryScheduler.cancel(resetBackoff)
     }
     
     /**
@@ -1850,7 +1937,10 @@ class BleTransportFacade(
         // does not rule out an asynchronous onScanFailed a moment later. A
         // device with no peers in range simply holds at the cap, which costs
         // nothing: every deliberate stop resets the ladder via stopScanning.
-        bleRecoveryDelayMs = BLE_RECOVERY_RETRY_MIN_MS
+        if (!adapterWasOff) {
+            bleRecoveryScheduler.resetBackoff()
+            reportBleAvailability(true, "scan_result")
+        }
 
         // Duplicate advertisement detection - avoid processing identical advertisements
         // This improves performance in dense networks
@@ -3829,4 +3919,3 @@ class BleTransportFacade(
     }
 
 }
-

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -808,40 +808,75 @@ class BleTransportFacade(
      * cancelled by [stopScanning] so a paused or stopped transport cannot bring
      * scanning back behind the app's back.
      *
-     * Known limit: this heals advertising only as a passenger on a scan
-     * recovery. A device whose scan is healthy while advertising alone is dead
+     * Known limits. First, advertising is healed only as a passenger on a scan
+     * recovery: a device whose scan is healthy while advertising alone is dead
      * — an adapter reset that re-attached a null advertiser, or a terminal
      * `onStartFailure` — returns at the [isScanning] guard below and stays
-     * discoverable-to-nobody. Closing that needs its own advertising-side
-     * retry; it is not covered here.
+     * discoverable-to-nobody. Second, this does not escalate:
+     * [evaluateBleHealthAfterRestart], the stack rebuild that repeated scan
+     * stalls climb to, hangs off the scan watchdog and so is unreachable while
+     * there is no live scan to watch. That is the right trade for an adapter
+     * that is simply off — there is nothing to rebuild until it comes back —
+     * but it does mean a genuinely wedged stack is retried at the cap rather
+     * than escalated. Both need their own retry paths and are not covered here.
      */
     private val bleRecoveryRunnable = object : Runnable {
         override fun run() {
             if (state != TransportState.RUNNING || isScanning) {
                 return
             }
-            // Re-acquire the scanner before retrying: getBluetoothLeScanner()
-            // yields null while the adapter is off, so the instance cached at
-            // start (or nulled by an adapter reset that ran while it was off)
-            // can belong to a dead adapter session. Only overwrite on a
-            // non-null read, so a still-working cached scanner is never lost.
+            // Re-acquire the scanner before retrying. Not because the cached
+            // instance goes stale — the platform hands back a per-adapter
+            // singleton, not a fresh object per session — but because
+            // [evaluateBleHealthAfterRestart] assigns whatever
+            // getBluetoothLeScanner() returns, which is null while the adapter
+            // is down, and nothing else re-reads it afterwards. Only overwrite
+            // on a non-null read, so a working cached scanner is never lost.
             bluetoothAdapter?.bluetoothLeScanner?.let { bluetoothLeScanner = it }
-            // Same for the advertiser, which the adapter-reset path re-attaches
-            // from the same nullable read and so can have left detached.
+            // Same for the advertiser, which that path re-attaches from the
+            // same nullable read and so can have left detached.
             bluetoothAdapter?.bluetoothLeAdvertiser?.let { leAdvertiser.attachAdvertiser(it) }
-            // Scan first. startScanning is what re-arms this runnable when the
-            // adapter is still off, so nothing that can throw may sit upstream
-            // of it: run() is a bare handler post, and an escape here would
-            // leave nothing pending — the exact terminal state this runnable
-            // exists to prevent.
-            startScanning("adapter_recovery")
-            // Best-effort, and explicitly non-fatal: LeAdvertiser.start
-            // rethrows SecurityException by design so the synchronous start()
-            // path can surface it to its caller, but there is no caller on a
-            // handler post. start() is also gated on its own in-flight flag and
-            // on GATT-service readiness, so this is a no-op when advertising is
-            // already healthy or the service has not come back yet.
-            runCatching { startAdvertising("adapter_recovery") }
+            // Scan first, and let nothing that can throw sit upstream of it:
+            // run() is a bare handler post, so an escape both takes the host app
+            // down and leaves nothing pending — the exact terminal state this
+            // runnable exists to prevent. startScanning re-arms us on every exit
+            // it handles itself, but it rethrows SecurityException by design so
+            // startUnsafe can surface it to its caller, and there is no caller
+            // here to receive it. Re-arm by hand on that one path.
+            try {
+                startScanning("adapter_recovery")
+            } catch (e: Exception) {
+                Log.e(TAG, "BLE recovery scan attempt failed", e)
+                emitDiagnostic("error", "BLE recovery scan attempt failed", mapOf(
+                    "exception" to e.javaClass.simpleName,
+                    "message" to (e.message ?: "unknown"),
+                ))
+                scheduleBleRecovery()
+            }
+            // Tear advertising down before retrying it, or the retry is a no-op
+            // in the very scenario this runnable exists for. The platform stops
+            // advertising on adapter-off *without* delivering onStartFailure,
+            // and nothing between the watchdog restart and here calls
+            // stopAdvertising — so LeAdvertiser's in-flight gate is still raised
+            // from the pre-outage session and start() would return at it on
+            // every tick, leaving the device scanning but discoverable to
+            // nobody. stop() is throw-safe (it catches both platform refusals)
+            // and returns immediately when there is no callback to release, so
+            // the cost when advertising is genuinely live is one re-registration.
+            stopAdvertising()
+            // Best-effort, and explicitly non-fatal: LeAdvertiser.start rethrows
+            // SecurityException for the same reason startScanning does. start()
+            // is still gated on GATT-service readiness, so this defers itself
+            // when the service registration has not come back yet.
+            try {
+                startAdvertising("adapter_recovery")
+            } catch (e: Exception) {
+                Log.w(TAG, "BLE recovery advertising attempt failed", e)
+                emitDiagnostic("warning", "BLE recovery advertising attempt failed", mapOf(
+                    "exception" to e.javaClass.simpleName,
+                    "message" to (e.message ?: "unknown"),
+                ))
+            }
         }
     }
 
@@ -1462,32 +1497,47 @@ class BleTransportFacade(
                         SCAN_FAILED_FEATURE_UNSUPPORTED -> "Feature unsupported"
                         else -> "Unknown error $errorCode"
                     }
-                    Log.e(TAG, "BLE scan failed: $errorMsg (code=$errorCode)")
                     // Repost to main so the state mutation and the runnable
                     // teardown match the threading contract the rest of the
                     // facade follows.
                     mainHandler.post {
-                        emitDiagnostic("error", "BLE scan failed", mapOf(
-                            "errorCode" to errorCode,
-                            "errorMessage" to errorMsg
-                        ))
                         // Ignore a failure belonging to a callback we have
                         // already replaced or torn down — the scan we would
                         // stop is a newer, possibly healthy one, and a
-                        // deliberate stop/pause must not be undone. Same
-                        // identity check LeAdvertiser.onStartFailure uses.
+                        // deliberate stop/pause must not be undone. Checked
+                        // ahead of the logging below so a stale failure is
+                        // silent as well as inert. Same identity check
+                        // LeAdvertiser.onStartFailure uses.
                         if (scanCallback !== self) return@post
+                        // Throttled, because the retry armed below re-enters
+                        // startScan on a ladder: a stack that keeps refusing
+                        // asynchronously would otherwise emit an error at the
+                        // retry cadence for as long as the transport runs.
+                        if (logThrottler.shouldLog("scan_failed", intervalMs = 60_000L)) {
+                            Log.e(TAG, "BLE scan failed: $errorMsg (code=$errorCode)")
+                            emitDiagnostic("error", "BLE scan failed", mapOf(
+                                "errorCode" to errorCode,
+                                "errorMessage" to errorMsg
+                            ))
+                        }
                         // Route through stopScanning instead of clearing the
                         // flags inline. Reaching this callback means startScan
                         // returned normally — the refusal is asynchronous — so
                         // isScanning is still true and the framework may yet
-                        // hold a scanner registration for this callback
-                        // (SCAN_FAILED_ALREADY_STARTED is precisely that case).
-                        // stopScanning releases it and runs the one shared
-                        // teardown; leaving it registered and re-entering
-                        // startScanning with a fresh callback would strand one
-                        // registration per attempt against a per-app cap of 5.
+                        // hold a scanner registration for this callback: the
+                        // client entry is inserted before registration is
+                        // attempted, and only stopScan removes it. stopScanning
+                        // releases it and runs the one shared teardown; leaving
+                        // it and re-entering startScanning with a fresh callback
+                        // would strand one entry per attempt against a per-app
+                        // cap of 5.
                         stopScanning("scan_failed")
+                        // Terminal — the hardware cannot do what we are asking,
+                        // so a retry only burns wakeups for the life of the
+                        // process. isAvailable() screens most such devices out
+                        // at start via FEATURE_BLUETOOTH_LE, but not every OEM
+                        // reports the capability consistently.
+                        if (errorCode == SCAN_FAILED_FEATURE_UNSUPPORTED) return@post
                         // Arm recovery after the teardown, since stopScanning
                         // cancels a pending one by design. Without this an
                         // async scan failure lands in exactly the state
@@ -1522,11 +1572,13 @@ class BleTransportFacade(
                 return
             }
             isScanning = true
-            // A live scan ends the recovery episode. stopScanning already
-            // resets the ladder on the paths that go through it, but the
-            // recovery runnable reaches a successful start without one, so
-            // reset here too or the next adapter-off inherits a stale rung.
-            bleRecoveryDelayMs = BLE_RECOVERY_RETRY_MIN_MS
+            // Deliberately no ladder reset here. Reaching this line proves only
+            // that startScan *returned*; the refusal can still arrive
+            // asynchronously at onScanFailed, and resetting on the synchronous
+            // return would pin a stack that keeps failing that way to the
+            // bottom rung forever — retry, return, reset, fail, retry. The reset
+            // lives in [handleScanResult] instead, which is the first point that
+            // proves a scan is actually alive.
             val now = System.currentTimeMillis()
             lastDiscoveryAt = now
             lastProactiveScanRefresh = now
@@ -1792,7 +1844,14 @@ class BleTransportFacade(
         val address = device.address
         val now = System.currentTimeMillis()
         lastDiscoveryAt = now
-        
+        // A result in hand is the one proof the scan is genuinely live, which is
+        // what ends a recovery episode and resets its backoff ladder. Anchored
+        // here rather than on a successful startScan return because that return
+        // does not rule out an asynchronous onScanFailed a moment later. A
+        // device with no peers in range simply holds at the cap, which costs
+        // nothing: every deliberate stop resets the ladder via stopScanning.
+        bleRecoveryDelayMs = BLE_RECOVERY_RETRY_MIN_MS
+
         // Duplicate advertisement detection - avoid processing identical advertisements
         // This improves performance in dense networks
         val advertHash = computeAdvertisementHash(result)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/BleTransportFacade.kt
@@ -343,7 +343,9 @@ class BleTransportFacade(
     // failures must not rebuild the peripheral or churn a healthy advertiser.
     private var adapterWasOff = false
     // Last availability state successfully delivered to the Rust core. Null
-    // means this facade has not reported a state in its current lifetime.
+    // means this facade has not reported a state in its current session;
+    // [stopUnsafe] clears it, because one facade instance is reused across
+    // disable/enable and the dedup below must not span that boundary.
     private var reportedBleAvailable: Boolean? = null
     
     // Advertiser component (delegates to LeAdvertiser).
@@ -837,6 +839,13 @@ class BleTransportFacade(
             val recoveredAdvertiser = bluetoothAdapter?.bluetoothLeAdvertiser
             recoveredAdvertiser?.let { leAdvertiser.attachAdvertiser(it) }
             var scanStartFailure: Exception? = null
+            // Whether [startScanning] below already armed the next attempt. A
+            // start that lands while the adapter-off latch is still raised
+            // re-arms through onScanStarted, so the peripheral repair further
+            // down must not arm a second time: schedule() climbs the ladder on
+            // every call, and arming twice per attempt makes each retry wait a
+            // rung longer than the ladder claims and hit the cap early.
+            var recoveryArmed = false
             if (!isScanning) {
                 // Scan first, and let nothing that can throw sit upstream of it:
                 // run() is a bare handler post, so an escape both takes the host
@@ -858,6 +867,10 @@ class BleTransportFacade(
                         return
                     }
                 }
+                // Reaching here means startScan returned. onScanStarted armed
+                // the follow-up iff the adapter-off latch was raised, which is
+                // exactly the condition the repair below runs under.
+                recoveryArmed = isScanning && adapterWasOff
             }
             if (!isScanning) return
 
@@ -868,7 +881,7 @@ class BleTransportFacade(
                 // successful scan would make the active-scan guard swallow the
                 // only remaining path that can restore discoverability.
                 if (recoveredAdvertiser == null) {
-                    scheduleBleRecovery()
+                    if (!recoveryArmed) scheduleBleRecovery()
                     return
                 }
                 try {
@@ -880,17 +893,29 @@ class BleTransportFacade(
                     check(setupGattServer()) { "GATT server setup did not start" }
                     startAdvertising("adapter_recovery")
                     adapterWasOff = false
+                    // The episode is over: drop the follow-up onScanStarted
+                    // armed above — its guard would no-op on it anyway — and
+                    // put the ladder back on its bottom rung so the next outage
+                    // is retried fast rather than at the cap. handleScanResult
+                    // cannot do this for us on a device with no peers in range.
+                    cancelBleRecovery()
                 } catch (e: Exception) {
-                    // Keep the adapter-off latch raised and turn the scan back
-                    // into a recovery episode so the peripheral repair is not
-                    // silently abandoned after a partial restart.
-                    try {
-                        stopScanning("adapter_recovery_failed", preserveRecoveryBackoff = true)
-                    } finally {
-                        // stopScanning emits through an app-owned callback;
-                        // even if that throws, the next repair must be armed.
-                        scheduleBleRecovery()
-                    }
+                    // Keep the scan. The entry guard above re-enters with a
+                    // live scan while [adapterWasOff] is raised, so the next
+                    // attempt retries the peripheral repair on its own; tearing
+                    // the scan down here buys that retry nothing, and against a
+                    // persistently failing repair it would cost a discovery gap
+                    // and a rehydrate reconnect burst every single cycle, for as
+                    // long as the transport runs. Arm before the emitters below,
+                    // which are app code and may throw.
+                    if (!recoveryArmed) scheduleBleRecovery()
+                    // The scan survived, so the central role — discovery and
+                    // outbound connections — works; only discoverability is
+                    // still broken, and the retry armed above owns it. Report
+                    // on the same basis [startUnsafe] does when setupGattServer
+                    // fails there, rather than leaving the core convinced BLE
+                    // is unusable for as long as the repair keeps failing.
+                    reportBleAvailability(true, "recovery_scan_only")
                     Log.e(TAG, "BLE adapter recovery failed", e)
                     emitDiagnostic("error", "BLE adapter recovery failed", mapOf(
                         "exception" to e.javaClass.simpleName,
@@ -1245,6 +1270,13 @@ class BleTransportFacade(
 
         updateState(TransportState.STOPPED)
         reportBleAvailability(false, "stop")
+        // Scope the dedup to this session. One facade instance is reused
+        // across disable/enable, and the module also reports
+        // bleStatusChanged(false) out of band on its disable path — so a value
+        // carried across the boundary can silently suppress the next session's
+        // first report and leave the core holding BLE unavailable for the whole
+        // of it while this transport scans normally.
+        reportedBleAvailable = null
 
         // Leave [shuttingDown] raised until [startUnsafe] explicitly lowers
         // it. Any late binder callbacks from the previous session that
@@ -1935,6 +1967,15 @@ class BleTransportFacade(
     }
     
     private fun handleScanResult(result: ScanResult) {
+        // Scan results are posted here from a binder thread, so one produced
+        // just before stopScan lands *behind* [stopUnsafe] on the main queue.
+        // Such a straggler must not be treated as evidence of a live scan: it
+        // would re-report BLE as available for a transport that is already
+        // stopped, re-stamp lastDiscoveryAt, reset the backoff rung
+        // [onScanFailed] deliberately preserved, and walk the connection path
+        // against maps stopUnsafe has just cleared.
+        if (shuttingDown || !isScanning) return
+
         val device = result.device
         val rssi = result.rssi
         val address = device.address

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/LeAdvertiser.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/LeAdvertiser.kt
@@ -98,15 +98,6 @@ class LeAdvertiser(
         // earn itself ADVERTISE_FAILED_ALREADY_STARTED.
         if (startInFlight) return
 
-        // Nothing to start against: getBluetoothLeAdvertiser() returns null
-        // while the adapter is off, and the facade's adapter-reset path
-        // re-attaches whatever it reads — so this is null exactly when the user
-        // has Bluetooth switched off. Bail before raising the gate below: the
-        // start call itself is a no-op on a null advertiser, so no callback
-        // would ever arrive to lower it again, and every later start() would
-        // return at the guard above with advertising wedged off for good.
-        if (advertiser == null) return
-
         if (!host.isGattServerReady()) {
             pendingAdvertiseReason = reason
             if (host.shouldLog("advert_waiting_gatt", 5000L)) {
@@ -119,6 +110,21 @@ class LeAdvertiser(
             }
             return
         }
+
+        // Nothing to start against: getBluetoothLeAdvertiser() returns null
+        // while the adapter is off, and the facade's adapter-reset path
+        // re-attaches whatever it reads — so this is null exactly when the user
+        // has Bluetooth switched off. Bail before raising the gate below: the
+        // start call itself is a no-op on a null advertiser, so no callback
+        // would ever arrive to lower it again, and every later start() would
+        // return at the in-flight guard above with advertising wedged off for
+        // good.
+        //
+        // Deliberately below the GATT-readiness check rather than above it. A
+        // null advertiser must still latch [pendingAdvertiseReason], so an
+        // attach that lands while the service registration is in flight is
+        // picked up by [onGattServerReady] instead of being dropped silently.
+        if (advertiser == null) return
 
         startInFlight = true
         try {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/LeAdvertiser.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/LeAdvertiser.kt
@@ -69,6 +69,20 @@ class LeAdvertiser(
      * main-handler post in the failure callback, which left a window where
      * a synchronous `start()` after a failure would be silently dropped by
      * the gate. Separating the gate from the stop-reference closes it.
+     *
+     * Note it is deliberately *not* lowered by `onStartSuccess`: it guards a
+     * live advertisement as well as an in-flight one, since a second
+     * `startAdvertising` against a running one earns
+     * `ADVERTISE_FAILED_ALREADY_STARTED`, whose handler nulls
+     * [advertiseCallback] and so discards the only reference that could stop
+     * the advertisement that is actually running.
+     *
+     * The consequence, which callers must own: an adapter switched off stops
+     * advertising at the platform without delivering any callback, so the gate
+     * stays raised over an advertisement that is already dead and every later
+     * `start()` returns at it. Recovering from an adapter-off therefore means
+     * calling [stop] first — re-attaching an advertiser and re-calling [start]
+     * is silently a no-op. Pinned by `LeAdvertiserTest`.
      */
     @Volatile
     private var startInFlight: Boolean = false

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/LeAdvertiser.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/LeAdvertiser.kt
@@ -138,7 +138,17 @@ class LeAdvertiser(
         // null advertiser must still latch [pendingAdvertiseReason], so an
         // attach that lands while the service registration is in flight is
         // picked up by [onGattServerReady] instead of being dropped silently.
-        if (advertiser == null) return
+        if (advertiser == null) {
+            if (host.shouldLog("advertiser_unavailable", 60_000L)) {
+                Log.i(TAG, "Deferring advertising — BLE advertiser unavailable (reason: $reason)")
+                diagnosticEmitter(
+                    "info",
+                    "Deferring BLE advertising — advertiser unavailable",
+                    mapOf("reason" to reason),
+                )
+            }
+            return
+        }
 
         startInFlight = true
         try {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/LeAdvertiser.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ble/LeAdvertiser.kt
@@ -98,6 +98,15 @@ class LeAdvertiser(
         // earn itself ADVERTISE_FAILED_ALREADY_STARTED.
         if (startInFlight) return
 
+        // Nothing to start against: getBluetoothLeAdvertiser() returns null
+        // while the adapter is off, and the facade's adapter-reset path
+        // re-attaches whatever it reads — so this is null exactly when the user
+        // has Bluetooth switched off. Bail before raising the gate below: the
+        // start call itself is a no-op on a null advertiser, so no callback
+        // would ever arrive to lower it again, and every later start() would
+        // return at the guard above with advertising wedged off for good.
+        if (advertiser == null) return
+
         if (!host.isGattServerReady()) {
             pendingAdvertiseReason = reason
             if (host.shouldLog("advert_waiting_gatt", 5000L)) {
@@ -183,6 +192,27 @@ class LeAdvertiser(
                 mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")),
             )
             throw e
+        } catch (e: IllegalStateException) {
+            // The platform refuses both LE entry points while the adapter is
+            // off by throwing IllegalStateException("BT Adapter is not turned
+            // ON") — the advertiser exactly as the scanner does. This one is
+            // reached from bare handler posts ([scheduleRestart], the facade's
+            // adapter-reset path), where nothing above would catch it, so the
+            // user switching Bluetooth off mid-session takes the host app down.
+            //
+            // Clearing the in-flight gate is the load-bearing half: it is
+            // raised before the call and otherwise only lowered by stop() or a
+            // terminal onStartFailure, neither of which runs when the call
+            // throws — so leaving it raised would make every later start()
+            // return early and wedge advertising off permanently.
+            advertiseCallback = null
+            startInFlight = false
+            Log.i(TAG, "Skipping startAdvertising — BT adapter not on: ${e.message}")
+            diagnosticEmitter(
+                "info",
+                "Skipping startAdvertising — BT adapter not on",
+                mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")),
+            )
         }
     }
 
@@ -205,6 +235,18 @@ class LeAdvertiser(
             diagnosticEmitter(
                 "error",
                 "Permission denied while stopping advertising",
+                mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")),
+            )
+        } catch (e: IllegalStateException) {
+            // Same adapter-off refusal as start(). State is already reset above
+            // — the gate and the callback reference come down before the call —
+            // so there is nothing to repair here; the throw just must not
+            // escape, because refresh() reaches this from evict and
+            // membership-change paths that run on bare handler posts.
+            Log.i(TAG, "Skipping stopAdvertising — BT adapter not on: ${e.message}")
+            diagnosticEmitter(
+                "info",
+                "Skipping stopAdvertising — BT adapter not on",
                 mapOf("exception" to e.javaClass.simpleName, "message" to (e.message ?: "unknown")),
             )
         }

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/BleRecoverySchedulerTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/BleRecoverySchedulerTest.kt
@@ -77,6 +77,35 @@ class BleRecoverySchedulerTest {
         assertEquals(1, runs)
     }
 
+    @Test
+    fun `scan resume re-arms a cancelled adapter recovery episode`() {
+        var runs = 0
+        val scheduler = scheduler { runs++ }
+
+        // Adapter-off detection arms recovery, then app backgrounding cancels
+        // it. A successful scan start on resume must not strand the remaining
+        // GATT and advertising repair.
+        scheduler.schedule()
+        scheduler.cancel()
+        scheduler.onScanStarted(adapterRecoveryPending = true)
+
+        advanceTo(9_999L)
+        assertEquals(0, runs)
+        advanceTo(10_000L)
+        assertEquals(1, runs)
+    }
+
+    @Test
+    fun `ordinary scan start does not arm adapter recovery`() {
+        var runs = 0
+        val scheduler = scheduler { runs++ }
+
+        scheduler.onScanStarted(adapterRecoveryPending = false)
+        advanceTo(30_000L)
+
+        assertEquals(0, runs)
+    }
+
     private fun scheduler(block: () -> Unit) = BleRecoveryScheduler(
         handler = handler,
         task = Runnable(block),

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/BleRecoverySchedulerTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/BleRecoverySchedulerTest.kt
@@ -1,0 +1,91 @@
+package com.offlineprotocol.ble
+
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@LooperMode(LooperMode.Mode.PAUSED)
+class BleRecoverySchedulerTest {
+    private val looper = shadowOf(Looper.getMainLooper())
+    private val handler = Handler(Looper.getMainLooper())
+    private var elapsedMs = 0L
+
+    @Test
+    fun `successive recovery attempts climb and cap the backoff ladder`() {
+        var runs = 0
+        val scheduler = scheduler { runs++ }
+
+        scheduler.schedule()
+        advanceTo(9_999L)
+        assertEquals(0, runs)
+        advanceTo(10_000L)
+        assertEquals(1, runs)
+
+        scheduler.schedule()
+        advanceTo(29_999L)
+        assertEquals(1, runs)
+        advanceTo(30_000L)
+        assertEquals(2, runs)
+
+        scheduler.schedule()
+        advanceTo(59_999L)
+        assertEquals(2, runs)
+        advanceTo(60_000L)
+        assertEquals(3, runs)
+
+        scheduler.schedule()
+        advanceTo(90_000L)
+        assertEquals(4, runs)
+    }
+
+    @Test
+    fun `transient teardown preserves the next retry rung`() {
+        var runs = 0
+        val scheduler = scheduler { runs++ }
+
+        scheduler.schedule()
+        scheduler.cancel(resetBackoff = false)
+        scheduler.schedule()
+
+        advanceTo(19_999L)
+        assertEquals(0, runs)
+        advanceTo(20_000L)
+        assertEquals(1, runs)
+    }
+
+    @Test
+    fun `deliberate cancellation resets the next retry to the floor`() {
+        var runs = 0
+        val scheduler = scheduler { runs++ }
+
+        scheduler.schedule()
+        scheduler.cancel()
+        scheduler.schedule()
+
+        advanceTo(9_999L)
+        assertEquals(0, runs)
+        advanceTo(10_000L)
+        assertEquals(1, runs)
+    }
+
+    private fun scheduler(block: () -> Unit) = BleRecoveryScheduler(
+        handler = handler,
+        task = Runnable(block),
+        minDelayMs = 10_000L,
+        maxDelayMs = 30_000L,
+    )
+
+    private fun advanceTo(targetMs: Long) {
+        looper.idleFor(targetMs - elapsedMs, TimeUnit.MILLISECONDS)
+        elapsedMs = targetMs
+    }
+}

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserIllegalStateTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserIllegalStateTest.kt
@@ -24,6 +24,7 @@ import org.robolectric.annotation.Implements
 class ThrowingBluetoothLeAdvertiserShadow {
     companion object {
         var throwOnStart = false
+        var throwOnStop = false
     }
 
     @Implementation
@@ -39,7 +40,11 @@ class ThrowingBluetoothLeAdvertiserShadow {
     }
 
     @Implementation
-    protected fun stopAdvertising(callback: AdvertiseCallback) = Unit
+    protected fun stopAdvertising(callback: AdvertiseCallback) {
+        if (throwOnStop) {
+            throw IllegalStateException("BT Adapter is not turned ON")
+        }
+    }
 }
 
 @RunWith(RobolectricTestRunner::class)
@@ -69,6 +74,7 @@ class LeAdvertiserIllegalStateTest {
     @After
     fun resetShadow() {
         ThrowingBluetoothLeAdvertiserShadow.throwOnStart = false
+        ThrowingBluetoothLeAdvertiserShadow.throwOnStop = false
     }
 
     @Test
@@ -86,6 +92,26 @@ class LeAdvertiserIllegalStateTest {
         assertTrue(seen.contains("Skipping startAdvertising — BT adapter not on"))
 
         ThrowingBluetoothLeAdvertiserShadow.throwOnStart = false
+        advertiser.start("adapter-recovered")
+        assertEquals(2, host.advertiseDataBuilds)
+    }
+
+    @Test
+    fun `adapter-off stop failure leaves the next start admitted`() {
+        val platformAdvertiser =
+            ((RuntimeEnvironment.getApplication() as Context)
+                .getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
+                .adapter!!
+                .bluetoothLeAdvertiser
+        advertiser.attachAdvertiser(platformAdvertiser)
+        advertiser.start("initial")
+        assertEquals(1, host.advertiseDataBuilds)
+
+        ThrowingBluetoothLeAdvertiserShadow.throwOnStop = true
+        advertiser.stop()
+        assertTrue(seen.contains("Skipping stopAdvertising — BT adapter not on"))
+
+        ThrowingBluetoothLeAdvertiserShadow.throwOnStop = false
         advertiser.start("adapter-recovered")
         assertEquals(2, host.advertiseDataBuilds)
     }

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserIllegalStateTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserIllegalStateTest.kt
@@ -1,0 +1,92 @@
+package com.offlineprotocol.ble
+
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@Implements(BluetoothLeAdvertiser::class)
+@Suppress("UNUSED_PARAMETER")
+class ThrowingBluetoothLeAdvertiserShadow {
+    companion object {
+        var throwOnStart = false
+    }
+
+    @Implementation
+    protected fun startAdvertising(
+        settings: AdvertiseSettings,
+        advertiseData: AdvertiseData,
+        scanResponse: AdvertiseData,
+        callback: AdvertiseCallback,
+    ) {
+        if (throwOnStart) {
+            throw IllegalStateException("BT Adapter is not turned ON")
+        }
+    }
+
+    @Implementation
+    protected fun stopAdvertising(callback: AdvertiseCallback) = Unit
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], shadows = [ThrowingBluetoothLeAdvertiserShadow::class])
+class LeAdvertiserIllegalStateTest {
+    private class FakeHost : LeAdvertiser.Host {
+        var advertiseDataBuilds = 0
+
+        override fun isGattServerReady(): Boolean = true
+        override fun buildAdvertiseData(): AdvertiseData {
+            advertiseDataBuilds++
+            return AdvertiseData.Builder().build()
+        }
+        override fun buildScanResponse(): AdvertiseData = AdvertiseData.Builder().build()
+        override fun refreshPublishedIdentity() = Unit
+        override fun shouldLog(key: String, intervalMs: Long): Boolean = true
+    }
+
+    private val seen = mutableListOf<String>()
+    private val host = FakeHost()
+    private val advertiser = LeAdvertiser(
+        mainHandler = Handler(Looper.getMainLooper()),
+        host = host,
+        diagnosticEmitter = { _, message, _ -> seen.add(message) },
+    )
+
+    @After
+    fun resetShadow() {
+        ThrowingBluetoothLeAdvertiserShadow.throwOnStart = false
+    }
+
+    @Test
+    fun `adapter-off start failure releases the in-flight gate`() {
+        val platformAdvertiser =
+            ((RuntimeEnvironment.getApplication() as Context)
+                .getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
+                .adapter!!
+                .bluetoothLeAdvertiser
+        advertiser.attachAdvertiser(platformAdvertiser)
+
+        ThrowingBluetoothLeAdvertiserShadow.throwOnStart = true
+        advertiser.start("adapter-off-race")
+        assertEquals(1, host.advertiseDataBuilds)
+        assertTrue(seen.contains("Skipping startAdvertising — BT adapter not on"))
+
+        ThrowingBluetoothLeAdvertiserShadow.throwOnStart = false
+        advertiser.start("adapter-recovered")
+        assertEquals(2, host.advertiseDataBuilds)
+    }
+}

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserTest.kt
@@ -13,40 +13,56 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 /**
- * Pins what [LeAdvertiser.start] must do when it has no platform advertiser to
- * start against — the state this class is in whenever the user has Bluetooth
- * switched off, since `getBluetoothLeAdvertiser()` returns null for exactly
- * that reason and the facade's adapter-reset path re-attaches whatever it
- * reads.
+ * Pins the gate behaviour of [LeAdvertiser.start] on the two paths that decide
+ * whether a device is discoverable at all after the user toggles Bluetooth: a
+ * start with no platform advertiser attached (`getBluetoothLeAdvertiser()`
+ * returns null while the adapter is off, and the facade's adapter-reset path
+ * re-attaches whatever it reads), and a start that follows an adapter-off which
+ * left the in-flight gate raised over an advertisement the platform has already
+ * torn down.
  *
- * Two properties, both invisible in the source once written and both permanent
+ * Three properties, all invisible in the source once written and all permanent
  * if broken:
  *
- *  1. The in-flight gate must stay *down*. It is raised immediately before the
- *     platform call and otherwise lowered only by `stop()` or a terminal
- *     `onStartFailure` — neither of which runs when there is no call to make.
- *     Raising it against a null advertiser therefore wedges advertising off for
- *     the rest of the process lifetime.
- *  2. The deferral must still be latched. The null check sits *below* the
- *     GATT-readiness check precisely so an advertiser attached while the
- *     service registration is still in flight is picked up by
+ *  1. A null advertiser must leave the in-flight gate *down*. It is raised
+ *     immediately before the platform call and otherwise lowered only by
+ *     `stop()` or a terminal `onStartFailure` — neither of which runs when
+ *     there is no call to make. Raising it against a null advertiser wedges
+ *     advertising off for the rest of the process lifetime.
+ *  2. A null advertiser must still latch the deferral. The null check sits
+ *     *below* the GATT-readiness check precisely so an advertiser attached
+ *     while the service registration is still in flight is picked up by
  *     [LeAdvertiser.onGattServerReady] rather than dropped on the floor.
+ *  3. After a successful start, the gate stays raised until an explicit
+ *     `stop()` — including across an adapter-off, which the platform performs
+ *     without any callback. This is why the facade's recovery runnable stops
+ *     before it re-starts; re-attaching and re-starting alone is a no-op.
  *
- * Neither is directly observable — `startInFlight` and `pendingAdvertiseReason`
- * are private, and Robolectric's shadow advertiser accepts `startAdvertising`
- * without invoking the callback, so `isAdvertising` never flips. Both tests
- * therefore observe the same downstream tell: `stop()` emits "Stopped BLE
- * advertising" only when a start actually reached the platform call and left an
- * `advertiseCallback` behind. A start that was swallowed by a wedged gate, or
- * never triggered because the deferral was dropped, leaves that emission out.
+ * None of it is directly observable — `startInFlight` and
+ * `pendingAdvertiseReason` are private, and Robolectric's shadow advertiser
+ * accepts `startAdvertising` without invoking the callback, so `isAdvertising`
+ * never flips. The probe is [FakeHost.advertiseDataBuilds]: `buildAdvertiseData`
+ * is called just-in-time *inside* `start`, past all three gates, so it counts
+ * exactly the starts that reached the platform call and nothing else.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class LeAdvertiserTest {
 
     private class FakeHost(var gattReady: Boolean) : LeAdvertiser.Host {
+        /**
+         * Number of starts that got past every gate and reached the platform
+         * call. `buildAdvertiseData` is invoked just-in-time after the in-flight
+         * gate, the GATT-readiness check and the null-advertiser bail, so this
+         * is an exact count of admitted starts.
+         */
+        var advertiseDataBuilds = 0
+
         override fun isGattServerReady(): Boolean = gattReady
-        override fun buildAdvertiseData(): AdvertiseData = AdvertiseData.Builder().build()
+        override fun buildAdvertiseData(): AdvertiseData {
+            advertiseDataBuilds++
+            return AdvertiseData.Builder().build()
+        }
         override fun buildScanResponse(): AdvertiseData = AdvertiseData.Builder().build()
         override fun refreshPublishedIdentity() {}
         // Defeat throttling so every admitted call is individually observable.
@@ -74,6 +90,7 @@ class LeAdvertiserTest {
 
         // Bluetooth off: nothing attached, so this start has nothing to do.
         advertiser.start("while-adapter-off")
+        assertEquals(0, host.advertiseDataBuilds)
 
         // Adapter comes back and the facade re-attaches. This start must be
         // admitted — if the previous one had raised the gate, it would return
@@ -81,9 +98,31 @@ class LeAdvertiserTest {
         // for good.
         advertiser.attachAdvertiser(platformAdvertiser())
         advertiser.start("after-adapter-recovery")
+        assertEquals(1, host.advertiseDataBuilds)
+    }
 
+    @Test
+    fun `a start surviving an adapter cycle is admitted only after a stop`() {
+        host.gattReady = true
+        advertiser.attachAdvertiser(platformAdvertiser())
+        advertiser.start("initial")
+        assertEquals(1, host.advertiseDataBuilds)
+
+        // Bluetooth goes off and comes back. The platform stops advertising
+        // without delivering onStartFailure, so nothing lowered the gate that
+        // this successful start raised — it now guards an advertisement that is
+        // already dead. A recovery that only re-attaches and re-starts, which is
+        // the obvious shape, is swallowed whole and the device stays
+        // discoverable to nobody.
+        advertiser.attachAdvertiser(platformAdvertiser())
+        advertiser.start("adapter_recovery")
+        assertEquals(1, host.advertiseDataBuilds)
+
+        // Which is what makes the stop in the facade's recovery runnable
+        // load-bearing rather than defensive.
         advertiser.stop()
-        assertEquals(listOf("Stopped BLE advertising"), seen)
+        advertiser.start("adapter_recovery")
+        assertEquals(2, host.advertiseDataBuilds)
     }
 
     @Test
@@ -93,29 +132,26 @@ class LeAdvertiserTest {
         host.gattReady = false
         advertiser.start("deferred-while-adapter-off")
         assertEquals(listOf("Waiting for GATT service registration"), seen)
+        assertEquals(0, host.advertiseDataBuilds)
 
         // Service registration lands after the adapter came back. The latched
         // reason is what makes this start happen at all.
         advertiser.attachAdvertiser(platformAdvertiser())
         host.gattReady = true
         advertiser.onGattServerReady()
-
-        advertiser.stop()
-        assertEquals(
-            listOf("Waiting for GATT service registration", "Stopped BLE advertising"),
-            seen,
-        )
+        assertEquals(1, host.advertiseDataBuilds)
     }
 
     @Test
     fun `onGattServerReady is inert when no start was ever deferred`() {
-        // Guards the negative half of the test above: the "Stopped BLE
-        // advertising" tell has to come from the latched deferral, not from
-        // onGattServerReady starting unconditionally.
+        // Guards the negative half of the test above: the admitted start there
+        // has to come from the latched deferral, not from onGattServerReady
+        // starting unconditionally.
         host.gattReady = true
         advertiser.attachAdvertiser(platformAdvertiser())
 
         advertiser.onGattServerReady()
+        assertEquals(0, host.advertiseDataBuilds)
 
         advertiser.stop()
         assertEquals(emptyList<String>(), seen)

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserTest.kt
@@ -91,6 +91,10 @@ class LeAdvertiserTest {
         // Bluetooth off: nothing attached, so this start has nothing to do.
         advertiser.start("while-adapter-off")
         assertEquals(0, host.advertiseDataBuilds)
+        assertEquals(
+            listOf("Deferring BLE advertising — advertiser unavailable"),
+            seen,
+        )
 
         // Adapter comes back and the facade re-attaches. This start must be
         // admitted — if the previous one had raised the gate, it would return

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ble/LeAdvertiserTest.kt
@@ -1,0 +1,123 @@
+package com.offlineprotocol.ble
+
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.AdvertiseData
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Pins what [LeAdvertiser.start] must do when it has no platform advertiser to
+ * start against — the state this class is in whenever the user has Bluetooth
+ * switched off, since `getBluetoothLeAdvertiser()` returns null for exactly
+ * that reason and the facade's adapter-reset path re-attaches whatever it
+ * reads.
+ *
+ * Two properties, both invisible in the source once written and both permanent
+ * if broken:
+ *
+ *  1. The in-flight gate must stay *down*. It is raised immediately before the
+ *     platform call and otherwise lowered only by `stop()` or a terminal
+ *     `onStartFailure` — neither of which runs when there is no call to make.
+ *     Raising it against a null advertiser therefore wedges advertising off for
+ *     the rest of the process lifetime.
+ *  2. The deferral must still be latched. The null check sits *below* the
+ *     GATT-readiness check precisely so an advertiser attached while the
+ *     service registration is still in flight is picked up by
+ *     [LeAdvertiser.onGattServerReady] rather than dropped on the floor.
+ *
+ * Neither is directly observable — `startInFlight` and `pendingAdvertiseReason`
+ * are private, and Robolectric's shadow advertiser accepts `startAdvertising`
+ * without invoking the callback, so `isAdvertising` never flips. Both tests
+ * therefore observe the same downstream tell: `stop()` emits "Stopped BLE
+ * advertising" only when a start actually reached the platform call and left an
+ * `advertiseCallback` behind. A start that was swallowed by a wedged gate, or
+ * never triggered because the deferral was dropped, leaves that emission out.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class LeAdvertiserTest {
+
+    private class FakeHost(var gattReady: Boolean) : LeAdvertiser.Host {
+        override fun isGattServerReady(): Boolean = gattReady
+        override fun buildAdvertiseData(): AdvertiseData = AdvertiseData.Builder().build()
+        override fun buildScanResponse(): AdvertiseData = AdvertiseData.Builder().build()
+        override fun refreshPublishedIdentity() {}
+        // Defeat throttling so every admitted call is individually observable.
+        override fun shouldLog(key: String, intervalMs: Long): Boolean = true
+    }
+
+    private val seen = mutableListOf<String>()
+    private val host = FakeHost(gattReady = true)
+    private val advertiser = LeAdvertiser(
+        mainHandler = Handler(Looper.getMainLooper()),
+        host = host,
+        diagnosticEmitter = { _, message, _ -> seen.add(message) },
+    )
+
+    /** A real (Robolectric-shadowed) platform advertiser to attach. */
+    private fun platformAdvertiser() =
+        ((RuntimeEnvironment.getApplication() as Context)
+            .getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
+            .adapter!!
+            .bluetoothLeAdvertiser
+
+    @Test
+    fun `start against a null advertiser leaves the in-flight gate down`() {
+        host.gattReady = true
+
+        // Bluetooth off: nothing attached, so this start has nothing to do.
+        advertiser.start("while-adapter-off")
+
+        // Adapter comes back and the facade re-attaches. This start must be
+        // admitted — if the previous one had raised the gate, it would return
+        // at `if (startInFlight) return` and advertising would be wedged off
+        // for good.
+        advertiser.attachAdvertiser(platformAdvertiser())
+        advertiser.start("after-adapter-recovery")
+
+        advertiser.stop()
+        assertEquals(listOf("Stopped BLE advertising"), seen)
+    }
+
+    @Test
+    fun `a null advertiser still latches the deferral for onGattServerReady`() {
+        // GATT registration in flight *and* no advertiser yet — the null check
+        // must not short-circuit the deferral that the GATT branch sets up.
+        host.gattReady = false
+        advertiser.start("deferred-while-adapter-off")
+        assertEquals(listOf("Waiting for GATT service registration"), seen)
+
+        // Service registration lands after the adapter came back. The latched
+        // reason is what makes this start happen at all.
+        advertiser.attachAdvertiser(platformAdvertiser())
+        host.gattReady = true
+        advertiser.onGattServerReady()
+
+        advertiser.stop()
+        assertEquals(
+            listOf("Waiting for GATT service registration", "Stopped BLE advertising"),
+            seen,
+        )
+    }
+
+    @Test
+    fun `onGattServerReady is inert when no start was ever deferred`() {
+        // Guards the negative half of the test above: the "Stopped BLE
+        // advertising" tell has to come from the latched deferral, not from
+        // onGattServerReady starting unconditionally.
+        host.gattReady = true
+        advertiser.attachAdvertiser(platformAdvertiser())
+
+        advertiser.onGattServerReady()
+
+        advertiser.stop()
+        assertEquals(emptyList<String>(), seen)
+    }
+}


### PR DESCRIPTION
Follow-up to #279, addressing the review findings on that PR plus one sibling crash they surfaced.

## 1. Nothing re-armed scanning after the swallowed `startScan` (the big one)

#279 stopped the crash, but not the failure. Walk the exact path it was written for — the watchdog firing while Bluetooth is off:

1. `restartScanning("watchdog")` → `stopScanning`: `stopScan` throws, the handler tears down **and cancels the scan watchdog and the connection monitor**.
2. `startScanning`: `startScan` throws, the handler logs and returns. `scheduleScanWatchdog()` only runs on success, so **nothing scan-related is left pending on the handler**.
3. User re-enables Bluetooth → nothing happens. `maybeProactivelyRefreshScan` only runs from `handleScanResult` (needs a live scan), the forced-refresh path likewise, there is no `ACTION_STATE_CHANGED` receiver anywhere in the bindings, and the module's `resume()` is a `@ReactMethod` the app must call — it is not wired to host lifecycle.

The transport keeps reporting `RUNNING` while the mesh is deaf. Any Bluetooth-off period past the 30s watchdog interval reaches this, so it is the common case rather than a narrow race. Before #279 the crash was the (terrible) recovery; after it there was none.

Fix: `bleRecoveryRunnable`, a deduped 10s retry armed from every `startScanning` exit that fails to get a scan going, cancelled by `stopScanning`. It re-reads the scanner and re-attaches the advertiser before retrying — both read null while the adapter is off, and the adapter-reset path re-attaches whatever it reads. Re-arming the scan is what puts the whole self-healing chain back in motion (watchdog, connection monitor, proactive/forced refresh, and the adapter reset they escalate to all hang off an active scan), which is why the runnable only has to get scanning going rather than rebuild the stack.

Cancellation sits at the top of `stopScanning`, ahead of its `isScanning` guard, because a pending recovery exists precisely when `isScanning` is false. That covers `pause()` — which leaves the transport `RUNNING`, so without it a paused transport would put itself back on air.

Also added an adapter check before `startScan`. The steady state of a switched-off adapter is now one throttled info diagnostic per minute instead of a caught exception on every heartbeat, which leaves the catch for the genuine race it documents.

## 2. Both catches were far wider than the framework call

The `startScanning` catch covered ~80 lines including `rehydratePreviouslyConnectedDevices()` → `connectToDevice`. Any `IllegalStateException` from that body was swallowed and relabelled "BT adapter not on" at info level — including this file's own `assertMainThread`, which is a `check(...)` introduced so threading drift "fails loud instead of silent". Both catches now wrap only `startScan`/`stopScan`; everything else propagates as it did before #279.

## 3. Duplicated teardown, and a `SecurityException` path that had none

The six-step teardown was copy-pasted between `stopScanning`'s success path and its `IllegalStateException` handler, and the `SecurityException` handler had neither copy — a permission failure there left `isScanning` true, which short-circuits the next `startScanning` at its guard and strands the watchdog and connection monitor firing against a dead scanner. Teardown now sits outside the try and runs on every outcome. For the adapter-off throw the framework-side scan is already dead and local state just has to follow; for a `SecurityException` it is not, since the call was refused and dropping `scanCallback` discards the only reference that could stop it. That is an accepted leak — Android kills the process on a runtime permission revocation — rather than an equivalence, and it beats the alternative in both cases.

## 4. `LeAdvertiser` had the same crash (beyond the review findings)

Flagging this explicitly since it is not one of the three findings. The platform refuses both LE entry points while the adapter is off the same way, and `LeAdvertiser` caught only `SecurityException` around each — so the identical crash survived #279, reachable from bare `mainHandler` posts (`scheduleRestart`, and the facade's adapter-reset path calling `stopAdvertising()`/`startAdvertising()`) where nothing catches it. Left alone, the app would still die on the same user action a second after the scan fix worked.

`start()` also has to lower its in-flight gate in the handler: the gate is raised before the call and otherwise only lowered by `stop()` or a terminal `onStartFailure`, neither of which runs when the call throws, so leaving it raised makes every later `start()` return early with advertising wedged off for good. Same reason `start()` now bails on a null advertiser rather than raising a gate no callback can lower — the adapter-reset path attaches `bluetoothAdapter?.bluetoothLeAdvertiser`, which is null exactly when the user has Bluetooth off.

## 5. Review follow-up (second commit)

Three gaps in the above, all found reviewing it back:

**`onScanFailed` was the same dead end, still open.** The runnable covers `startScan` refusing to run; it did not cover `startScan` accepting and the framework changing its mind a moment later. That callback cleared `isScanning`, cancelled the watchdog and the connection monitor, and scheduled nothing — the exact terminal state this PR exists to prevent. `SCAN_FAILED_INTERNAL_ERROR` and `SCAN_FAILED_APPLICATION_REGISTRATION_FAILED` reach it on any device, and builds that surface a mid-transition adapter here rather than by throwing reach it via this PR's own scenario. It now routes through `stopScanning` — reaching the callback means `startScan` *returned*, so the framework may still hold a registration for it (`SCAN_FAILED_ALREADY_STARTED` is exactly that), and re-entering `startScanning` with a fresh callback would strand one per attempt against a per-app cap of 5 — then arms recovery after the teardown, since `stopScanning` cancels a pending one by design. Callback identity is checked first so a failure from a scan already replaced cannot tear down its healthy successor.

**The runnable advertised before it scanned.** `LeAdvertiser.start` rethrows `SecurityException` so the synchronous `start()` path can surface it to a caller, and there is no caller on a bare handler post — one throw and the recovery loop is gone permanently, because `startScanning` is what re-arms it. Scan first; the advertising attempt, always documented as best-effort, is now wrapped.

**The null-advertiser bail sat above the GATT-readiness check**, so a null advertiser skipped the deferral too and an advertiser attached mid-registration was dropped rather than picked up by `onGattServerReady()`. Moved below, and now tested.

## Scope and limits

- Deliberately **not** an `ACTION_STATE_CHANGED` receiver. That is the better event-driven shape and would also make teardown deterministic instead of exception-driven, but it is a larger change with real lifecycle risk (registration leaks, double-registration, exported-flag handling across API levels) for a bounded latency win. The retry runnable matches how every other self-healing path in this class already works.
- Recovery restores scanning and, best-effort, advertising. It does **not** re-register the GATT service, so after a long adapter-off the device may recover discovery (the central role, which is what finds peers and connects out) before it is discoverable again. Rebuilding the stack stays owned by `evaluateBleHealthAfterRestart`, which recovery makes reachable again.
- **Advertising is only healed as a passenger on a scan recovery.** The runnable returns at its `isScanning` guard, so a device whose scan is healthy while advertising alone is dead — an adapter reset that re-attached a null advertiser, or a terminal `onStartFailure`, which clears the gate and schedules no retry — stays discoverable to nobody. Closing that needs its own advertising-side retry and is not in this PR. Documented on `bleRecoveryRunnable` so the next reader does not assume the runnable covers it.
- Recovery latency after the user switches Bluetooth back on is now up to 30s rather than a flat 10s, because the retry backs off (10s, doubling, capped at 30s) so a long adapter-off does not sit at six wakeups a minute forever. The cap is deliberately low: nothing else re-arms the scan, so it *is* the worst-case deaf window.

## Tests

`LeAdvertiserTest` covers the two properties of `start()` that are permanent if broken and invisible in the source once written: the in-flight gate must stay down when there is no advertiser to start against, and a null advertiser must still latch the deferral so an advertiser attached mid-GATT-registration is picked up by `onGattServerReady()`. Neither is directly observable — `startInFlight` and `pendingAdvertiseReason` are private, and Robolectric's shadow advertiser accepts `startAdvertising` without invoking the callback — so both assert on the downstream tell: `stop()` emits `Stopped BLE advertising` only when a start actually reached the platform call. Verified non-vacuous by moving the null guard back above the GATT check, which fails the deferral test.

This was possible because `LeAdvertiser` already takes its handler, host and diagnostic sink as injected seams. The facade's scan lifecycle still has no tests and does not get any here — that genuinely needs a fully constructed facade, and extracting a predicate to have something to assert on would be theater. It is verified instead by running the suite through the CI harness (28 classes, 264 tests) and by walking each path (watchdog restart, pause/resume, stop, adapter reset, scan-failed, normal operation) against the changed code.
