### PR TITLE
fix(ci): only pass --provenance to npm publish from a public repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -665,9 +665,37 @@ jobs:
       # publishes a signed link from the tarball back to this workflow run, so
       # the registry copy is verifiable too rather than trusted on the strength
       # of the publishing token alone.
+      #
+      # It is conditional because the registry refuses it from a private source
+      # repository — "Unsupported GitHub Actions source repository visibility"
+      # (HTTP 422), which failed the v0.20.1 publish after the GitHub release had
+      # already been created. The rule is npm's, not ours, and it is coherent:
+      # a provenance statement nobody can check against the named source proves
+      # nothing. So the flag follows repository visibility rather than being
+      # hardcoded either way, and this re-enables itself if the repo is ever made
+      # public. Note the GitHub attestation above is unaffected — it verifies via
+      # the API against the repo, so a private repo is fine there.
+      #
+      # Decided in its own always-running step so a dry run reports which branch a
+      # real release would take; the publish itself is the only part dry runs skip.
+      - name: Resolve npm provenance eligibility
+        id: provenance
+        env:
+          REPO_VISIBILITY: ${{ github.event.repository.visibility }}
+        run: |
+          if [[ "$REPO_VISIBILITY" == "public" ]]; then
+            echo "FLAG=--provenance" >> "$GITHUB_OUTPUT"
+            echo "Source repository is public — publishing with provenance."
+          else
+            echo "FLAG=" >> "$GITHUB_OUTPUT"
+            echo "::warning title=npm provenance skipped::Source repository visibility is \
+          '${REPO_VISIBILITY:-unknown}'; npm accepts provenance only from public repositories, \
+          so the tarball publishes without it. The GitHub release assets are still attested."
+          fi
+
       - name: Publish to npm
         if: inputs.dry_run != true
         working-directory: bindings/react-native
-        run: npm publish --access public --provenance
+        run: npm publish --access public ${{ steps.provenance.outputs.FLAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes the failed **v0.20.1** npm publish.

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@offline-protocol%2fmesh-sdk
npm error Error verifying sigstore provenance bundle: Unsupported GitHub Actions
source repository visibility: "private". Only public source repositories are
supported when publishing with provenance.
```

`--provenance` was added in #314. `release.yml` runs only on a `v*` tag, so its
first execution was during a real release — the same no-PR-coverage gap #314's
own packaging script was moved out of the workflow to avoid.

## What broke, and what did not

| | |
|---|---|
| GitHub release `v0.20.1` | ✅ **live and complete** — 6 archives + `SHA256SUMS.txt` + notices, attested |
| npm `0.20.1` | ❌ **not published** — registry rejected it; `latest` is still `0.20.0`, nothing partial |

Every build/package/attest job succeeded. Only the final `npm publish` step failed.

## The fix

The flag now follows repository visibility rather than being hardcoded:

```yaml
- name: Resolve npm provenance eligibility
  id: provenance
  env:
    REPO_VISIBILITY: ${{ github.event.repository.visibility }}
  run: |
    if [[ "$REPO_VISIBILITY" == "public" ]]; then ...
```

Three things worth calling out:

- **A condition, not a deletion.** npm's rule is coherent — a provenance statement
  whose source nobody can fetch proves nothing — and making the repo public later
  re-enables provenance with no further change.
- **The GitHub attestation stays on.** It verifies through the API against the
  repo, so a private repo is fine there. Only the *registry* copy loses its link,
  and `gh attestation verify` on the release assets is unaffected.
- **The check fails toward publishing.** Anything other than a literal `"public"`,
  including an absent field, takes the no-provenance branch — the one that always
  succeeds. Losing an optional signal beats failing the release again. The skip
  surfaces as a workflow warning rather than passing silently.

The decision is made in a step that runs on **dry runs too**, so `workflow_dispatch`
now reports which branch a real release would take. That is the only PR-time
coverage available here — the publish step itself cannot run outside a release.

## Verification

Both branches executed against the extracted `run` block:

| `REPO_VISIBILITY` | `FLAG` | |
|---|---|---|
| `public` | `--provenance` | logs "publishing with provenance" |
| `private` | *(empty)* | emits the `::warning` |
| *(unset)* | *(empty)* | emits the `::warning`, `'unknown'` |

YAML re-parsed and the step wiring re-inspected after the edit.

## Note on the transparency log

npm published the provenance statement to the public Rekor log *before* the
registry rejected it (`logIndex=2369299715`). Rekor is append-only, so that entry
— repo name, commit SHA, workflow ref — is permanent and public. Low impact: the
npm package is public and already points at this repo. Flagging it because it is
not reversible.