### PR TITLE
fix(bindings): stop MeshForegroundService on a sticky restart with no mesh host

### DIFF
--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
@@ -20,7 +20,9 @@ import androidx.core.app.NotificationCompat
  * Lifecycle:
  *   - Started when protocol.start() is called and BLE/WiFi/Internet transports are active.
  *   - Stopped when protocol.stop() is called or the user explicitly disables mesh.
- *   - Uses START_STICKY so the system restarts the service after a process kill.
+ *   - Uses START_STICKY so the system hands the service back after a process
+ *     kill, but that restart only survives if a host has a mesh running again
+ *     by the time it lands — see [handleStickyRestart].
  *
  * The service itself does NOT own the protocol or transport instances.
  * It exists solely to prevent the OS from killing the process while mesh
@@ -62,9 +64,16 @@ class MeshForegroundService : Service() {
         private var startRequested: Boolean = false
 
         /**
-         * Callback invoked when the service is restarted after a process kill
-         * (START_STICKY re-delivery). The host module should set this so it can
-         * re-initialize the protocol.
+         * Optional hook, invoked on a START_STICKY restart *only* when a host is
+         * registered in [onStopRequestedByUser]. A restart into a hostless
+         * process stops the service instead of announcing itself to nobody —
+         * see [handleStickyRestart].
+         *
+         * Nothing in production assigns this yet, and a host that does still
+         * cannot rebuild the protocol from here: that needs the ProtocolConfig,
+         * which only JS has. Issue #291 tracks the two designs that could supply
+         * it (persist the config natively, or wake JS); this is the seam either
+         * would attach to.
          */
         @Volatile
         var onServiceRestarted: (() -> Unit)? = null
@@ -141,8 +150,10 @@ class MeshForegroundService : Service() {
             //
             // Both flags are needed: startRequested covers a stop racing a
             // service that is still coming up (isRunning not yet set), and
-            // isRunning covers an instance we never requested — a START_STICKY
-            // restart after process death, which resets the statics.
+            // isRunning covers an instance we never requested. Process death
+            // resets the statics, so a sticky restart that found a host and a
+            // tap on a stale notification re-creating us both leave a running
+            // service that no start() in this process accounts for.
             if (!startRequested && !isRunning) return
             startRequested = false
             val intent = Intent(context, MeshForegroundService::class.java).apply {
@@ -191,14 +202,53 @@ class MeshForegroundService : Service() {
                 Log.i(TAG, "Starting mesh foreground service")
                 promoteToForeground()
             }
-            null -> {
-                // Service restarted by the system after process kill (START_STICKY).
-                // Re-enter foreground immediately to prevent ANR, then notify host.
-                Log.i(TAG, "Service restarted after process kill")
-                promoteToForeground()
-                onServiceRestarted?.invoke()
-            }
+            null -> return handleStickyRestart()
         }
+        return START_STICKY
+    }
+
+    /**
+     * Handle a null-intent re-delivery — the system restarting us under
+     * START_STICKY after the process was killed.
+     *
+     * The old process took the protocol, every transport and the host module
+     * with it, so this instance is only worth keeping if a host in the *new*
+     * process has since brought a mesh back up. [onStopRequestedByUser] is
+     * exactly that signal: the module registers it immediately before starting
+     * this service and clears it by identity on every teardown path, so a
+     * non-null slot means a live host that believes mesh is running. That
+     * ordering does happen — an app that boots React Native from
+     * Application.onCreate can have re-started the mesh before this
+     * re-delivered intent lands.
+     *
+     * With no host, staying up is strictly worse than dying. The notification
+     * claims "Mesh Active" over a protocol nothing can rebuild, and survives
+     * until the user taps Stop or the OS reaps us. Worse where the promotion is
+     * refused outright: on targetSdk 31+ entering the foreground from the
+     * background is only allowed under a fixed set of exemptions, and a sticky
+     * restart is not one of them, so [promoteToForeground] swallows a
+     * ForegroundServiceStartNotAllowedException and what is left is an empty
+     * process squatting with no notification at all. Stopping is the honest
+     * outcome for both, and START_NOT_STICKY keeps the system from handing the
+     * same restart straight back — an exit, not a loop.
+     *
+     * Stopping without a successful promotion is legal here: the five-second
+     * startForeground() obligation attaches to Context.startForegroundService()
+     * calls, which a system restart is not.
+     *
+     * Re-initializing the protocol instead would need the ProtocolConfig, which
+     * only JS has. See issue #291 for the two designs that could supply it;
+     * whichever lands attaches here, through [onServiceRestarted].
+     */
+    private fun handleStickyRestart(): Int {
+        if (onStopRequestedByUser == null) {
+            Log.i(TAG, "Service restarted after process kill with no mesh host; stopping")
+            stopForegroundAndSelf()
+            return START_NOT_STICKY
+        }
+        Log.i(TAG, "Service restarted after process kill; host present")
+        promoteToForeground()
+        onServiceRestarted?.invoke()
         return START_STICKY
     }
 

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/MeshForegroundService.kt
@@ -87,6 +87,13 @@ class MeshForegroundService : Service() {
          * no JS-visible state change — the user sees "mesh off" while the
          * radios keep draining until the OS reaps the process.
          *
+         * Carries a second meaning that constrains when it may be set: a
+         * non-null slot is the only signal in the process that a live host
+         * believes mesh is running, which is what [handleStickyRestart] gates
+         * on. So it is registered as mesh comes up and surrendered as mesh goes
+         * down — see [stop] — rather than tracking the module's own lifetime,
+         * which outlives the mesh.
+         *
          * Held in a companion field, so a host that captures itself here must
          * drop it on teardown or it pins that host for the process lifetime.
          * Mutated only through [registerStopRequestCallback] and
@@ -141,7 +148,26 @@ class MeshForegroundService : Service() {
             }
         }
 
-        fun stop(context: Context) {
+        /**
+         * Brings the keep-alive down, and with it [host]'s registration when
+         * that is still the live one.
+         *
+         * Surrendering the registration is part of stopping rather than a
+         * courtesy. The slot doubles as the sticky-restart liveness signal (see
+         * [handleStickyRestart]), so leaving it set over a mesh the host has
+         * already torn down re-arms the exact restart that gate exists to
+         * refuse — "Mesh Active" and START_STICKY over a protocol that is gone.
+         * It has to fall with the mesh, which is here, not with the module,
+         * which outlives it and may never be torn down at all.
+         *
+         * The clear runs ahead of the nothing-to-stop guard below, so a host
+         * whose service is already down still deregisters, and it clears by
+         * identity, so a departing host cannot disarm its replacement — see
+         * [clearStopRequestCallback]. [host] is nullable only for callers that
+         * hold no registration to surrender; one that does must pass it.
+         */
+        fun stop(context: Context, host: (() -> Unit)?) {
+            host?.let { clearStopRequestCallback(it) }
             // Skip when there is nothing to stop. Callers invoke this from
             // both stop() and invalidate(), so a stop-after-stop would
             // otherwise create an instance purely to tear it down — and since
@@ -214,12 +240,14 @@ class MeshForegroundService : Service() {
      * The old process took the protocol, every transport and the host module
      * with it, so this instance is only worth keeping if a host in the *new*
      * process has since brought a mesh back up. [onStopRequestedByUser] is
-     * exactly that signal: the module registers it immediately before starting
-     * this service and clears it by identity on every teardown path, so a
-     * non-null slot means a live host that believes mesh is running. That
-     * ordering does happen — an app that boots React Native from
-     * Application.onCreate can have re-started the mesh before this
-     * re-delivered intent lands.
+     * exactly that signal, because it is scoped to the mesh and not to the
+     * host: the module registers it immediately before starting this service
+     * and surrenders it to [stop] as the mesh comes down, so a non-null slot
+     * means a host that believes mesh is running *now* — not merely one that
+     * started it at some point. A slot that outlived its mesh would send this
+     * gate straight back into the behaviour it exists to refuse. That ordering
+     * does happen — an app that boots React Native from Application.onCreate
+     * can have re-started the mesh before this re-delivered intent lands.
      *
      * With no host, staying up is strictly worse than dying. The notification
      * claims "Mesh Active" over a protocol nothing can rebuild, and survives

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -157,6 +157,12 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
      * per-ReactContext, so during a reload this module may be tearing down
      * *after* its replacement registered, and an unconditional null would
      * disarm the live host's Stop action.
+     *
+     * A backstop, not the main path, and idempotent so it stays cheap as one:
+     * mesh teardown surrenders the registration through [stopForegroundService]
+     * instead, because the slot is the service's sticky-restart liveness signal
+     * and must fall with the mesh rather than with the module. This covers a
+     * teardown that never reached that step.
      */
     private fun releaseForegroundStopCallback() {
         val ours = foregroundStopCallback ?: return
@@ -3991,7 +3997,16 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
      */
     private fun stopForegroundService() {
         try {
-            MeshForegroundService.stop(reactApplicationContext)
+            // Surrender our registration along with the stop. That slot is also
+            // the service's sticky-restart liveness signal, so it has to fall
+            // when the mesh does — not when this module does, which is later
+            // and may never happen at all. Left set over a stopped mesh, a
+            // sticky restart reads it as "a host has mesh up" and re-posts
+            // "Mesh Active" over a protocol that is gone. Cleared by identity
+            // inside stop(), so a reload's replacement host stays armed.
+            val ours = foregroundStopCallback
+            foregroundStopCallback = null
+            MeshForegroundService.stop(reactApplicationContext, ours)
             emitDiagnostic("info", "Mesh foreground service stopped")
         } catch (e: Exception) {
             android.util.Log.w(NAME, "Failed to stop foreground service: ${e.message}", e)

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
@@ -42,7 +42,10 @@ import org.robolectric.annotation.Config
  * service back after a process kill, but the protocol, the transports and the
  * module died with the old process, and nothing native can rebuild them — so
  * the restart has to check whether a host has brought a mesh back up before it
- * re-posts a notification claiming one is running.
+ * re-posts a notification claiming one is running. That check reads the same
+ * stop-callback slot, which is why the slot's lifetime is pinned here too: it
+ * has to be surrendered when the mesh stops, not when the module dies, or the
+ * gate reads "host present" over a mesh that is already down.
  *
  * Action strings are written out verbatim rather than read from the companion:
  * they cross a process boundary inside a PendingIntent that can outlive the
@@ -89,7 +92,7 @@ class MeshForegroundServiceTest {
         MeshForegroundService.onServiceRestarted = null
         controller?.destroy()
         controller = null
-        MeshForegroundService.stop(context)
+        MeshForegroundService.stop(context, null)
         drainStartedServices()
     }
 
@@ -304,6 +307,70 @@ class MeshForegroundServiceTest {
     }
 
     @Test
+    fun `stopping the mesh surrenders the host registration`() {
+        val host = registerHost { }
+
+        // Nothing is up, so stop() takes its nothing-to-stop early return. The
+        // registration must go anyway: it tracks the mesh rather than the
+        // module, and the mesh is down either way. Clearing after that guard
+        // instead of before it would strand the slot on exactly the path the
+        // app runs twice (stop() and invalidate()).
+        MeshForegroundService.stop(context, host)
+
+        assertNull(
+            "the slot is the sticky-restart liveness signal and must fall with the mesh",
+            MeshForegroundService.onStopRequestedByUser
+        )
+    }
+
+    @Test
+    fun `a stale host stopping the mesh leaves the current one armed`() {
+        var staleInvoked = 0
+        var currentInvoked = 0
+        // The same reload overlap the clear path guards against, reached
+        // through a stop: the replacement registers before the outgoing module
+        // tears its own mesh down. Surrendering by identity is what keeps the
+        // live host's Stop action armed.
+        val stale = registerHost { staleInvoked += 1 }
+        registerHost { currentInvoked += 1 }
+
+        MeshForegroundService.stop(context, stale)
+        drainStartedServices()
+
+        createService()
+        deliver(ACTION_STOP_FROM_NOTIFICATION)
+
+        assertEquals("a stale host's stop must not disarm the current one", 1, currentInvoked)
+        assertEquals(0, staleInvoked)
+    }
+
+    @Test
+    fun `sticky restart after the host stopped the mesh stops instead of re-promoting`() {
+        var restarted = 0
+        MeshForegroundService.onServiceRestarted = { restarted += 1 }
+
+        // The window the host-present branch exists for, with a mesh that went
+        // down inside it: the kill leaves a restart pending, the new process
+        // boots React Native, brings mesh up and takes it back down — all
+        // before the re-delivered intent lands. A slot scoped to the module
+        // rather than the mesh would still read "host present" here and
+        // re-post "Mesh Active" over a protocol that is gone.
+        val host = registerHost { }
+        MeshForegroundService.start(context)
+        drainStartedServices()
+        MeshForegroundService.stop(context, host)
+        drainStartedServices()
+
+        createService()
+        val service = deliver(null)
+
+        assertEquals("a host that stopped its mesh is not a host to notify", 0, restarted)
+        assertTrue(shadowOf(service).isForegroundStopped)
+        assertTrue(shadowOf(service).isStoppedBySelf)
+        assertFalse(MeshForegroundService.isRunning)
+    }
+
+    @Test
     fun `stop does not create a service when none was started`() {
         // Establish the precondition explicitly: onDestroy clears both the
         // running flag and the start-request flag that survive between tests.
@@ -312,7 +379,7 @@ class MeshForegroundServiceTest {
         controller = null
         drainStartedServices()
 
-        MeshForegroundService.stop(context)
+        MeshForegroundService.stop(context, null)
 
         // Without the guard this would start the service just to stop it —
         // and since onCreate now promotes, that is a notification flash on a
@@ -331,7 +398,7 @@ class MeshForegroundServiceTest {
         MeshForegroundService.start(context)
         drainStartedServices()
 
-        MeshForegroundService.stop(context)
+        MeshForegroundService.stop(context, null)
 
         val stopIntent = shadowOf(RuntimeEnvironment.getApplication()).nextStartedService
         assertNotNull("stop() must reach a service that start() already requested", stopIntent)

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/MeshForegroundServiceTest.kt
@@ -1,5 +1,6 @@
 package com.offlineprotocol
 
+import android.app.Service
 import android.content.Context
 import android.content.Intent
 import org.junit.After
@@ -18,8 +19,8 @@ import org.robolectric.android.controller.ServiceController
 import org.robolectric.annotation.Config
 
 /**
- * Pins the two invariants that keep [MeshForegroundService] from taking the
- * process down with it.
+ * Pins the three invariants that keep [MeshForegroundService] from taking the
+ * process down with it, or from outliving the mesh it advertises.
  *
  * The first is the reason this class exists at all: Android gives an app five
  * seconds after `startForegroundService()` to call `startForeground()`, and
@@ -36,6 +37,12 @@ import org.robolectric.annotation.Config
  * *right* host: the callback slot is process-global while hosts are
  * per-ReactContext, so clearing it is by identity and a departing host must
  * leave its replacement armed.
+ *
+ * The third is what a START_STICKY restart may assert. The system hands the
+ * service back after a process kill, but the protocol, the transports and the
+ * module died with the old process, and nothing native can rebuild them — so
+ * the restart has to check whether a host has brought a mesh back up before it
+ * re-posts a notification claiming one is running.
  *
  * Action strings are written out verbatim rather than read from the companion:
  * they cross a process boundary inside a PendingIntent that can outlive the
@@ -242,8 +249,14 @@ class MeshForegroundServiceTest {
     }
 
     @Test
-    fun `sticky restart re-promotes and notifies the host`() {
+    fun `sticky restart re-promotes and notifies a host that is already back up`() {
         var restarted = 0
+        // A registered stop callback is what "a host in this process has a mesh
+        // running" looks like — the module registers it immediately before
+        // starting the service. Reachable on a restart because an app that
+        // boots React Native from Application.onCreate can beat the
+        // re-delivered intent.
+        registerHost { }
         MeshForegroundService.onServiceRestarted = { restarted += 1 }
 
         createService()
@@ -253,6 +266,41 @@ class MeshForegroundServiceTest {
         assertEquals(1, restarted)
         assertEquals(NOTIFICATION_ID, shadowOf(service).lastForegroundNotificationId)
         assertTrue(MeshForegroundService.isRunning)
+        assertFalse(shadowOf(service).isStoppedBySelf)
+    }
+
+    @Test
+    fun `sticky restart with no host stops instead of outliving the mesh`() {
+        var restarted = 0
+        MeshForegroundService.onServiceRestarted = { restarted += 1 }
+        assertNull("no host registered is the whole precondition", MeshForegroundService.onStopRequestedByUser)
+
+        createService()
+        val service = deliver(null)
+
+        // The protocol died with the old process and nothing here can rebuild
+        // it, so "Mesh Active" would be a lie that outlives the mesh. On 12+ it
+        // is worse: the promotion is refused from the background, leaving an
+        // empty process squatting with no notification at all.
+        assertEquals("there is no host to notify", 0, restarted)
+        assertTrue(shadowOf(service).isForegroundStopped)
+        assertTrue(shadowOf(service).isStoppedBySelf)
+        assertFalse(MeshForegroundService.isRunning)
+    }
+
+    @Test
+    fun `sticky restart return value tracks host presence`() {
+        // Pins the return values the ServiceController API hides. Both branches
+        // run against one instance: this is about what onStartCommand returns,
+        // not about the lifecycle around it.
+        val service = createService()
+
+        // START_NOT_STICKY, or the system hands the same restart straight back
+        // and the stop above becomes a loop rather than an exit.
+        assertEquals(Service.START_NOT_STICKY, service.onStartCommand(null, 0, 1))
+
+        registerHost { }
+        assertEquals(Service.START_STICKY, service.onStartCommand(null, 0, 2))
     }
 
     @Test


### PR DESCRIPTION
Fixes the reported half of #291. Directions (a) and (b) from that issue — actually re-initializing the protocol after a restart — remain open; see "What this deliberately does not do" below.

## The bug

`MeshForegroundService.onServiceRestarted` is declared (`:70`) and invoked (`:199`) but **nothing in production ever assigns it** — the only assignments are in `MeshForegroundServiceTest`. The START_STICKY restart path was built as half of a two-party protocol (service notifies host → host re-initializes the protocol) whose host half was never implemented, and the null-intent branch re-promoted to the foreground **unconditionally** regardless.

That leaves two bad outcomes after a process kill, depending on whether the promotion is allowed:

- **It succeeds** (pre-12, or the app is foregrounded): a "Mesh Active" notification with a working-looking Stop action, over a protocol and transports that died with the old process and that nothing native can rebuild. It stays up until the user taps Stop or the OS reaps the service.
- **It is refused** (targetSdk 31+ with the app backgrounded): apps targeting API 31+ [cannot start a foreground service from the background](https://developer.android.com/develop/background-work/services/fgs/restrictions-bg-start) outside a fixed exemption list, and a system sticky restart is not on it. `promoteToForeground()` swallows the `ForegroundServiceStartNotAllowedException`, so what is left is an empty process squatting with no notification at all.

## The fix

Gate the null-intent branch on host liveness, extracted into `handleStickyRestart()`:

- **No host** → `stopForegroundAndSelf()` and return `START_NOT_STICKY`, so the system does not hand the same restart straight back. Stopping without a successful promotion is legal here: the five-second `startForeground()` obligation attaches to `Context.startForegroundService()` calls, which a system restart is not.
- **Host present** → today's behaviour (promote + `onServiceRestarted?.invoke()`, `START_STICKY`).

`onStopRequestedByUser` is the liveness signal because it means precisely the right thing: `OfflineProtocolModule.startForegroundService()` registers it immediately before `MeshForegroundService.start()`, and clears it by identity on every teardown path. A non-null slot is a live host in *this* process that believes mesh is running. The host-present branch is not dead code — an app that boots React Native from `Application.onCreate` can re-start the mesh before the re-delivered intent lands, and intent-delivery order is not guaranteed.

`onServiceRestarted` is kept, retitled as an optional hook, because the restart moment is the only seam directions (a)/(b) can attach to.

## What this deliberately does not do

It does not re-initialize the protocol. That needs the `ProtocolConfig`, which only JS has — the design decision #291 was filed to make. This is the issue's option **(c)**, which it argues is "cheap, independent of the others, and strictly better than today's behavior." I did not wire the module to assign `onServiceRestarted` (a JS event, direction (b)): in the scenario that actually matters the module does not exist yet, so the assignment would be dead exactly when needed, and it would also hit the known `sendEvent`-drops-at-zero-listeners gap.

## Known residual

`onCreate` still promotes unconditionally, so a foregrounded/pre-12 restart shows the notification for the milliseconds between `onCreate` and the stop. That promotion cannot move: a tap on a stale notification re-creates the service via `startForegroundService()`, and the `onCreate` promotion is the only thing satisfying the five-second deadline before the stop is handled (coupling documented at `MeshForegroundService.kt:294–299`). The channel is `IMPORTANCE_LOW`, so it is a silent tray blip, not a heads-up.

## Blast radius

Android bindings only — one production file and its test file. No module, Rust, UniFFI, TypeScript, or iOS changes; no FFI, event, or wire surface touched. The only behavioural loss is a warm empty process after a kill. No flag: the old behaviour has no defensible use. Revert is clean — no persisted state.

## Tests

`MeshForegroundServiceTest` 12 → 14, full Android suite **274 passing**.

- reworked `sticky restart re-promotes and notifies a host that is already back up` (was `…and notifies the host`, which pinned the lying behaviour — it registers a host now)
- added `sticky restart with no host stops instead of outliving the mesh`
- added `sticky restart return value tracks host presence` (pins `START_NOT_STICKY`/`START_STICKY`, which the `ServiceController` API hides)

Both new tests were confirmed **red against the pre-fix production code** and green after. The reworked one passes against both, correctly — that path was already right.