### PR TITLE
chore(release): 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,30 @@ All notable changes to the Offline Protocol SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This changelog covers everything after the **v0.7.1** release.
 
-## [Unreleased]
+## [0.20.1] — 2026-08-07
+
+> **Nothing breaks a build, and one event changes meaning.** A receiver no
+> longer acknowledges a frame it failed to decrypt or failed to parse — it
+> withholds the ACK so the sender's resend can deliver, where before the sender
+> was told "delivered" for a message that was dropped. The visible consequence
+> is that **`messageDecryptionFailed` is now advisory and fires once per failed
+> *attempt*, not once per message.** If your UI settles a message on it — marks
+> it lost, removes it from a list — switch to `messageFailed`, or
+> `fileReceiveFailed` for media, which are the terminal signals. Everything here
+> stays under the existing `encryption.cryptoRecoveryEnabled` kill switch
+> (default on); `false` restores the previous drop-and-ACK.
+>
+> A media chunk that fails its identity binding is now answered with silence
+> like the text path, which is deliberately *not* under that switch — it governs
+> what the receiver reveals to whoever injected the frame, not whether anything
+> can be recovered. One side effect: a repeated injection of the identical frame
+> re-emits `MEDIA_SENDER_GROUP_MISMATCH` on each attempt rather than being
+> suppressed by dedup after the first. The rate is the signal.
+>
+> GitHub releases now attach the compiled binaries — six archives plus
+> `SHA256SUMS.txt`, each carrying its own licence and export notices, and all of
+> them attested. npm is unchanged and remains the supported route for React
+> Native.
 
 ### Changed
 

--- a/bindings/react-native/package-lock.json
+++ b/bindings/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@offline-protocol/mesh-sdk",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@offline-protocol/mesh-sdk",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@types/react-native": "^0.72.8",

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offline-protocol/mesh-sdk",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Offline-first mesh networking SDK with intelligent transport switching for React Native",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -36,6 +36,14 @@ a `ProtocolState` your app *persisted itself* (AsyncStorage, redux-persist):
 that value returns as a number and now matches nothing, so treat an
 unrecognised persisted value as `Stopped`.
 
+`v0.20.1` adds one more, and this one *does* need a change if your UI settles a
+message on it: `messageDecryptionFailed` is now advisory and fires once per
+failed **attempt** rather than once per message, because a receiver that cannot
+decrypt or parse a frame now withholds the delivery ACK so the sender's resend
+can deliver.
+[§11.1](#111-messagedecryptionfailed-is-advisory-not-terminal-v0201) has the
+full contract and the events to settle on instead.
+
 Work through it in order. [§0](#0-before-you-ship-downgrade-is-not-a-rollback)
 is a release-engineering decision, not a code change, and it is the one that
 cannot be undone later.
@@ -954,6 +962,54 @@ reported. `detail` carries the reason.
 - A retry of a failed `initialize_mls` can settle the same id twice. A duplicate
   terminal event is deliberate — it is a far smaller lie than silence. Make your
   handler idempotent.
+
+### 11.1 `messageDecryptionFailed` is advisory, not terminal *(v0.20.1)*
+
+No new event type — but this one changes meaning, and an app that settles a
+message on it now settles too early.
+
+A receiver that cannot decrypt or parse an inbound frame used to drop it and
+send a delivery ACK anyway, so the sender marked the message delivered and
+stopped retrying: silent loss behind an ACK claiming the opposite. It now
+**withholds the ACK**, which is what lets the sender's resend deliver — and for
+a DM that resend is re-sealed against the peer's current session, so it carries
+a live ratchet generation rather than replaying bytes that already failed.
+
+The consequence for your event handler:
+
+| Event | Before | Now |
+|---|---|---|
+| `messageDecryptionFailed` | effectively terminal — one per lost message | **advisory**, once per failed *attempt*, bounded by the sender's ACK retry budget |
+| `messageFailed` | terminal | terminal — **settle here** |
+| `fileReceiveFailed` | terminal | terminal — **settle here for media** |
+
+**What to change.** If your UI marks a message lost, removes it from a list, or
+resolves a promise on `messageDecryptionFailed`, move that to `messageFailed`
+(or `fileReceiveFailed` for media). Treat `messageDecryptionFailed` as "this
+attempt did not decrypt" — useful for diagnostics, and expect repeats for the
+same message. Make the handler idempotent, as with the settlements above.
+
+Media has no sender-side re-seal (chunks are re-encoded rather than replayed),
+so an undecryptable chunk recovers the way an interrupted transfer already
+does: the withheld ACK drives the media outbox to surface `MediaResendRequired`
+and the app re-supplies the bytes.
+
+**What did not change is the re-key.** Only a proven epoch mismatch tears down
+and rebuilds a session. These failures withhold the ACK but never re-key —
+turning every malformed frame into a session teardown would be an unbounded
+churn vector. And **failures *after* a successful decrypt stay terminal and
+still ACK** (an empty or non-UTF-8 plaintext, a decrypted media body that does
+not parse): the generation is spent, so no resend could ever deliver.
+
+All of the above sits under the existing `encryption.cryptoRecoveryEnabled`
+kill switch (default on); setting it `false` restores the previous
+drop-and-ACK. One related change is deliberately **not** under that switch: a
+media chunk failing its identity binding is now answered with silence, matching
+what the text path has always done, because it governs what the receiver
+reveals to whoever injected the frame rather than whether anything can be
+recovered. A repeated injection of the identical frame therefore re-emits
+`MEDIA_SENDER_GROUP_MISMATCH` on each attempt instead of being suppressed by
+dedup after the first — the rate is the signal, as with `SESSION_REKEY_TRIGGERED`.
 
 ---
 


### PR DESCRIPTION
Cuts **v0.20.1**. Three commits since `v0.20.0`, all `fix`/`ci`:

| PR | |
|---|---|
| [#317](https://github.com/Offline-Protocol/offline-protocol-sdk/pull/317) | stop ACKing messages that failed to decrypt |
| [#321](https://github.com/Offline-Protocol/offline-protocol-sdk/pull/321) | finish the no-ACK boundary — closes #318, #319, #320 |
| [#314](https://github.com/Offline-Protocol/offline-protocol-sdk/pull/314) | attach compiled binaries to the GitHub release |

All three were already in `[Unreleased]`; no entry was missing this time.

## Why a patch, not a minor

No public surface changed. The `offline_protocol.udl` and `types.ts` diffs since
`v0.20.0` are **comment-only**, and `config.rs` / `events.rs` / `error.rs` have
zero non-comment additions — verified with
`git diff v0.20.0..HEAD -- <file> | grep -vE '^\+[[:space:]]*(///|//)'`.

Precedent agrees: `v0.18.2` shipped `wipePersistedState`, an entirely new public
API, as a patch. A release that adds no API at all is comfortably one.

## The one thing app teams must act on

Not a break — a meaning change. `messageDecryptionFailed` is now **advisory**
and fires once per failed *attempt* rather than once per message, because a
receiver that cannot decrypt or parse a frame now withholds the delivery ACK so
the sender's resend can deliver. A UI that settles a message on that event now
settles too early and should move to `messageFailed` (or `fileReceiveFailed` for
media).

Because the version number no longer signals this, the docs carry it instead:
the release-header blockquote leads with it, and a new
[`docs/UPGRADING.md` §11.1](docs/UPGRADING.md) gives the full contract — the
before/after event table, what stays terminal (failures *after* a successful
decrypt), why the re-key is unchanged, and the `encryption.cryptoRecoveryEnabled`
kill switch that restores the previous behaviour.

## Files

- `CHANGELOG.md` — `[Unreleased]` → `[0.20.1] — 2026-08-07` + release header; no empty `[Unreleased]` left behind
- `bindings/react-native/package.json` + `package-lock.json` — `0.20.1`
- `docs/UPGRADING.md` — new §11.1, plus a pointer to it from the intro
- `SECURITY.md` — **untouched**; the supported line stays `0.20.x`

## Verification

| Check | |
|---|---|
| `cargo clippy --workspace --locked -- -D warnings` | pass |
| `cargo test --workspace --lib` | pass — 1230 + 252 + 124 + 86 + 81 + 69 + 54 + 33, 0 failed |
| `cargo fmt --all -- --check` | pass |
| `scripts/check-license-consistency.sh` | pass |
| `npx tsc --noEmit` (bindings/react-native) | pass |
| `scripts/tests/test-package-release-assets.sh` | pass — incl. negative controls |

Merging this and tagging `v0.20.1` on `main` fires `release.yml`, which for the
first time attaches the six binary archives + `SHA256SUMS.txt` alongside the npm
publish.