### PR TITLE
feat(protocol): carry messages between devices that cannot hear each other

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ For details, see the [DORS Deep Dive](docs/dors.md) and [DORS Configuration Guid
 
 ## Mesh Networking
 
-The SDK implements a cluster-based, self-organizing mesh network. Devices discover peers via BLE advertisements, form clusters with scored peer connections, and bridge separate clusters automatically. Messages route through the mesh using gossip-based forwarding with TTL-based expiration and gradient routing when routes are known.
+The SDK implements a cluster-based, self-organizing mesh network. Devices discover peers via BLE advertisements, form clusters with scored peer connections, and bridge separate clusters automatically.
+
+A message addressed to someone out of radio range is carried by the devices in between: each hands it onward to a bounded set of neighbors until it arrives or runs out of hops. Delivery acknowledgements travel back the same way, so a message that crossed several devices is not mistaken for a lost one. Devices only carry traffic when their own battery policy allows it, and every device caps how much it forwards — per second overall and per neighbor — so a crowded room stays usable rather than filling with repeated copies.
 
 For details, see the [Mesh Networking Guide](docs/mesh.md).
 

--- a/crates/offline-protocol-reliability/src/lib.rs
+++ b/crates/offline-protocol-reliability/src/lib.rs
@@ -13,10 +13,15 @@ pub mod ack_optimization;
 pub mod constants;
 pub mod deduplicator;
 pub mod error;
+pub mod relay_seen;
 pub mod retry_queue;
 
 pub use ack_manager::{AckConfig, AckEvictionInfo, AckManager};
 pub use ack_optimization::{AckOptimizationConfig, AckOptimizer, AggregatedAck, PiggybackAckData};
 pub use deduplicator::{Deduplicator, DeduplicatorConfig, DeduplicatorMode, DeduplicatorStats};
 pub use error::{Error, Result};
+pub use relay_seen::{
+    RelaySeenCache, RelaySeenConfig, SeenOutcome, DEFAULT_RELAY_SEEN_CAPACITY,
+    DEFAULT_RELAY_SEEN_RETENTION_SECS,
+};
 pub use retry_queue::{RetryConfig, RetryQueue, RetryQueueStats};

--- a/crates/offline-protocol-reliability/src/relay_seen.rs
+++ b/crates/offline-protocol-reliability/src/relay_seen.rs
@@ -1,0 +1,283 @@
+//! Suppression cache for messages that have already been forwarded.
+//!
+//! A forwarding node sees the whole neighborhood's traffic, not just its own:
+//! every frame that crosses it arrives once per link that carries it. Forwarding
+//! each arrival would turn one message into as many copies as the network has
+//! edges, and those copies would arrive back at nodes that already forwarded
+//! them, and so on. This cache is what stops that — the record that says "this
+//! id has been handled, ignore further arrivals."
+//!
+//! It is deliberately **separate from [`Deduplicator`](crate::Deduplicator)**,
+//! which answers a different question. The deduplicator tracks messages
+//! addressed to *us*, and its entries are load-bearing for delivery semantics:
+//! entries are removed again (`unmark_seen`) when a message could not be
+//! delivered, so the sender's retry is reprocessed rather than silently
+//! re-acknowledged. Forwarding traffic has no such lifecycle — an id is either
+//! handled or not — and mixing the two populations would let relay volume evict
+//! the delivery-critical entries.
+//!
+//! # Sizing
+//!
+//! Capacity has to cover the whole *network's* traffic for as long as copies of
+//! a message can still be in flight, not just our own. Two windows matter: a
+//! flood's lifetime (bounded by hop limit times per-hop latency, so seconds),
+//! and the sender's early retransmissions (tens of seconds). The defaults cover
+//! both with margin, and are chosen so that at the maximum rate a node will
+//! accept forwarding traffic, the cache still holds far more than
+//! [`DEFAULT_RELAY_SEEN_RETENTION_SECS`] of it — meaning entries expire by age
+//! rather than being pushed out by volume. That ordering is what makes the
+//! suppression guarantee hold: an id evicted early would be forwarded a second
+//! time, and by every other node too, which is how a flood becomes a storm.
+//!
+//! Eviction is O(1): entries leave in insertion order, which for a
+//! fixed retention window is also expiry order.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+/// Maximum ids tracked before the oldest is dropped.
+pub const DEFAULT_RELAY_SEEN_CAPACITY: usize = 8192;
+
+/// How long an id stays suppressed.
+pub const DEFAULT_RELAY_SEEN_RETENTION_SECS: u64 = 600;
+
+/// Configuration for [`RelaySeenCache`].
+#[derive(Debug, Clone)]
+pub struct RelaySeenConfig {
+    /// Maximum ids tracked at once.
+    pub capacity: usize,
+    /// How long an id stays suppressed.
+    pub retention: Duration,
+}
+
+impl Default for RelaySeenConfig {
+    fn default() -> Self {
+        Self {
+            capacity: DEFAULT_RELAY_SEEN_CAPACITY,
+            retention: Duration::from_secs(DEFAULT_RELAY_SEEN_RETENTION_SECS),
+        }
+    }
+}
+
+/// What a cache lookup found for an id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeenOutcome {
+    /// Not seen before; it has now been recorded.
+    Fresh,
+    /// Seen before, within the retention window.
+    Duplicate,
+}
+
+/// Bounded, insertion-ordered record of recently handled message ids.
+#[derive(Debug)]
+pub struct RelaySeenCache {
+    config: RelaySeenConfig,
+    entries: HashMap<String, Instant>,
+    order: VecDeque<String>,
+    duplicates_suppressed: u64,
+    capacity_evictions: u64,
+}
+
+impl RelaySeenCache {
+    /// Creates a cache with the default sizing.
+    pub fn new() -> Self {
+        Self::with_config(RelaySeenConfig::default())
+    }
+
+    /// Creates a cache with explicit sizing.
+    pub fn with_config(config: RelaySeenConfig) -> Self {
+        let capacity = config.capacity.max(1);
+        Self {
+            config: RelaySeenConfig { capacity, ..config },
+            entries: HashMap::with_capacity(capacity.min(1024)),
+            order: VecDeque::with_capacity(capacity.min(1024)),
+            duplicates_suppressed: 0,
+            capacity_evictions: 0,
+        }
+    }
+
+    /// Records `message_id`, reporting whether it had been seen already.
+    ///
+    /// This is the single entry point: checking and recording are one step so
+    /// no caller can test an id and then forget to record it, which would
+    /// forward every copy.
+    pub fn observe(&mut self, message_id: &str) -> SeenOutcome {
+        self.expire(Instant::now());
+
+        if self.entries.contains_key(message_id) {
+            self.duplicates_suppressed = self.duplicates_suppressed.saturating_add(1);
+            return SeenOutcome::Duplicate;
+        }
+
+        while self.entries.len() >= self.config.capacity {
+            if self.pop_oldest().is_some() {
+                self.capacity_evictions = self.capacity_evictions.saturating_add(1);
+            } else {
+                break;
+            }
+        }
+
+        self.entries.insert(message_id.to_string(), Instant::now());
+        self.order.push_back(message_id.to_string());
+        SeenOutcome::Fresh
+    }
+
+    /// Whether `message_id` is currently suppressed, without recording it.
+    pub fn contains(&self, message_id: &str) -> bool {
+        match self.entries.get(message_id) {
+            Some(seen_at) => seen_at.elapsed() < self.config.retention,
+            None => false,
+        }
+    }
+
+    /// Drops entries older than the retention window.
+    ///
+    /// Called automatically by [`Self::observe`]; exposed so an idle node can
+    /// release memory from its process tick.
+    pub fn expire(&mut self, now: Instant) {
+        while let Some(oldest_id) = self.order.front() {
+            let expired = match self.entries.get(oldest_id) {
+                Some(seen_at) => now.duration_since(*seen_at) >= self.config.retention,
+                // Not in the map: a stale order entry, drop it.
+                None => true,
+            };
+            if !expired {
+                break;
+            }
+            self.pop_oldest();
+        }
+    }
+
+    /// Number of ids currently tracked.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the cache holds no ids.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// How many arrivals were suppressed as already-handled.
+    pub fn duplicates_suppressed(&self) -> u64 {
+        self.duplicates_suppressed
+    }
+
+    /// How many ids were dropped for capacity rather than age.
+    ///
+    /// Expected to stay at zero: an id evicted while copies of it are still in
+    /// flight would be forwarded again. A rising count means the cache is too
+    /// small for the traffic the node is seeing.
+    pub fn capacity_evictions(&self) -> u64 {
+        self.capacity_evictions
+    }
+
+    /// Removes every entry.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.order.clear();
+    }
+
+    fn pop_oldest(&mut self) -> Option<String> {
+        let oldest = self.order.pop_front()?;
+        self.entries.remove(&oldest);
+        Some(oldest)
+    }
+}
+
+impl Default for RelaySeenCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_sighting_is_fresh_and_repeats_are_duplicates() {
+        let mut cache = RelaySeenCache::new();
+        assert_eq!(cache.observe("m1"), SeenOutcome::Fresh);
+        assert_eq!(cache.observe("m1"), SeenOutcome::Duplicate);
+        assert_eq!(cache.observe("m1"), SeenOutcome::Duplicate);
+        assert_eq!(cache.duplicates_suppressed(), 2);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn distinct_ids_are_tracked_independently() {
+        let mut cache = RelaySeenCache::new();
+        assert_eq!(cache.observe("m1"), SeenOutcome::Fresh);
+        assert_eq!(cache.observe("m2"), SeenOutcome::Fresh);
+        assert!(cache.contains("m1"));
+        assert!(cache.contains("m2"));
+    }
+
+    #[test]
+    fn capacity_evicts_oldest_first_and_is_counted() {
+        let mut cache = RelaySeenCache::with_config(RelaySeenConfig {
+            capacity: 3,
+            retention: Duration::from_secs(600),
+        });
+
+        cache.observe("m1");
+        cache.observe("m2");
+        cache.observe("m3");
+        assert_eq!(cache.capacity_evictions(), 0);
+
+        // Fourth id pushes out the first.
+        cache.observe("m4");
+        assert_eq!(cache.len(), 3);
+        assert_eq!(cache.capacity_evictions(), 1);
+        assert!(!cache.contains("m1"));
+        assert!(cache.contains("m2"));
+        assert!(cache.contains("m4"));
+
+        // And the evicted id is treated as new again — the condition the
+        // capacity is sized to keep out of reach in production.
+        assert_eq!(cache.observe("m1"), SeenOutcome::Fresh);
+    }
+
+    #[test]
+    fn entries_expire_by_age() {
+        let mut cache = RelaySeenCache::with_config(RelaySeenConfig {
+            capacity: 128,
+            retention: Duration::from_millis(0),
+        });
+
+        cache.observe("m1");
+        // A zero retention means the entry is already expired when the next
+        // observation sweeps.
+        assert_eq!(cache.observe("m2"), SeenOutcome::Fresh);
+        assert!(!cache.contains("m1"));
+        assert_eq!(cache.capacity_evictions(), 0);
+    }
+
+    #[test]
+    fn expiry_never_leaves_orphaned_order_entries() {
+        let mut cache = RelaySeenCache::with_config(RelaySeenConfig {
+            capacity: 4,
+            retention: Duration::from_millis(0),
+        });
+
+        for i in 0..16 {
+            cache.observe(&format!("m{i}"));
+        }
+
+        // The insertion-order queue must stay in lockstep with the map, or the
+        // cache leaks memory that no expiry pass can reach.
+        assert_eq!(cache.order.len(), cache.entries.len());
+        assert!(cache.len() <= 4);
+    }
+
+    #[test]
+    fn clear_drops_everything() {
+        let mut cache = RelaySeenCache::new();
+        cache.observe("m1");
+        cache.observe("m2");
+        cache.clear();
+        assert!(cache.is_empty());
+        assert!(!cache.contains("m1"));
+    }
+}

--- a/crates/offline-protocol-reliability/src/relay_seen.rs
+++ b/crates/offline-protocol-reliability/src/relay_seen.rs
@@ -122,6 +122,30 @@ impl RelaySeenCache {
         SeenOutcome::Fresh
     }
 
+    /// Forgets `message_id`, so a later copy is treated as new again.
+    ///
+    /// For a frame that was recorded as handled and then dropped **without
+    /// ever being transmitted** — displaced from a queue, abandoned for
+    /// waiting too long, refused room on the way back. The record would
+    /// otherwise refuse every later copy for the rest of the retention window,
+    /// including the sender's own retransmissions, which carry the same id: a
+    /// route closed for ten minutes by a few seconds of congestion, with
+    /// nothing on the air to justify it.
+    ///
+    /// Safe only because nothing was transmitted. An id forgotten after the
+    /// frame reached a neighbor could be forwarded a second time — by every
+    /// node — which is how a flood becomes a storm, so callers must be certain
+    /// the frame travelled nowhere.
+    pub fn forget(&mut self, message_id: &str) {
+        if self.entries.remove(message_id).is_some() {
+            // Keep the insertion-order queue in lockstep with the map. Leaving
+            // the stale entry would be tolerated by `expire`, but it would also
+            // be counted as a capacity eviction by `observe`, and that counter
+            // is the signal that the cache is undersized.
+            self.order.retain(|id| id != message_id);
+        }
+    }
+
     /// Whether `message_id` is currently suppressed, without recording it.
     pub fn contains(&self, message_id: &str) -> bool {
         match self.entries.get(message_id) {
@@ -269,6 +293,38 @@ mod tests {
         // cache leaks memory that no expiry pass can reach.
         assert_eq!(cache.order.len(), cache.entries.len());
         assert!(cache.len() <= 4);
+    }
+
+    #[test]
+    fn a_forgotten_id_is_new_again_and_leaves_no_orphan() {
+        let mut cache = RelaySeenCache::new();
+        cache.observe("m1");
+        cache.observe("m2");
+
+        cache.forget("m1");
+
+        assert!(
+            !cache.contains("m1"),
+            "a forgotten id must not be suppressed"
+        );
+        assert!(cache.contains("m2"), "and its neighbors are untouched");
+        assert_eq!(cache.observe("m1"), SeenOutcome::Fresh);
+        // The order queue must not keep the forgotten id, or `observe` would
+        // count popping it as a capacity eviction.
+        assert_eq!(cache.order.len(), cache.entries.len());
+        assert_eq!(cache.capacity_evictions(), 0);
+    }
+
+    #[test]
+    fn forgetting_an_unknown_id_is_a_no_op() {
+        let mut cache = RelaySeenCache::new();
+        cache.observe("m1");
+
+        cache.forget("never-seen");
+
+        assert!(cache.contains("m1"));
+        assert_eq!(cache.order.len(), 1);
+        assert_eq!(cache.entries.len(), 1);
     }
 
     #[test]

--- a/crates/offline-protocol-router/src/lib.rs
+++ b/crates/offline-protocol-router/src/lib.rs
@@ -20,7 +20,10 @@ pub use dors::{
     TransportScoreFactors, TransportSelector,
 };
 pub use error::{Error, Result};
-pub use relay::{RelayConfig, RelayDemotionReason, RelayManager, RelayRole, RelayTransition};
+pub use relay::{
+    RelayConfig, RelayDemotionReason, RelayManager, RelayRole, RelayTransition,
+    CRITICAL_RELAY_BATTERY_LEVEL,
+};
 pub use router::{
     ForwardingDecision, GossipConfig, GradientRoutingConfig, GradientRoutingTable, PathConfig,
     PathSelector, RouteEntry,

--- a/crates/offline-protocol-router/src/relay.rs
+++ b/crates/offline-protocol-router/src/relay.rs
@@ -2,6 +2,17 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Battery level below which a device stops doing anything for other people,
+/// however willing its configuration is.
+///
+/// This is the hard floor beneath the soft [`RelayConfig::min_battery_for_relay`]:
+/// a charging device, or one configured [`RelayPriority::Always`], is excused
+/// the soft minimum but never this. It is public because the protocol crate
+/// applies the same floor to message forwarding — a device must not keep
+/// carrying traffic at a level that would have stripped it of the relay role,
+/// and two copies of the number would eventually disagree.
+pub const CRITICAL_RELAY_BATTERY_LEVEL: u8 = 15;
+
 /// Configuration for relay behavior.
 #[derive(Debug, Clone)]
 pub struct RelayConfig {
@@ -205,7 +216,7 @@ impl RelayManager {
 
         // If priority is Always, stay as relay unless critical battery
         if matches!(self.config.relay_priority, RelayPriority::Always) {
-            return battery_level < 15;
+            return battery_level < CRITICAL_RELAY_BATTERY_LEVEL;
         }
 
         // Demote if connections drop below threshold
@@ -239,7 +250,7 @@ impl RelayManager {
     /// transition classifier and the demotion decision never disagree.
     fn demotion_battery_floor(&self, is_charging: bool) -> u8 {
         if matches!(self.config.relay_priority, RelayPriority::Always) || is_charging {
-            15
+            CRITICAL_RELAY_BATTERY_LEVEL
         } else {
             self.config.min_battery_for_relay
         }

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -1232,6 +1232,20 @@ impl Transport for BleTransport {
         }
     }
 
+    /// Called when raw fragment data arrives from a known peer.
+    ///
+    /// Delegates to the inherent
+    /// [`BleTransport::on_fragment_received_from`], which records the peer on
+    /// the reassembled message. An empty `peer_id` is treated as "the platform
+    /// did not identify this link" and falls back to the anonymous path rather
+    /// than failing the frame.
+    fn on_fragment_received_from(&self, fragment_data: Vec<u8>, peer_id: String) -> Result<()> {
+        if peer_id.is_empty() {
+            return self.on_fragment_received(fragment_data);
+        }
+        BleTransport::on_fragment_received_from(self, fragment_data, peer_id)
+    }
+
     /// Gets the next fragment to send (for platform implementation).
     ///
     /// Returns (recipient, fragment_data) or None if no messages to send.

--- a/crates/offline-protocol-transport/src/ble.rs
+++ b/crates/offline-protocol-transport/src/ble.rs
@@ -529,9 +529,23 @@ impl BleTransport {
     /// send boundary; do not hold `peer_mtus` across the whole loop,
     /// which would serialise every fragmenting send on a single peer.
     pub fn fragment_message(&self, message: &Message) -> Result<Vec<Vec<u8>>> {
+        self.fragment_message_for(message.recipient.as_str(), message)
+    }
+
+    /// [`Self::fragment_message`], but sized against an explicit **physical
+    /// peer** rather than the message recipient.
+    ///
+    /// The two differ only for a forwarded frame, where the link this batch is
+    /// about to cross belongs to `peer_id` and the recipient is some node
+    /// further along. MTU is a property of that link, so it must be looked up
+    /// by the peer actually being written to — sizing a forwarded frame
+    /// against the final recipient's MTU would apply a stranger's link
+    /// parameters (or, more often, silently fall back to the floor because the
+    /// recipient has no entry at all).
+    pub fn fragment_message_for(&self, peer_id: &str, message: &Message) -> Result<Vec<Vec<u8>>> {
         let message_bytes = self.serialize_message(message)?;
 
-        let recipient = message.recipient.as_str();
+        let recipient = peer_id;
         // Look up the per-peer MTU. On a miss, the `peers` map tells
         // us whether this is a keying-contract break (recipient is
         // still a registered direct peer but has no MTU on file — the
@@ -1066,6 +1080,61 @@ impl Transport for BleTransport {
         Ok(())
     }
 
+    /// Queues `message` for a specific connected peer.
+    ///
+    /// Identical to [`Transport::send`] except that the queue key — which is
+    /// both the write target for the platform bridge and the MTU key for
+    /// fragmentation — is `peer_id` rather than `message.recipient`.
+    fn send_to_peer(&self, peer_id: &str, message: &Message) -> Result<()> {
+        let status = self.status();
+
+        if status != TransportStatus::Available {
+            return Err(crate::Error::TransportNotAvailable(format!(
+                "BLE transport is not available (status: {:?})",
+                status
+            )));
+        }
+
+        {
+            let peers = self.peers.lock_or_recover();
+            if !peers.contains_key(peer_id) {
+                return Err(crate::Error::PeerNotReachable(format!(
+                    "BLE: {} is not a connected peer",
+                    peer_id
+                )));
+            }
+        }
+
+        {
+            let mut queue = self.send_queue.lock_or_recover();
+            queue.push_back((peer_id.to_string(), message.clone()));
+        }
+
+        self.update_queue_metric();
+        self.notify_fragments_available();
+
+        Ok(())
+    }
+
+    /// Lists every registered direct peer.
+    ///
+    /// Membership is deliberately the same test [`Transport::send`] and
+    /// [`Transport::send_to_peer`] apply — presence in `peers` — rather than
+    /// the `PeerDevice::connected` flag. The two must agree: a peer omitted
+    /// here but accepted by the send path is a usable link a forwarding caller
+    /// would never try, whereas the reverse costs only a synchronous error the
+    /// caller already handles by moving to the next neighbor.
+    fn connected_peers(&self) -> Vec<crate::PeerLink> {
+        if self.status() != TransportStatus::Available {
+            return Vec::new();
+        }
+        self.peers
+            .lock_or_recover()
+            .values()
+            .map(|peer| crate::PeerLink::with_rssi(peer.device_id.clone(), peer.rssi))
+            .collect()
+    }
+
     fn receive(&self) -> Result<Option<Message>> {
         let mut queue = self.receive_queue.lock_or_recover();
         Ok(queue.pop_front())
@@ -1187,7 +1256,10 @@ impl Transport for BleTransport {
             return Ok(None);
         };
 
-        let fragments = self.fragment_message(&message)?;
+        // Size against the queue key, not `message.recipient`: the key is the
+        // peer this batch is about to be written to, which for a forwarded
+        // frame is the next hop rather than the final recipient.
+        let fragments = self.fragment_message_for(&recipient, &message)?;
 
         if fragments.is_empty() {
             self.update_queue_metric();
@@ -1336,6 +1408,61 @@ mod tests {
             AppId::new("app").unwrap(),
             "hi",
         )
+    }
+
+    #[test]
+    fn send_to_peer_targets_the_hop_and_sizes_by_its_mtu() {
+        let transport = BleTransport::new("relay");
+        transport.start().unwrap();
+        transport.on_peer_discovered(peer_device("carol"));
+        // Carol's link negotiated a large MTU; bob (the recipient) is not a
+        // peer here at all, so sizing by recipient would fall back to the floor.
+        transport.set_peer_mtu("carol", 500);
+
+        let message = small_message(); // addressed to bob
+        transport.send_to_peer("carol", &message).unwrap();
+
+        let (target, _) = transport
+            .get_next_fragment()
+            .unwrap()
+            .expect("fragment queued for the hop");
+        assert_eq!(target, "carol");
+        // Sized against carol's 500-byte MTU, not the 185-byte floor: a small
+        // message fits in exactly one fragment.
+        assert!(transport.get_next_fragment().unwrap().is_none());
+        assert_eq!(transport.fragment_fallback_count(), 0);
+    }
+
+    #[test]
+    fn send_to_peer_refuses_an_unconnected_peer() {
+        let transport = BleTransport::new("relay");
+        transport.start().unwrap();
+        transport.on_peer_discovered(peer_device("carol"));
+
+        let result = transport.send_to_peer("dave", &small_message());
+        assert!(matches!(result, Err(crate::Error::PeerNotReachable(_))));
+    }
+
+    #[test]
+    fn connected_peers_matches_what_the_send_path_accepts() {
+        let transport = BleTransport::new("relay");
+        transport.on_peer_discovered(peer_device("carol"));
+
+        // Nothing is addressable while the transport is down.
+        assert!(transport.connected_peers().is_empty());
+
+        transport.start().unwrap();
+        let links = transport.connected_peers();
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].peer_id, "carol");
+        assert_eq!(links[0].rssi, Some(-60));
+        // Every listed link is one send_to_peer will accept.
+        assert!(transport
+            .send_to_peer(&links[0].peer_id, &small_message())
+            .is_ok());
+
+        transport.on_peer_lost("carol");
+        assert!(transport.connected_peers().is_empty());
     }
 
     #[test]

--- a/crates/offline-protocol-transport/src/lib.rs
+++ b/crates/offline-protocol-transport/src/lib.rs
@@ -63,7 +63,10 @@ pub use nostr::{NostrConfig, NostrTransport, NostrTransportBuilder, SignedNostrE
 pub use nostr_crypto::{routing_tag_for_device_id, NostrEvent, NostrKeypair};
 pub use reticulum::{ReticulumConfig, ReticulumTransport};
 pub use traits::{Transport, TransportStatus};
-pub use types::{LinkQuality, SharedCallback, TransportMetrics, TransportType};
+pub use types::{
+    LinkQuality, PeerLink, SharedCallback, TransportMetrics, TransportType,
+    DEFAULT_LINK_QUALITY_WITHOUT_RSSI,
+};
 pub use wifi_direct::{WifiDirectConfig, WifiDirectPeer, WifiDirectTransport};
 
 // MockTransport is only available to this crate's tests or explicit test consumers.

--- a/crates/offline-protocol-transport/src/mock.rs
+++ b/crates/offline-protocol-transport/src/mock.rs
@@ -19,6 +19,10 @@ pub struct MockTransport {
     fail_next_sends: Arc<Mutex<usize>>,
     /// Simulated live links, in the order they were registered.
     connected_peers: Arc<Mutex<Vec<PeerLink>>>,
+    /// When set, `send` refuses a recipient with no live link, the way a
+    /// radio-backed transport does. Off by default so tests that only care
+    /// about what was sent need not declare a topology.
+    reject_unknown_recipients: Arc<Mutex<bool>>,
     /// Every `send_to_peer` call, as `(peer_id, message)`, so forwarding tests
     /// can assert *which neighbor* a frame crossed and how many times it was
     /// transmitted — the counts that distinguish a controlled flood from a
@@ -46,7 +50,17 @@ impl MockTransport {
             fail_next_sends: Arc::new(Mutex::new(0)),
             connected_peers: Arc::new(Mutex::new(Vec::new())),
             peer_sends: Arc::new(Mutex::new(Vec::new())),
+            reject_unknown_recipients: Arc::new(Mutex::new(false)),
         }
+    }
+
+    /// Makes `send` behave like a radio-backed transport: a recipient with no
+    /// live link is refused rather than silently accepted.
+    ///
+    /// This is what lets a test exercise the path a message takes when its
+    /// recipient is out of range — the case mesh forwarding exists for.
+    pub fn set_reject_unknown_recipients(&self, reject: bool) {
+        *self.reject_unknown_recipients.lock().unwrap() = reject;
     }
 
     /// Declares the simulated set of directly connected peers.
@@ -152,6 +166,17 @@ impl Transport for MockTransport {
     }
 
     fn send(&self, message: &Message) -> Result<()> {
+        if *self.reject_unknown_recipients.lock().unwrap() {
+            let recipient = message.recipient.as_str();
+            let peers = self.connected_peers.lock().unwrap();
+            if !peers.iter().any(|link| link.peer_id == recipient) {
+                return Err(crate::Error::PeerNotReachable(format!(
+                    "mock: no connected peer for recipient {}",
+                    recipient
+                )));
+            }
+        }
+
         {
             let mut fail = self.fail_next_sends.lock().unwrap();
             if *fail > 0 {

--- a/crates/offline-protocol-transport/src/mock.rs
+++ b/crates/offline-protocol-transport/src/mock.rs
@@ -1,6 +1,6 @@
 //! Mock transport for testing.
 
-use crate::{Result, Transport, TransportMetrics, TransportStatus, TransportType};
+use crate::{PeerLink, Result, Transport, TransportMetrics, TransportStatus, TransportType};
 use offline_protocol_core::Message;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
@@ -17,6 +17,13 @@ pub struct MockTransport {
     metrics: Arc<Mutex<TransportMetrics>>,
     /// When > 0, next send() calls fail this many times (for escalation/fallback tests).
     fail_next_sends: Arc<Mutex<usize>>,
+    /// Simulated live links, in the order they were registered.
+    connected_peers: Arc<Mutex<Vec<PeerLink>>>,
+    /// Every `send_to_peer` call, as `(peer_id, message)`, so forwarding tests
+    /// can assert *which neighbor* a frame crossed and how many times it was
+    /// transmitted — the counts that distinguish a controlled flood from a
+    /// storm.
+    peer_sends: Arc<Mutex<Vec<(String, Message)>>>,
 }
 
 impl std::fmt::Debug for MockTransport {
@@ -37,7 +44,51 @@ impl MockTransport {
             receive_queue: Arc::new(Mutex::new(VecDeque::new())),
             metrics: Arc::new(Mutex::new(TransportMetrics::default())),
             fail_next_sends: Arc::new(Mutex::new(0)),
+            connected_peers: Arc::new(Mutex::new(Vec::new())),
+            peer_sends: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    /// Declares the simulated set of directly connected peers.
+    pub fn set_connected_peers(&self, peers: Vec<PeerLink>) {
+        *self.connected_peers.lock().unwrap() = peers;
+    }
+
+    /// Adds one simulated live link.
+    pub fn add_connected_peer(&self, peer_id: impl Into<String>, rssi: i16) {
+        self.connected_peers
+            .lock()
+            .unwrap()
+            .push(PeerLink::with_rssi(peer_id, rssi));
+    }
+
+    /// Drops one simulated live link (peer churn).
+    pub fn remove_connected_peer(&self, peer_id: &str) {
+        self.connected_peers
+            .lock()
+            .unwrap()
+            .retain(|link| link.peer_id != peer_id);
+    }
+
+    /// Returns every `(peer_id, message)` handed to `send_to_peer`.
+    pub fn peer_sends(&self) -> Vec<(String, Message)> {
+        self.peer_sends.lock().unwrap().clone()
+    }
+
+    /// Number of times `message_id` was transmitted to any peer — the
+    /// per-node transmission count a storm test asserts against.
+    pub fn peer_send_count_for(&self, message_id: &str) -> usize {
+        self.peer_sends
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(_, message)| message.id.as_str() == message_id)
+            .count()
+    }
+
+    /// Clears the recorded per-peer sends.
+    pub fn clear_peer_sends(&self) {
+        self.peer_sends.lock().unwrap().clear();
     }
 
     /// Makes the next `n` send attempts return an error (for retry-failure / escalation tests).
@@ -136,6 +187,45 @@ impl Transport for MockTransport {
         Ok(())
     }
 
+    fn send_to_peer(&self, peer_id: &str, message: &Message) -> Result<()> {
+        if self.status() != TransportStatus::Available {
+            return Err(crate::Error::TransportNotAvailable(
+                "mock transport is not available".to_string(),
+            ));
+        }
+
+        {
+            let peers = self.connected_peers.lock().unwrap();
+            if !peers.iter().any(|link| link.peer_id == peer_id) {
+                return Err(crate::Error::PeerNotReachable(format!(
+                    "mock: {} is not a connected peer",
+                    peer_id
+                )));
+            }
+        }
+
+        {
+            let mut fail = self.fail_next_sends.lock().unwrap();
+            if *fail > 0 {
+                *fail = fail.saturating_sub(1);
+                return Err(crate::Error::SendFailed("mock fail_next_sends".to_string()));
+            }
+        }
+
+        self.peer_sends
+            .lock()
+            .unwrap()
+            .push((peer_id.to_string(), message.clone()));
+        Ok(())
+    }
+
+    fn connected_peers(&self) -> Vec<PeerLink> {
+        if self.status() != TransportStatus::Available {
+            return Vec::new();
+        }
+        self.connected_peers.lock().unwrap().clone()
+    }
+
     fn receive(&self) -> Result<Option<Message>> {
         let mut queue = self.receive_queue.lock().unwrap();
         Ok(queue.pop_front())
@@ -160,6 +250,59 @@ impl Transport for MockTransport {
 mod tests {
     use super::*;
     use offline_protocol_core::{AppId, UserId};
+
+    fn test_message() -> Message {
+        Message::new(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test").unwrap(),
+            "Test message",
+        )
+    }
+
+    #[test]
+    fn send_to_peer_records_the_hop_not_the_recipient() {
+        let transport = MockTransport::new(TransportType::BLE);
+        transport.start().unwrap();
+        transport.add_connected_peer("carol", -60);
+
+        // A frame addressed to bob, handed across the link to carol.
+        let message = test_message();
+        transport.send_to_peer("carol", &message).unwrap();
+
+        let sends = transport.peer_sends();
+        assert_eq!(sends.len(), 1);
+        assert_eq!(sends[0].0, "carol");
+        assert_eq!(sends[0].1.recipient.as_str(), "bob");
+        assert_eq!(transport.peer_send_count_for(&message.id.as_str()), 1);
+    }
+
+    #[test]
+    fn send_to_peer_refuses_a_peer_without_a_live_link() {
+        let transport = MockTransport::new(TransportType::BLE);
+        transport.start().unwrap();
+        transport.add_connected_peer("carol", -60);
+
+        // The failure must be synchronous so a forwarding caller can pick a
+        // different neighbor instead of assuming the frame is on its way.
+        assert!(transport.send_to_peer("dave", &test_message()).is_err());
+        assert!(transport.peer_sends().is_empty());
+    }
+
+    #[test]
+    fn connected_peers_follows_link_state() {
+        let transport = MockTransport::new(TransportType::BLE);
+        transport.add_connected_peer("carol", -60);
+
+        // Links are only real while the transport itself is available.
+        assert!(transport.connected_peers().is_empty());
+
+        transport.start().unwrap();
+        assert_eq!(transport.connected_peers().len(), 1);
+
+        transport.remove_connected_peer("carol");
+        assert!(transport.connected_peers().is_empty());
+    }
 
     #[test]
     fn test_mock_transport_send_receive() {

--- a/crates/offline-protocol-transport/src/traits.rs
+++ b/crates/offline-protocol-transport/src/traits.rs
@@ -197,6 +197,23 @@ pub trait Transport: Send + Sync + Any {
         )))
     }
 
+    /// Like [`Transport::on_fragment_received`], but attaches a
+    /// transport-verified `peer_id` to the reassembled message.
+    ///
+    /// This is the fragmenting counterpart to
+    /// [`Transport::on_data_received_from`]. The peer id it records is the
+    /// link the frame physically arrived on, which is what lets the protocol
+    /// layer tell "who handed me this" apart from "who wrote this" — the two
+    /// are the same peer only at the first hop.
+    fn on_fragment_received_from(&self, fragment_data: Vec<u8>, peer_id: String) -> Result<()> {
+        let _ = (fragment_data, peer_id);
+        Err(crate::Error::Other(format!(
+            "{} transport does not reassemble fragments; \
+             use on_data_received_from instead",
+            self.transport_type()
+        )))
+    }
+
     // ------------------------------------------------------------------
     // Platform-bridge egress / poll (Rust → platform)
     // ------------------------------------------------------------------

--- a/crates/offline-protocol-transport/src/traits.rs
+++ b/crates/offline-protocol-transport/src/traits.rs
@@ -65,7 +65,56 @@ pub trait Transport: Send + Sync + Any {
     /// that instead *broadcasts* serialized bytes to every neighbor would break
     /// that assumption and must re-establish per-link codec safety before
     /// emitting anything other than JSON.
+    ///
+    /// [`Transport::send_to_peer`] keeps the same invariant by moving the key:
+    /// there the physical target is `peer_id`, so codec and MTU decisions are
+    /// made against *that* peer's confirmed capabilities rather than the
+    /// recipient's. Frames still go out one addressed link at a time; nothing
+    /// in this crate emits one serialized buffer to many peers.
     fn send(&self, message: &Message) -> Result<()>;
+
+    /// Queues a message for delivery to a **specific directly connected
+    /// peer**, regardless of `message.recipient`.
+    ///
+    /// This is the addressed-hop counterpart to [`Transport::send`]: it exists
+    /// so a caller can hand a frame to a neighbor that is not the frame's final
+    /// recipient (mesh forwarding), while [`Transport::send`] remains the
+    /// "deliver this to its recipient" call. Transports that cannot address a
+    /// peer independently of the recipient return an error, which is the
+    /// default.
+    ///
+    /// Implementations must treat `peer_id` as the physical target for every
+    /// link-layer decision — MTU selection, queue keying, wire-codec choice —
+    /// because that is the peer whose capabilities were negotiated. Using
+    /// `message.recipient` for any of those on a forwarded frame would apply a
+    /// third party's link parameters to this hop.
+    ///
+    /// Returns `Ok(())` if the transport accepted the message for that peer,
+    /// `Err` if the peer is not a live link or the transport is unavailable.
+    fn send_to_peer(&self, peer_id: &str, message: &Message) -> Result<()> {
+        let _ = message;
+        Err(crate::Error::Other(format!(
+            "{} transport cannot address peer {} independently of the recipient",
+            self.transport_type(),
+            peer_id
+        )))
+    }
+
+    /// Lists the peers this transport currently holds a live link to.
+    ///
+    /// Only transports whose links are peer-to-peer (BLE, Wi-Fi Direct) report
+    /// anything; carriers that reach peers through infrastructure return the
+    /// default empty list, since "directly connected" has no meaning for them.
+    ///
+    /// This is deliberately a *live connectivity* view, not a discovery
+    /// memory: entries appear when the platform reports a connection and
+    /// disappear when it reports a loss or the transport leaves
+    /// [`TransportStatus::Available`]. Callers that fan out to neighbors
+    /// depend on that — addressing a remembered-but-gone peer would queue
+    /// frames for a link that no longer exists.
+    fn connected_peers(&self) -> Vec<crate::PeerLink> {
+        Vec::new()
+    }
 
     /// Attempts to receive a message from this transport.
     ///

--- a/crates/offline-protocol-transport/src/types.rs
+++ b/crates/offline-protocol-transport/src/types.rs
@@ -149,6 +149,60 @@ impl TransportMetrics {
     }
 }
 
+/// A live link to a directly connected peer.
+///
+/// This is the per-peer view of a transport's connectivity, as opposed to
+/// [`TransportMetrics`], which aggregates the transport as a whole. It is what
+/// lets a caller address a specific neighbor rather than a final recipient —
+/// see [`Transport::connected_peers`](crate::Transport::connected_peers) and
+/// [`Transport::send_to_peer`](crate::Transport::send_to_peer).
+///
+/// `peer_id` is the **user-level identifier** of the neighbor (the same string
+/// a message would carry as `recipient`), never a raw transport address: it is
+/// the key the send path and the per-peer MTU table are both keyed by.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerLink {
+    /// User-level identifier of the directly connected peer.
+    pub peer_id: String,
+    /// Last observed signal strength for this link, when the transport
+    /// measures one. Wi-Fi Direct and non-radio carriers report `None`.
+    pub rssi: Option<i16>,
+}
+
+impl PeerLink {
+    /// Creates a link record for a peer whose signal strength is unknown.
+    pub fn new(peer_id: impl Into<String>) -> Self {
+        Self {
+            peer_id: peer_id.into(),
+            rssi: None,
+        }
+    }
+
+    /// Creates a link record carrying a measured signal strength.
+    pub fn with_rssi(peer_id: impl Into<String>, rssi: i16) -> Self {
+        Self {
+            peer_id: peer_id.into(),
+            rssi: Some(rssi),
+        }
+    }
+
+    /// Link quality derived from RSSI, or a neutral mid-scale value when the
+    /// transport reports no signal strength. Keeps callers that score links
+    /// from having to special-case carriers without a radio metric.
+    pub fn link_quality(&self) -> LinkQuality {
+        match self.rssi {
+            Some(rssi) => LinkQuality::from_rssi(rssi),
+            None => LinkQuality::new(DEFAULT_LINK_QUALITY_WITHOUT_RSSI),
+        }
+    }
+}
+
+/// Link quality assumed for a live link whose transport reports no RSSI.
+///
+/// Mid-scale rather than optimistic: an unmeasured link should not outrank a
+/// measured good one, nor be discarded like a measured bad one.
+pub const DEFAULT_LINK_QUALITY_WITHOUT_RSSI: u8 = 50;
+
 /// Link quality score (0-100, where 100 is perfect).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct LinkQuality(u8);

--- a/crates/offline-protocol-transport/src/wifi_direct.rs
+++ b/crates/offline-protocol-transport/src/wifi_direct.rs
@@ -67,8 +67,20 @@ pub struct WifiDirectTransport {
     config: WifiDirectConfig,
     /// Transport status
     status: Arc<Mutex<TransportStatus>>,
-    /// Discovered peers
+    /// Discovered peers, keyed by device address (MAC).
+    ///
+    /// This is the *discovery* view reported by `WifiP2pManager`, so its key
+    /// is a hardware address. It deliberately stays separate from
+    /// [`Self::connected_links`], which is keyed by user-level id — the two
+    /// answer different questions ("what did we see?" vs "who can we address
+    /// right now?") and only the latter is safe to route by.
     peers: Arc<Mutex<HashMap<String, WifiDirectPeer>>>,
+    /// Live links, keyed by the peer's user-level id.
+    ///
+    /// Populated from the platform's connect/disconnect callbacks, which are
+    /// the only signals that carry a user id. Drained whenever the transport
+    /// leaves `Available`, so it can never hand out a link that has gone away.
+    connected_links: Arc<Mutex<HashMap<String, SystemTime>>>,
     /// Received message queue
     receive_queue: Arc<Mutex<VecDeque<Message>>>,
     /// Send queue
@@ -94,6 +106,7 @@ impl WifiDirectTransport {
             config,
             status: Arc::new(Mutex::new(TransportStatus::Unavailable)),
             peers: Arc::new(Mutex::new(HashMap::new())),
+            connected_links: Arc::new(Mutex::new(HashMap::new())),
             receive_queue: Arc::new(Mutex::new(VecDeque::new())),
             send_queue: Arc::new(Mutex::new(VecDeque::new())),
             metrics: Arc::new(Mutex::new(TransportMetrics::default())),
@@ -140,6 +153,26 @@ impl WifiDirectTransport {
     pub fn on_peer_lost(&self, device_address: &str) {
         let mut peers = self.peers.lock_or_recover();
         peers.remove(device_address);
+    }
+
+    /// Records a live link to `peer_id` (platform connect callback).
+    ///
+    /// Takes the peer's **user-level id**, which is what the send path and
+    /// [`Transport::connected_peers`] are keyed by — unlike
+    /// [`Self::on_peer_discovered`], whose key is a hardware address.
+    pub fn on_peer_connected(&self, peer_id: impl Into<String>) {
+        let peer_id = peer_id.into();
+        if peer_id.is_empty() {
+            return;
+        }
+        self.connected_links
+            .lock_or_recover()
+            .insert(peer_id, SystemTime::now());
+    }
+
+    /// Drops the live link to `peer_id` (platform disconnect callback).
+    pub fn on_peer_disconnected(&self, peer_id: &str) {
+        self.connected_links.lock_or_recover().remove(peer_id);
     }
 
     /// Called when a message is received from a peer.
@@ -233,6 +266,51 @@ impl Transport for WifiDirectTransport {
         Ok(())
     }
 
+    /// Queues `message` for a specific connected peer.
+    ///
+    /// Unlike [`Transport::send`], which accepts any recipient and lets the
+    /// platform discover it cannot be reached, this refuses a peer with no
+    /// live link — a forwarding caller needs the failure synchronously so it
+    /// can pick another neighbor instead.
+    fn send_to_peer(&self, peer_id: &str, message: &Message) -> Result<()> {
+        if self.status() != TransportStatus::Available {
+            return Err(crate::Error::TransportNotAvailable(
+                "Wi-Fi Direct transport is not available".to_string(),
+            ));
+        }
+
+        if !self.connected_links.lock_or_recover().contains_key(peer_id) {
+            return Err(crate::Error::PeerNotReachable(format!(
+                "Wi-Fi Direct: {} is not a connected peer",
+                peer_id
+            )));
+        }
+
+        {
+            let mut queue = self.send_queue.lock_or_recover();
+            queue.push_back((peer_id.to_string(), message.clone()));
+
+            let mut metrics = self.metrics.lock_or_recover();
+            metrics.queue_depth = queue.len();
+            metrics.congestion = ((metrics.queue_depth as f32) / 20.0).clamp(0.0, 1.0);
+        }
+
+        self.notify_messages_available();
+
+        Ok(())
+    }
+
+    fn connected_peers(&self) -> Vec<crate::PeerLink> {
+        if self.status() != TransportStatus::Available {
+            return Vec::new();
+        }
+        self.connected_links
+            .lock_or_recover()
+            .keys()
+            .map(crate::PeerLink::new)
+            .collect()
+    }
+
     fn receive(&self) -> Result<Option<Message>> {
         let mut queue = self.receive_queue.lock_or_recover();
         Ok(queue.pop_front())
@@ -246,6 +324,7 @@ impl Transport for WifiDirectTransport {
     fn stop(&self) -> Result<()> {
         *self.status.lock_or_recover() = TransportStatus::Disconnected;
         self.peers.lock_or_recover().clear();
+        self.connected_links.lock_or_recover().clear();
         self.send_queue.lock_or_recover().clear();
         self.receive_queue.lock_or_recover().clear();
         let mut metrics = self.metrics.lock_or_recover();
@@ -268,6 +347,7 @@ impl Transport for WifiDirectTransport {
 
         if previous == TransportStatus::Available && status != TransportStatus::Available {
             self.peers.lock_or_recover().clear();
+            self.connected_links.lock_or_recover().clear();
             self.send_queue.lock_or_recover().clear();
             self.receive_queue.lock_or_recover().clear();
             let mut metrics = self.metrics.lock_or_recover();

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -2538,6 +2538,29 @@ impl OfflineProtocol {
         Ok(Some(f(ble_transport)))
     }
 
+    /// [`Self::with_ble_transport_fallible`] for the Wi-Fi Direct transport.
+    fn with_wifi_direct_transport_fallible<F, R>(&self, f: F) -> Result<Option<R>, ProtocolError>
+    where
+        F: FnOnce(&offline_protocol_transport::WifiDirectTransport) -> R,
+    {
+        let protocol = self.lock_inner()?;
+        let transport_arc = match protocol
+            .transport_manager()
+            .get_transport(CoreTransportType::WiFiDirect)
+        {
+            Some(arc) => arc,
+            None => return Ok(None),
+        };
+        let wifi_transport = match transport_arc
+            .as_any()
+            .downcast_ref::<offline_protocol_transport::WifiDirectTransport>(
+        ) {
+            Some(wd) => wd,
+            None => return Ok(None),
+        };
+        Ok(Some(f(wifi_transport)))
+    }
+
     /// Acquire the inner + transport locks, downcast to `NostrTransport`,
     /// and call `f` with it.  Returns `None` when the transport is absent or
     /// not a `NostrTransport`.  Only for Nostr-specific inherent methods
@@ -3338,9 +3361,14 @@ impl OfflineProtocol {
     }
 
     /// BLE: Fragment received
+    ///
+    /// `sender_id` is the peer whose link the fragment arrived on. It is
+    /// recorded on the reassembled message so the protocol layer can tell the
+    /// peer that handed us a frame from the peer that wrote it — the same at
+    /// the first hop, different for anything forwarded.
     pub fn ble_fragment_received(
         &self,
-        _sender_id: String,
+        sender_id: String,
         fragment: Vec<u8>,
     ) -> Result<(), ProtocolError> {
         let mut protocol = self.lock_inner()?;
@@ -3348,9 +3376,11 @@ impl OfflineProtocol {
             .transport_manager()
             .get_transport(CoreTransportType::BLE)
         {
-            transport_arc.on_fragment_received(fragment).map_err(|e| {
-                ProtocolError::TransportError(format!("Fragment processing failed: {}", e))
-            })?;
+            transport_arc
+                .on_fragment_received_from(fragment, sender_id)
+                .map_err(|e| {
+                    ProtocolError::TransportError(format!("Fragment processing failed: {}", e))
+                })?;
         }
 
         while protocol.receive_message().is_some() {}
@@ -3764,7 +3794,9 @@ impl OfflineProtocol {
             .transport_manager()
             .get_transport(CoreTransportType::WiFiDirect)
         {
-            if let Err(e) = transport_arc.on_data_received(data) {
+            // Record the arriving link, as BLE does — the peer that handed us
+            // the frame is what a forwarding decision needs.
+            if let Err(e) = transport_arc.on_data_received_from(data, sender_id.clone()) {
                 return Err(ProtocolError::TransportError(format!(
                     "Failed to process WiFi Direct message: {}",
                     e
@@ -3809,6 +3841,12 @@ impl OfflineProtocol {
             wifi_direct_state.connected_peer = Some(peer_id.clone());
         }
 
+        // Register the link with the transport so it can be addressed directly,
+        // mirroring what ble_peer_discovered does for BLE.
+        self.with_wifi_direct_transport_fallible(|wifi_transport| {
+            wifi_transport.on_peer_connected(peer_id.clone());
+        })?;
+
         self.notify_neighbor_reachable(&peer_id, "WiFiDirect", None)
     }
 
@@ -3821,6 +3859,12 @@ impl OfflineProtocol {
                 wifi_direct_state.connected_peer = None;
             }
         }
+
+        // Drop the link from the transport so it stops being offered as an
+        // addressable neighbor.
+        self.with_wifi_direct_transport_fallible(|wifi_transport| {
+            wifi_transport.on_peer_disconnected(&peer_id);
+        })?;
 
         // Notify the core protocol of neighbor loss, matching ble_peer_lost —
         // WiFi Direct is the only other carrier with an explicit disconnect

--- a/crates/offline-protocol/src/config.rs
+++ b/crates/offline-protocol/src/config.rs
@@ -1,6 +1,7 @@
 //! Protocol configuration.
 
 use crate::constants::DEFAULT_INITIAL_TTL;
+use crate::protocol::mesh_relay::MeshRelayConfig;
 use offline_protocol_reliability::{AckConfig, DeduplicatorConfig, RetryConfig};
 use offline_protocol_router::{DorsConfig, PathConfig, RelayConfig};
 use serde::{Deserialize, Serialize};
@@ -541,8 +542,17 @@ pub struct ProtocolConfig {
     /// DORS (Dynamic Offline Relay Switch) configuration.
     pub dors: DorsConfig,
 
-    /// Relay management configuration.
+    /// Relay management configuration: whether this device carries traffic
+    /// for other people at all, and the battery floors under which it stops.
     pub relay: RelayConfig,
+
+    /// How this device carries traffic for other people: how far frames
+    /// travel, how many neighbors each is handed to, and the ceilings that
+    /// keep forwarding from crowding the radio out.
+    ///
+    /// Whether to forward is [`Self::relay`]'s decision; this is the shape of
+    /// it once the answer is yes.
+    pub mesh_relay: MeshRelayConfig,
 
     /// Path selection configuration.
     pub path: PathConfig,
@@ -577,6 +587,7 @@ impl ProtocolConfig {
             transport: TransportConfig::default(),
             dors: DorsConfig::default(),
             relay: RelayConfig::default(),
+            mesh_relay: MeshRelayConfig::default(),
             path: PathConfig::default(),
             reliability: ReliabilityConfig::default(),
             encryption: EncryptionConfig::default(),
@@ -858,6 +869,12 @@ impl ProtocolConfigBuilder {
     /// Configures relay management.
     pub fn relay(mut self, config: RelayConfig) -> Self {
         self.config.relay = config;
+        self
+    }
+
+    /// Configures how traffic is carried for other people.
+    pub fn mesh_relay(mut self, config: MeshRelayConfig) -> Self {
+        self.config.mesh_relay = config;
         self
     }
 

--- a/crates/offline-protocol/src/lib.rs
+++ b/crates/offline-protocol/src/lib.rs
@@ -34,6 +34,7 @@ pub use events::{
 };
 pub use group_mesh::{GroupRichReadiness, GroupSendOptions, RelaySyncState};
 pub use offline_protocol_services::MeshServices;
+pub use protocol::mesh_relay::{MeshRelayConfig, MeshRelayStats};
 pub use protocol::{MediaSendOptions, OfflineProtocol, SendMessageOptions};
 pub use protocol_state_storage::{
     ProtocolStateError, ProtocolStateResult, ProtocolStateStorage,

--- a/crates/offline-protocol/src/protocol/blocking.rs
+++ b/crates/offline-protocol/src/protocol/blocking.rs
@@ -302,7 +302,12 @@ mod tests {
         use offline_protocol_transport::{mock::MockTransport, TransportType};
         use std::sync::{Arc, Mutex};
 
-        let mut proto = make_protocol("alice");
+        let mut config = ProtocolConfig::new("test-app", "alice");
+        config.encryption.require_encryption = false;
+        // Flush forwarding in the same breath as receiving it.
+        config.mesh_relay.jitter_min = std::time::Duration::from_millis(0);
+        config.mesh_relay.jitter_max = std::time::Duration::from_millis(0);
+        let mut proto = crate::OfflineProtocol::new(config).unwrap();
         proto.block_user("mallory").unwrap();
 
         let relay_events = Arc::new(Mutex::new(Vec::<Event>::new()));
@@ -315,6 +320,10 @@ mod tests {
 
         let mock = MockTransport::new(TransportType::BLE);
         mock.start().unwrap();
+        // Blocking someone stops us talking to them; it does not stop this
+        // device carrying the crowd's traffic, so a neighbor must be present
+        // for that forwarding to be observable.
+        mock.add_connected_peer("dave", -55);
 
         // Message from blocked user but addressed to a THIRD party — should NOT be blocked.
         // With relay enabled, the message is forwarded and NOT returned to the app layer.
@@ -339,6 +348,7 @@ mod tests {
             received.is_none(),
             "Relay messages for third parties should be forwarded, not returned"
         );
+        proto.process().unwrap();
 
         // Verify that a MessageRelayed event was emitted — blocking must not
         // suppress relay forwarding for messages addressed to third parties.

--- a/crates/offline-protocol/src/protocol/config_accessors.rs
+++ b/crates/offline-protocol/src/protocol/config_accessors.rs
@@ -1,5 +1,6 @@
 //! Configuration accessors, diagnostics, and service registration.
 
+use super::mesh_relay::MeshRelayStats;
 use super::{
     lock_shared_state, OfflineProtocol, PendingQueueMetrics, ProtocolState, KNOWN_PEER_TTL_SECS,
     MEDIA_TRANSFER_STALE_TIMEOUT_SECS,
@@ -158,6 +159,29 @@ impl OfflineProtocol {
     /// are never tracked.
     pub fn is_known_peer(&self, peer_id: &str) -> bool {
         self.known_peers.contains_key(peer_id)
+    }
+
+    /// Reports how much traffic this device is carrying for other people.
+    ///
+    /// Useful for showing a user what their device is contributing, and for
+    /// spotting a neighborhood in trouble: a rising `rate_deferred` means
+    /// forwarding is hitting its ceiling, and `peer_rate_limited` means a
+    /// single neighbor is sending more than its share. `dropped_for_capacity`
+    /// is expected to stay at zero — see [`MeshRelayStats::dropped_for_capacity`].
+    pub fn mesh_relay_stats(&self) -> MeshRelayStats {
+        let counters = self.mesh_relay.counters();
+        MeshRelayStats {
+            forwarded: counters.forwarded,
+            queued: counters.queued,
+            awaiting_transmission: self.mesh_relay.pending_len(),
+            duplicates_suppressed: counters.duplicates_suppressed,
+            covered_by_a_neighbor: counters.cancelled_by_duplicate,
+            peer_rate_limited: counters.peer_rate_limited,
+            rate_deferred: counters.rate_deferred,
+            hop_limit_reached: counters.hop_limit_reached,
+            reach_clamped: counters.ttl_clamped,
+            dropped_for_capacity: self.mesh_relay.seen_capacity_evictions(),
+        }
     }
 
     /// Returns a mutable reference to the retry queue (test-only).

--- a/crates/offline-protocol/src/protocol/config_accessors.rs
+++ b/crates/offline-protocol/src/protocol/config_accessors.rs
@@ -172,6 +172,7 @@ impl OfflineProtocol {
         let counters = self.mesh_relay.counters();
         MeshRelayStats {
             forwarded: counters.forwarded,
+            transmissions: counters.transmissions,
             queued: counters.queued,
             awaiting_transmission: self.mesh_relay.pending_len(),
             duplicates_suppressed: counters.duplicates_suppressed,

--- a/crates/offline-protocol/src/protocol/config_accessors.rs
+++ b/crates/offline-protocol/src/protocol/config_accessors.rs
@@ -171,6 +171,7 @@ impl OfflineProtocol {
     pub(crate) fn cleanup_expired_entries(&mut self) {
         self.deduplicator.cleanup_expired();
         self.retry_queue.cleanup_expired();
+        self.mesh_relay.maintain(std::time::Instant::now());
         self.prune_stale_known_peers(std::time::Instant::now());
         self.cleanup_expired_pending_messages_if_due();
         self.cleanup_outbox();

--- a/crates/offline-protocol/src/protocol/mesh_relay.rs
+++ b/crates/offline-protocol/src/protocol/mesh_relay.rs
@@ -35,7 +35,7 @@
 //! of transmission (so a forward cancelled while waiting costs no budget).
 
 use offline_protocol_core::{Message, MessagePriority};
-use offline_protocol_reliability::{RelaySeenCache, RelaySeenConfig, SeenOutcome};
+use offline_protocol_reliability::{RelaySeenCache, RelaySeenConfig};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -343,28 +343,48 @@ impl MeshRelayGovernor {
     /// Runs the full admission sequence and, when the frame is accepted,
     /// queues an adjusted copy for later transmission. `degree` is the current
     /// neighbor count, which sets both the hop budget and the delay spread.
+    /// `is_last_hop` says whether the frame's recipient is one of our own
+    /// neighbors, which changes what a duplicate means — see below.
     pub fn admit(
         &mut self,
         message: &Message,
         arrival_peer: Option<&str>,
         degree: usize,
+        is_last_hop: bool,
     ) -> RelayAdmission {
         let now = Instant::now();
         let message_id = message.id.as_str();
 
-        // Suppression first: it is the cheapest check and the one that has to
-        // run on every arrival for the others to matter.
-        if self.seen.observe(&message_id) == SeenOutcome::Duplicate {
+        // Has this id been dealt with? Checked without recording, because a
+        // frame that is about to be *refused* must not be remembered as
+        // handled: another copy of it arriving over a healthy link a moment
+        // later is the alternate path that should still carry it. Recording on
+        // rejection would leave the id suppressed for the whole retention
+        // window, so a single link running hot — or one frame with its hop
+        // budget rewritten to nothing, which nothing here can authenticate —
+        // would blank every path through this device.
+        if self.seen.contains(&message_id) {
             self.counters.duplicates_suppressed =
                 self.counters.duplicates_suppressed.saturating_add(1);
 
-            // If our own copy is still waiting, a neighbor has just covered
-            // this frame for everyone in earshot of them. Stand down.
+            // Our own copy is still waiting, so a neighbor has transmitted
+            // this frame already.
             if let Some(index) = self
                 .pending
                 .iter()
                 .position(|p| p.message.id.as_str() == message_id)
             {
+                // Standing down is right in the middle of a network, where a
+                // neighbor's transmission reaches the same region ours would.
+                // It is wrong at the last hop: our pending copy is addressed
+                // to the recipient themselves, and no other device can be
+                // assumed to hold that link. Dropping it there loses the
+                // delivery outright — and leaves the id suppressed, so the
+                // sender's retries cannot rescue it either.
+                if is_last_hop {
+                    return RelayAdmission::Rejected(RelayRejection::AlreadySeen);
+                }
+
                 self.pending.remove(index);
                 self.counters.cancelled_by_duplicate =
                     self.counters.cancelled_by_duplicate.saturating_add(1);
@@ -395,6 +415,13 @@ impl MeshRelayGovernor {
             return RelayAdmission::Rejected(RelayRejection::QueueFull);
         }
 
+        // Accepted: now it is genuinely handled, and further copies can be
+        // suppressed. Recording here rather than at the top also means the
+        // cache fills at the rate frames are *taken on*, which the per-neighbor
+        // and per-device limits bound — not at the rate they arrive, which
+        // nothing bounds.
+        self.seen.observe(&message_id);
+
         let due_at = now + self.jitter_for(&message_id, degree);
         self.pending.push(PendingRelay {
             message: forwarded,
@@ -409,10 +436,16 @@ impl MeshRelayGovernor {
     /// Returns the forwards whose delay has elapsed, removing them from the
     /// queue.
     ///
-    /// Pacing is applied here rather than at admission so a forward cancelled
-    /// while waiting costs nothing. Frames held back for rate stay queued and
-    /// are retried on the next call, unless they have waited so long past their
-    /// due time that forwarding them no longer helps.
+    /// Frames whose delay has not elapsed stay queued, as do frames the device
+    /// has no budget left to transmit. A frame that has waited far past its
+    /// turn is abandoned instead: by then other paths have carried it or the
+    /// sender has retransmitted, and holding it only displaces newer traffic.
+    ///
+    /// Budget is *checked* here and *spent* in [`Self::take_send_token`], once
+    /// per link a frame actually crosses. Spending it here instead would
+    /// undercount by the fan-out — one release from this queue can put the
+    /// frame on several links — and the whole point of the ceiling is that it
+    /// bounds what reaches the radio.
     pub fn take_due(&mut self, now: Instant) -> Vec<PendingRelay> {
         self.seen.expire(now);
 
@@ -430,8 +463,7 @@ impl MeshRelayGovernor {
                 continue;
             }
 
-            if self.send_budget.try_take(now) {
-                self.counters.forwarded = self.counters.forwarded.saturating_add(1);
+            if self.has_send_budget(now) {
                 due.push(relay);
             } else {
                 self.counters.rate_deferred = self.counters.rate_deferred.saturating_add(1);
@@ -441,6 +473,29 @@ impl MeshRelayGovernor {
 
         self.pending = keep;
         due
+    }
+
+    /// Whether any budget remains to transmit right now.
+    fn has_send_budget(&mut self, now: Instant) -> bool {
+        self.send_budget.refill(now);
+        self.send_budget.tokens >= 1.0
+    }
+
+    /// Claims budget for putting one frame on one link.
+    ///
+    /// Every transmission goes through here — forwarding another device's
+    /// frame and handing over one of our own alike — because the ceiling is
+    /// about what this device puts on the air, not about whose message it is.
+    /// Returns false when the device is at its limit and the caller should not
+    /// transmit.
+    pub fn take_send_token(&mut self) -> bool {
+        if self.send_budget.try_take(Instant::now()) {
+            self.counters.forwarded = self.counters.forwarded.saturating_add(1);
+            true
+        } else {
+            self.counters.rate_deferred = self.counters.rate_deferred.saturating_add(1);
+            false
+        }
     }
 
     /// Records an id as handled without forwarding it.
@@ -459,28 +514,45 @@ impl MeshRelayGovernor {
     /// between two nodes.
     pub fn select_targets<'a>(
         &self,
-        neighbors: impl IntoIterator<Item = &'a str>,
+        neighbors: impl IntoIterator<Item = (&'a str, u8)>,
         exclude: &[&str],
         message_id: &str,
     ) -> Vec<String> {
-        let mut candidates: Vec<&str> = neighbors
+        let mut candidates: Vec<(&str, u8)> = neighbors
             .into_iter()
-            .filter(|peer| !exclude.contains(peer))
+            .filter(|(peer, _)| !exclude.contains(peer))
             .collect();
 
         if candidates.len() <= self.config.fanout {
-            return candidates.into_iter().map(str::to_string).collect();
+            return candidates
+                .into_iter()
+                .map(|(peer, _)| peer.to_string())
+                .collect();
         }
 
-        // Order by a hash of (id, peer, self) so the subset is stable for a
-        // given frame — a second copy of the same frame would pick the same
-        // neighbors rather than a fresh set — while different frames spread
-        // across different neighbors.
-        candidates.sort_by_key(|peer| Self::hash_of(&[message_id, peer, &self.local_id]));
+        // Strongest links first: a fan-out slot spent on a barely-connected
+        // neighbor is one the frame probably does not survive, and there are
+        // only a few slots.
+        //
+        // Ties break on a hash of (id, peer, self), which does two things.
+        // Within a group of equally good links it spreads different messages
+        // across different neighbors rather than pinning every frame to the
+        // same one. And it is stable per frame: a second copy of the same
+        // message picks the same neighbors instead of a fresh set, so a
+        // retransmission does not widen its own footprint.
+        candidates.sort_by(|(a_peer, a_quality), (b_peer, b_quality)| {
+            b_quality.cmp(a_quality).then_with(|| {
+                Self::hash_of(&[message_id, a_peer, &self.local_id]).cmp(&Self::hash_of(&[
+                    message_id,
+                    b_peer,
+                    &self.local_id,
+                ]))
+            })
+        });
         candidates
             .into_iter()
             .take(self.config.fanout)
-            .map(str::to_string)
+            .map(|(peer, _)| peer.to_string())
             .collect()
     }
 
@@ -643,7 +715,7 @@ mod tests {
         let mut gov = governor();
         let msg = frame();
 
-        assert_eq!(gov.admit(&msg, Some("b"), 3), RelayAdmission::Queued);
+        assert_eq!(gov.admit(&msg, Some("b"), 3, false), RelayAdmission::Queued);
 
         // Copies arriving after ours has gone out are suppressed, not forwarded.
         let due = gov.take_due(Instant::now());
@@ -651,11 +723,11 @@ mod tests {
 
         for _ in 0..5 {
             assert_eq!(
-                gov.admit(&msg, Some("c"), 3),
+                gov.admit(&msg, Some("c"), 3, false),
                 RelayAdmission::Rejected(RelayRejection::AlreadySeen)
             );
         }
-        assert_eq!(gov.counters().forwarded, 1);
+        assert_eq!(gov.counters().queued, 1);
         assert_eq!(gov.counters().duplicates_suppressed, 5);
     }
 
@@ -674,12 +746,12 @@ mod tests {
         );
         let msg = frame();
 
-        assert_eq!(gov.admit(&msg, Some("b"), 6), RelayAdmission::Queued);
+        assert_eq!(gov.admit(&msg, Some("b"), 6, false), RelayAdmission::Queued);
         assert_eq!(gov.pending_len(), 1);
 
         // The same frame arrives again while ours is still waiting.
         assert_eq!(
-            gov.admit(&msg, Some("c"), 6),
+            gov.admit(&msg, Some("c"), 6, false),
             RelayAdmission::Rejected(RelayRejection::SupersededByDuplicate)
         );
 
@@ -699,7 +771,7 @@ mod tests {
         let mut gov = governor();
         let msg = frame_with(255, MessagePriority::Medium);
 
-        assert_eq!(gov.admit(&msg, Some("b"), 2), RelayAdmission::Queued);
+        assert_eq!(gov.admit(&msg, Some("b"), 2, false), RelayAdmission::Queued);
         let due = gov.take_due(Instant::now());
 
         assert_eq!(due.len(), 1);
@@ -713,7 +785,7 @@ mod tests {
         let msg = frame_with(255, MessagePriority::Medium);
 
         assert_eq!(
-            gov.admit(&msg, Some("b"), DEFAULT_RELAY_DENSE_DEGREE),
+            gov.admit(&msg, Some("b"), DEFAULT_RELAY_DENSE_DEGREE, false),
             RelayAdmission::Queued
         );
         let due = gov.take_due(Instant::now());
@@ -727,7 +799,7 @@ mod tests {
         let msg = frame_with(1, MessagePriority::Medium);
 
         assert_eq!(
-            gov.admit(&msg, Some("b"), 3),
+            gov.admit(&msg, Some("b"), 3, false),
             RelayAdmission::Rejected(RelayRejection::HopLimitReached)
         );
         assert_eq!(gov.counters().hop_limit_reached, 1);
@@ -741,7 +813,7 @@ mod tests {
         // forward. Verifies the budget lands exactly on `TTL::is_exhausted`
         // rather than a hop early or late.
         assert_eq!(
-            gov.admit(&frame_with(2, MessagePriority::Medium), Some("b"), 3),
+            gov.admit(&frame_with(2, MessagePriority::Medium), Some("b"), 3, false),
             RelayAdmission::Queued
         );
         let due = gov.take_due(Instant::now());
@@ -758,7 +830,7 @@ mod tests {
         }
 
         assert_eq!(
-            gov.admit(&msg, Some("b"), 3),
+            gov.admit(&msg, Some("b"), 3, false),
             RelayAdmission::Rejected(RelayRejection::HopLimitReached)
         );
     }
@@ -771,7 +843,7 @@ mod tests {
         // suppression cannot help with, since every id is new.
         let mut accepted_from_noisy = 0;
         for _ in 0..200 {
-            if gov.admit(&frame(), Some("noisy"), 3) == RelayAdmission::Queued {
+            if gov.admit(&frame(), Some("noisy"), 3, false) == RelayAdmission::Queued {
                 accepted_from_noisy += 1;
             }
         }
@@ -785,15 +857,17 @@ mod tests {
         // A different neighbor still gets through: the limit is per link, so
         // one bad actor degrades only itself.
         assert_eq!(
-            gov.admit(&frame(), Some("quiet"), 3),
+            gov.admit(&frame(), Some("quiet"), 3, false),
             RelayAdmission::Queued
         );
     }
 
     #[test]
     fn transmission_never_exceeds_the_node_budget() {
-        // The invariant the whole design rests on: whatever arrives, the radio
-        // spend is capped. Frames held back stay queued rather than vanishing.
+        // The invariant the whole design rests on: whatever arrives, what the
+        // radio is asked to send is capped. Asserted on transmissions rather
+        // than on queue releases, because one release can put a frame on
+        // several links and it is the links that cost airtime.
         let mut gov = MeshRelayGovernor::with_config(
             "relay-node",
             MeshRelayConfig {
@@ -806,26 +880,104 @@ mod tests {
         );
 
         for _ in 0..200 {
-            gov.admit(&frame(), Some("b"), 3);
+            gov.admit(&frame(), Some("b"), 3, false);
         }
+        let due = gov.take_due(Instant::now());
+        assert!(!due.is_empty());
 
-        let now = Instant::now();
-        let due = gov.take_due(now);
+        // Ask for far more transmissions than the budget allows.
+        let granted = (0..1000).filter(|_| gov.take_send_token()).count();
 
         assert!(
-            due.len() <= DEFAULT_RELAY_BURST as usize,
-            "released {} frames in one pass, budget is {}",
-            due.len(),
-            DEFAULT_RELAY_BURST
+            granted <= DEFAULT_RELAY_BURST as usize + 1,
+            "granted {granted} transmissions against a burst of {DEFAULT_RELAY_BURST}"
         );
+        assert_eq!(gov.counters().forwarded as usize, granted);
         assert!(gov.counters().rate_deferred > 0);
-        assert!(gov.pending_len() > 0, "deferred frames must stay queued");
+    }
+
+    #[test]
+    fn a_refused_frame_leaves_the_way_open_for_another_copy() {
+        // A frame turned away must not be remembered as handled: the copy
+        // arriving over a healthy link a moment later is the alternate path,
+        // and suppressing it would blank every route through this device for
+        // the whole retention window.
+        let mut gov = governor();
+
+        // Refused for having no hops left — the cheapest thing an attacker can
+        // forge, since nothing authenticates the claim.
+        let msg = frame_with(1, MessagePriority::Medium);
+        assert_eq!(
+            gov.admit(&msg, Some("hostile"), 3, false),
+            RelayAdmission::Rejected(RelayRejection::HopLimitReached)
+        );
+
+        // The same message, arriving intact by another route.
+        let mut healthy = msg.clone();
+        healthy.ttl = TTL::new(8).unwrap();
+        assert_eq!(
+            gov.admit(&healthy, Some("good"), 3, false),
+            RelayAdmission::Queued,
+            "a refused frame must not blackhole its id"
+        );
+    }
+
+    #[test]
+    fn a_rate_limited_neighbor_does_not_blackhole_the_ids_it_sent() {
+        let mut gov = governor();
+
+        // Exhaust one neighbor's allowance with distinct frames.
+        let mut refused = Vec::new();
+        for _ in 0..200 {
+            let msg = frame();
+            if gov.admit(&msg, Some("noisy"), 3, false)
+                == RelayAdmission::Rejected(RelayRejection::PeerRateLimited)
+            {
+                refused.push(msg);
+            }
+        }
+        assert!(!refused.is_empty());
+
+        // Those same messages, reaching us through someone else, must still be
+        // carried.
+        let victim = &refused[0];
+        assert_eq!(
+            gov.admit(victim, Some("quiet"), 3, false),
+            RelayAdmission::Queued
+        );
+    }
+
+    #[test]
+    fn the_last_hop_does_not_stand_down_for_a_neighbor() {
+        // Standing down assumes a neighbor's transmission covers the same
+        // ground ours would. At the last hop it does not: our copy is going to
+        // the recipient over a link only we are known to hold, so dropping it
+        // loses the delivery.
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                jitter_min: Duration::from_millis(50),
+                jitter_max: Duration::from_millis(200),
+                ..Default::default()
+            },
+        );
+        let msg = frame();
+
+        assert_eq!(gov.admit(&msg, Some("b"), 3, true), RelayAdmission::Queued);
+        // Another forwarder hands us the same frame.
+        assert_eq!(
+            gov.admit(&msg, Some("c"), 3, true),
+            RelayAdmission::Rejected(RelayRejection::AlreadySeen)
+        );
+
+        assert_eq!(gov.pending_len(), 1, "the delivering copy must survive");
+        assert_eq!(gov.counters().cancelled_by_duplicate, 0);
     }
 
     #[test]
     fn a_forward_waiting_far_past_its_turn_is_abandoned() {
         let mut gov = governor();
-        gov.admit(&frame(), Some("b"), 3);
+        gov.admit(&frame(), Some("b"), 3, false);
 
         // Long enough that other paths have carried it or the sender has
         // retransmitted; holding it would only displace newer traffic.
@@ -850,10 +1002,13 @@ mod tests {
         );
 
         for _ in 0..4 {
-            assert_eq!(gov.admit(&frame(), Some("b"), 3), RelayAdmission::Queued);
+            assert_eq!(
+                gov.admit(&frame(), Some("b"), 3, false),
+                RelayAdmission::Queued
+            );
         }
         assert_eq!(
-            gov.admit(&frame(), Some("b"), 3),
+            gov.admit(&frame(), Some("b"), 3, false),
             RelayAdmission::Rejected(RelayRejection::QueueFull)
         );
         assert_eq!(gov.pending_len(), 4);
@@ -873,11 +1028,16 @@ mod tests {
             },
         );
 
-        gov.admit(&frame_with(8, MessagePriority::Low), Some("b"), 3);
-        gov.admit(&frame_with(8, MessagePriority::Low), Some("b"), 3);
+        gov.admit(&frame_with(8, MessagePriority::Low), Some("b"), 3, false);
+        gov.admit(&frame_with(8, MessagePriority::Low), Some("b"), 3, false);
 
         assert_eq!(
-            gov.admit(&frame_with(8, MessagePriority::Critical), Some("b"), 3),
+            gov.admit(
+                &frame_with(8, MessagePriority::Critical),
+                Some("b"),
+                3,
+                false
+            ),
             RelayAdmission::Queued
         );
         assert_eq!(gov.pending_len(), 2);
@@ -891,7 +1051,7 @@ mod tests {
     fn a_frame_is_never_sent_back_where_it_came_from() {
         let gov = governor();
         let targets = gov.select_targets(
-            ["alice", "b", "c", "d"],
+            [("alice", 80), ("b", 80), ("c", 80), ("d", 80)],
             &["b", "alice"], // arrival neighbor and the peer that wrote it
             "msg-1",
         );
@@ -905,7 +1065,18 @@ mod tests {
     #[test]
     fn fanout_is_capped_and_stable_for_a_given_frame() {
         let gov = governor();
-        let neighbors = ["n0", "n1", "n2", "n3", "n4", "n5", "n6", "n7"];
+        // All equally good, so the tie-break is what decides — which is the
+        // property under test.
+        let neighbors = [
+            ("n0", 70),
+            ("n1", 70),
+            ("n2", 70),
+            ("n3", 70),
+            ("n4", 70),
+            ("n5", 70),
+            ("n6", 70),
+            ("n7", 70),
+        ];
 
         let first = gov.select_targets(neighbors, &[], "msg-1");
         let again = gov.select_targets(neighbors, &[], "msg-1");
@@ -927,7 +1098,7 @@ mod tests {
         gov.mark_handled(&msg.id.as_str());
 
         assert_eq!(
-            gov.admit(&msg, Some("b"), 3),
+            gov.admit(&msg, Some("b"), 3, false),
             RelayAdmission::Rejected(RelayRejection::AlreadySeen)
         );
     }

--- a/crates/offline-protocol/src/protocol/mesh_relay.rs
+++ b/crates/offline-protocol/src/protocol/mesh_relay.rs
@@ -187,8 +187,22 @@ pub struct PendingRelay {
 pub struct MeshRelayCounters {
     /// Frames queued for forwarding.
     pub queued: u64,
-    /// Frames transmitted to a neighbor.
+    /// Times a frame was put on a link, counting each link separately.
+    ///
+    /// This is the airtime meter — what the send budget actually bounds — so it
+    /// counts this device handing over its *own* messages too. For "how much
+    /// have I carried for other people", see [`Self::forwarded`].
+    pub transmissions: u64,
+    /// Third-party frames that crossed at least one link on someone's behalf.
+    ///
+    /// Counted once per frame carried, not once per link, and never for this
+    /// device's own traffic.
     pub forwarded: u64,
+    /// Frames put back on the queue because the device ran out of budget
+    /// before they reached any neighbor.
+    pub requeued_for_budget: u64,
+    /// Queued forwards displaced to make room for a higher-priority frame.
+    pub queue_evicted: u64,
     /// Arrivals suppressed as already handled.
     pub duplicates_suppressed: u64,
     /// Pending forwards cancelled because a neighbor covered them.
@@ -212,8 +226,15 @@ pub struct MeshRelayCounters {
 /// A snapshot, safe to poll: every field counts since start-up.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MeshRelayStats {
-    /// Frames transmitted onward to a neighbor.
+    /// Frames carried onward on someone else's behalf, counted once each.
     pub forwarded: u64,
+    /// Times this device put a frame on a link, counting each link separately
+    /// and including hand-offs of its own messages.
+    ///
+    /// This is what the per-second forwarding budget bounds, so it is the
+    /// number to compare against that ceiling — [`Self::forwarded`] is the
+    /// contribution figure to show a user.
+    pub transmissions: u64,
     /// Frames accepted for forwarding.
     pub queued: u64,
     /// Frames waiting to go out right now.
@@ -226,6 +247,10 @@ pub struct MeshRelayStats {
     /// Frames refused because the neighbor sending them was over its share.
     pub peer_rate_limited: u64,
     /// Transmissions held back because this device was at its forwarding rate.
+    ///
+    /// A frame counted here is delayed, not dropped: it goes back on the queue
+    /// and is tried again on the next tick, until it is either sent or has
+    /// waited so long past its turn that carrying it no longer helps.
     pub rate_deferred: u64,
     /// Frames that had travelled as far as they were allowed to.
     pub hop_limit_reached: u64,
@@ -395,6 +420,14 @@ impl MeshRelayGovernor {
         }
 
         // Per-neighbor admission, before the frame can occupy queue space.
+        //
+        // A frame whose arrival link the carrier did not identify skips this
+        // step: there is no link to charge it to, and inventing a shared bucket
+        // for "unknown" would let one such carrier throttle every other. Those
+        // frames are still bounded by the queue capacity and the per-second
+        // send budget below, which is what makes skipping it acceptable — the
+        // per-neighbor limit shapes *fairness between links*, and a frame with
+        // no known link has no share to exceed.
         if let Some(peer) = arrival_peer {
             if !self.take_peer_token(peer, now) {
                 self.counters.peer_rate_limited = self.counters.peer_rate_limited.saturating_add(1);
@@ -410,7 +443,7 @@ impl MeshRelayGovernor {
             return RelayAdmission::Rejected(RelayRejection::HopLimitReached);
         };
 
-        if self.pending.len() >= self.config.queue_capacity && !self.evict_for(&forwarded) {
+        if self.pending.len() >= self.config.queue_capacity && !self.evict_for(&forwarded, now) {
             self.counters.queue_full = self.counters.queue_full.saturating_add(1);
             return RelayAdmission::Rejected(RelayRejection::QueueFull);
         }
@@ -446,6 +479,14 @@ impl MeshRelayGovernor {
     /// undercount by the fan-out — one release from this queue can put the
     /// frame on several links — and the whole point of the ceiling is that it
     /// bounds what reaches the radio.
+    ///
+    /// The check is therefore not a reservation, and cannot be: a released
+    /// frame may still find the budget gone by the time it reaches the radio,
+    /// because the frames released alongside it spend from the same bucket. A
+    /// caller that gets nothing onto a link for that reason must hand the frame
+    /// back with [`Self::requeue`] rather than drop it — the id is already
+    /// recorded as handled here, so dropping it would lose this copy *and*
+    /// refuse the copies and retransmissions that follow.
     pub fn take_due(&mut self, now: Instant) -> Vec<PendingRelay> {
         self.seen.expire(now);
 
@@ -490,12 +531,42 @@ impl MeshRelayGovernor {
     /// transmit.
     pub fn take_send_token(&mut self) -> bool {
         if self.send_budget.try_take(Instant::now()) {
-            self.counters.forwarded = self.counters.forwarded.saturating_add(1);
+            self.counters.transmissions = self.counters.transmissions.saturating_add(1);
             true
         } else {
             self.counters.rate_deferred = self.counters.rate_deferred.saturating_add(1);
             false
         }
+    }
+
+    /// Records that a third-party frame was carried onward.
+    ///
+    /// Separate from [`Self::take_send_token`], which meters airtime for every
+    /// frame this device transmits including its own. Counted once per frame
+    /// carried rather than once per link, so it reads as "messages I moved for
+    /// other people".
+    pub fn record_forwarded(&mut self) {
+        self.counters.forwarded = self.counters.forwarded.saturating_add(1);
+    }
+
+    /// Puts a released forward back on the queue, keeping its original due
+    /// time.
+    ///
+    /// For the frame that reached no neighbor because the budget ran out
+    /// between [`Self::take_due`] releasing it and the radio being asked. It
+    /// keeps its due time deliberately: the overdue cut-off in `take_due` is
+    /// measured from that, so a frame that stays starved is eventually
+    /// abandoned instead of being retried forever.
+    ///
+    /// Refused only if the queue has filled meanwhile, which is the same
+    /// bound every other queued frame is subject to.
+    pub fn requeue(&mut self, relay: PendingRelay) {
+        if self.pending.len() >= self.config.queue_capacity {
+            self.counters.queue_full = self.counters.queue_full.saturating_add(1);
+            return;
+        }
+        self.counters.requeued_for_budget = self.counters.requeued_for_budget.saturating_add(1);
+        self.pending.push(relay);
     }
 
     /// Records an id as handled without forwarding it.
@@ -600,19 +671,36 @@ impl MeshRelayGovernor {
 
     /// Makes room for a higher-priority forward by displacing the
     /// lowest-priority one that is not yet due.
-    fn evict_for(&mut self, candidate: &Message) -> bool {
+    ///
+    /// Frames already past their due time are left alone: they are on their way
+    /// to the radio this tick, so taking one costs a transmission that was
+    /// about to happen while the frame replacing it still has to wait out its
+    /// hold. Only when every lower-priority frame is already due does it
+    /// displace one of those instead of refusing outright.
+    fn evict_for(&mut self, candidate: &Message, now: Instant) -> bool {
         let candidate_rank = priority_rank(candidate.priority);
+        let lower_priority = |p: &PendingRelay| priority_rank(p.message.priority) < candidate_rank;
+
         let victim = self
             .pending
             .iter()
             .enumerate()
-            .filter(|(_, p)| priority_rank(p.message.priority) < candidate_rank)
-            .min_by_key(|(_, p)| priority_rank(p.message.priority));
+            .filter(|(_, p)| lower_priority(p) && p.due_at > now)
+            .min_by_key(|(_, p)| priority_rank(p.message.priority))
+            .map(|(index, _)| index)
+            .or_else(|| {
+                self.pending
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, p)| lower_priority(p))
+                    .min_by_key(|(_, p)| priority_rank(p.message.priority))
+                    .map(|(index, _)| index)
+            });
 
         match victim {
-            Some((index, _)) => {
+            Some(index) => {
                 self.pending.remove(index);
-                self.counters.queue_full = self.counters.queue_full.saturating_add(1);
+                self.counters.queue_evicted = self.counters.queue_evicted.saturating_add(1);
                 true
             }
             None => false,
@@ -625,7 +713,27 @@ impl MeshRelayGovernor {
             // because entries are only created for peers we hold a link to,
             // but churn over a long session can still accumulate.
             if self.peer_budgets.len() >= MAX_RELAY_RATE_PEERS {
-                self.peer_budgets.clear();
+                // Make room by forgetting the link that is spending least,
+                // rather than by clearing the table. A wholesale reset hands
+                // every neighbor a fresh burst — including the noisy one the
+                // per-link limit exists to hold back, which is the entry it can
+                // least afford to lose. The bucket that has recovered the most
+                // tokens is the one whose absence changes the least: at full
+                // capacity it is indistinguishable from a link never tracked.
+                //
+                // Costs a scan of the table, but only once the ceiling is
+                // reached and only when a genuinely new link appears.
+                for bucket in self.peer_budgets.values_mut() {
+                    bucket.refill(now);
+                }
+                let most_recovered = self
+                    .peer_budgets
+                    .iter()
+                    .max_by(|(_, a), (_, b)| a.tokens.total_cmp(&b.tokens))
+                    .map(|(peer, _)| peer.clone());
+                if let Some(peer) = most_recovered {
+                    self.peer_budgets.remove(&peer);
+                }
             }
             self.peer_budgets.insert(
                 peer_id.to_string(),
@@ -657,6 +765,16 @@ impl MeshRelayGovernor {
         Duration::from_millis(min_ms + (hash % span))
     }
 
+    /// Stable hash used to spread delays and fan-out choices.
+    ///
+    /// `DefaultHasher` is unseeded, so this is predictable to anyone who knows
+    /// the inputs — both of which (a message id and a user id) are visible on
+    /// the wire. That is accepted: knowing it buys only the ability to guess
+    /// which neighbor fires first or which three links a frame takes, and every
+    /// path it could steer a frame down is already bounded by the fan-out cap
+    /// and the send budget. It must stay *stable*, which a randomly-seeded
+    /// hasher would not be — a second copy of a frame has to pick the same
+    /// neighbors, or a retransmission widens its own footprint.
     fn hash_of(parts: &[&str]) -> u64 {
         let mut hasher = DefaultHasher::new();
         for part in parts {
@@ -760,7 +878,7 @@ mod tests {
         assert!(gov
             .take_due(Instant::now() + Duration::from_secs(1))
             .is_empty());
-        assert_eq!(gov.counters().forwarded, 0);
+        assert_eq!(gov.counters().transmissions, 0);
     }
 
     #[test]
@@ -892,8 +1010,155 @@ mod tests {
             granted <= DEFAULT_RELAY_BURST as usize + 1,
             "granted {granted} transmissions against a burst of {DEFAULT_RELAY_BURST}"
         );
-        assert_eq!(gov.counters().forwarded as usize, granted);
+        assert_eq!(gov.counters().transmissions as usize, granted);
         assert!(gov.counters().rate_deferred > 0);
+    }
+
+    #[test]
+    fn a_frame_that_reached_no_neighbor_for_budget_goes_back_on_the_queue() {
+        // `take_due` checks the budget without reserving it, so a batch of due
+        // frames can be released against a single token: the first spends it
+        // and the rest reach the radio with nothing left. Those frames have
+        // been forwarded nowhere, and their ids are already recorded as
+        // handled — dropping one would lose this copy and refuse both the
+        // copies behind it and the sender's retransmissions for the whole
+        // retention window. It has to go back on the queue.
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                peer_rate_per_sec: 10_000.0,
+                peer_burst: 10_000.0,
+                ..immediate_config()
+            },
+        );
+
+        for _ in 0..40 {
+            gov.admit(&frame(), Some("b"), 3, false);
+        }
+        let due = gov.take_due(Instant::now());
+        assert!(
+            due.len() > DEFAULT_RELAY_BURST as usize,
+            "the batch must outrun the budget for this to be the case under test"
+        );
+
+        // Drain the budget the way a fan-out does, then hand back everything
+        // that got nowhere.
+        let mut requeued = 0;
+        for relay in due {
+            if gov.take_send_token() {
+                continue;
+            }
+            gov.requeue(relay);
+            requeued += 1;
+        }
+
+        assert!(requeued > 0, "the budget must have run out mid-batch");
+        assert_eq!(gov.pending_len(), requeued, "every starved frame is kept");
+        assert_eq!(gov.counters().requeued_for_budget as usize, requeued);
+    }
+
+    #[test]
+    fn a_requeued_frame_is_still_abandoned_once_it_is_far_past_its_turn() {
+        // Re-queueing must not become an unbounded retry: a frame kept for
+        // budget keeps its original due time, so the overdue cut-off still
+        // reaches it.
+        let mut gov = governor();
+        gov.admit(&frame(), Some("b"), 3, false);
+        let mut due = gov.take_due(Instant::now());
+        assert_eq!(due.len(), 1);
+
+        gov.requeue(due.remove(0));
+        assert_eq!(gov.pending_len(), 1);
+
+        let later = gov.take_due(Instant::now() + RELAY_QUEUE_MAX_OVERDUE + Duration::from_secs(1));
+        assert!(later.is_empty());
+        assert_eq!(gov.counters().abandoned_overdue, 1);
+        assert_eq!(gov.pending_len(), 0);
+    }
+
+    #[test]
+    fn eviction_prefers_a_frame_that_has_not_yet_gone_out() {
+        // A due frame is on its way to the radio this tick; taking it costs a
+        // transmission that was about to happen, while the frame replacing it
+        // still has to wait out its hold.
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                queue_capacity: 2,
+                jitter_min: Duration::from_millis(0),
+                jitter_max: Duration::from_millis(0),
+                peer_rate_per_sec: 10_000.0,
+                peer_burst: 10_000.0,
+                ..Default::default()
+            },
+        );
+
+        // One low-priority frame due immediately.
+        let due_now = frame_with(8, MessagePriority::Low);
+        gov.admit(&due_now, Some("b"), 3, false);
+
+        // A second low-priority frame that is not due for a while.
+        gov.config.jitter_min = Duration::from_millis(500);
+        gov.config.jitter_max = Duration::from_millis(500);
+        let waiting = frame_with(8, MessagePriority::Low);
+        gov.admit(&waiting, Some("b"), 3, false);
+
+        // An urgent frame needs the room.
+        gov.admit(
+            &frame_with(8, MessagePriority::Critical),
+            Some("b"),
+            3,
+            false,
+        );
+
+        assert_eq!(gov.counters().queue_evicted, 1);
+        assert_eq!(
+            gov.counters().queue_full,
+            0,
+            "making room is not the same as refusing"
+        );
+        assert!(
+            gov.pending
+                .iter()
+                .any(|p| p.message.id.as_str() == due_now.id.as_str()),
+            "the frame already due must survive"
+        );
+        assert!(
+            !gov.pending
+                .iter()
+                .any(|p| p.message.id.as_str() == waiting.id.as_str()),
+            "the frame still waiting is the one displaced"
+        );
+    }
+
+    #[test]
+    fn a_full_peer_table_keeps_the_links_that_are_spending() {
+        // Clearing the table wholesale hands every neighbor a fresh burst,
+        // including the noisy one the per-link limit exists to hold back.
+        let mut gov = MeshRelayGovernor::with_config("relay-node", immediate_config());
+
+        // One neighbor spends most of its allowance.
+        for _ in 0..(DEFAULT_RELAY_PEER_BURST as usize - 1) {
+            gov.admit(&frame(), Some("noisy"), 3, false);
+        }
+
+        // Fill the table with links that arrive once and go quiet.
+        for i in 0..MAX_RELAY_RATE_PEERS {
+            gov.admit(&frame(), Some(&format!("idle-{i}")), 3, false);
+        }
+
+        assert!(gov.peer_budgets.len() <= MAX_RELAY_RATE_PEERS);
+        // Still tracked at all: the entry the limit exists to hold back is the
+        // one it can least afford to forget, and it never sends again here, so
+        // an eviction would leave it absent rather than rebuilt.
+        let noisy = gov
+            .peer_budgets
+            .get("noisy")
+            .expect("a link mid-spend must not be forgotten to make room for idle ones");
+        assert!(
+            noisy.tokens < noisy.capacity,
+            "the noisy link kept its spent allowance rather than being handed a fresh burst"
+        );
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol/mesh_relay.rs
+++ b/crates/offline-protocol/src/protocol/mesh_relay.rs
@@ -501,6 +501,11 @@ impl MeshRelayGovernor {
             }
 
             if now.saturating_duration_since(relay.due_at) > RELAY_QUEUE_MAX_OVERDUE {
+                // Never made it onto a link, so its id must not stay
+                // suppressed: the sender's retransmissions carry the same id,
+                // and refusing them would close this route for the whole
+                // retention window over a few seconds of congestion.
+                self.seen.forget(&relay.message.id.as_str());
                 self.counters.abandoned_overdue = self.counters.abandoned_overdue.saturating_add(1);
                 continue;
             }
@@ -569,6 +574,11 @@ impl MeshRelayGovernor {
     /// bound every other queued frame is subject to.
     pub fn requeue(&mut self, relay: PendingRelay) {
         if self.pending.len() >= self.config.queue_capacity {
+            // Refused room on the way back, so this frame is being dropped
+            // having reached nobody. Release its id for the same reason the
+            // overdue cut-off does — a copy behind it, or the sender's own
+            // retransmission, is now the only way it travels.
+            self.seen.forget(&relay.message.id.as_str());
             self.counters.queue_full = self.counters.queue_full.saturating_add(1);
             return;
         }
@@ -736,7 +746,12 @@ impl MeshRelayGovernor {
 
         match victim {
             Some(index) => {
-                self.pending.remove(index);
+                let displaced = self.pending.remove(index);
+                // Displaced before it ever reached a link. Its id goes back to
+                // being unknown, so the copy behind it — or the sender's
+                // retransmission — can still be carried by this device once
+                // there is room again.
+                self.seen.forget(&displaced.message.id.as_str());
                 self.counters.queue_evicted = self.counters.queue_evicted.saturating_add(1);
                 true
             }
@@ -1111,6 +1126,97 @@ mod tests {
         assert!(later.is_empty());
         assert_eq!(gov.counters().abandoned_overdue, 1);
         assert_eq!(gov.pending_len(), 0);
+    }
+
+    #[test]
+    fn a_frame_abandoned_for_waiting_too_long_releases_its_id() {
+        // A frame dropped for waiting past its turn never reached a link, so
+        // nothing is circulating that a second forward could duplicate. Its id
+        // must go back to being unknown, or the sender's retransmissions —
+        // which carry the same id — are refused for the whole retention window
+        // because of a few seconds of congestion.
+        let mut gov = governor();
+        let msg = frame();
+        gov.admit(&msg, Some("b"), 3, false);
+
+        let due = gov.take_due(Instant::now() + RELAY_QUEUE_MAX_OVERDUE + Duration::from_secs(1));
+        assert!(due.is_empty());
+        assert_eq!(gov.counters().abandoned_overdue, 1);
+
+        assert_eq!(
+            gov.admit(&msg, Some("c"), 3, false),
+            RelayAdmission::Queued,
+            "the sender's retransmission must still be carried"
+        );
+    }
+
+    #[test]
+    fn a_frame_displaced_from_the_queue_releases_its_id() {
+        // Same rule for a frame evicted to make room for an urgent one: it was
+        // never transmitted, so the route through this device must stay open.
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                queue_capacity: 1,
+                peer_rate_per_sec: 10_000.0,
+                peer_burst: 10_000.0,
+                ..immediate_config()
+            },
+        );
+
+        let routine = frame_with(8, MessagePriority::Low);
+        gov.admit(&routine, Some("b"), 3, false);
+        gov.admit(
+            &frame_with(8, MessagePriority::Critical),
+            Some("b"),
+            3,
+            false,
+        );
+        assert_eq!(gov.counters().queue_evicted, 1);
+
+        // The urgent frame goes out, leaving room again. A later copy of the
+        // displaced one — or the sender's retransmission — must be carryable.
+        gov.take_due(Instant::now());
+        assert_eq!(
+            gov.admit(&routine, Some("c"), 3, false),
+            RelayAdmission::Queued,
+            "the displaced frame's id must not be blackholed"
+        );
+    }
+
+    #[test]
+    fn a_frame_refused_room_on_the_way_back_releases_its_id() {
+        // The third drop that happens after the id was recorded: a frame that
+        // reached no neighbor and finds the queue full when handed back.
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                queue_capacity: 1,
+                peer_rate_per_sec: 10_000.0,
+                peer_burst: 10_000.0,
+                ..immediate_config()
+            },
+        );
+
+        let starved = frame();
+        gov.admit(&starved, Some("b"), 3, false);
+        let mut due = gov.take_due(Instant::now());
+        assert_eq!(due.len(), 1);
+
+        // The queue fills while the frame is out being transmitted, so there is
+        // no room for it on the way back.
+        gov.admit(&frame(), Some("b"), 3, false);
+        gov.requeue(due.remove(0));
+        assert_eq!(gov.counters().queue_full, 1);
+        assert_eq!(gov.pending_len(), 1, "the dropped frame is not held");
+
+        // Once the queue drains, the copy behind it must still be carryable.
+        gov.take_due(Instant::now());
+        assert_eq!(
+            gov.admit(&starved, Some("c"), 3, false),
+            RelayAdmission::Queued,
+            "a frame that got nowhere and could not be kept must stay carryable"
+        );
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol/mesh_relay.rs
+++ b/crates/offline-protocol/src/protocol/mesh_relay.rs
@@ -625,10 +625,18 @@ impl MeshRelayGovernor {
         self.pending.push(relay);
     }
 
-    /// Records an id as handled without forwarding it.
+    /// Records an id as handled without queueing a forward for it.
     ///
-    /// Used for frames we consume ourselves, so a copy arriving later by
-    /// another path is not forwarded on their behalf.
+    /// Used for frames this device **originates** and hands to its neighbors:
+    /// a copy circling back to us through the mesh is then recognized rather
+    /// than carried onward as though it were someone else's.
+    ///
+    /// Deliberately not called for frames addressed to us. A later copy of one
+    /// of those is still addressed to us, so it never reaches the forwarding
+    /// path at all — recording it would only fill the cache at delivery rate,
+    /// which the capacity is not sized for and which would make
+    /// [`Self::seen_capacity_evictions`] climb for reasons unrelated to relay
+    /// load.
     pub fn mark_handled(&mut self, message_id: &str) {
         self.seen.observe(message_id);
     }
@@ -1626,7 +1634,9 @@ mod tests {
     }
 
     #[test]
-    fn a_frame_we_consumed_ourselves_is_not_forwarded_for_someone_else() {
+    fn a_frame_we_originated_is_not_carried_back_for_someone_else() {
+        // Our own message, handed to neighbors. When a neighbor's copy reaches
+        // us again we must recognize it, not take it on as third-party traffic.
         let mut gov = governor();
         let msg = frame();
 

--- a/crates/offline-protocol/src/protocol/mesh_relay.rs
+++ b/crates/offline-protocol/src/protocol/mesh_relay.rs
@@ -207,6 +207,38 @@ pub struct MeshRelayCounters {
     pub ttl_clamped: u64,
 }
 
+/// What this device has carried for other people.
+///
+/// A snapshot, safe to poll: every field counts since start-up.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MeshRelayStats {
+    /// Frames transmitted onward to a neighbor.
+    pub forwarded: u64,
+    /// Frames accepted for forwarding.
+    pub queued: u64,
+    /// Frames waiting to go out right now.
+    pub awaiting_transmission: usize,
+    /// Arrivals ignored because the frame had already been handled.
+    pub duplicates_suppressed: u64,
+    /// Forwards dropped because a neighbor transmitted the same frame first —
+    /// the saving that keeps a crowded room from repeating itself.
+    pub covered_by_a_neighbor: u64,
+    /// Frames refused because the neighbor sending them was over its share.
+    pub peer_rate_limited: u64,
+    /// Transmissions held back because this device was at its forwarding rate.
+    pub rate_deferred: u64,
+    /// Frames that had travelled as far as they were allowed to.
+    pub hop_limit_reached: u64,
+    /// Frames whose claimed reach was cut down to local policy.
+    pub reach_clamped: u64,
+    /// Ids forgotten for lack of room rather than age.
+    ///
+    /// Expected to stay at zero. A non-zero value means this device is seeing
+    /// more traffic than it can remember having handled, and a frame it forgets
+    /// can be forwarded a second time.
+    pub dropped_for_capacity: u64,
+}
+
 /// A refilling allowance, in frames.
 #[derive(Debug, Clone)]
 struct TokenBucket {
@@ -267,11 +299,6 @@ pub struct MeshRelayGovernor {
 }
 
 impl MeshRelayGovernor {
-    /// Creates a governor for `local_id` with default tunables.
-    pub fn new(local_id: impl Into<String>) -> Self {
-        Self::with_config(local_id, MeshRelayConfig::default())
-    }
-
     /// Creates a governor with explicit tunables.
     pub fn with_config(local_id: impl Into<String>, config: MeshRelayConfig) -> Self {
         let now = Instant::now();
@@ -287,7 +314,10 @@ impl MeshRelayGovernor {
         }
     }
 
-    /// The tunables in force.
+    /// The tunables in force. Apps read these from
+    /// `ProtocolConfig::mesh_relay`; this is for the tests that assert the
+    /// defaults hold together.
+    #[cfg(test)]
     pub fn config(&self) -> &MeshRelayConfig {
         &self.config
     }
@@ -300,11 +330,6 @@ impl MeshRelayGovernor {
     /// Forwards awaiting transmission.
     pub fn pending_len(&self) -> usize {
         self.pending.len()
-    }
-
-    /// Whether an id has already been handled.
-    pub fn has_seen(&self, message_id: &str) -> bool {
-        self.seen.contains(message_id)
     }
 
     /// Ids dropped from the suppression cache for capacity rather than age.
@@ -416,11 +441,6 @@ impl MeshRelayGovernor {
 
         self.pending = keep;
         due
-    }
-
-    /// Whether any queued forward is due at `now`, without taking it.
-    pub fn has_due(&self, now: Instant) -> bool {
-        self.pending.iter().any(|relay| relay.due_at <= now)
     }
 
     /// Records an id as handled without forwarding it.

--- a/crates/offline-protocol/src/protocol/mesh_relay.rs
+++ b/crates/offline-protocol/src/protocol/mesh_relay.rs
@@ -198,9 +198,10 @@ pub struct MeshRelayCounters {
     /// Counted once per frame carried, not once per link, and never for this
     /// device's own traffic.
     pub forwarded: u64,
-    /// Frames put back on the queue because the device ran out of budget
-    /// before they reached any neighbor.
-    pub requeued_for_budget: u64,
+    /// Frames put back on the queue because they reached no neighbor at all —
+    /// the budget ran out, the links chosen for them went away, or there was
+    /// no usable link to choose.
+    pub requeued: u64,
     /// Queued forwards displaced to make room for a higher-priority frame.
     pub queue_evicted: u64,
     /// Arrivals suppressed as already handled.
@@ -552,11 +553,17 @@ impl MeshRelayGovernor {
     /// Puts a released forward back on the queue, keeping its original due
     /// time.
     ///
-    /// For the frame that reached no neighbor because the budget ran out
-    /// between [`Self::take_due`] releasing it and the radio being asked. It
-    /// keeps its due time deliberately: the overdue cut-off in `take_due` is
-    /// measured from that, so a frame that stays starved is eventually
-    /// abandoned instead of being retried forever.
+    /// For the frame that reached no neighbor at all between [`Self::take_due`]
+    /// releasing it and the radio being asked — because the budget ran out,
+    /// because every link picked for it had gone away, or because there was no
+    /// usable link to pick. All three end the same way: the frame has travelled
+    /// nowhere, its id is already recorded as handled, and dropping it would
+    /// refuse the copies and retransmissions behind it for the whole retention
+    /// window.
+    ///
+    /// It keeps its due time deliberately: the overdue cut-off in `take_due` is
+    /// measured from that, so a frame that stays stuck is eventually abandoned
+    /// instead of being retried forever.
     ///
     /// Refused only if the queue has filled meanwhile, which is the same
     /// bound every other queued frame is subject to.
@@ -565,7 +572,7 @@ impl MeshRelayGovernor {
             self.counters.queue_full = self.counters.queue_full.saturating_add(1);
             return;
         }
-        self.counters.requeued_for_budget = self.counters.requeued_for_budget.saturating_add(1);
+        self.counters.requeued = self.counters.requeued.saturating_add(1);
         self.pending.push(relay);
     }
 
@@ -1084,7 +1091,7 @@ mod tests {
 
         assert!(requeued > 0, "the budget must have run out mid-batch");
         assert_eq!(gov.pending_len(), requeued, "every starved frame is kept");
-        assert_eq!(gov.counters().requeued_for_budget as usize, requeued);
+        assert_eq!(gov.counters().requeued as usize, requeued);
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol/mesh_relay.rs
+++ b/crates/offline-protocol/src/protocol/mesh_relay.rs
@@ -74,6 +74,23 @@ pub const DEFAULT_RELAY_RATE_PER_SEC: f32 = 10.0;
 /// Burst allowance on top of the sustained forwarding rate.
 pub const DEFAULT_RELAY_BURST: f32 = 30.0;
 
+/// Transmissions held back from carrying other people's traffic so this device
+/// can always get its own frames out.
+///
+/// Own traffic and forwarded traffic share one budget, because they share one
+/// radio. Without a reserve they also share one queue discipline, and a device
+/// forwarding at its ceiling would starve its *own* sends behind strangers'
+/// — including the delivery acknowledgement for a message it just received,
+/// whose absence makes a delivered message look lost. Carving the reserve out
+/// of the burst rather than adding a second bucket keeps the ceiling exactly
+/// where it was: this changes who may spend the last few tokens, not how many
+/// there are.
+///
+/// It costs forwarding no throughput at saturation. Tokens refill continuously,
+/// so a forward simply waits for the level to climb back above the reserve —
+/// which at the sustained rate is a fraction of a second.
+pub const RELAY_OWN_TRAFFIC_RESERVE: f32 = 5.0;
+
 /// Sustained ceiling on frames accepted for forwarding from any one neighbor.
 ///
 /// Keeps a single noisy or hostile link from consuming the whole node's
@@ -294,9 +311,11 @@ impl TokenBucket {
         }
     }
 
-    fn try_take(&mut self, now: Instant) -> bool {
+    /// Spends a token, but only while more than `floor` would remain
+    /// untouched. A `floor` of zero spends down to empty.
+    fn try_take_above(&mut self, floor: f32, now: Instant) -> bool {
         self.refill(now);
-        if self.tokens >= 1.0 {
+        if self.tokens >= 1.0 + floor {
             self.tokens -= 1.0;
             true
         } else {
@@ -317,6 +336,10 @@ pub struct MeshRelayGovernor {
     /// Forwards awaiting their delay, in the order they were queued.
     pending: Vec<PendingRelay>,
     send_budget: TokenBucket,
+    /// Tokens of [`Self::send_budget`] that only this device's own frames may
+    /// spend. Clamped to half the burst so a small configured burst cannot
+    /// reserve the whole bucket and stop forwarding outright.
+    own_reserve: f32,
     peer_budgets: HashMap<String, TokenBucket>,
     counters: MeshRelayCounters,
     /// Seeds the per-frame delay so two nodes holding the same frame pick
@@ -331,6 +354,7 @@ impl MeshRelayGovernor {
         let seen = RelaySeenCache::with_config(config.seen.clone());
         Self {
             send_budget: TokenBucket::new(config.burst, config.rate_per_sec, now),
+            own_reserve: RELAY_OWN_TRAFFIC_RESERVE.min(config.burst.max(0.0) / 2.0),
             seen,
             pending: Vec::new(),
             peer_budgets: HashMap::new(),
@@ -522,21 +546,36 @@ impl MeshRelayGovernor {
         due
     }
 
-    /// Whether any budget remains to transmit right now.
+    /// Whether any budget remains to forward right now.
+    ///
+    /// Measured against the same reserve [`Self::take_send_token`] respects, so
+    /// `take_due` does not release a batch the flush is about to refuse.
     fn has_send_budget(&mut self, now: Instant) -> bool {
         self.send_budget.refill(now);
-        self.send_budget.tokens >= 1.0
+        self.send_budget.tokens >= 1.0 + self.own_reserve
     }
 
-    /// Claims budget for putting one frame on one link.
+    /// Claims budget for putting one **forwarded** frame on one link.
     ///
-    /// Every transmission goes through here — forwarding another device's
-    /// frame and handing over one of our own alike — because the ceiling is
-    /// about what this device puts on the air, not about whose message it is.
-    /// Returns false when the device is at its limit and the caller should not
-    /// transmit.
+    /// Stops short of the own-traffic reserve: at the ceiling, other people's
+    /// traffic waits so this device can still send its own. See
+    /// [`RELAY_OWN_TRAFFIC_RESERVE`] and [`Self::take_own_send_token`].
     pub fn take_send_token(&mut self) -> bool {
-        if self.send_budget.try_take(Instant::now()) {
+        self.claim_transmission(self.own_reserve)
+    }
+
+    /// Claims budget for putting one of **this device's own** frames on one
+    /// link.
+    ///
+    /// Metered against the same ceiling — it is the same radio — but allowed
+    /// into the reserve, so a device forwarding at its limit can still get its
+    /// own messages and acknowledgements out.
+    pub fn take_own_send_token(&mut self) -> bool {
+        self.claim_transmission(0.0)
+    }
+
+    fn claim_transmission(&mut self, floor: f32) -> bool {
+        if self.send_budget.try_take_above(floor, Instant::now()) {
             self.counters.transmissions = self.counters.transmissions.saturating_add(1);
             true
         } else {
@@ -795,7 +834,7 @@ impl MeshRelayGovernor {
 
         self.peer_budgets
             .get_mut(peer_id)
-            .map(|bucket| bucket.try_take(now))
+            .map(|bucket| bucket.try_take_above(0.0, now))
             .unwrap_or(true)
     }
 
@@ -1217,6 +1256,73 @@ mod tests {
             RelayAdmission::Queued,
             "a frame that got nowhere and could not be kept must stay carryable"
         );
+    }
+
+    #[test]
+    fn forwarding_leaves_room_for_this_devices_own_traffic() {
+        // One radio, one budget — but a device saturated with other people's
+        // traffic must still be able to send its own, above all the delivery
+        // acknowledgement whose absence makes a delivered message look lost.
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                queue_capacity: 512,
+                peer_rate_per_sec: 10_000.0,
+                peer_burst: 10_000.0,
+                ..immediate_config()
+            },
+        );
+
+        for _ in 0..200 {
+            gov.admit(&frame(), Some("b"), 3, false);
+        }
+        gov.take_due(Instant::now());
+
+        // Drain the budget the way a saturated forwarder does.
+        let forwarded = (0..1000).filter(|_| gov.take_send_token()).count();
+        assert!(forwarded > 0, "forwarding must get its share first");
+        assert!(
+            !gov.take_send_token(),
+            "forwarding must stop at the reserve, not at empty"
+        );
+
+        // The reserve is still there for us.
+        let own = (0..1000).filter(|_| gov.take_own_send_token()).count();
+        assert!(
+            own >= RELAY_OWN_TRAFFIC_RESERVE as usize,
+            "own traffic got {own} transmissions against a reserve of {RELAY_OWN_TRAFFIC_RESERVE}"
+        );
+
+        // And the ceiling still holds across both: the reserve is carved out of
+        // the burst, not added to it.
+        assert!(
+            (forwarded + own) <= DEFAULT_RELAY_BURST as usize + 1,
+            "{forwarded} forwarded + {own} own exceeds the burst of {DEFAULT_RELAY_BURST}"
+        );
+    }
+
+    #[test]
+    fn a_small_configured_burst_still_forwards() {
+        // The reserve is clamped to half the burst, so a device configured with
+        // a burst smaller than the reserve does not silently stop forwarding
+        // altogether.
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                burst: 2.0,
+                rate_per_sec: 1.0,
+                peer_rate_per_sec: 10_000.0,
+                peer_burst: 10_000.0,
+                ..immediate_config()
+            },
+        );
+
+        gov.admit(&frame(), Some("b"), 3, false);
+        assert!(
+            !gov.take_due(Instant::now()).is_empty(),
+            "a small burst must still release forwards"
+        );
+        assert!(gov.take_send_token(), "and still allow transmitting them");
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol/mesh_relay.rs
+++ b/crates/offline-protocol/src/protocol/mesh_relay.rs
@@ -577,6 +577,36 @@ impl MeshRelayGovernor {
         self.seen.observe(message_id);
     }
 
+    /// Absorbs an arrival that is a copy of a frame already dealt with and
+    /// needs no further decision, reporting whether it did.
+    ///
+    /// This is [`Self::admit`]'s suppression check, split out so a caller can
+    /// reach it without first assembling the arguments `admit` needs. In a
+    /// dense neighborhood most third-party arrivals are copies, and the caller's
+    /// `degree` and `is_last_hop` cost a status snapshot across every transport
+    /// and an enumeration of every link — work the suppression check would only
+    /// throw away.
+    ///
+    /// Deliberately answers `false` while we still hold a pending copy of the
+    /// id, even though that is also a duplicate: standing down for a neighbor
+    /// is the one duplicate outcome that depends on the neighbor set, so it has
+    /// to go through the full path. Those are rare — the pending window is one
+    /// jitter delay wide.
+    pub fn absorb_settled_duplicate(&mut self, message_id: &str) -> bool {
+        if !self.seen.contains(message_id) {
+            return false;
+        }
+        if self
+            .pending
+            .iter()
+            .any(|p| p.message.id.as_str() == message_id)
+        {
+            return false;
+        }
+        self.counters.duplicates_suppressed = self.counters.duplicates_suppressed.saturating_add(1);
+        true
+    }
+
     /// Neighbors a frame should be forwarded to, given the current neighbor
     /// set and the peers it must not go back to.
     ///
@@ -1074,6 +1104,27 @@ mod tests {
         assert!(later.is_empty());
         assert_eq!(gov.counters().abandoned_overdue, 1);
         assert_eq!(gov.pending_len(), 0);
+    }
+
+    #[test]
+    fn a_settled_duplicate_is_absorbed_without_the_full_admission_path() {
+        let mut gov = governor();
+        let msg = frame();
+
+        assert!(
+            !gov.absorb_settled_duplicate(&msg.id.as_str()),
+            "an id never seen is not a duplicate"
+        );
+
+        gov.admit(&msg, Some("b"), 3, false);
+        // While our copy is still pending, standing down is a decision that
+        // needs the neighbor set, so the cheap path must decline to make it.
+        assert!(!gov.absorb_settled_duplicate(&msg.id.as_str()));
+
+        // Once it has gone out, further copies are settled duplicates.
+        gov.take_due(Instant::now());
+        assert!(gov.absorb_settled_duplicate(&msg.id.as_str()));
+        assert_eq!(gov.counters().duplicates_suppressed, 1);
     }
 
     #[test]

--- a/crates/offline-protocol/src/protocol/mesh_relay.rs
+++ b/crates/offline-protocol/src/protocol/mesh_relay.rs
@@ -1,0 +1,933 @@
+//! Admission control and pacing for mesh forwarding.
+//!
+//! Forwarding is what turns a set of nearby devices into a network: a frame
+//! addressed to someone out of radio range is carried by the devices in
+//! between. The hazard is that the same property which gives coverage —
+//! every node repeating what it hears — also multiplies traffic, and in a
+//! dense room the multiplication can outrun the radio. This module is the
+//! governor on that: it decides whether a frame is forwarded at all, when,
+//! and how fast frames may leave.
+//!
+//! Four mechanisms, each covering something the others cannot:
+//!
+//! 1. **Suppression** ([`RelaySeenCache`]) — an id is forwarded once. Without
+//!    it, copies circulate until their hop limit runs out, and every node
+//!    repeats every copy.
+//! 2. **Jitter with cancellation** — a forward waits a short randomized delay
+//!    before going out, and is dropped if the same id arrives again while it
+//!    waits. In a dense cluster the first neighbor to fire covers everyone who
+//!    can hear it, and the rest stand down. This is what makes cost scale with
+//!    *coverage* rather than with the number of links, and it adapts on its own
+//!    as the room fills up — no threshold to tune.
+//! 3. **Hop limits** — an arriving frame's remaining hop budget is clamped
+//!    before use, so a frame that claims an implausible budget (nothing
+//!    authenticates it at this layer) cannot circulate longer than one our own
+//!    policy would have issued.
+//! 4. **Budgets** — a hard ceiling on frames per second, in total and per
+//!    neighbor. The first three assume frames are what they appear to be;
+//!    budgets hold even when they are not. Whatever arrives, and however it is
+//!    shaped, a node cannot be made to transmit faster than its budget: that
+//!    invariant is what bounds the worst case, so the failure mode under attack
+//!    or overload is added delay rather than a radio that never goes quiet.
+//!
+//! Ordering matters. Suppression runs before anything expensive, admission
+//! before queueing (so a flood cannot grow the queue), and pacing at the moment
+//! of transmission (so a forward cancelled while waiting costs no budget).
+
+use offline_protocol_core::{Message, MessagePriority};
+use offline_protocol_reliability::{RelaySeenCache, RelaySeenConfig, SeenOutcome};
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::time::{Duration, Instant};
+
+/// Hop budget a forwarded frame is clamped to under normal density.
+pub const DEFAULT_RELAY_MAX_TTL: u8 = 8;
+
+/// Hop budget used once the local neighborhood is dense.
+///
+/// With many neighbors, coverage is reached in fewer hops — the same message
+/// travels further per hop — so a lower ceiling reaches the same devices for
+/// less traffic.
+pub const DEFAULT_RELAY_DENSE_MAX_TTL: u8 = 5;
+
+/// Neighbor count at or above which the dense hop budget applies.
+pub const DEFAULT_RELAY_DENSE_DEGREE: usize = 6;
+
+/// Absolute ceiling on how many times a frame may be forwarded, regardless of
+/// the hop budget it carries. A backstop against a frame whose hop fields have
+/// been shaped to evade the clamp.
+pub const RELAY_MAX_HOP_COUNT: u8 = 16;
+
+/// Neighbors a single frame is forwarded to.
+pub const DEFAULT_RELAY_FANOUT: usize = 3;
+
+/// Shortest delay before a queued forward is transmitted.
+pub const DEFAULT_RELAY_JITTER_MIN_MS: u64 = 20;
+
+/// Longest delay before a queued forward is transmitted, at low density.
+pub const DEFAULT_RELAY_JITTER_MAX_MS: u64 = 200;
+
+/// Sustained ceiling on forwarded frames leaving this node, per second.
+pub const DEFAULT_RELAY_RATE_PER_SEC: f32 = 10.0;
+
+/// Burst allowance on top of the sustained forwarding rate.
+pub const DEFAULT_RELAY_BURST: f32 = 30.0;
+
+/// Sustained ceiling on frames accepted for forwarding from any one neighbor.
+///
+/// Keeps a single noisy or hostile link from consuming the whole node's
+/// forwarding budget: its frames are refused at the door, leaving the budget
+/// for everyone else's traffic.
+pub const DEFAULT_RELAY_PEER_RATE_PER_SEC: f32 = 5.0;
+
+/// Burst allowance for a single neighbor.
+pub const DEFAULT_RELAY_PEER_BURST: f32 = 15.0;
+
+/// Maximum forwards waiting for their delay to elapse.
+pub const DEFAULT_RELAY_QUEUE_CAPACITY: usize = 256;
+
+/// Maximum neighbors tracked for per-neighbor rate limiting.
+pub const MAX_RELAY_RATE_PEERS: usize = 256;
+
+/// How long a queued forward may sit past its due time before being abandoned.
+///
+/// If a node is so far over budget that a frame waits this long, the frame's
+/// usefulness has passed — other paths have carried it or the sender has
+/// retransmitted — and holding it only displaces newer traffic.
+const RELAY_QUEUE_MAX_OVERDUE: Duration = Duration::from_secs(5);
+
+/// Tunables for mesh forwarding.
+#[derive(Debug, Clone)]
+pub struct MeshRelayConfig {
+    /// Hop budget a forwarded frame is clamped to.
+    pub max_ttl: u8,
+    /// Hop budget applied once the neighborhood is dense.
+    pub dense_max_ttl: u8,
+    /// Neighbor count at which the dense budget applies.
+    pub dense_degree: usize,
+    /// Neighbors a frame is forwarded to.
+    pub fanout: usize,
+    /// Shortest pre-transmit delay.
+    pub jitter_min: Duration,
+    /// Longest pre-transmit delay at low density.
+    pub jitter_max: Duration,
+    /// Sustained forwarding rate, frames per second.
+    pub rate_per_sec: f32,
+    /// Burst allowance above the sustained rate.
+    pub burst: f32,
+    /// Sustained per-neighbor acceptance rate.
+    pub peer_rate_per_sec: f32,
+    /// Per-neighbor burst allowance.
+    pub peer_burst: f32,
+    /// Maximum forwards awaiting transmission.
+    pub queue_capacity: usize,
+    /// Suppression cache sizing.
+    pub seen: RelaySeenConfig,
+}
+
+impl Default for MeshRelayConfig {
+    fn default() -> Self {
+        Self {
+            max_ttl: DEFAULT_RELAY_MAX_TTL,
+            dense_max_ttl: DEFAULT_RELAY_DENSE_MAX_TTL,
+            dense_degree: DEFAULT_RELAY_DENSE_DEGREE,
+            fanout: DEFAULT_RELAY_FANOUT,
+            jitter_min: Duration::from_millis(DEFAULT_RELAY_JITTER_MIN_MS),
+            jitter_max: Duration::from_millis(DEFAULT_RELAY_JITTER_MAX_MS),
+            rate_per_sec: DEFAULT_RELAY_RATE_PER_SEC,
+            burst: DEFAULT_RELAY_BURST,
+            peer_rate_per_sec: DEFAULT_RELAY_PEER_RATE_PER_SEC,
+            peer_burst: DEFAULT_RELAY_PEER_BURST,
+            queue_capacity: DEFAULT_RELAY_QUEUE_CAPACITY,
+            seen: RelaySeenConfig::default(),
+        }
+    }
+}
+
+/// Why a frame was not queued for forwarding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayRejection {
+    /// Already handled; this is another copy of a frame we have dealt with.
+    AlreadySeen,
+    /// Another copy arrived while this one was waiting, so the pending forward
+    /// was cancelled — a neighbor has covered it.
+    SupersededByDuplicate,
+    /// The frame has no hop budget left.
+    HopLimitReached,
+    /// The neighbor that sent it is over its acceptance rate.
+    PeerRateLimited,
+    /// No room in the pending queue.
+    QueueFull,
+}
+
+/// The outcome of offering an inbound frame to the governor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayAdmission {
+    /// Queued; it will be transmitted once its delay elapses.
+    Queued,
+    /// Not queued.
+    Rejected(RelayRejection),
+}
+
+/// A forward waiting for its delay to elapse.
+#[derive(Debug, Clone)]
+pub struct PendingRelay {
+    /// The frame to forward, with hop fields already adjusted.
+    pub message: Message,
+    /// The neighbor it arrived from, which must not receive it back.
+    pub arrival_peer: Option<String>,
+    /// When it becomes eligible to transmit.
+    pub due_at: Instant,
+}
+
+/// Running totals, for telemetry and for tests that assert a flood stayed
+/// bounded.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MeshRelayCounters {
+    /// Frames queued for forwarding.
+    pub queued: u64,
+    /// Frames transmitted to a neighbor.
+    pub forwarded: u64,
+    /// Arrivals suppressed as already handled.
+    pub duplicates_suppressed: u64,
+    /// Pending forwards cancelled because a neighbor covered them.
+    pub cancelled_by_duplicate: u64,
+    /// Frames refused because their sender was over its rate.
+    pub peer_rate_limited: u64,
+    /// Frames refused because the pending queue was full.
+    pub queue_full: u64,
+    /// Frames dropped for having no hop budget left.
+    pub hop_limit_reached: u64,
+    /// Transmissions deferred because the node was at its forwarding rate.
+    pub rate_deferred: u64,
+    /// Queued forwards abandoned after waiting too long past their due time.
+    pub abandoned_overdue: u64,
+    /// Hop budgets reduced because the frame claimed more than policy allows.
+    pub ttl_clamped: u64,
+}
+
+/// A refilling allowance, in frames.
+#[derive(Debug, Clone)]
+struct TokenBucket {
+    tokens: f32,
+    capacity: f32,
+    refill_per_sec: f32,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(capacity: f32, refill_per_sec: f32, now: Instant) -> Self {
+        Self {
+            tokens: capacity.max(0.0),
+            capacity: capacity.max(0.0),
+            refill_per_sec: refill_per_sec.max(0.0),
+            last_refill: now,
+        }
+    }
+
+    fn refill(&mut self, now: Instant) {
+        let elapsed = now
+            .saturating_duration_since(self.last_refill)
+            .as_secs_f32();
+        if elapsed > 0.0 {
+            self.tokens = (self.tokens + elapsed * self.refill_per_sec).min(self.capacity);
+            self.last_refill = now;
+        }
+    }
+
+    fn try_take(&mut self, now: Instant) -> bool {
+        self.refill(now);
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Decides what gets forwarded, when, and how fast.
+///
+/// Holds no transports and sends nothing itself: it answers questions and hands
+/// back due work, so its behavior is testable without a radio and its policy
+/// stays in one place rather than spread through the receive path.
+#[derive(Debug)]
+pub struct MeshRelayGovernor {
+    config: MeshRelayConfig,
+    seen: RelaySeenCache,
+    /// Forwards awaiting their delay, in the order they were queued.
+    pending: Vec<PendingRelay>,
+    send_budget: TokenBucket,
+    peer_budgets: HashMap<String, TokenBucket>,
+    counters: MeshRelayCounters,
+    /// Seeds the per-frame delay so two nodes holding the same frame pick
+    /// different delays.
+    local_id: String,
+}
+
+impl MeshRelayGovernor {
+    /// Creates a governor for `local_id` with default tunables.
+    pub fn new(local_id: impl Into<String>) -> Self {
+        Self::with_config(local_id, MeshRelayConfig::default())
+    }
+
+    /// Creates a governor with explicit tunables.
+    pub fn with_config(local_id: impl Into<String>, config: MeshRelayConfig) -> Self {
+        let now = Instant::now();
+        let seen = RelaySeenCache::with_config(config.seen.clone());
+        Self {
+            send_budget: TokenBucket::new(config.burst, config.rate_per_sec, now),
+            seen,
+            pending: Vec::new(),
+            peer_budgets: HashMap::new(),
+            counters: MeshRelayCounters::default(),
+            local_id: local_id.into(),
+            config,
+        }
+    }
+
+    /// The tunables in force.
+    pub fn config(&self) -> &MeshRelayConfig {
+        &self.config
+    }
+
+    /// Running totals.
+    pub fn counters(&self) -> &MeshRelayCounters {
+        &self.counters
+    }
+
+    /// Forwards awaiting transmission.
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Whether an id has already been handled.
+    pub fn has_seen(&self, message_id: &str) -> bool {
+        self.seen.contains(message_id)
+    }
+
+    /// Ids dropped from the suppression cache for capacity rather than age.
+    /// Expected to stay zero; see [`RelaySeenCache::capacity_evictions`].
+    pub fn seen_capacity_evictions(&self) -> u64 {
+        self.seen.capacity_evictions()
+    }
+
+    /// Offers an inbound third-party frame for forwarding.
+    ///
+    /// Runs the full admission sequence and, when the frame is accepted,
+    /// queues an adjusted copy for later transmission. `degree` is the current
+    /// neighbor count, which sets both the hop budget and the delay spread.
+    pub fn admit(
+        &mut self,
+        message: &Message,
+        arrival_peer: Option<&str>,
+        degree: usize,
+    ) -> RelayAdmission {
+        let now = Instant::now();
+        let message_id = message.id.as_str();
+
+        // Suppression first: it is the cheapest check and the one that has to
+        // run on every arrival for the others to matter.
+        if self.seen.observe(&message_id) == SeenOutcome::Duplicate {
+            self.counters.duplicates_suppressed =
+                self.counters.duplicates_suppressed.saturating_add(1);
+
+            // If our own copy is still waiting, a neighbor has just covered
+            // this frame for everyone in earshot of them. Stand down.
+            if let Some(index) = self
+                .pending
+                .iter()
+                .position(|p| p.message.id.as_str() == message_id)
+            {
+                self.pending.remove(index);
+                self.counters.cancelled_by_duplicate =
+                    self.counters.cancelled_by_duplicate.saturating_add(1);
+                return RelayAdmission::Rejected(RelayRejection::SupersededByDuplicate);
+            }
+
+            return RelayAdmission::Rejected(RelayRejection::AlreadySeen);
+        }
+
+        // Per-neighbor admission, before the frame can occupy queue space.
+        if let Some(peer) = arrival_peer {
+            if !self.take_peer_token(peer, now) {
+                self.counters.peer_rate_limited = self.counters.peer_rate_limited.saturating_add(1);
+                return RelayAdmission::Rejected(RelayRejection::PeerRateLimited);
+            }
+        }
+
+        // Hop accounting. The arriving budget is clamped to what our own policy
+        // would have issued before it is spent, so an inflated claim buys at
+        // most this one hop.
+        let Some(forwarded) = self.prepare_hop(message, degree) else {
+            self.counters.hop_limit_reached = self.counters.hop_limit_reached.saturating_add(1);
+            return RelayAdmission::Rejected(RelayRejection::HopLimitReached);
+        };
+
+        if self.pending.len() >= self.config.queue_capacity && !self.evict_for(&forwarded) {
+            self.counters.queue_full = self.counters.queue_full.saturating_add(1);
+            return RelayAdmission::Rejected(RelayRejection::QueueFull);
+        }
+
+        let due_at = now + self.jitter_for(&message_id, degree);
+        self.pending.push(PendingRelay {
+            message: forwarded,
+            arrival_peer: arrival_peer.map(str::to_string),
+            due_at,
+        });
+        self.counters.queued = self.counters.queued.saturating_add(1);
+
+        RelayAdmission::Queued
+    }
+
+    /// Returns the forwards whose delay has elapsed, removing them from the
+    /// queue.
+    ///
+    /// Pacing is applied here rather than at admission so a forward cancelled
+    /// while waiting costs nothing. Frames held back for rate stay queued and
+    /// are retried on the next call, unless they have waited so long past their
+    /// due time that forwarding them no longer helps.
+    pub fn take_due(&mut self, now: Instant) -> Vec<PendingRelay> {
+        self.seen.expire(now);
+
+        let mut due = Vec::new();
+        let mut keep: Vec<PendingRelay> = Vec::with_capacity(self.pending.len());
+
+        for relay in std::mem::take(&mut self.pending) {
+            if relay.due_at > now {
+                keep.push(relay);
+                continue;
+            }
+
+            if now.saturating_duration_since(relay.due_at) > RELAY_QUEUE_MAX_OVERDUE {
+                self.counters.abandoned_overdue = self.counters.abandoned_overdue.saturating_add(1);
+                continue;
+            }
+
+            if self.send_budget.try_take(now) {
+                self.counters.forwarded = self.counters.forwarded.saturating_add(1);
+                due.push(relay);
+            } else {
+                self.counters.rate_deferred = self.counters.rate_deferred.saturating_add(1);
+                keep.push(relay);
+            }
+        }
+
+        self.pending = keep;
+        due
+    }
+
+    /// Whether any queued forward is due at `now`, without taking it.
+    pub fn has_due(&self, now: Instant) -> bool {
+        self.pending.iter().any(|relay| relay.due_at <= now)
+    }
+
+    /// Records an id as handled without forwarding it.
+    ///
+    /// Used for frames we consume ourselves, so a copy arriving later by
+    /// another path is not forwarded on their behalf.
+    pub fn mark_handled(&mut self, message_id: &str) {
+        self.seen.observe(message_id);
+    }
+
+    /// Neighbors a frame should be forwarded to, given the current neighbor
+    /// set and the peers it must not go back to.
+    ///
+    /// Excludes the neighbor it arrived from and the peer that wrote it —
+    /// both already have it, and returning it is how a frame ends up bouncing
+    /// between two nodes.
+    pub fn select_targets<'a>(
+        &self,
+        neighbors: impl IntoIterator<Item = &'a str>,
+        exclude: &[&str],
+        message_id: &str,
+    ) -> Vec<String> {
+        let mut candidates: Vec<&str> = neighbors
+            .into_iter()
+            .filter(|peer| !exclude.contains(peer))
+            .collect();
+
+        if candidates.len() <= self.config.fanout {
+            return candidates.into_iter().map(str::to_string).collect();
+        }
+
+        // Order by a hash of (id, peer, self) so the subset is stable for a
+        // given frame — a second copy of the same frame would pick the same
+        // neighbors rather than a fresh set — while different frames spread
+        // across different neighbors.
+        candidates.sort_by_key(|peer| Self::hash_of(&[message_id, peer, &self.local_id]));
+        candidates
+            .into_iter()
+            .take(self.config.fanout)
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Drops per-neighbor rate state for a peer that has gone away.
+    pub fn forget_peer(&mut self, peer_id: &str) {
+        self.peer_budgets.remove(peer_id);
+    }
+
+    /// Releases expired suppression entries. Safe to call from a periodic tick.
+    pub fn maintain(&mut self, now: Instant) {
+        self.seen.expire(now);
+    }
+
+    /// Builds the copy to forward, or `None` when the frame has no hop budget
+    /// left.
+    fn prepare_hop(&mut self, message: &Message, degree: usize) -> Option<Message> {
+        if message.hop_count.value() >= RELAY_MAX_HOP_COUNT {
+            return None;
+        }
+
+        let ceiling = if degree >= self.config.dense_degree {
+            self.config.dense_max_ttl
+        } else {
+            self.config.max_ttl
+        };
+
+        let claimed = message.ttl.value();
+        let effective = claimed.min(ceiling);
+        if effective < claimed {
+            self.counters.ttl_clamped = self.counters.ttl_clamped.saturating_add(1);
+        }
+
+        // A budget of 1 or less is spent: this node is the last that may hold
+        // the frame, matching `TTL::is_exhausted`.
+        let remaining = offline_protocol_core::TTL::from_value(effective).decrement()?;
+
+        let mut forwarded = message.clone();
+        // Rewrite rather than decrement in place: the frame leaves with a
+        // budget this node vouches for, so an inflated claim cannot survive
+        // past this hop.
+        forwarded.ttl = remaining;
+        let _ = forwarded.increment_hop();
+        Some(forwarded)
+    }
+
+    /// Makes room for a higher-priority forward by displacing the
+    /// lowest-priority one that is not yet due.
+    fn evict_for(&mut self, candidate: &Message) -> bool {
+        let candidate_rank = priority_rank(candidate.priority);
+        let victim = self
+            .pending
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| priority_rank(p.message.priority) < candidate_rank)
+            .min_by_key(|(_, p)| priority_rank(p.message.priority));
+
+        match victim {
+            Some((index, _)) => {
+                self.pending.remove(index);
+                self.counters.queue_full = self.counters.queue_full.saturating_add(1);
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn take_peer_token(&mut self, peer_id: &str, now: Instant) -> bool {
+        if !self.peer_budgets.contains_key(peer_id) {
+            // Bound the map: an attacker cannot grow it with invented peer ids
+            // because entries are only created for peers we hold a link to,
+            // but churn over a long session can still accumulate.
+            if self.peer_budgets.len() >= MAX_RELAY_RATE_PEERS {
+                self.peer_budgets.clear();
+            }
+            self.peer_budgets.insert(
+                peer_id.to_string(),
+                TokenBucket::new(self.config.peer_burst, self.config.peer_rate_per_sec, now),
+            );
+        }
+
+        self.peer_budgets
+            .get_mut(peer_id)
+            .map(|bucket| bucket.try_take(now))
+            .unwrap_or(true)
+    }
+
+    /// The delay before a queued forward is transmitted.
+    ///
+    /// Derived from the frame and this node's identity, so two nodes holding
+    /// the same frame wait different amounts and one of them gets to cancel.
+    /// The spread widens with density, because that is where the contention is.
+    fn jitter_for(&self, message_id: &str, degree: usize) -> Duration {
+        let min_ms = self.config.jitter_min.as_millis() as u64;
+        let max_ms = (self.config.jitter_max.as_millis() as u64).max(min_ms);
+
+        // More neighbors means more nodes racing to forward the same frame, so
+        // give them more room to separate.
+        let density_scale = 1 + (degree / self.config.dense_degree.max(1)) as u64;
+        let span = (max_ms - min_ms).saturating_mul(density_scale).max(1);
+
+        let hash = Self::hash_of(&[message_id, &self.local_id]);
+        Duration::from_millis(min_ms + (hash % span))
+    }
+
+    fn hash_of(parts: &[&str]) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        for part in parts {
+            part.hash(&mut hasher);
+        }
+        hasher.finish()
+    }
+}
+
+fn priority_rank(priority: MessagePriority) -> u8 {
+    match priority {
+        MessagePriority::Low => 0,
+        MessagePriority::Medium => 1,
+        MessagePriority::High => 2,
+        MessagePriority::Critical => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use offline_protocol_core::{AppId, UserId, TTL};
+
+    /// Zero jitter so `admit` queues a forward that is immediately due, which
+    /// keeps the tests deterministic without a clock abstraction.
+    fn immediate_config() -> MeshRelayConfig {
+        MeshRelayConfig {
+            jitter_min: Duration::from_millis(0),
+            jitter_max: Duration::from_millis(0),
+            ..Default::default()
+        }
+    }
+
+    fn governor() -> MeshRelayGovernor {
+        MeshRelayGovernor::with_config("relay-node", immediate_config())
+    }
+
+    fn frame_with(ttl: u8, priority: MessagePriority) -> Message {
+        Message::builder(
+            UserId::new("alice").unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("app").unwrap(),
+        )
+        .content("hello")
+        .priority(priority)
+        .ttl(TTL::new(ttl).unwrap())
+        .build()
+    }
+
+    fn frame() -> Message {
+        frame_with(8, MessagePriority::Medium)
+    }
+
+    #[test]
+    fn a_frame_is_forwarded_once_however_many_copies_arrive() {
+        let mut gov = governor();
+        let msg = frame();
+
+        assert_eq!(gov.admit(&msg, Some("b"), 3), RelayAdmission::Queued);
+
+        // Copies arriving after ours has gone out are suppressed, not forwarded.
+        let due = gov.take_due(Instant::now());
+        assert_eq!(due.len(), 1);
+
+        for _ in 0..5 {
+            assert_eq!(
+                gov.admit(&msg, Some("c"), 3),
+                RelayAdmission::Rejected(RelayRejection::AlreadySeen)
+            );
+        }
+        assert_eq!(gov.counters().forwarded, 1);
+        assert_eq!(gov.counters().duplicates_suppressed, 5);
+    }
+
+    #[test]
+    fn a_neighbor_beating_us_to_it_cancels_our_pending_forward() {
+        // The density control: in a cluster where everyone hears everyone, the
+        // first node to transmit covers the rest, and they stand down instead
+        // of each sending their own copy.
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                jitter_min: Duration::from_millis(50),
+                jitter_max: Duration::from_millis(200),
+                ..Default::default()
+            },
+        );
+        let msg = frame();
+
+        assert_eq!(gov.admit(&msg, Some("b"), 6), RelayAdmission::Queued);
+        assert_eq!(gov.pending_len(), 1);
+
+        // The same frame arrives again while ours is still waiting.
+        assert_eq!(
+            gov.admit(&msg, Some("c"), 6),
+            RelayAdmission::Rejected(RelayRejection::SupersededByDuplicate)
+        );
+
+        assert_eq!(gov.pending_len(), 0);
+        assert_eq!(gov.counters().cancelled_by_duplicate, 1);
+        assert!(gov
+            .take_due(Instant::now() + Duration::from_secs(1))
+            .is_empty());
+        assert_eq!(gov.counters().forwarded, 0);
+    }
+
+    #[test]
+    fn an_inflated_hop_budget_is_cut_to_local_policy() {
+        // Nothing authenticates the hop budget at this layer, so a frame can
+        // claim any value. It must not buy more than one hop past our own
+        // ceiling.
+        let mut gov = governor();
+        let msg = frame_with(255, MessagePriority::Medium);
+
+        assert_eq!(gov.admit(&msg, Some("b"), 2), RelayAdmission::Queued);
+        let due = gov.take_due(Instant::now());
+
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].message.ttl.value(), DEFAULT_RELAY_MAX_TTL - 1);
+        assert_eq!(gov.counters().ttl_clamped, 1);
+    }
+
+    #[test]
+    fn a_dense_neighborhood_uses_the_lower_hop_ceiling() {
+        let mut gov = governor();
+        let msg = frame_with(255, MessagePriority::Medium);
+
+        assert_eq!(
+            gov.admit(&msg, Some("b"), DEFAULT_RELAY_DENSE_DEGREE),
+            RelayAdmission::Queued
+        );
+        let due = gov.take_due(Instant::now());
+        assert_eq!(due[0].message.ttl.value(), DEFAULT_RELAY_DENSE_MAX_TTL - 1);
+    }
+
+    #[test]
+    fn a_frame_out_of_hops_is_not_forwarded() {
+        let mut gov = governor();
+        // A budget of 1 is spent: this node is the last that may hold it.
+        let msg = frame_with(1, MessagePriority::Medium);
+
+        assert_eq!(
+            gov.admit(&msg, Some("b"), 3),
+            RelayAdmission::Rejected(RelayRejection::HopLimitReached)
+        );
+        assert_eq!(gov.counters().hop_limit_reached, 1);
+    }
+
+    #[test]
+    fn the_last_hop_is_forwarded_and_the_one_after_it_is_not() {
+        let mut gov = governor();
+
+        // Two hops left: goes out with one, which the next node will refuse to
+        // forward. Verifies the budget lands exactly on `TTL::is_exhausted`
+        // rather than a hop early or late.
+        assert_eq!(
+            gov.admit(&frame_with(2, MessagePriority::Medium), Some("b"), 3),
+            RelayAdmission::Queued
+        );
+        let due = gov.take_due(Instant::now());
+        assert_eq!(due[0].message.ttl.value(), 1);
+        assert!(due[0].message.is_ttl_exhausted());
+    }
+
+    #[test]
+    fn the_hop_ceiling_stops_a_frame_that_evaded_the_budget() {
+        let mut gov = governor();
+        let mut msg = frame_with(255, MessagePriority::Medium);
+        for _ in 0..RELAY_MAX_HOP_COUNT {
+            let _ = msg.increment_hop();
+        }
+
+        assert_eq!(
+            gov.admit(&msg, Some("b"), 3),
+            RelayAdmission::Rejected(RelayRejection::HopLimitReached)
+        );
+    }
+
+    #[test]
+    fn one_noisy_neighbor_cannot_consume_the_whole_node() {
+        let mut gov = governor();
+
+        // Spend the noisy neighbor's allowance on unique frames — the shape
+        // suppression cannot help with, since every id is new.
+        let mut accepted_from_noisy = 0;
+        for _ in 0..200 {
+            if gov.admit(&frame(), Some("noisy"), 3) == RelayAdmission::Queued {
+                accepted_from_noisy += 1;
+            }
+        }
+
+        assert!(
+            accepted_from_noisy <= DEFAULT_RELAY_PEER_BURST as usize + 2,
+            "accepted {accepted_from_noisy} frames from one neighbor"
+        );
+        assert!(gov.counters().peer_rate_limited > 0);
+
+        // A different neighbor still gets through: the limit is per link, so
+        // one bad actor degrades only itself.
+        assert_eq!(
+            gov.admit(&frame(), Some("quiet"), 3),
+            RelayAdmission::Queued
+        );
+    }
+
+    #[test]
+    fn transmission_never_exceeds_the_node_budget() {
+        // The invariant the whole design rests on: whatever arrives, the radio
+        // spend is capped. Frames held back stay queued rather than vanishing.
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                queue_capacity: 512,
+                // Admission is not what is under test here.
+                peer_rate_per_sec: 10_000.0,
+                peer_burst: 10_000.0,
+                ..immediate_config()
+            },
+        );
+
+        for _ in 0..200 {
+            gov.admit(&frame(), Some("b"), 3);
+        }
+
+        let now = Instant::now();
+        let due = gov.take_due(now);
+
+        assert!(
+            due.len() <= DEFAULT_RELAY_BURST as usize,
+            "released {} frames in one pass, budget is {}",
+            due.len(),
+            DEFAULT_RELAY_BURST
+        );
+        assert!(gov.counters().rate_deferred > 0);
+        assert!(gov.pending_len() > 0, "deferred frames must stay queued");
+    }
+
+    #[test]
+    fn a_forward_waiting_far_past_its_turn_is_abandoned() {
+        let mut gov = governor();
+        gov.admit(&frame(), Some("b"), 3);
+
+        // Long enough that other paths have carried it or the sender has
+        // retransmitted; holding it would only displace newer traffic.
+        let due = gov.take_due(Instant::now() + RELAY_QUEUE_MAX_OVERDUE + Duration::from_secs(1));
+        assert!(due.is_empty());
+        assert_eq!(gov.counters().abandoned_overdue, 1);
+        assert_eq!(gov.pending_len(), 0);
+    }
+
+    #[test]
+    fn a_full_queue_refuses_rather_than_growing() {
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                queue_capacity: 4,
+                jitter_min: Duration::from_millis(500),
+                jitter_max: Duration::from_millis(500),
+                peer_rate_per_sec: 10_000.0,
+                peer_burst: 10_000.0,
+                ..Default::default()
+            },
+        );
+
+        for _ in 0..4 {
+            assert_eq!(gov.admit(&frame(), Some("b"), 3), RelayAdmission::Queued);
+        }
+        assert_eq!(
+            gov.admit(&frame(), Some("b"), 3),
+            RelayAdmission::Rejected(RelayRejection::QueueFull)
+        );
+        assert_eq!(gov.pending_len(), 4);
+    }
+
+    #[test]
+    fn a_full_queue_still_takes_an_urgent_frame_over_a_routine_one() {
+        let mut gov = MeshRelayGovernor::with_config(
+            "relay-node",
+            MeshRelayConfig {
+                queue_capacity: 2,
+                jitter_min: Duration::from_millis(500),
+                jitter_max: Duration::from_millis(500),
+                peer_rate_per_sec: 10_000.0,
+                peer_burst: 10_000.0,
+                ..Default::default()
+            },
+        );
+
+        gov.admit(&frame_with(8, MessagePriority::Low), Some("b"), 3);
+        gov.admit(&frame_with(8, MessagePriority::Low), Some("b"), 3);
+
+        assert_eq!(
+            gov.admit(&frame_with(8, MessagePriority::Critical), Some("b"), 3),
+            RelayAdmission::Queued
+        );
+        assert_eq!(gov.pending_len(), 2);
+        assert!(gov
+            .take_due(Instant::now() + Duration::from_secs(1))
+            .iter()
+            .any(|r| r.message.priority == MessagePriority::Critical));
+    }
+
+    #[test]
+    fn a_frame_is_never_sent_back_where_it_came_from() {
+        let gov = governor();
+        let targets = gov.select_targets(
+            ["alice", "b", "c", "d"],
+            &["b", "alice"], // arrival neighbor and the peer that wrote it
+            "msg-1",
+        );
+
+        assert!(!targets.contains(&"b".to_string()));
+        assert!(!targets.contains(&"alice".to_string()));
+        assert!(targets.contains(&"c".to_string()));
+        assert!(targets.contains(&"d".to_string()));
+    }
+
+    #[test]
+    fn fanout_is_capped_and_stable_for_a_given_frame() {
+        let gov = governor();
+        let neighbors = ["n0", "n1", "n2", "n3", "n4", "n5", "n6", "n7"];
+
+        let first = gov.select_targets(neighbors, &[], "msg-1");
+        let again = gov.select_targets(neighbors, &[], "msg-1");
+
+        assert_eq!(first.len(), DEFAULT_RELAY_FANOUT);
+        assert_eq!(first, again, "a second copy must pick the same neighbors");
+
+        // Different frames spread across different neighbors rather than
+        // hammering one set.
+        let other = gov.select_targets(neighbors, &[], "msg-2");
+        assert_eq!(other.len(), DEFAULT_RELAY_FANOUT);
+    }
+
+    #[test]
+    fn a_frame_we_consumed_ourselves_is_not_forwarded_for_someone_else() {
+        let mut gov = governor();
+        let msg = frame();
+
+        gov.mark_handled(&msg.id.as_str());
+
+        assert_eq!(
+            gov.admit(&msg, Some("b"), 3),
+            RelayAdmission::Rejected(RelayRejection::AlreadySeen)
+        );
+    }
+
+    #[test]
+    fn the_suppression_cache_holds_a_saturated_node_for_its_full_window() {
+        // Capacity has to outlast in-flight copies at the maximum rate the node
+        // will accept traffic. If it did not, an id could be forgotten while
+        // copies were still circulating and be forwarded a second time — by
+        // every node, which is how a flood becomes a storm.
+        let gov = governor();
+        let max_admissions_per_sec = DEFAULT_RELAY_PEER_RATE_PER_SEC * MAX_RELAY_RATE_PEERS as f32;
+        let sustained_ceiling = DEFAULT_RELAY_RATE_PER_SEC.min(max_admissions_per_sec);
+        let ids_in_window = sustained_ceiling * gov.config().seen.retention.as_secs_f32();
+
+        assert!(
+            (gov.config().seen.capacity as f32) >= ids_in_window,
+            "cache holds {} ids but a saturated node sees {} within the retention window",
+            gov.config().seen.capacity,
+            ids_in_window
+        );
+    }
+}

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -3,6 +3,7 @@
 mod blocking;
 mod config_accessors;
 mod decryption_queue;
+mod mesh_relay;
 mod message_dispatch;
 mod nostr_publication;
 mod observability;

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -3,7 +3,7 @@
 mod blocking;
 mod config_accessors;
 mod decryption_queue;
-mod mesh_relay;
+pub(crate) mod mesh_relay;
 mod message_dispatch;
 mod nostr_publication;
 mod observability;
@@ -38,6 +38,7 @@ use crate::{
     TransportManager,
 };
 use chrono::{DateTime, Utc};
+use mesh_relay::MeshRelayGovernor;
 use offline_protocol_core::{LamportClock, Message, MessageId, MutexExt};
 use offline_protocol_mls::{EncryptedMessage, MlsManager, MlsStorage, WelcomeMessage};
 use offline_protocol_reliability::{AckManager, Deduplicator, RetryQueue};
@@ -89,6 +90,12 @@ pub struct OfflineProtocol {
 
     /// Deduplicator for preventing duplicates.
     pub(crate) deduplicator: Deduplicator,
+
+    /// Decides which frames this device carries for other people, when they
+    /// go out, and how fast. Kept separate from [`Self::deduplicator`], whose
+    /// entries track messages addressed to us and are removed again when
+    /// delivery has to be retried.
+    pub(crate) mesh_relay: MeshRelayGovernor,
 
     /// Shared mutable state.
     shared_state: Arc<Mutex<SharedState>>,
@@ -623,6 +630,10 @@ impl OfflineProtocol {
             ack_manager: AckManager::with_config(config.reliability.ack.clone()),
             retry_queue: RetryQueue::with_config(config.reliability.retry.clone()),
             deduplicator: Deduplicator::with_config(config.reliability.dedup.clone()),
+            mesh_relay: MeshRelayGovernor::with_config(
+                config.user_id.clone(),
+                config.mesh_relay.clone(),
+            ),
             shared_state: Arc::new(Mutex::new(SharedState::new())),
             outbox: HashMap::new(),
             pending_reseal: HashMap::new(),
@@ -1757,6 +1768,10 @@ impl OfflineProtocol {
     fn evict_known_peer(&mut self, peer_id: &str) {
         self.key_package_sent_to.remove(peer_id);
         self.known_peers.remove(peer_id);
+        // Release the forwarding allowance held for this link. A peer that
+        // reconnects starts with a full allowance, which is correct: the limit
+        // exists to pace a live link, not to punish one that came back.
+        self.mesh_relay.forget_peer(peer_id);
     }
 
     /// Establishes a secure MLS session with a peer.
@@ -2284,6 +2299,12 @@ impl OfflineProtocol {
                 return Ok(()); // Don't process if not running
             }
         }
+
+        // Transmit forwards whose hold has elapsed. Runs early and before the
+        // retry ladders: other people's traffic is time-sensitive in a way our
+        // own retries are not — a frame held too long is dropped rather than
+        // sent late.
+        self.flush_mesh_relays();
 
         self.process_retry_queue()?;
         self.process_welcome_retry_queue()?;

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -206,12 +206,6 @@ impl OfflineProtocol {
 
                     self.deduplicator.mark_seen(message.id.clone());
 
-                    // Record the id as handled so that a copy of this same
-                    // message reaching us later by another path is not
-                    // forwarded on someone else's behalf. Delivery is ours to
-                    // make, not to pass on.
-                    self.mesh_relay.mark_handled(&message.id.as_str());
-
                     // Handle internal MLS messages
                     let mut was_decrypted = false;
                     if let Some(result) =

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -3,7 +3,7 @@
 use super::mesh_relay::RelayAdmission as MeshRelayAdmission;
 use super::{
     internal_prefixes, lock_shared_state, ChunkOutcome, InternalMessageResult, OfflineProtocol,
-    PendingMediaMetadataEntry, ProtocolState, RichPayloadV1,
+    PendingMediaMetadataEntry, ProtocolState, RichPayloadV1, CRITICAL_RELAY_BATTERY_LEVEL,
 };
 use crate::constants::{ACK_FOR_KEY, RELAY_LEARNED_ROUTE_QUALITY};
 use crate::events::{Event, SecurityWarningCode};
@@ -449,8 +449,34 @@ impl OfflineProtocol {
             return;
         }
 
-        let degree = self.transport_manager.mesh_neighbors().len();
-        match self.mesh_relay.admit(message, arrival_peer, degree) {
+        // Carrying other people's messages is the first thing to give up when
+        // the battery is going: a device that spends its last few percent
+        // relaying cannot send its own message when its owner needs to. The
+        // device keeps sending and receiving its own traffic either way.
+        //
+        // An unknown battery level is treated as willing — most platforms
+        // report one, and refusing to carry anything on a device that simply
+        // does not publish a level would quietly remove it from the network.
+        if !self.battery_allows_relaying() {
+            debug!(
+                message_id = %message.id,
+                "Not forwarding: battery is below the level for carrying traffic"
+            );
+            return;
+        }
+
+        let neighbors = self.transport_manager.mesh_neighbors();
+        let degree = neighbors.len();
+        // Whether we hold the link to the recipient ourselves. At the last hop
+        // no other device can be assumed to have it, so our copy must not be
+        // dropped in favour of a neighbor's.
+        let is_last_hop = neighbors
+            .iter()
+            .any(|n| n.peer_id == message.recipient.as_str());
+        match self
+            .mesh_relay
+            .admit(message, arrival_peer, degree, is_last_hop)
+        {
             MeshRelayAdmission::Queued => {
                 debug!(
                     message_id = %message.id,
@@ -467,6 +493,31 @@ impl OfflineProtocol {
                 );
             }
         }
+    }
+
+    /// Whether the battery is healthy enough to carry other people's traffic.
+    ///
+    /// Applies [`RelayConfig::min_battery_for_relay`], the same floor the relay
+    /// role uses, with the same exemption for a charging device: plugged in,
+    /// only a critical level stops it. An unknown level means yes — see the
+    /// caller.
+    fn battery_allows_relaying(&self) -> bool {
+        let (_statuses, available) = self.transport_manager.snapshot_status_and_available();
+        let (battery_level, is_charging) =
+            crate::telemetry::aggregator::device_battery_from_available(
+                self.transport_manager.current_transport(),
+                &available,
+            );
+
+        let Some(level) = battery_level else {
+            return true;
+        };
+
+        if level < CRITICAL_RELAY_BATTERY_LEVEL {
+            return false;
+        }
+
+        is_charging || level >= self.config.relay.min_battery_for_relay
     }
 
     /// Transmits the forwards whose delay has elapsed.
@@ -494,7 +545,9 @@ impl OfflineProtocol {
                 exclude.push(peer);
             }
             let onward = self.mesh_relay.select_targets(
-                neighbors.iter().map(|n| n.peer_id.as_str()),
+                neighbors
+                    .iter()
+                    .map(|n| (n.peer_id.as_str(), n.link_quality())),
                 &exclude,
                 &message.id.as_str(),
             );
@@ -523,6 +576,18 @@ impl OfflineProtocol {
 
             let mut delivered_to = 0usize;
             for target in &targets {
+                // Each link this frame crosses is one transmission against the
+                // device's ceiling. Running out mid-fan-out stops the fan-out
+                // rather than the frame: the neighbors already reached carry it
+                // on, and the sender's retry covers the rest.
+                if !self.mesh_relay.take_send_token() {
+                    debug!(
+                        message_id = %message.id,
+                        "At the forwarding limit; stopping this fan-out here"
+                    );
+                    break;
+                }
+
                 match self.transport_manager.send_to_neighbor(target, &message) {
                     Ok(transport) => {
                         delivered_to += 1;

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -534,9 +534,14 @@ impl OfflineProtocol {
 
         let neighbors = self.transport_manager.mesh_neighbors();
 
+        // `relay` is borrowed rather than destructured throughout: a frame that
+        // reaches no neighbor has to be handed back whole, and cloning the
+        // message to keep that option open would copy the payload — up to a
+        // whole media chunk — on every flush.
         for relay in due {
-            let message = relay.message;
+            let message = &relay.message;
             let recipient = message.recipient.as_str().to_string();
+            let message_id = message.id.as_str();
             let hop_count = message.hop_count.value();
             let remaining_ttl = message.ttl.value();
 
@@ -549,7 +554,7 @@ impl OfflineProtocol {
                     .iter()
                     .map(|n| (n.peer_id.as_str(), n.link_quality())),
                 &exclude,
-                &message.id.as_str(),
+                &message_id,
             );
 
             // If the destination is one of our own neighbors, hand it over
@@ -575,12 +580,14 @@ impl OfflineProtocol {
             }
 
             let mut delivered_to = 0usize;
+            let mut out_of_budget = false;
             for target in &targets {
                 // Each link this frame crosses is one transmission against the
                 // device's ceiling. Running out mid-fan-out stops the fan-out
                 // rather than the frame: the neighbors already reached carry it
                 // on, and the sender's retry covers the rest.
                 if !self.mesh_relay.take_send_token() {
+                    out_of_budget = true;
                     debug!(
                         message_id = %message.id,
                         "At the forwarding limit; stopping this fan-out here"
@@ -588,7 +595,7 @@ impl OfflineProtocol {
                     break;
                 }
 
-                match self.transport_manager.send_to_neighbor(target, &message) {
+                match self.transport_manager.send_to_neighbor(target, message) {
                     Ok(transport) => {
                         delivered_to += 1;
                         // Handing it to the recipient themselves ends the
@@ -625,7 +632,21 @@ impl OfflineProtocol {
                 }
             }
 
+            // Nothing reached a neighbor, and the reason was budget rather than
+            // the links: the frames released alongside this one spent the
+            // allowance between them. Hand it back instead of dropping it — its
+            // id is already recorded as handled here, so a drop would lose this
+            // copy *and* refuse both the copies arriving behind it and the
+            // sender's retransmissions, for the whole retention window. It
+            // keeps its due time, so a frame that stays starved is eventually
+            // abandoned rather than retried forever.
+            if delivered_to == 0 && out_of_budget {
+                self.mesh_relay.requeue(relay);
+                continue;
+            }
+
             if delivered_to > 0 {
+                self.mesh_relay.record_forwarded();
                 self.emit_event(Event::message_relayed(
                     message.id.as_str(),
                     message.sender.as_str().to_string(),

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -100,6 +100,13 @@ impl OfflineProtocol {
         loop {
             match self.transport_manager.receive() {
                 Ok(Some((transport_used, mut message))) => {
+                    // The peer whose link this frame physically arrived on.
+                    // Distinct from `message.sender`, which is who wrote it:
+                    // the two agree only at the first hop. `None` when the
+                    // carrier does not identify links (Nostr) or the platform
+                    // did not supply an id.
+                    let arrival_peer = message.transport_peer_id().map(str::to_string);
+
                     // Block filter (early): check before any side-effects so
                     // that blocked users cannot advance our Lamport clock,
                     // leak our presence via re-ACK, or trigger any processing.
@@ -173,7 +180,7 @@ impl OfflineProtocol {
                             );
                             continue;
                         }
-                        self.try_relay_message(&message);
+                        self.try_relay_message(&message, arrival_peer.as_deref());
                         continue;
                     }
 
@@ -379,14 +386,20 @@ impl OfflineProtocol {
     /// Learns a route back to the sender, checks relay configuration and TTL,
     /// then forwards the message with hop count incremented and TTL decremented.
     /// Emits a `MessageRelayed` event on success.
-    fn try_relay_message(&mut self, message: &Message) {
-        // Learn route back to sender through whoever gave us this message.
-        // Note: in multi-hop scenarios this records sender as both destination
-        // and next_hop, which is correct for 1-hop but conservative for deeper
-        // chains (the transport layer does not expose the immediate peer ID).
+    ///
+    /// `arrival_peer` is the neighbor that handed us this frame, when the
+    /// carrier identified the link.
+    fn try_relay_message(&mut self, message: &Message, arrival_peer: Option<&str>) {
+        // Learn the route back toward the sender. The next hop is the neighbor
+        // that handed us the frame, not the sender itself: for anything past
+        // the first hop the sender is several links away and naming it here
+        // would record a next hop we cannot address. Frames from carriers that
+        // do not identify links fall back to the sender, which is correct at
+        // one hop and no worse than before beyond it.
+        let learned_next_hop = arrival_peer.unwrap_or_else(|| message.sender.as_str());
         self.path_selector.learn_route_from_message(
             message,
-            message.sender.as_str(),
+            learned_next_hop,
             RELAY_LEARNED_ROUTE_QUALITY,
         );
 

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -409,9 +409,6 @@ impl OfflineProtocol {
         }
     }
 
-    /// Whether another copy of an already-delivered message should be
-    /// acknowledged again.
-    ///
     /// Considers an inbound frame addressed to a third party for forwarding.
     ///
     /// Learns the route back toward the sender, then offers the frame to the
@@ -423,6 +420,26 @@ impl OfflineProtocol {
     /// `arrival_peer` is the neighbor that handed us this frame, when the
     /// carrier identified the link.
     fn try_relay_message(&mut self, message: &Message, arrival_peer: Option<&str>) {
+        // Cheapest answer first. This device sees the whole neighborhood's
+        // traffic, so in a crowded room most third-party arrivals are copies of
+        // a frame it has already dealt with — and everything below would be
+        // thrown away by the suppression check inside `admit`: a route-table
+        // write, a battery snapshot that locks and allocates across every
+        // transport, and an enumeration of every link. Answering a duplicate
+        // costs a hash lookup instead.
+        //
+        // Route learning is skipped along with the rest, which is deliberate:
+        // the copy teaches nothing the first one did not, and the table is not
+        // what forwarding decisions are made from. A duplicate we still hold a
+        // pending copy of is *not* absorbed here — standing down for a neighbor
+        // needs the neighbor set — so that case still takes the full path.
+        if self
+            .mesh_relay
+            .absorb_settled_duplicate(&message.id.as_str())
+        {
+            return;
+        }
+
         // Learn the route back toward the sender. The next hop is the neighbor
         // that handed us the frame, not the sender itself: for anything past
         // the first hop the sender is several links away and naming it here

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -589,22 +589,24 @@ impl OfflineProtocol {
             let deliver_direct = targets.first() == Some(&recipient);
 
             if targets.is_empty() {
+                // Nowhere to hand it right now: we hold no link, or the only
+                // ones we hold are the peers this frame must not go back to.
+                // Falls through to the hand-back below rather than being
+                // dropped — a neighbor may well appear within the few seconds
+                // the frame is still worth carrying.
                 debug!(
                     message_id = %message.id,
                     "No onward neighbor for this frame"
                 );
-                continue;
             }
 
             let mut delivered_to = 0usize;
-            let mut out_of_budget = false;
             for target in &targets {
                 // Each link this frame crosses is one transmission against the
                 // device's ceiling. Running out mid-fan-out stops the fan-out
                 // rather than the frame: the neighbors already reached carry it
                 // on, and the sender's retry covers the rest.
                 if !self.mesh_relay.take_send_token() {
-                    out_of_budget = true;
                     debug!(
                         message_id = %message.id,
                         "At the forwarding limit; stopping this fan-out here"
@@ -649,29 +651,32 @@ impl OfflineProtocol {
                 }
             }
 
-            // Nothing reached a neighbor, and the reason was budget rather than
-            // the links: the frames released alongside this one spent the
-            // allowance between them. Hand it back instead of dropping it — its
-            // id is already recorded as handled here, so a drop would lose this
-            // copy *and* refuse both the copies arriving behind it and the
-            // sender's retransmissions, for the whole retention window. It
-            // keeps its due time, so a frame that stays starved is eventually
-            // abandoned rather than retried forever.
-            if delivered_to == 0 && out_of_budget {
+            // Nothing reached a neighbor. Hand it back instead of dropping it:
+            // its id is already recorded as handled here, so a drop would lose
+            // this copy *and* refuse both the copies arriving behind it and the
+            // sender's retransmissions, for the whole retention window.
+            //
+            // Why it got nowhere does not change that. The budget ran out (the
+            // frames released alongside this one spent the allowance between
+            // them), every link chosen for it went away between being picked
+            // and being written to, or there was no usable link to pick. In all
+            // three the frame has travelled nowhere and this queue is the only
+            // thing that still remembers it. It keeps its due time, so one that
+            // stays stuck is abandoned by the overdue cut-off rather than
+            // retried forever.
+            if delivered_to == 0 {
                 self.mesh_relay.requeue(relay);
                 continue;
             }
 
-            if delivered_to > 0 {
-                self.mesh_relay.record_forwarded();
-                self.emit_event(Event::message_relayed(
-                    message.id.as_str(),
-                    message.sender.as_str().to_string(),
-                    recipient,
-                    hop_count,
-                    remaining_ttl,
-                ));
-            }
+            self.mesh_relay.record_forwarded();
+            self.emit_event(Event::message_relayed(
+                message.id.as_str(),
+                message.sender.as_str().to_string(),
+                recipient,
+                hop_count,
+                remaining_ttl,
+            ));
         }
     }
 

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -1,5 +1,6 @@
 //! Message receive loop and file chunk handling.
 
+use super::mesh_relay::RelayAdmission as MeshRelayAdmission;
 use super::{
     internal_prefixes, lock_shared_state, ChunkOutcome, InternalMessageResult, OfflineProtocol,
     PendingMediaMetadataEntry, ProtocolState, RichPayloadV1,
@@ -107,12 +108,44 @@ impl OfflineProtocol {
                     // did not supply an id.
                     let arrival_peer = message.transport_peer_id().map(str::to_string);
 
+                    // Traffic for someone else is forwarded, not processed, and
+                    // that decision comes first.
+                    //
+                    // Everything below this point treats the frame as part of
+                    // our own exchange: it merges the sender's clock into ours,
+                    // settles our outbox from acknowledgements, and consumes the
+                    // frame. None of that is true of a frame merely passing
+                    // through us — its acknowledgements belong to the pair it
+                    // travels between, and once a node carries the whole
+                    // neighborhood's traffic, absorbing every clock it sees
+                    // would drag ours to the network's maximum.
+                    //
+                    // Never forward a frame claiming our own origin: a genuine
+                    // self-originated frame is never received inbound with a
+                    // foreign recipient (the send path does not loop back), so
+                    // this is a routing loop or a forgery aimed at
+                    // `internet_control_op`'s self-origination gate — re-issuing
+                    // it from our outbox would let a mesh peer drive
+                    // relay-native control ops on our authenticated relay
+                    // connection. (A sender==self frame addressed *to* us is the
+                    // legitimate relay echo and falls through unchanged.)
+                    if message.recipient.as_str() != self.config.user_id {
+                        if message.sender.as_str() == self.config.user_id {
+                            debug!(
+                                message_id = %message.id,
+                                recipient = %message.recipient,
+                                "Dropping inbound frame forging our own origin"
+                            );
+                            continue;
+                        }
+                        self.try_relay_message(&message, arrival_peer.as_deref());
+                        continue;
+                    }
+
                     // Block filter (early): check before any side-effects so
                     // that blocked users cannot advance our Lamport clock,
                     // leak our presence via re-ACK, or trigger any processing.
-                    // Relay messages for third parties pass through.
-                    let sender_blocked = self.is_user_blocked(message.sender.as_str())
-                        && message.recipient.as_str() == self.config.user_id;
+                    let sender_blocked = self.is_user_blocked(message.sender.as_str());
 
                     // Merge Lamport clock for every non-blocked received message
                     // — including duplicates, ACKs, and internal protocol
@@ -161,28 +194,11 @@ impl OfflineProtocol {
 
                     self.deduplicator.mark_seen(message.id.clone());
 
-                    // Relay: if this message is not for us, forward it.
-                    // Never relay a frame claiming our own origin: a genuine
-                    // self-originated frame is never received inbound with a
-                    // foreign recipient (the send path does not loop back), so
-                    // this is a routing loop or a forgery aimed at
-                    // `internet_control_op`'s self-origination gate — re-issuing
-                    // it from our outbox would let a mesh peer drive
-                    // relay-native control ops on our authenticated relay
-                    // connection. (A sender==self frame addressed *to* us is the
-                    // legitimate relay echo and falls through unchanged.)
-                    if message.recipient.as_str() != self.config.user_id {
-                        if message.sender.as_str() == self.config.user_id {
-                            debug!(
-                                message_id = %message.id,
-                                recipient = %message.recipient,
-                                "Dropping inbound frame forging our own origin"
-                            );
-                            continue;
-                        }
-                        self.try_relay_message(&message, arrival_peer.as_deref());
-                        continue;
-                    }
+                    // Record the id as handled so that a copy of this same
+                    // message reaching us later by another path is not
+                    // forwarded on someone else's behalf. Delivery is ours to
+                    // make, not to pass on.
+                    self.mesh_relay.mark_handled(&message.id.as_str());
 
                     // Handle internal MLS messages
                     let mut was_decrypted = false;
@@ -381,11 +397,13 @@ impl OfflineProtocol {
         }
     }
 
-    /// Attempts to relay (forward) a message destined for a third party.
+    /// Considers an inbound frame addressed to a third party for forwarding.
     ///
-    /// Learns a route back to the sender, checks relay configuration and TTL,
-    /// then forwards the message with hop count incremented and TTL decremented.
-    /// Emits a `MessageRelayed` event on success.
+    /// Learns the route back toward the sender, then offers the frame to the
+    /// governor, which decides whether it travels any further. Nothing is
+    /// transmitted here: an accepted frame is queued and goes out from
+    /// [`Self::flush_mesh_relays`] once its delay elapses, which is what gives
+    /// a neighbor the chance to cover it first.
     ///
     /// `arrival_peer` is the neighbor that handed us this frame, when the
     /// carrier identified the link.
@@ -403,58 +421,119 @@ impl OfflineProtocol {
             RELAY_LEARNED_ROUTE_QUALITY,
         );
 
+        // Carrying traffic for others costs this device's radio and battery,
+        // so it stays a local decision.
         let relay_allowed = self.config.relay.allow_relay
             && self.config.relay.relay_priority != RelayPriority::Never;
 
         if !relay_allowed {
             debug!(
                 message_id = %message.id,
-                "Dropping relay message: relay disabled"
+                "Not forwarding: relaying is disabled on this device"
             );
             return;
         }
 
-        if message.is_ttl_exhausted() {
-            debug!(
-                message_id = %message.id,
-                sender = %message.sender,
-                recipient = %message.recipient,
-                "Dropping relay message: TTL exhausted"
-            );
-            return;
-        }
-
-        let mut relay_msg = message.clone();
-        let _ = relay_msg.decrement_ttl();
-        let _ = relay_msg.increment_hop();
-
-        let hop_count = relay_msg.hop_count.value();
-        let remaining_ttl = relay_msg.ttl.value();
-
-        match self.transport_manager.send(&relay_msg) {
-            Ok(()) => {
+        let degree = self.transport_manager.mesh_neighbors().len();
+        match self.mesh_relay.admit(message, arrival_peer, degree) {
+            MeshRelayAdmission::Queued => {
                 debug!(
-                    message_id = %relay_msg.id,
-                    sender = %relay_msg.sender,
-                    recipient = %relay_msg.recipient,
-                    hop_count,
-                    remaining_ttl,
-                    "Relayed message for third party"
+                    message_id = %message.id,
+                    recipient = %message.recipient,
+                    degree,
+                    "Queued frame for forwarding"
                 );
+            }
+            MeshRelayAdmission::Rejected(reason) => {
+                debug!(
+                    message_id = %message.id,
+                    ?reason,
+                    "Not forwarding"
+                );
+            }
+        }
+    }
+
+    /// Transmits the forwards whose delay has elapsed.
+    ///
+    /// Called from the process tick. Each frame goes to a bounded set of
+    /// neighbors chosen by the governor, never back to the peer it came from or
+    /// to the peer that wrote it. A frame whose recipient is a neighbor of ours
+    /// is handed straight to them instead — the shortest path we can see.
+    pub(super) fn flush_mesh_relays(&mut self) {
+        let due = self.mesh_relay.take_due(Instant::now());
+        if due.is_empty() {
+            return;
+        }
+
+        let neighbors = self.transport_manager.mesh_neighbors();
+
+        for relay in due {
+            let message = relay.message;
+            let recipient = message.recipient.as_str().to_string();
+            let hop_count = message.hop_count.value();
+            let remaining_ttl = message.ttl.value();
+
+            // If the destination is one of our own neighbors, hand it over
+            // directly: no fan-out is worth more than arriving.
+            let direct = neighbors.iter().any(|n| n.peer_id == recipient);
+            let targets = if direct {
+                vec![recipient.clone()]
+            } else {
+                let mut exclude: Vec<&str> = vec![message.sender.as_str()];
+                if let Some(peer) = relay.arrival_peer.as_deref() {
+                    exclude.push(peer);
+                }
+                self.mesh_relay.select_targets(
+                    neighbors.iter().map(|n| n.peer_id.as_str()),
+                    &exclude,
+                    &message.id.as_str(),
+                )
+            };
+
+            if targets.is_empty() {
+                debug!(
+                    message_id = %message.id,
+                    "No onward neighbor for this frame"
+                );
+                continue;
+            }
+
+            let mut delivered_to = 0usize;
+            for target in &targets {
+                match self.transport_manager.send_to_neighbor(target, &message) {
+                    Ok(transport) => {
+                        delivered_to += 1;
+                        debug!(
+                            message_id = %message.id,
+                            next_hop = %target,
+                            transport = ?transport,
+                            hop_count,
+                            remaining_ttl,
+                            "Forwarded frame to neighbor"
+                        );
+                    }
+                    Err(err) => {
+                        // A link that went away between selection and send.
+                        // The other targets still carry the frame.
+                        debug!(
+                            message_id = %message.id,
+                            next_hop = %target,
+                            error = %err,
+                            "Could not forward to neighbor"
+                        );
+                    }
+                }
+            }
+
+            if delivered_to > 0 {
                 self.emit_event(Event::message_relayed(
-                    relay_msg.id.as_str(),
-                    relay_msg.sender.as_str().to_string(),
-                    relay_msg.recipient.as_str().to_string(),
+                    message.id.as_str(),
+                    message.sender.as_str().to_string(),
+                    recipient,
                     hop_count,
                     remaining_ttl,
                 ));
-            }
-            Err(err) => {
-                warn!(
-                    message_id = %relay_msg.id,
-                    error = %err,
-                    "Failed to relay message"
-                );
             }
         }
     }

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -167,6 +167,18 @@ impl OfflineProtocol {
                         // Re-ACK duplicate packets so the sender can stop
                         // retrying — but NOT for blocked users, to avoid
                         // leaking presence information.
+                        //
+                        // Every copy is answered, including the several that
+                        // one delivery produces when it travels through nearby
+                        // devices. Answering only the first was tried and
+                        // rejected: a copy arriving moments later and a
+                        // retransmission arriving because the answer was lost
+                        // are not distinguishable here, and staying quiet for
+                        // the second turns a delivered message into a failed
+                        // one. The redundant answers are bounded — a delivery
+                        // arrives by at most as many paths as neighbors carried
+                        // it, answers never provoke further answers, and every
+                        // frame that leaves is rate-capped like any other.
                         if !sender_blocked && message.requires_ack {
                             if let Err(err) = self.send_delivery_ack(&message, transport_used) {
                                 error!(
@@ -397,6 +409,9 @@ impl OfflineProtocol {
         }
     }
 
+    /// Whether another copy of an already-delivered message should be
+    /// acknowledged again.
+    ///
     /// Considers an inbound frame addressed to a third party for forwarding.
     ///
     /// Learns the route back toward the sender, then offers the frame to the

--- a/crates/offline-protocol/src/protocol/receive.rs
+++ b/crates/offline-protocol/src/protocol/receive.rs
@@ -489,22 +489,29 @@ impl OfflineProtocol {
             let hop_count = message.hop_count.value();
             let remaining_ttl = message.ttl.value();
 
+            let mut exclude: Vec<&str> = vec![message.sender.as_str()];
+            if let Some(peer) = relay.arrival_peer.as_deref() {
+                exclude.push(peer);
+            }
+            let onward = self.mesh_relay.select_targets(
+                neighbors.iter().map(|n| n.peer_id.as_str()),
+                &exclude,
+                &message.id.as_str(),
+            );
+
             // If the destination is one of our own neighbors, hand it over
-            // directly: no fan-out is worth more than arriving.
-            let direct = neighbors.iter().any(|n| n.peer_id == recipient);
-            let targets = if direct {
-                vec![recipient.clone()]
+            // directly: no fan-out is worth more than arriving. Should that
+            // link fail between choosing it and writing to it, fall back to
+            // carrying it onward rather than dropping a frame we could still
+            // move.
+            let targets = if neighbors.iter().any(|n| n.peer_id == recipient) {
+                let mut ordered = vec![recipient.clone()];
+                ordered.extend(onward.into_iter().filter(|peer| peer != &recipient));
+                ordered
             } else {
-                let mut exclude: Vec<&str> = vec![message.sender.as_str()];
-                if let Some(peer) = relay.arrival_peer.as_deref() {
-                    exclude.push(peer);
-                }
-                self.mesh_relay.select_targets(
-                    neighbors.iter().map(|n| n.peer_id.as_str()),
-                    &exclude,
-                    &message.id.as_str(),
-                )
+                onward
             };
+            let deliver_direct = targets.first() == Some(&recipient);
 
             if targets.is_empty() {
                 debug!(
@@ -519,6 +526,18 @@ impl OfflineProtocol {
                 match self.transport_manager.send_to_neighbor(target, &message) {
                     Ok(transport) => {
                         delivered_to += 1;
+                        // Handing it to the recipient themselves ends the
+                        // journey; the remaining neighbors are only a fallback
+                        // for that link failing.
+                        if deliver_direct && target == &recipient {
+                            debug!(
+                                message_id = %message.id,
+                                next_hop = %target,
+                                transport = ?transport,
+                                "Delivered to its recipient directly"
+                            );
+                            break;
+                        }
                         debug!(
                             message_id = %message.id,
                             next_hop = %target,

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -2968,6 +2968,34 @@ impl OfflineProtocol {
     ) -> Result<()> {
         self.mark_message_sent(message, transport, Some(1));
         self.ensure_ack_registration(message)?;
+
+        // A transport reporting success is not always evidence the frame can
+        // arrive. Wi-Fi Direct and Reticulum accept any recipient and return
+        // `Ok`, so a send to someone we hold no link to is queued for a link
+        // that never drains — and because the mesh hand-off used to hang off
+        // the *failure* path, a device with either carrier up would swallow the
+        // frame instead of asking its neighbors to carry it. That is precisely
+        // the out-of-range case forwarding exists for, so the question is asked
+        // directly rather than inferred from an error that never comes.
+        //
+        // Offering here is additive, never a replacement: the outbox entry and
+        // the ACK registration above stand either way, and if the accepting
+        // carrier did deliver after all, the recipient's deduplicator absorbs
+        // the second copy.
+        if !self
+            .transport_manager
+            .can_reach_without_carrying(message.recipient.as_str())
+        {
+            let handed_to_mesh = self.offer_to_mesh(message);
+            if handed_to_mesh > 0 {
+                debug!(
+                    message_id = %message.id,
+                    recipient = %message.recipient,
+                    handed_to_mesh,
+                    "Transport accepted a recipient it cannot reach; also handed to neighbors"
+                );
+            }
+        }
         Ok(())
     }
 
@@ -3035,6 +3063,17 @@ impl OfflineProtocol {
         // relay-declining device unable to answer anything that reached it
         // across the mesh, so its sender would retransmit to exhaustion and
         // report a failure for a message that was delivered and read.
+
+        // Never hand a self-addressed frame to the mesh. Those are the relay
+        // hint frames (`__GRP_RELAY_REG__`, `__GRP_RELAY_BCAST__`), which mean
+        // something only to our own bridge: a neighbor receiving one would see
+        // a frame addressed to somebody else and carry it further, spending
+        // airtime to deliver a control op nobody can act on. They are pinned to
+        // Internet for the same reason.
+        if message.recipient.as_str() == self.config.user_id {
+            return 0;
+        }
+
         let neighbors = self.transport_manager.mesh_neighbors();
         if neighbors.is_empty() {
             return 0;
@@ -3770,22 +3809,38 @@ impl OfflineProtocol {
             return Ok(());
         }
 
-        // Fallback: try any available transport via DORS
         debug!(
             message_id = %message.id,
             inbound_transport = ?inbound_transport,
             "Inbound transport unavailable for ACK, falling back to DORS selection"
         );
-        if self.transport_manager.send(&ack_message).is_ok() {
+
+        // The sender is not reachable on the link their message arrived over.
+        // If nothing else we hold can reach them either, the answer has to
+        // travel back the way the message came — carried by the devices in
+        // between. Without this, multi-hop delivery looks like failure to the
+        // sender, who retransmits a message we already have and read.
+        //
+        // This is asked *before* the DORS fallback, and asked rather than
+        // inferred from a send error, because a send error is not what a
+        // swallowed frame produces: Wi-Fi Direct and Reticulum accept any
+        // recipient and return `Ok`. Ordering it first also keeps us from
+        // spending a send into a queue that will never drain.
+        if !self
+            .transport_manager
+            .can_reach_without_carrying(ack_message.recipient.as_str())
+            && self.offer_to_mesh(&ack_message) > 0
+        {
+            debug!(
+                message_id = %message.id,
+                ack_to = %ack_message.recipient,
+                "Sender is not directly reachable; handed the acknowledgement to the mesh"
+            );
             return Ok(());
         }
 
-        // The sender is not somewhere we can reach directly. A message that
-        // arrived across several devices has an answer that must travel the
-        // same way back — without this, multi-hop delivery would look like
-        // failure to the sender, who would retransmit a message we already
-        // have.
-        if self.offer_to_mesh(&ack_message) > 0 {
+        // Fallback: try any available transport via DORS
+        if self.transport_manager.send(&ack_message).is_ok() {
             return Ok(());
         }
 

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -2993,15 +2993,98 @@ impl OfflineProtocol {
         // Ensure message is persisted to outbox for recovery
         self.ensure_outbox_entry(message);
 
+        // No transport could reach the recipient directly — but a neighbor
+        // might be able to, or know someone who can. Offer the frame to the
+        // mesh before settling for a retry: this is the case the whole
+        // forwarding path exists for, someone out of our range but inside the
+        // crowd's.
+        //
+        // The outbox entry and retry stay in place regardless. Handing a frame
+        // to neighbors is not proof it arrived, and the acknowledgement coming
+        // back is what settles it.
+        let handed_to_mesh = self.offer_to_mesh(message);
+
         // Schedule retry (enqueue is infallible — no attempt limit)
         let next_retry_at = self.retry_queue.enqueue(message.clone(), 0);
 
         warn!(
             message_id = %message.id,
             transport = ?transport,
+            handed_to_mesh,
             "Deferred message due to send error"
         );
         Ok(next_retry_at)
+    }
+
+    /// Hands a locally-originated frame to nearby devices so it can travel
+    /// toward a recipient we cannot reach ourselves.
+    ///
+    /// Returns how many neighbors took a copy. Zero means we are alone, or
+    /// every neighbor refused the link — in both cases the retry ladder and the
+    /// outbox remain the recovery path, exactly as before.
+    ///
+    /// Unlike a forwarded frame, this one is not held back: the delay before
+    /// forwarding exists so neighbors holding the *same* frame do not all
+    /// transmit at once, and nobody else is holding this one yet.
+    pub(super) fn offer_to_mesh(&mut self, message: &Message) -> usize {
+        if !self.config.relay.allow_relay
+            || self.config.relay.relay_priority
+                == offline_protocol_router::relay::RelayPriority::Never
+        {
+            // A device that does not carry other people's traffic still sends
+            // its own — but sending it *through* other devices is the same
+            // favor in reverse, so honor the same opt-out.
+            return 0;
+        }
+
+        let neighbors = self.transport_manager.mesh_neighbors();
+        if neighbors.is_empty() {
+            return 0;
+        }
+
+        // Ours to originate: record it as handled so a copy coming back to us
+        // through the mesh is recognized and not forwarded again.
+        self.mesh_relay.mark_handled(&message.id.as_str());
+
+        // If the recipient is standing right there, hand it to them. Reached
+        // here it means the ordinary send could not use that link, but trying
+        // it costs one call and beats routing around the destination.
+        let recipient = message.recipient.as_str();
+        let targets = if neighbors.iter().any(|n| n.peer_id == recipient) {
+            vec![recipient.to_string()]
+        } else {
+            self.mesh_relay.select_targets(
+                neighbors.iter().map(|n| n.peer_id.as_str()),
+                &[],
+                &message.id.as_str(),
+            )
+        };
+
+        let mut handed_to = 0usize;
+        for target in targets {
+            match self.transport_manager.send_to_neighbor(&target, message) {
+                Ok(transport) => {
+                    handed_to += 1;
+                    debug!(
+                        message_id = %message.id,
+                        recipient = %message.recipient,
+                        next_hop = %target,
+                        transport = ?transport,
+                        "Handed message to a neighbor to carry"
+                    );
+                }
+                Err(err) => {
+                    debug!(
+                        message_id = %message.id,
+                        next_hop = %target,
+                        error = %err,
+                        "Neighbor could not take the message"
+                    );
+                }
+            }
+        }
+
+        handed_to
     }
 
     /// Confirms that a message was successfully sent by the transport layer.
@@ -3681,7 +3764,23 @@ impl OfflineProtocol {
             inbound_transport = ?inbound_transport,
             "Inbound transport unavailable for ACK, falling back to DORS selection"
         );
-        self.transport_manager.send(&ack_message)
+        if self.transport_manager.send(&ack_message).is_ok() {
+            return Ok(());
+        }
+
+        // The sender is not somewhere we can reach directly. A message that
+        // arrived across several devices has an answer that must travel the
+        // same way back — without this, multi-hop delivery would look like
+        // failure to the sender, who would retransmit a message we already
+        // have.
+        if self.offer_to_mesh(&ack_message) > 0 {
+            return Ok(());
+        }
+
+        Err(Error::Other(format!(
+            "no route back to {} for delivery acknowledgement",
+            ack_message.recipient
+        )))
     }
 
     /// Builds and sends a delivery ACK from the group-message drain, which

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -3027,16 +3027,14 @@ impl OfflineProtocol {
     /// forwarding exists so neighbors holding the *same* frame do not all
     /// transmit at once, and nobody else is holding this one yet.
     pub(super) fn offer_to_mesh(&mut self, message: &Message) -> usize {
-        if !self.config.relay.allow_relay
-            || self.config.relay.relay_priority
-                == offline_protocol_router::relay::RelayPriority::Never
-        {
-            // A device that does not carry other people's traffic still sends
-            // its own — but sending it *through* other devices is the same
-            // favor in reverse, so honor the same opt-out.
-            return 0;
-        }
-
+        // Deliberately not gated on `allow_relay`. That setting is about what
+        // this device does for *other people* — whether it spends its battery
+        // carrying their traffic. This is the device's own message, and the
+        // ones it must be able to send include the acknowledgement for a
+        // message it just received. Gating it here would leave a
+        // relay-declining device unable to answer anything that reached it
+        // across the mesh, so its sender would retransmit to exhaustion and
+        // report a failure for a message that was delivered and read.
         let neighbors = self.transport_manager.mesh_neighbors();
         if neighbors.is_empty() {
             return 0;
@@ -3054,7 +3052,9 @@ impl OfflineProtocol {
             vec![recipient.to_string()]
         } else {
             self.mesh_relay.select_targets(
-                neighbors.iter().map(|n| n.peer_id.as_str()),
+                neighbors
+                    .iter()
+                    .map(|n| (n.peer_id.as_str(), n.link_quality())),
                 &[],
                 &message.id.as_str(),
             )
@@ -3062,6 +3062,18 @@ impl OfflineProtocol {
 
         let mut handed_to = 0usize;
         for target in targets {
+            // Metered against the same ceiling as carrying other people's
+            // traffic: it is the same radio. Without this a large transfer,
+            // which offers every chunk separately, would put an unbounded burst
+            // on the air in one call.
+            if !self.mesh_relay.take_send_token() {
+                debug!(
+                    message_id = %message.id,
+                    "At the forwarding limit; not handing this to further neighbors"
+                );
+                break;
+            }
+
             match self.transport_manager.send_to_neighbor(&target, message) {
                 Ok(transport) => {
                     handed_to += 1;

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -3105,7 +3105,12 @@ impl OfflineProtocol {
             // traffic: it is the same radio. Without this a large transfer,
             // which offers every chunk separately, would put an unbounded burst
             // on the air in one call.
-            if !self.mesh_relay.take_send_token() {
+            //
+            // Own traffic spends from the reserve that forwarding leaves alone,
+            // so a device carrying the neighborhood at its ceiling can still
+            // get its own frames out — an acknowledgement above all, whose
+            // absence makes a delivered message look lost to its sender.
+            if !self.mesh_relay.take_own_send_token() {
                 debug!(
                     message_id = %message.id,
                     "At the forwarding limit; not handing this to further neighbors"

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -3802,56 +3802,71 @@ impl OfflineProtocol {
             .metadata(ACK_TRANSPORT_KEY, Self::transport_label(inbound_transport))
             .build();
 
-        // Try sending ACK via the same transport that received the message first.
-        // This is the preferred path as it's known to work for this peer.
-        // If the inbound transport is no longer available (e.g., internet disconnected),
-        // fall back to DORS selection to try any available transport.
+        self.route_ack(&ack_message, inbound_transport)
+    }
+
+    /// Gets an acknowledgement back to whoever sent us the message it answers.
+    ///
+    /// The single route-selection point for every delivery ACK, direct or
+    /// group. Keeping one ladder is deliberate: it has four callers across two
+    /// builders, and the failure this ordering exists to prevent is silent —
+    /// a copy of the ladder that drifted would look fine and lose answers.
+    ///
+    /// Three routes, in order:
+    ///
+    /// 1. **The link it arrived on**, when that carrier can actually address
+    ///    the sender. Preferred because it is known to work for this peer.
+    /// 2. **The mesh**, when nothing we hold reaches the sender directly: the
+    ///    answer travels back the way the message came, carried by the devices
+    ///    in between. Without this, multi-hop delivery looks like failure to a
+    ///    sender who retransmits a message we already have and read.
+    /// 3. **DORS**, which picks among whatever else is available.
+    ///
+    /// Step 1 is *gated on addressability* rather than on a send error, and
+    /// that gate is load-bearing. A transport returning `Ok` is not evidence
+    /// the frame can arrive: Wi-Fi Direct enqueues for any recipient, and it is
+    /// the preferred mesh carrier — so on the last hop of a forwarded frame the
+    /// answer would be queued for a link that never drains, reported as sent,
+    /// and step 2 would never run. The sender's retransmissions would take the
+    /// same path every time, ending in a failure report for a delivered
+    /// message.
+    fn route_ack(&mut self, ack_message: &Message, inbound_transport: TransportType) -> Result<()> {
+        let ack_to = ack_message.recipient.as_str().to_string();
+
         if self
             .transport_manager
-            .send_via_transport(&ack_message, inbound_transport)
-            .is_ok()
+            .can_address_via(inbound_transport, &ack_to)
+            && self
+                .transport_manager
+                .send_via_transport(ack_message, inbound_transport)
+                .is_ok()
         {
             return Ok(());
         }
 
         debug!(
-            message_id = %message.id,
+            ack_to = %ack_to,
             inbound_transport = ?inbound_transport,
-            "Inbound transport unavailable for ACK, falling back to DORS selection"
+            "Inbound transport cannot answer this sender; looking for another route"
         );
 
-        // The sender is not reachable on the link their message arrived over.
-        // If nothing else we hold can reach them either, the answer has to
-        // travel back the way the message came — carried by the devices in
-        // between. Without this, multi-hop delivery looks like failure to the
-        // sender, who retransmits a message we already have and read.
-        //
-        // This is asked *before* the DORS fallback, and asked rather than
-        // inferred from a send error, because a send error is not what a
-        // swallowed frame produces: Wi-Fi Direct and Reticulum accept any
-        // recipient and return `Ok`. Ordering it first also keeps us from
-        // spending a send into a queue that will never drain.
-        if !self
-            .transport_manager
-            .can_reach_without_carrying(ack_message.recipient.as_str())
-            && self.offer_to_mesh(&ack_message) > 0
+        if !self.transport_manager.can_reach_without_carrying(&ack_to)
+            && self.offer_to_mesh(ack_message) > 0
         {
             debug!(
-                message_id = %message.id,
-                ack_to = %ack_message.recipient,
+                ack_to = %ack_to,
                 "Sender is not directly reachable; handed the acknowledgement to the mesh"
             );
             return Ok(());
         }
 
-        // Fallback: try any available transport via DORS
-        if self.transport_manager.send(&ack_message).is_ok() {
+        if self.transport_manager.send(ack_message).is_ok() {
             return Ok(());
         }
 
         Err(Error::Other(format!(
             "no route back to {} for delivery acknowledgement",
-            ack_message.recipient
+            ack_to
         )))
     }
 
@@ -3880,20 +3895,9 @@ impl OfflineProtocol {
             .metadata(ACK_TRANSPORT_KEY, Self::transport_label(inbound_transport))
             .build();
 
-        // Prefer the transport the message arrived on; fall back to DORS.
-        if self
-            .transport_manager
-            .send_via_transport(&ack_message, inbound_transport)
-            .is_ok()
-        {
-            return Ok(());
-        }
-        debug!(
-            message_id = %acked_message_id,
-            inbound_transport = ?inbound_transport,
-            "Inbound transport unavailable for group ACK, falling back to DORS selection"
-        );
-        self.transport_manager.send(&ack_message)
+        // Same ladder as a direct-message ACK, mesh fallback included: a group
+        // frame reaches its members over the same hops a DM does.
+        self.route_ack(&ack_message, inbound_transport)
     }
 
     pub(super) fn handle_ack_message(&mut self, message: &Message) {

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -21485,6 +21485,140 @@ fn test_relay_forwards_third_party_message() {
     }
 }
 
+/// Drives one third-party frame through a device whose battery reports
+/// `level` and `is_charging`, and returns how many neighbors it was handed to.
+///
+/// The device always has a neighbor to carry it and forwarding is otherwise
+/// allowed, so the only thing deciding the outcome is the battery gate.
+fn neighbors_carried_to_at_battery(level: Option<u8>, is_charging: bool) -> usize {
+    let mut protocol = OfflineProtocol::new(create_relay_test_config_for_user("user123")).unwrap();
+
+    let mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    mock.set_metrics(TransportMetrics {
+        battery_level: level,
+        is_charging,
+        ..TransportMetrics::default()
+    });
+    mock.add_connected_peer("carol", -55);
+    let transport_handle = mock.clone();
+
+    mock.queue_message(Message::new(
+        UserId::new("alice").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        "carry me if you can",
+    ));
+
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
+
+    assert!(
+        protocol.receive_message().is_none(),
+        "a third-party frame is never surfaced to the app"
+    );
+    // Admission (including the battery gate) happens on receive; transmission
+    // happens on the tick.
+    protocol.process().unwrap();
+
+    transport_handle.peer_sends().len()
+}
+
+#[test]
+fn a_healthy_battery_carries_other_peoples_traffic() {
+    assert_eq!(neighbors_carried_to_at_battery(Some(80), false), 1);
+}
+
+#[test]
+fn a_battery_below_the_relay_floor_carries_nothing() {
+    // Carrying other people's messages is the first thing to give up when the
+    // battery is going: a device that spends its last few percent relaying
+    // cannot send its own message when its owner needs to. Default floor is 30.
+    assert_eq!(
+        neighbors_carried_to_at_battery(Some(20), false),
+        0,
+        "below the relay battery floor, nothing is carried for others"
+    );
+}
+
+#[test]
+fn a_charging_device_carries_below_the_floor() {
+    // Plugged in, the soft floor is excused — the same exemption the relay
+    // role itself applies, so the two policies do not disagree about whether
+    // this device should be working for the network.
+    assert_eq!(
+        neighbors_carried_to_at_battery(Some(20), true),
+        1,
+        "a charging device below the soft floor must still carry"
+    );
+}
+
+#[test]
+fn a_critical_battery_carries_nothing_even_while_charging() {
+    // The hard floor beneath the soft one. `CRITICAL_RELAY_BATTERY_LEVEL` is
+    // shared with the relay-role policy, so a device cannot keep carrying
+    // traffic at a level that would have stripped it of the role.
+    assert!(
+        crate::protocol::CRITICAL_RELAY_BATTERY_LEVEL == 15,
+        "the shared critical floor moved; this test's levels assume 15"
+    );
+    assert_eq!(
+        neighbors_carried_to_at_battery(Some(10), true),
+        0,
+        "a critical battery stops carrying even while charging"
+    );
+}
+
+#[test]
+fn an_unknown_battery_level_is_treated_as_willing() {
+    // Most platforms report a level. Refusing to carry anything on a device
+    // that simply does not publish one would quietly remove it from the
+    // network, which is a worse failure than carrying on an unknown battery.
+    assert_eq!(
+        neighbors_carried_to_at_battery(None, false),
+        1,
+        "an unknown battery level must not silently remove a device from the mesh"
+    );
+}
+
+#[test]
+fn a_device_with_infrastructure_does_not_spend_the_mesh_on_its_own_traffic() {
+    // `can_reach_without_carrying` is what keeps a device from handing copies
+    // to its neighbors when a carrier that does its own routing is up. The
+    // swallowing-transport test proves the offer fires when it should; this
+    // proves it stays quiet when it should not.
+    let mut protocol = OfflineProtocol::new(create_relay_test_config_for_user("user123")).unwrap();
+
+    let ble = MockTransport::new(TransportType::BLE);
+    ble.start().unwrap();
+    ble.add_connected_peer("carol", -55);
+    let ble_handle = ble.clone();
+
+    // An infrastructure carrier that reaches peers we hold no radio link to.
+    let internet = MockTransport::new(TransportType::Internet);
+    internet.start().unwrap();
+
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(ble));
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::Internet, Box::new(internet));
+    protocol.start().unwrap();
+
+    // Addressed to someone who is not a neighbor: the relay can route it.
+    protocol
+        .send_message("distant", "over the wire", None, None::<String>)
+        .unwrap();
+
+    assert!(
+        ble_handle.peer_sends().is_empty(),
+        "with a routing carrier up, neighbors must not be asked to carry copies"
+    );
+}
+
 #[test]
 fn a_forward_whose_links_all_failed_is_kept_rather_than_dropped() {
     // A link can go away between being chosen for a frame and being written to.

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -21486,6 +21486,119 @@ fn test_relay_forwards_third_party_message() {
 }
 
 #[test]
+fn a_forward_whose_links_all_failed_is_kept_rather_than_dropped() {
+    // A link can go away between being chosen for a frame and being written to.
+    // The frame has then travelled nowhere — but its id was recorded as handled
+    // when it was admitted, so dropping it here would lose this copy *and*
+    // refuse every copy and retransmission behind it for the whole retention
+    // window. It has to go back on the queue, the same way a frame starved of
+    // budget does.
+    let mut protocol = OfflineProtocol::new(create_relay_test_config_for_user("user123")).unwrap();
+
+    let mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    // Carol stays listed as a live link throughout: the failure is the write,
+    // not the enumeration, which is exactly the race being covered.
+    mock.add_connected_peer("carol", -55);
+    let transport_handle = mock.clone();
+
+    let msg = Message::new(
+        UserId::new("alice").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        "carry me",
+    );
+    mock.queue_message(msg);
+
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
+
+    assert!(
+        protocol.receive_message().is_none(),
+        "a third-party message is forwarded, not returned"
+    );
+
+    // The one write this flush attempts fails.
+    transport_handle.set_fail_next_sends(1);
+    protocol.process().unwrap();
+
+    assert!(
+        transport_handle.peer_sends().is_empty(),
+        "nothing can have reached a neighbor"
+    );
+    assert_eq!(
+        protocol.mesh_relay_stats().awaiting_transmission,
+        1,
+        "the frame must still be held, not dropped with its id suppressed"
+    );
+    assert_eq!(
+        protocol.mesh_relay_stats().forwarded,
+        0,
+        "a frame that reached nobody was not carried"
+    );
+
+    // The link works on the next tick, and the frame we kept goes out.
+    protocol.process().unwrap();
+
+    let forwarded = transport_handle.peer_sends();
+    assert_eq!(forwarded.len(), 1, "the kept frame is forwarded");
+    assert_eq!(forwarded[0].0, "carol");
+    assert_eq!(forwarded[0].1.recipient.as_str(), "bob");
+    assert_eq!(protocol.mesh_relay_stats().awaiting_transmission, 0);
+    assert_eq!(protocol.mesh_relay_stats().forwarded, 1);
+}
+
+#[test]
+fn a_forward_with_no_usable_neighbor_is_kept_rather_than_dropped() {
+    // Same hazard, reached the other way: the only link this device holds is
+    // the one the frame arrived on, which it must not go back to. There is
+    // nowhere to send it *this* tick — which is not a reason to blackhole the
+    // id for the next ten minutes.
+    let mut protocol = OfflineProtocol::new(create_relay_test_config_for_user("user123")).unwrap();
+
+    let mock = MockTransport::new(TransportType::BLE);
+    mock.start().unwrap();
+    mock.add_connected_peer("dave", -55);
+    let transport_handle = mock.clone();
+
+    let msg = Message::new(
+        UserId::new("alice").unwrap(),
+        UserId::new("bob").unwrap(),
+        AppId::new("test-app").unwrap(),
+        "nowhere to go yet",
+    );
+    // Dave handed it to us, so dave is excluded as a target and no other link
+    // exists.
+    mock.queue_message_from(msg, "dave".to_string());
+
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(mock));
+    protocol.start().unwrap();
+
+    assert!(protocol.receive_message().is_none());
+
+    protocol.process().unwrap();
+    assert!(transport_handle.peer_sends().is_empty());
+    assert_eq!(
+        protocol.mesh_relay_stats().awaiting_transmission,
+        1,
+        "with nowhere to send it, the frame is held rather than dropped"
+    );
+
+    // A second neighbor appears, and the frame we kept can travel.
+    transport_handle.add_connected_peer("erin", -60);
+    protocol.process().unwrap();
+
+    let forwarded = transport_handle.peer_sends();
+    assert_eq!(forwarded.len(), 1, "the frame goes out once a link exists");
+    assert_eq!(forwarded[0].0, "erin");
+    assert_eq!(protocol.mesh_relay_stats().awaiting_transmission, 0);
+}
+
+#[test]
 fn relay_restamps_binary_for_capable_third_party() {
     // A relayed message must be (re-)stamped from the relay's own per-peer
     // negotiation for the next hop — not left on whatever codec it arrived with.

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -31,6 +31,19 @@ pub(crate) fn create_test_config_for_user(user_id: &str) -> ProtocolConfig {
     config
 }
 
+/// A config whose forwarding holds no frames back, so a test can queue a frame
+/// and flush it in the same breath.
+///
+/// The hold exists to let neighbors cover each other in a real neighborhood;
+/// tests that assert *what* was forwarded rather than *when* would otherwise
+/// have to sleep. Tests covering the hold itself set their own timings.
+pub(crate) fn create_relay_test_config_for_user(user_id: &str) -> ProtocolConfig {
+    let mut config = create_test_config_for_user(user_id);
+    config.mesh_relay.jitter_min = std::time::Duration::from_millis(0);
+    config.mesh_relay.jitter_max = std::time::Duration::from_millis(0);
+    config
+}
+
 #[derive(Default, Clone)]
 struct RecordingMlsEmitter {
     events: Arc<Mutex<Vec<MlsLifecycleEvent>>>,
@@ -21396,7 +21409,7 @@ fn test_reset_tofu_for_peer_allows_repinning() {
 
 #[test]
 fn test_relay_forwards_third_party_message() {
-    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mut protocol = OfflineProtocol::new(create_relay_test_config_for_user("user123")).unwrap();
 
     let relay_events = Arc::new(Mutex::new(Vec::<Event>::new()));
     let relay_events_clone = relay_events.clone();
@@ -21408,6 +21421,10 @@ fn test_relay_forwards_third_party_message() {
 
     let mock = MockTransport::new(TransportType::BLE);
     mock.start().unwrap();
+    // Someone to carry it onward: without a neighbor there is nowhere for a
+    // forwarded frame to go.
+    mock.add_connected_peer("carol", -55);
+    let transport_handle = mock.clone();
 
     // Create a message from alice to bob (not for us = user123)
     let msg = Message::new(
@@ -21430,6 +21447,18 @@ fn test_relay_forwards_third_party_message() {
     assert!(
         received.is_none(),
         "Third-party message should be relayed, not returned"
+    );
+
+    // Forwarding goes out from the process tick.
+    protocol.process().unwrap();
+
+    let forwarded = transport_handle.peer_sends();
+    assert_eq!(forwarded.len(), 1, "forwarded to exactly one neighbor");
+    assert_eq!(forwarded[0].0, "carol", "handed to the neighbor");
+    assert_eq!(
+        forwarded[0].1.recipient.as_str(),
+        "bob",
+        "still addressed to its recipient"
     );
 
     // Verify MessageRelayed event was emitted with correct fields
@@ -21462,10 +21491,13 @@ fn relay_restamps_binary_for_capable_third_party() {
     // negotiation for the next hop — not left on whatever codec it arrived with.
     // Here we relay a third-party message to bob, who advertised binary support,
     // and assert the frame that leaves is a binary frame.
-    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mut protocol = OfflineProtocol::new(create_relay_test_config_for_user("user123")).unwrap();
 
     let mock = MockTransport::new(TransportType::BLE);
     mock.start().unwrap();
+    // Bob is our neighbor here, so he is both the recipient and the physical
+    // next hop — the link whose negotiation decides the codec.
+    mock.add_connected_peer("bob", -55);
     let transport_handle = mock.clone();
 
     // From alice to bob — a third party, since we are user123 — so it is relayed
@@ -21491,13 +21523,15 @@ fn relay_restamps_binary_for_capable_third_party() {
         protocol.receive_message().is_none(),
         "third-party message should be relayed, not returned"
     );
+    protocol.process().unwrap();
 
     // Isolate the frame relayed to bob (any incidental control sends go to other
     // recipients) and assert it was re-stamped binary.
-    let sent = transport_handle.sent_messages();
+    let sent = transport_handle.peer_sends();
     let to_bob: Vec<_> = sent
         .iter()
-        .filter(|m| m.recipient.as_str() == "bob")
+        .filter(|(peer, _)| peer == "bob")
+        .map(|(_, message)| message)
         .collect();
     assert_eq!(to_bob.len(), 1, "exactly one frame relayed to bob");
     assert_eq!(to_bob[0].content, "relay me");
@@ -21602,7 +21636,7 @@ fn test_relay_disabled_does_not_forward() {
 
 #[test]
 fn test_relay_preserves_original_sender() {
-    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    let mut protocol = OfflineProtocol::new(create_relay_test_config_for_user("user123")).unwrap();
 
     let relay_events = Arc::new(Mutex::new(Vec::<Event>::new()));
     let relay_events_clone = relay_events.clone();
@@ -21614,6 +21648,8 @@ fn test_relay_preserves_original_sender() {
 
     let mock = MockTransport::new(TransportType::BLE);
     mock.start().unwrap();
+    mock.add_connected_peer("carol", -55);
+    let transport_handle = mock.clone();
 
     let msg = Message::new(
         UserId::new("alice").unwrap(),
@@ -21630,6 +21666,14 @@ fn test_relay_preserves_original_sender() {
     protocol.start().unwrap();
 
     protocol.receive_message();
+    protocol.process().unwrap();
+
+    // The frame that leaves is the original, unmodified apart from its hop
+    // accounting: a carrier must not rewrite what it carries.
+    let forwarded = transport_handle.peer_sends();
+    assert_eq!(forwarded.len(), 1);
+    assert_eq!(forwarded[0].1.sender.as_str(), "alice");
+    assert_eq!(forwarded[0].1.content, "original content");
 
     let events = relay_events.lock().unwrap();
     assert_eq!(events.len(), 1);

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -154,10 +154,12 @@ pub(crate) const KNOWN_PEER_TTL_SECS: u64 = 1800;
 /// Battery level below which a device stops carrying traffic for other
 /// people even while charging.
 ///
-/// Mirrors the critical floor the relay-role policy uses
-/// (`RelayManager::demotion_battery_floor`), so a device does not keep
-/// relaying at a level that would have stripped it of the relay role.
-pub(crate) const CRITICAL_RELAY_BATTERY_LEVEL: u8 = 15;
+/// Re-exported from the router crate rather than restated here: message
+/// forwarding and the relay role apply the same floor, and a device must not
+/// keep carrying traffic at a level that would have stripped it of the role.
+/// Two copies of the number would eventually disagree, and nothing would
+/// notice.
+pub(crate) use offline_protocol_router::CRITICAL_RELAY_BATTERY_LEVEL;
 
 /// Metadata key for the Ed25519 signature over the control message content (base64).
 pub(crate) const CTRL_SIG_META_KEY: &str = "__ctrl_sig";

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -151,6 +151,14 @@ pub(crate) const MAX_KNOWN_PEERS: usize = 1000;
 /// advertisement or message), so erring long only delays hygiene.
 pub(crate) const KNOWN_PEER_TTL_SECS: u64 = 1800;
 
+/// Battery level below which a device stops carrying traffic for other
+/// people even while charging.
+///
+/// Mirrors the critical floor the relay-role policy uses
+/// (`RelayManager::demotion_battery_floor`), so a device does not keep
+/// relaying at a level that would have stripped it of the relay role.
+pub(crate) const CRITICAL_RELAY_BATTERY_LEVEL: u8 = 15;
+
 /// Metadata key for the Ed25519 signature over the control message content (base64).
 pub(crate) const CTRL_SIG_META_KEY: &str = "__ctrl_sig";
 /// Metadata key for the sender's Ed25519 public key (base64, 32 bytes raw).

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -84,6 +84,20 @@ pub struct MeshNeighbor {
     pub transport: TransportType,
 }
 
+impl MeshNeighbor {
+    /// How good this link is, on a 0–100 scale.
+    ///
+    /// Derived from signal strength where the carrier reports it, and a
+    /// mid-scale value where it does not — an unmeasured link should not
+    /// outrank a measured good one, nor be discarded like a measured bad one.
+    pub fn link_quality(&self) -> u8 {
+        match self.rssi {
+            Some(rssi) => offline_protocol_transport::LinkQuality::from_rssi(rssi).value(),
+            None => offline_protocol_transport::DEFAULT_LINK_QUALITY_WITHOUT_RSSI,
+        }
+    }
+}
+
 /// Dedupe window: don't re-emit same escalation trigger reason within this duration.
 const ESCALATION_TRIGGER_DEDUPE_SECS: u64 = 30;
 

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -917,6 +917,53 @@ impl TransportManager {
         neighbors
     }
 
+    /// Whether a frame for `peer_id` can plausibly arrive without being carried
+    /// by other devices.
+    ///
+    /// This exists because **a send returning `Ok` is not evidence of
+    /// reachability**. Only BLE refuses a recipient it holds no link to; Wi-Fi
+    /// Direct and Reticulum enqueue for any recipient and report success, so a
+    /// frame handed to them for someone out of range is queued for a link that
+    /// will never drain — reported as sent, silently swallowed. Anything that
+    /// decides "the mesh has to carry this" from a send failure therefore never
+    /// fires on a device where one of those carriers is up. Asking this instead
+    /// keeps that decision on facts we can check.
+    ///
+    /// Two ways the answer is yes:
+    ///
+    /// - An **infrastructure** carrier is available. Internet, Nostr and
+    ///   Reticulum do their own routing and reach peers we hold no radio link
+    ///   to, so a direct send is a real delivery attempt. (Reticulum counts
+    ///   here because it is a routing network in its own right — its `Ok` means
+    ///   "accepted for routing", which is as much as any relay-style carrier
+    ///   promises.)
+    /// - The peer is one of our own **mesh neighbors**, so a mesh carrier can
+    ///   hand the frame straight over.
+    ///
+    /// Checked in that order so the common online case costs a status scan and
+    /// never enumerates links.
+    pub fn can_reach_without_carrying(&self, peer_id: &str) -> bool {
+        let has_infrastructure = self.transports.iter().any(|(transport_type, transport)| {
+            !MESH_TRANSPORTS.contains(transport_type)
+                && transport.status() == TransportStatus::Available
+        });
+        if has_infrastructure {
+            return true;
+        }
+
+        MESH_TRANSPORTS.iter().any(|transport_type| {
+            self.transports
+                .get(transport_type)
+                .filter(|transport| transport.status() == TransportStatus::Available)
+                .is_some_and(|transport| {
+                    transport
+                        .connected_peers()
+                        .iter()
+                        .any(|link| link.peer_id == peer_id)
+                })
+        })
+    }
+
     /// Hands `message` to a specific mesh neighbor, whatever the message's own
     /// recipient is.
     ///

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -63,6 +63,27 @@ pub struct TransportManager {
     peer_binary_wire: HashSet<String>,
 }
 
+/// Carriers whose links are peer-to-peer, in the order a forwarding caller
+/// should prefer them.
+///
+/// These are the only transports that can carry a *mesh hop*: a frame handed
+/// straight to a neighbor's radio. Wi-Fi Direct leads because a link that
+/// exists at all is the higher-bandwidth one; BLE is the carrier that is
+/// almost always present. Everything else reaches peers through
+/// infrastructure, which is not a hop — it is an exit from the mesh.
+const MESH_TRANSPORTS: &[TransportType] = &[TransportType::WiFiDirect, TransportType::BLE];
+
+/// A peer reachable over a direct mesh link.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeshNeighbor {
+    /// User-level id of the neighbor.
+    pub peer_id: String,
+    /// Signal strength for the link, when the carrier measures one.
+    pub rssi: Option<i16>,
+    /// The carrier holding the link.
+    pub transport: TransportType,
+}
+
 /// Dedupe window: don't re-emit same escalation trigger reason within this duration.
 const ESCALATION_TRIGGER_DEDUPE_SECS: u64 = 30;
 
@@ -845,6 +866,97 @@ impl TransportManager {
         self.current_transport = Some(transport_type);
 
         Ok(())
+    }
+
+    /// Lists every peer reachable over a direct mesh link, with the transport
+    /// that link runs on.
+    ///
+    /// Only the peer-to-peer carriers are consulted: a mesh neighbor is one we
+    /// can hand a frame to over our own radio, which is what makes it a
+    /// candidate next hop. Infrastructure carriers (Internet, Nostr, Reticulum)
+    /// reach peers through something else, so they report no links and appear
+    /// here as nothing — a message routed through them is not taking a mesh
+    /// hop, it is leaving the mesh.
+    ///
+    /// A peer visible on more than one carrier is reported once, on the first
+    /// carrier that claims it; [`Self::send_to_neighbor`] resolves the same way,
+    /// so the pair stay consistent.
+    pub fn mesh_neighbors(&self) -> Vec<MeshNeighbor> {
+        let mut neighbors: Vec<MeshNeighbor> = Vec::new();
+
+        for transport_type in MESH_TRANSPORTS {
+            let Some(transport) = self.transports.get(transport_type) else {
+                continue;
+            };
+            for link in transport.connected_peers() {
+                if neighbors.iter().any(|n| n.peer_id == link.peer_id) {
+                    continue;
+                }
+                neighbors.push(MeshNeighbor {
+                    peer_id: link.peer_id,
+                    rssi: link.rssi,
+                    transport: *transport_type,
+                });
+            }
+        }
+
+        neighbors
+    }
+
+    /// Hands `message` to a specific mesh neighbor, whatever the message's own
+    /// recipient is.
+    ///
+    /// This is the forwarding primitive: the frame crosses one link, to the
+    /// peer named by `peer_id`. Because that peer is the physical target, the
+    /// binary wire codec is negotiated against **its** capabilities rather than
+    /// the recipient's — stamping a forwarded frame binary because the distant
+    /// recipient supports it could put bytes a neighbor cannot decode onto that
+    /// neighbor's link.
+    ///
+    /// Returns the transport the frame went out on.
+    pub fn send_to_neighbor(&self, peer_id: &str, message: &Message) -> Result<TransportType> {
+        let stamped;
+        let message = if message.wire_codec() != WireCodec::BinaryV1
+            && self.peer_binary_wire.contains(peer_id)
+        {
+            let mut m = message.clone();
+            m.set_wire_codec(WireCodec::BinaryV1);
+            stamped = m;
+            &stamped
+        } else if message.wire_codec() == WireCodec::BinaryV1
+            && !self.peer_binary_wire.contains(peer_id)
+        {
+            // The frame arrived stamped binary (or was stamped for a different
+            // peer) but this hop cannot decode it. Fall back to the JSON floor
+            // rather than writing bytes the neighbor will drop.
+            let mut m = message.clone();
+            m.set_wire_codec(WireCodec::Json);
+            stamped = m;
+            &stamped
+        } else {
+            message
+        };
+
+        let mut last_error: Option<String> = None;
+
+        for transport_type in MESH_TRANSPORTS {
+            let Some(transport) = self.transports.get(transport_type) else {
+                continue;
+            };
+            if transport.status() != TransportStatus::Available {
+                continue;
+            }
+            match transport.send_to_peer(peer_id, message) {
+                Ok(()) => return Ok(*transport_type),
+                Err(e) => last_error = Some(e.to_string()),
+            }
+        }
+
+        Err(Error::Transport(TransportError::PeerNotReachable(format!(
+            "no mesh transport holds a link to {}{}",
+            peer_id,
+            last_error.map(|e| format!(" ({})", e)).unwrap_or_default()
+        ))))
     }
 
     /// Attempts to receive a message from any transport.

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -964,6 +964,36 @@ impl TransportManager {
         })
     }
 
+    /// Whether `transport_type` can actually put a frame in front of `peer_id`.
+    ///
+    /// The narrower question [`Self::can_reach_without_carrying`] answers across
+    /// every carrier, asked of one. It exists for the same reason: a transport
+    /// returning `Ok` is not evidence the frame can arrive. A **mesh** carrier
+    /// can only address a peer it holds a live link to, and Wi-Fi Direct
+    /// enqueues for any recipient regardless — so a frame handed to it for
+    /// someone several hops away is queued for a link that never drains.
+    /// **Infrastructure** carriers do their own routing, so for them the answer
+    /// is yes whenever they are available.
+    ///
+    /// Callers that would otherwise trust a preferred transport — replying on
+    /// the link a message arrived over, above all — must ask this first, or the
+    /// reply dies on exactly the multi-hop path that made forwarding necessary.
+    pub fn can_address_via(&self, transport_type: TransportType, peer_id: &str) -> bool {
+        let Some(transport) = self.transports.get(&transport_type) else {
+            return false;
+        };
+        if transport.status() != TransportStatus::Available {
+            return false;
+        }
+        if !MESH_TRANSPORTS.contains(&transport_type) {
+            return true;
+        }
+        transport
+            .connected_peers()
+            .iter()
+            .any(|link| link.peer_id == peer_id)
+    }
+
     /// Hands `message` to a specific mesh neighbor, whatever the message's own
     /// recipient is.
     ///

--- a/crates/offline-protocol/tests/mesh_forwarding.rs
+++ b/crates/offline-protocol/tests/mesh_forwarding.rs
@@ -47,32 +47,30 @@ impl Neighborhood {
         };
 
         for id in node_ids {
-            let mut config = ProtocolConfig::new("mesh-test", *id);
-            // These tests are about who carries what, not about encryption.
-            config.encryption.require_encryption = false;
-            // No hold before forwarding: the tests drive time by stepping, and
-            // the hold's own behavior is covered by the governor's unit tests.
-            config.mesh_relay.jitter_min = std::time::Duration::from_millis(0);
-            config.mesh_relay.jitter_max = std::time::Duration::from_millis(0);
-
-            let radio = MockTransport::new(TransportType::BLE);
-            radio.start().unwrap();
-            // A device can only put a frame on a link it actually has.
-            radio.set_reject_unknown_recipients(true);
-            let handle = radio.clone();
-
-            let mut node = OfflineProtocol::new(config).unwrap();
-            node.transport_manager_mut()
-                .add_transport(TransportType::BLE, Box::new(radio));
-            node.start().unwrap();
-
-            neighborhood.nodes.insert(id.to_string(), node);
-            neighborhood.radios.insert(id.to_string(), handle);
-            neighborhood.links.insert(id.to_string(), Vec::new());
-            neighborhood.inboxes.insert(id.to_string(), Vec::new());
+            neighborhood.add_node(id, default_config(id));
         }
 
         neighborhood
+    }
+
+    /// Adds one device, which may be configured differently from the rest —
+    /// a device that declines to carry traffic, for instance.
+    fn add_node(&mut self, id: &str, config: ProtocolConfig) {
+        let radio = MockTransport::new(TransportType::BLE);
+        radio.start().unwrap();
+        // A device can only put a frame on a link it actually has.
+        radio.set_reject_unknown_recipients(true);
+        let handle = radio.clone();
+
+        let mut node = OfflineProtocol::new(config).unwrap();
+        node.transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(radio));
+        node.start().unwrap();
+
+        self.nodes.insert(id.to_string(), node);
+        self.radios.insert(id.to_string(), handle);
+        self.links.insert(id.to_string(), Vec::new());
+        self.inboxes.insert(id.to_string(), Vec::new());
     }
 
     /// Puts two devices in range of each other.
@@ -212,6 +210,18 @@ impl Neighborhood {
             .filter(|(_, to, id)| to == node_id && id == message_id)
             .count()
     }
+}
+
+/// The configuration every simulated device starts from.
+fn default_config(user_id: &str) -> ProtocolConfig {
+    let mut config = ProtocolConfig::new("mesh-test", user_id);
+    // These tests are about who carries what, not about encryption.
+    config.encryption.require_encryption = false;
+    // No hold before forwarding: the tests drive time by stepping, and the
+    // hold's own behavior is covered by the governor's unit tests.
+    config.mesh_relay.jitter_min = std::time::Duration::from_millis(0);
+    config.mesh_relay.jitter_max = std::time::Duration::from_millis(0);
+    config
 }
 
 fn message(from: &str, to: &str, content: &str) -> Message {
@@ -466,24 +476,11 @@ fn a_message_survives_the_carrier_walking_away() {
 fn a_device_that_opts_out_carries_nothing() {
     // Carrying other people's traffic costs battery, and a device is allowed to
     // decline. It must still be able to send and receive its own.
-    let mut config = ProtocolConfig::new("mesh-test", "bob");
-    config.encryption.require_encryption = false;
+    let mut config = default_config("bob");
     config.relay.allow_relay = false;
 
     let mut net = Neighborhood::new(&["alice", "carol"]);
-
-    let radio = MockTransport::new(TransportType::BLE);
-    radio.start().unwrap();
-    radio.set_reject_unknown_recipients(true);
-    let handle = radio.clone();
-    let mut bob = OfflineProtocol::new(config).unwrap();
-    bob.transport_manager_mut()
-        .add_transport(TransportType::BLE, Box::new(radio));
-    bob.start().unwrap();
-    net.nodes.insert("bob".to_string(), bob);
-    net.radios.insert("bob".to_string(), handle);
-    net.links.insert("bob".to_string(), Vec::new());
-    net.inboxes.insert("bob".to_string(), Vec::new());
+    net.add_node("bob", config);
 
     net.link("alice", "bob");
     net.link("bob", "carol");
@@ -503,6 +500,108 @@ fn a_device_that_opts_out_carries_nothing() {
             .count(),
         0,
         "and must not have transmitted it at all"
+    );
+}
+
+#[test]
+fn a_device_that_carries_nothing_still_gets_its_own_answer_out() {
+    // Declining to carry other people's traffic must not cost a device the
+    // ability to answer its own. Carol is two links from alice, so her
+    // acknowledgement can only get home by being handed to bob — the one thing
+    // a relay-declining device still has to be able to do, and the reason
+    // handing over our *own* frames is deliberately not gated on that setting.
+    // Without it her sender retransmits to exhaustion and reports a failure for
+    // a message that was delivered and read.
+    let mut config = default_config("carol");
+    config.relay.allow_relay = false;
+
+    let mut net = Neighborhood::new(&["alice", "bob"]);
+    net.add_node("carol", config);
+
+    net.link("alice", "bob");
+    net.link("bob", "carol");
+
+    net.send("alice", "carol", "do you copy?");
+
+    net.run_until_quiet(12);
+
+    assert_eq!(net.inbox("carol"), vec!["do you copy?".to_string()]);
+    assert!(
+        net.transmissions
+            .iter()
+            .any(|(from, to, _)| from == "carol" && to == "bob"),
+        "a device that carries nothing must still hand its own answer to a neighbor"
+    );
+    assert!(
+        net.transmissions
+            .iter()
+            .any(|(from, to, _)| from == "bob" && to == "alice"),
+        "and that answer must reach the sender"
+    );
+}
+
+#[test]
+fn an_answer_is_carried_even_when_a_transport_accepts_a_peer_it_cannot_reach() {
+    // Only BLE refuses a recipient it holds no link to. Wi-Fi Direct and
+    // Reticulum enqueue for anyone and return `Ok`, so a frame handed to them
+    // for someone out of range is queued for a link that never drains —
+    // reported as sent, silently swallowed.
+    //
+    // That matters most for an acknowledgement. Carol's answer to alice is two
+    // links away and has to be carried; if the decision to carry it is inferred
+    // from a send failure, the accepting carrier reports success first and the
+    // answer dies. Alice then retransmits a message carol already has, and
+    // eventually reports failure for a message that was delivered and read.
+    let mut carol = OfflineProtocol::new(default_config("carol")).unwrap();
+
+    // The link carol really has: bob, who can reach alice.
+    let ble = MockTransport::new(TransportType::BLE);
+    ble.start().unwrap();
+    ble.set_reject_unknown_recipients(true);
+    ble.add_connected_peer("bob", -55);
+    let ble_handle = ble.clone();
+
+    // A carrier that is up and takes any recipient without holding a link to
+    // one — the shape both Wi-Fi Direct and Reticulum have in production.
+    let swallowing = MockTransport::new(TransportType::WiFiDirect);
+    swallowing.start().unwrap();
+    let swallowing_handle = swallowing.clone();
+
+    carol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(ble));
+    carol
+        .transport_manager_mut()
+        .add_transport(TransportType::WiFiDirect, Box::new(swallowing));
+    carol.start().unwrap();
+
+    // Alice's message arrives over the link bob handed it across.
+    let msg = message("alice", "carol", "did this get through?");
+    ble_handle.queue_message_from(msg, "bob".to_string());
+    assert!(
+        carol.receive_message().is_some(),
+        "carol should have received the message"
+    );
+    carol.process().unwrap();
+
+    let carried: Vec<_> = ble_handle
+        .peer_sends()
+        .into_iter()
+        .filter(|(_, m)| m.recipient.as_str() == "alice")
+        .collect();
+    assert_eq!(
+        carried.len(),
+        1,
+        "carol's answer must be handed to a neighbor to carry"
+    );
+    assert_eq!(carried[0].0, "bob", "and handed to the neighbor she has");
+
+    assert!(
+        swallowing_handle
+            .sent_messages()
+            .iter()
+            .all(|m| m.recipient.as_str() != "alice"),
+        "the answer must not be spent on a carrier that cannot reach alice"
     );
 }
 

--- a/crates/offline-protocol/tests/mesh_forwarding.rs
+++ b/crates/offline-protocol/tests/mesh_forwarding.rs
@@ -346,31 +346,85 @@ fn a_message_does_not_circle_a_ring_forever() {
 
 #[test]
 fn everyone_hearing_everyone_does_not_multiply_the_traffic() {
-    // The crowded-room case. Eight devices, all in range of each other, and one
-    // message. Without restraint each device would repeat what it heard to
-    // everyone else and the room would fill with copies of one message.
-    let ids = ["n0", "n1", "n2", "n3", "n4", "n5", "n6", "n7"];
-    let mut net = Neighborhood::new(&ids);
-    for (i, a) in ids.iter().enumerate() {
-        for b in ids.iter().skip(i + 1) {
+    // The crowded-room case: a dense cluster of devices that all hear each
+    // other, carrying a message to someone standing just outside it. Without
+    // restraint every device in the cluster repeats what it heard to every
+    // other, and one message fills the room with copies.
+    //
+    // The recipient is deliberately outside the cluster. If they were inside
+    // it, the sender would simply hand the message over directly and no
+    // carrying would happen at all — the test would pass while exercising
+    // nothing.
+    let cluster = ["n0", "n1", "n2", "n3", "n4", "n5", "n6"];
+    let mut net = Neighborhood::new(&["n0", "n1", "n2", "n3", "n4", "n5", "n6", "far"]);
+    for (i, a) in cluster.iter().enumerate() {
+        for b in cluster.iter().skip(i + 1) {
             net.link(a, b);
         }
     }
+    // One device in the cluster — not the sender — can reach the recipient.
+    net.link("n6", "far");
 
-    let msg_id = net.send("n0", "n7", "in the crowd");
+    let msg_id = net.send("n0", "far", "in the crowd");
 
     net.run_until_quiet(24);
 
-    assert_eq!(net.inbox("n7"), vec!["in the crowd".to_string()]);
+    assert_eq!(net.inbox("far"), vec!["in the crowd".to_string()]);
 
-    // Eight devices with a link between every pair is 28 links. Uncontrolled
-    // forwarding would cross most of them repeatedly; the bound here is well
-    // under a single pass over the topology.
+    // Seven devices with a link between every pair is 21 links, plus the one
+    // out to the recipient. Delivery costs fewer transmissions than the cluster
+    // has links — uncontrolled repetition would cross them all, several times
+    // over, until the hop budget ran out.
+    //
+    // This is the *worst* case rather than the expected one. These devices run
+    // with the pre-transmit hold set to zero and are stepped in lock-step, so
+    // every forward is due at once and none of them ever gets the chance to
+    // stand down for a neighbor. Real timing spreads them out, and the
+    // cancellation that follows only lowers this number.
     let crossings = net.transmission_count(&msg_id);
     assert!(
-        crossings <= 20,
-        "one message crossed links {crossings} times in a room of {} devices",
-        ids.len()
+        crossings < 21,
+        "one message crossed links {crossings} times in a room of {} devices, \
+         which is more than the cluster has links",
+        cluster.len()
+    );
+
+    // And it really did travel through the cluster rather than going direct.
+    assert!(
+        net.transmissions
+            .iter()
+            .any(|(from, to, id)| from == "n6" && to == "far" && id == &msg_id),
+        "the message should have reached the recipient through the cluster"
+    );
+}
+
+#[test]
+fn the_only_device_that_can_reach_the_recipient_does_not_stand_down() {
+    // Two forwarders that can hear each other, only one of which can reach the
+    // recipient:
+    //
+    //     alice — bob — carol — dave
+    //       \_____________/
+    //
+    // Both bob and carol take a copy. Whichever transmits first hands it to the
+    // other, and standing down on a duplicate is normally right — a neighbor
+    // covered the same ground. But carol holds the only link to dave. If carol
+    // drops her copy because bob's arrived, dave never hears it, and the id is
+    // suppressed so the sender's retries cannot rescue it either.
+    let mut net = Neighborhood::new(&["alice", "bob", "carol", "dave"]);
+    net.link("alice", "bob");
+    net.link("alice", "carol");
+    net.link("bob", "carol");
+    net.link("carol", "dave");
+
+    net.send("alice", "dave", "only carol can finish this");
+
+    net.run_until_quiet(16);
+
+    assert_eq!(
+        net.inbox("dave"),
+        vec!["only carol can finish this".to_string()],
+        "the device holding the last link must deliver, not defer to a neighbor"
     );
 }
 

--- a/crates/offline-protocol/tests/mesh_forwarding.rs
+++ b/crates/offline-protocol/tests/mesh_forwarding.rs
@@ -606,6 +606,71 @@ fn an_answer_is_carried_even_when_a_transport_accepts_a_peer_it_cannot_reach() {
 }
 
 #[test]
+fn an_answer_is_carried_when_the_last_hop_arrived_over_the_swallowing_carrier() {
+    // The same hazard as above, reached the way it actually happens. Wi-Fi
+    // Direct is the *preferred* mesh carrier, so on a real fleet it is usually
+    // the link a forwarded frame's last hop crosses — and answering on the link
+    // a message arrived over is the first thing an acknowledgement tries.
+    //
+    // That combination is what makes the swallow reachable: Wi-Fi Direct
+    // accepts alice as a recipient it holds no link to, reports success, and
+    // the answer is queued for a link that never drains. Alice then
+    // retransmits a message carol has already read, until she reports it
+    // failed. Answering the arrival link therefore has to be gated on whether
+    // that carrier can address the sender at all.
+    let mut carol = OfflineProtocol::new(default_config("carol")).unwrap();
+
+    // The link carol really has: bob, who can reach alice.
+    let ble = MockTransport::new(TransportType::BLE);
+    ble.start().unwrap();
+    ble.set_reject_unknown_recipients(true);
+    ble.add_connected_peer("bob", -55);
+    let ble_handle = ble.clone();
+
+    // Up, holding no links, and accepting anyone — the production shape.
+    let swallowing = MockTransport::new(TransportType::WiFiDirect);
+    swallowing.start().unwrap();
+    let swallowing_handle = swallowing.clone();
+
+    carol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(ble));
+    carol
+        .transport_manager_mut()
+        .add_transport(TransportType::WiFiDirect, Box::new(swallowing));
+    carol.start().unwrap();
+
+    // Alice's message arrives over Wi-Fi Direct, handed across by bob.
+    let msg = message("alice", "carol", "did this get through?");
+    swallowing_handle.queue_message_from(msg, "bob".to_string());
+    assert!(
+        carol.receive_message().is_some(),
+        "carol should have received the message"
+    );
+    carol.process().unwrap();
+
+    assert!(
+        swallowing_handle
+            .sent_messages()
+            .iter()
+            .all(|m| m.recipient.as_str() != "alice"),
+        "the answer must not be spent on the carrier that only pretends to reach alice"
+    );
+
+    let carried: Vec<_> = ble_handle
+        .peer_sends()
+        .into_iter()
+        .filter(|(_, m)| m.recipient.as_str() == "alice")
+        .collect();
+    assert_eq!(
+        carried.len(),
+        1,
+        "carol's answer must be carried by the neighbor she has"
+    );
+    assert_eq!(carried[0].0, "bob");
+}
+
+#[test]
 fn a_frame_claiming_an_absurd_reach_is_cut_down() {
     // Nothing authenticates how far a frame says it may travel, so a device
     // must not take that claim at face value. The claim can only come off the

--- a/crates/offline-protocol/tests/mesh_forwarding.rs
+++ b/crates/offline-protocol/tests/mesh_forwarding.rs
@@ -1,0 +1,481 @@
+//! Multi-device forwarding, exercised over a simulated neighborhood.
+//!
+//! These tests build several protocol instances and wire them together by
+//! topology, then move frames between them exactly the way a radio would:
+//! whatever a device hands to a neighbor is delivered to that neighbor and to
+//! nobody else. Nothing here reaches for internals — a message is sent by one
+//! device and looked for at another, so what is being tested is the behavior
+//! the network actually provides.
+//!
+//! They assert two different things, and both matter:
+//!
+//! - **Reach** — a message gets to someone no single device can see.
+//! - **Cost** — it does so without the network transmitting more than it should.
+//!   Reach alone is easy to get by repeating everything endlessly; the counts in
+//!   these tests are what separate a working mesh from one that floods.
+
+use offline_protocol::{OfflineProtocol, ProtocolConfig};
+use offline_protocol_core::{AppId, Message, UserId};
+use offline_protocol_transport::{mock::MockTransport, Transport, TransportType};
+use std::collections::HashMap;
+
+/// A simulated neighborhood of devices.
+///
+/// Each device owns one mock radio. Links are declared, not discovered, so a
+/// test states its topology and knows exactly which devices can hear each
+/// other.
+struct Neighborhood {
+    nodes: HashMap<String, OfflineProtocol>,
+    radios: HashMap<String, MockTransport>,
+    /// Who each device can hear directly.
+    links: HashMap<String, Vec<String>>,
+    /// Every hand-off that has crossed a link, as `(from, to, message_id)`.
+    transmissions: Vec<(String, String, String)>,
+    /// What each device has surfaced to its app, kept because stepping the
+    /// network is what drains it.
+    inboxes: HashMap<String, Vec<String>>,
+}
+
+impl Neighborhood {
+    fn new(node_ids: &[&str]) -> Self {
+        let mut neighborhood = Self {
+            nodes: HashMap::new(),
+            radios: HashMap::new(),
+            links: HashMap::new(),
+            transmissions: Vec::new(),
+            inboxes: HashMap::new(),
+        };
+
+        for id in node_ids {
+            let mut config = ProtocolConfig::new("mesh-test", *id);
+            // These tests are about who carries what, not about encryption.
+            config.encryption.require_encryption = false;
+            // No hold before forwarding: the tests drive time by stepping, and
+            // the hold's own behavior is covered by the governor's unit tests.
+            config.mesh_relay.jitter_min = std::time::Duration::from_millis(0);
+            config.mesh_relay.jitter_max = std::time::Duration::from_millis(0);
+
+            let radio = MockTransport::new(TransportType::BLE);
+            radio.start().unwrap();
+            // A device can only put a frame on a link it actually has.
+            radio.set_reject_unknown_recipients(true);
+            let handle = radio.clone();
+
+            let mut node = OfflineProtocol::new(config).unwrap();
+            node.transport_manager_mut()
+                .add_transport(TransportType::BLE, Box::new(radio));
+            node.start().unwrap();
+
+            neighborhood.nodes.insert(id.to_string(), node);
+            neighborhood.radios.insert(id.to_string(), handle);
+            neighborhood.links.insert(id.to_string(), Vec::new());
+            neighborhood.inboxes.insert(id.to_string(), Vec::new());
+        }
+
+        neighborhood
+    }
+
+    /// Puts two devices in range of each other.
+    fn link(&mut self, a: &str, b: &str) {
+        self.radios[a].add_connected_peer(b, -55);
+        self.radios[b].add_connected_peer(a, -55);
+        self.links.get_mut(a).unwrap().push(b.to_string());
+        self.links.get_mut(b).unwrap().push(a.to_string());
+        // Each end learns of the other, as it would on discovery.
+        self.nodes.get_mut(a).unwrap().on_neighbor_discovered(b);
+        self.nodes.get_mut(b).unwrap().on_neighbor_discovered(a);
+    }
+
+    /// Takes a device out of range of everyone (it walks away).
+    fn unlink_all(&mut self, id: &str) {
+        let peers = self.links[id].clone();
+        for peer in peers {
+            self.radios[&peer].remove_connected_peer(id);
+            self.radios[id].remove_connected_peer(&peer);
+            self.nodes.get_mut(&peer).unwrap().on_neighbor_lost(id);
+            self.links.get_mut(&peer).unwrap().retain(|p| p != id);
+        }
+        self.links.get_mut(id).unwrap().clear();
+    }
+
+    /// Runs one round: every device processes what it holds, and whatever it
+    /// hands to a neighbor is delivered to that neighbor.
+    ///
+    /// Returns how many hand-offs crossed a link this round, so a caller can
+    /// run until the network goes quiet.
+    fn step(&mut self) -> usize {
+        // Let each device act on what it has received, keeping whatever it
+        // surfaced to its app.
+        for id in self.node_ids() {
+            let node = self.nodes.get_mut(&id).unwrap();
+            let mut delivered = Vec::new();
+            while let Some(message) = node.receive_message() {
+                delivered.push(message.content);
+            }
+            node.process().unwrap();
+            self.inboxes.get_mut(&id).unwrap().extend(delivered);
+        }
+
+        // Move what they put on the air. Two ways a frame leaves a device: it
+        // was addressed to a neighbor and sent normally, or it was handed to a
+        // neighbor to carry. Both cross exactly one link.
+        let mut moved = 0;
+        for from in self.node_ids() {
+            let mut handed: Vec<(String, Message)> = self.radios[&from]
+                .sent_messages()
+                .into_iter()
+                .map(|m| (m.recipient.as_str().to_string(), m))
+                .collect();
+            handed.extend(self.radios[&from].peer_sends());
+            self.radios[&from].clear_sent_messages();
+            self.radios[&from].clear_peer_sends();
+
+            for (to, message) in handed {
+                // A device can only be handed something by a device in range.
+                assert!(
+                    self.links[&from].contains(&to),
+                    "{from} transmitted to {to}, which it has no link to"
+                );
+                self.transmissions
+                    .push((from.clone(), to.clone(), message.id.as_str()));
+                // The receiver sees which link it arrived on, as a radio reports.
+                self.radios[&to].queue_message_from(message, from.clone());
+                moved += 1;
+            }
+        }
+
+        moved
+    }
+
+    /// Steps until nothing more moves, or the round limit is hit.
+    ///
+    /// The limit is a guard: a mesh that will not go quiet is the failure this
+    /// whole design is meant to prevent, so hitting it fails the test rather
+    /// than hanging it.
+    fn run_until_quiet(&mut self, max_rounds: usize) -> usize {
+        for round in 0..max_rounds {
+            if self.step() == 0 {
+                return round + 1;
+            }
+        }
+        panic!("network never went quiet after {max_rounds} rounds");
+    }
+
+    fn node_ids(&self) -> Vec<String> {
+        let mut ids: Vec<String> = self.nodes.keys().cloned().collect();
+        ids.sort();
+        ids
+    }
+
+    fn node(&mut self, id: &str) -> &mut OfflineProtocol {
+        self.nodes.get_mut(id).unwrap()
+    }
+
+    /// Sends a message the way an app would, returning its id.
+    ///
+    /// Going through the real send path is the point: whether the recipient is
+    /// reachable, and what happens when they are not, is exactly what these
+    /// tests are about.
+    fn send(&mut self, from: &str, to: &str, content: &str) -> String {
+        self.nodes
+            .get_mut(from)
+            .unwrap()
+            .send_message(to, content, None, None::<String>)
+            .expect("send should be accepted locally even with no route")
+            .as_str()
+    }
+
+    /// Everything `id` has surfaced to its app so far.
+    fn inbox(&mut self, id: &str) -> Vec<String> {
+        // Catch anything delivered since the last step.
+        let node = self.nodes.get_mut(id).unwrap();
+        let mut delivered = Vec::new();
+        while let Some(message) = node.receive_message() {
+            delivered.push(message.content);
+        }
+        self.inboxes.get_mut(id).unwrap().extend(delivered);
+        self.inboxes[id].clone()
+    }
+
+    /// How many times a message crossed any link.
+    fn transmission_count(&self, message_id: &str) -> usize {
+        self.transmissions
+            .iter()
+            .filter(|(_, _, id)| id == message_id)
+            .count()
+    }
+
+    /// How many times a message was handed to a particular device.
+    fn deliveries_to(&self, node_id: &str, message_id: &str) -> usize {
+        self.transmissions
+            .iter()
+            .filter(|(_, to, id)| to == node_id && id == message_id)
+            .count()
+    }
+}
+
+fn message(from: &str, to: &str, content: &str) -> Message {
+    Message::new(
+        UserId::new(from).unwrap(),
+        UserId::new(to).unwrap(),
+        AppId::new("mesh-test").unwrap(),
+        content,
+    )
+}
+
+#[test]
+fn a_message_reaches_someone_two_rooms_away() {
+    // alice — bob — carol. Alice and carol cannot hear each other at all.
+    let mut net = Neighborhood::new(&["alice", "bob", "carol"]);
+    net.link("alice", "bob");
+    net.link("bob", "carol");
+
+    let msg_id = net.send("alice", "carol", "meet at the north gate");
+
+    net.run_until_quiet(12);
+
+    assert_eq!(
+        net.inbox("carol"),
+        vec!["meet at the north gate".to_string()],
+        "carol must receive a message from someone she cannot hear"
+    );
+    assert_eq!(
+        net.deliveries_to("carol", &msg_id),
+        1,
+        "and receive it exactly once"
+    );
+}
+
+#[test]
+fn the_answer_finds_its_way_back() {
+    // The reverse path matters as much as the forward one: without it the
+    // sender keeps retransmitting a message that was delivered.
+    let mut net = Neighborhood::new(&["alice", "bob", "carol"]);
+    net.link("alice", "bob");
+    net.link("bob", "carol");
+
+    net.send("alice", "carol", "are you here?");
+
+    net.run_until_quiet(12);
+
+    assert_eq!(net.inbox("carol").len(), 1);
+
+    // Carol's acknowledgement is addressed to alice, who is two links away, so
+    // it can only have arrived by being carried.
+    let acked_back = net
+        .transmissions
+        .iter()
+        .any(|(from, to, _)| from == "bob" && to == "alice");
+    assert!(
+        acked_back,
+        "carol's answer must be carried back toward alice"
+    );
+}
+
+#[test]
+fn a_message_crosses_a_line_of_five_devices() {
+    // Depth, not just one hop: a — b — c — d — e, with each device able to hear
+    // only its immediate neighbors.
+    let mut net = Neighborhood::new(&["a", "b", "c", "d", "e"]);
+    net.link("a", "b");
+    net.link("b", "c");
+    net.link("c", "d");
+    net.link("d", "e");
+
+    let msg_id = net.send("a", "e", "all the way down");
+
+    net.run_until_quiet(20);
+
+    assert_eq!(net.inbox("e"), vec!["all the way down".to_string()]);
+    assert_eq!(net.deliveries_to("e", &msg_id), 1);
+}
+
+#[test]
+fn a_message_with_two_paths_arrives_once() {
+    // A diamond: both b and c can carry alice's message to dave. Both should
+    // try — that redundancy is the point of a mesh — but dave must surface it
+    // to his app exactly once.
+    let mut net = Neighborhood::new(&["alice", "b", "c", "dave"]);
+    net.link("alice", "b");
+    net.link("alice", "c");
+    net.link("b", "dave");
+    net.link("c", "dave");
+
+    let msg_id = net.send("alice", "dave", "two ways round");
+
+    net.run_until_quiet(16);
+
+    assert_eq!(
+        net.inbox("dave"),
+        vec!["two ways round".to_string()],
+        "arriving twice must not mean being read twice"
+    );
+
+    // And the redundancy stays redundancy: the message does not circulate.
+    // Six links exist; a message that kept going would cross far more.
+    assert!(
+        net.transmission_count(&msg_id) <= 6,
+        "message crossed links {} times, which is more than the topology needs",
+        net.transmission_count(&msg_id)
+    );
+}
+
+#[test]
+fn a_message_does_not_circle_a_ring_forever() {
+    // A loop is where uncontrolled forwarding shows itself: with no suppression
+    // a frame goes round and round until its hop budget runs out, multiplying
+    // at every device on the way.
+    let mut net = Neighborhood::new(&["a", "b", "c", "d"]);
+    net.link("a", "b");
+    net.link("b", "c");
+    net.link("c", "d");
+    net.link("d", "a");
+
+    let msg_id = net.send("a", "c", "round the ring");
+
+    let rounds = net.run_until_quiet(20);
+
+    assert_eq!(net.inbox("c"), vec!["round the ring".to_string()]);
+    assert!(
+        net.transmission_count(&msg_id) <= 8,
+        "message crossed links {} times going round a four-device ring",
+        net.transmission_count(&msg_id)
+    );
+    assert!(rounds < 20, "the ring must settle, not keep turning");
+}
+
+#[test]
+fn everyone_hearing_everyone_does_not_multiply_the_traffic() {
+    // The crowded-room case. Eight devices, all in range of each other, and one
+    // message. Without restraint each device would repeat what it heard to
+    // everyone else and the room would fill with copies of one message.
+    let ids = ["n0", "n1", "n2", "n3", "n4", "n5", "n6", "n7"];
+    let mut net = Neighborhood::new(&ids);
+    for (i, a) in ids.iter().enumerate() {
+        for b in ids.iter().skip(i + 1) {
+            net.link(a, b);
+        }
+    }
+
+    let msg_id = net.send("n0", "n7", "in the crowd");
+
+    net.run_until_quiet(24);
+
+    assert_eq!(net.inbox("n7"), vec!["in the crowd".to_string()]);
+
+    // Eight devices with a link between every pair is 28 links. Uncontrolled
+    // forwarding would cross most of them repeatedly; the bound here is well
+    // under a single pass over the topology.
+    let crossings = net.transmission_count(&msg_id);
+    assert!(
+        crossings <= 20,
+        "one message crossed links {crossings} times in a room of {} devices",
+        ids.len()
+    );
+}
+
+#[test]
+fn a_message_survives_the_carrier_walking_away() {
+    // Handing a message to a neighbor is not delivery. If that neighbor leaves
+    // before passing it on, the sender's own retry has to be what recovers it —
+    // which is why forwarding never settles the outbox.
+    let mut net = Neighborhood::new(&["alice", "bob", "carol"]);
+    net.link("alice", "bob");
+    net.link("bob", "carol");
+
+    net.send("alice", "carol", "still gets there");
+
+    // One round: alice hands it to bob, and bob has not passed it on yet.
+    net.step();
+    // Bob walks out of range of everyone, taking the message with him.
+    net.unlink_all("bob");
+    net.run_until_quiet(8);
+
+    assert!(
+        net.inbox("carol").is_empty(),
+        "with the only carrier gone, nothing should have arrived"
+    );
+
+    // Alice is now in range of carol directly, and her retry delivers.
+    net.link("alice", "carol");
+    net.node("alice").process().unwrap();
+    net.run_until_quiet(12);
+
+    assert_eq!(
+        net.inbox("carol"),
+        vec!["still gets there".to_string()],
+        "the sender's own retry must still be able to deliver"
+    );
+}
+
+#[test]
+fn a_device_that_opts_out_carries_nothing() {
+    // Carrying other people's traffic costs battery, and a device is allowed to
+    // decline. It must still be able to send and receive its own.
+    let mut config = ProtocolConfig::new("mesh-test", "bob");
+    config.encryption.require_encryption = false;
+    config.relay.allow_relay = false;
+
+    let mut net = Neighborhood::new(&["alice", "carol"]);
+
+    let radio = MockTransport::new(TransportType::BLE);
+    radio.start().unwrap();
+    radio.set_reject_unknown_recipients(true);
+    let handle = radio.clone();
+    let mut bob = OfflineProtocol::new(config).unwrap();
+    bob.transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(radio));
+    bob.start().unwrap();
+    net.nodes.insert("bob".to_string(), bob);
+    net.radios.insert("bob".to_string(), handle);
+    net.links.insert("bob".to_string(), Vec::new());
+    net.inboxes.insert("bob".to_string(), Vec::new());
+
+    net.link("alice", "bob");
+    net.link("bob", "carol");
+
+    let msg_id = net.send("alice", "carol", "please pass this on");
+
+    net.run_until_quiet(10);
+
+    assert!(
+        net.inbox("carol").is_empty(),
+        "a device that declined to carry traffic must not have carried it"
+    );
+    assert_eq!(
+        net.transmissions
+            .iter()
+            .filter(|(from, _, id)| from == "bob" && id == &msg_id)
+            .count(),
+        0,
+        "and must not have transmitted it at all"
+    );
+}
+
+#[test]
+fn a_frame_claiming_an_absurd_reach_is_cut_down() {
+    // Nothing authenticates how far a frame says it may travel, so a device
+    // must not take that claim at face value. The claim can only come off the
+    // wire, so it is injected at b as though a had sent it.
+    let mut net = Neighborhood::new(&["a", "b", "c"]);
+    net.link("a", "b");
+    net.link("b", "c");
+
+    let mut msg = message("a", "c", "travel forever");
+    msg.ttl = offline_protocol_core::TTL::new(255).unwrap();
+    net.radios["b"].queue_message_from(msg, "a".to_string());
+
+    net.step();
+
+    // What b handed onward carries a budget b vouches for, not the one that
+    // arrived.
+    let onward = net.radios["c"]
+        .receive()
+        .unwrap()
+        .expect("b should have carried it to c");
+    assert!(
+        onward.ttl.value() <= 8,
+        "a frame claiming 255 hops was passed on with {}",
+        onward.ttl.value()
+    );
+}

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -530,7 +530,7 @@ Carrying traffic is subject to the same relay policy as everything else (`allowR
 
 Step 1 is what keeps a message from multiplying, and it has a price worth knowing. Once a device takes a frame on, it ignores that id for the next ten minutes — including the sender's own retransmissions of it. So if the device that accepted a frame then fails to pass it on (it walks out of range, its battery drops below the floor, its queue is full of newer traffic), that particular route is closed for the rest of the window, and the message has to arrive some other way: through a device that never accepted it, or over the internet relay once one of the two comes back online.
 
-This is the trade every controlled flood makes — the alternative is a device re-forwarding the same message each time a copy reaches it, which is exactly the storm the step exists to prevent. Two things keep the cost bounded in practice: a frame is handed to several neighbors at once, so a single carrier walking away rarely closes every route; and a device only records an id once it has genuinely *accepted* the frame, so one turned away for rate, hop budget or queue space leaves the way open for the next copy.
+This is the trade every controlled flood makes — the alternative is a device re-forwarding the same message each time a copy reaches it, which is exactly the storm the step exists to prevent. Three things keep the cost bounded in practice: a frame is handed to several neighbors at once, so a single carrier walking away rarely closes every route; a device only records an id once it has genuinely *accepted* the frame, so one turned away for rate, hop budget or queue space leaves the way open for the next copy; and a frame that was accepted but then dropped **without ever being transmitted** — displaced by more urgent traffic, abandoned after waiting too long, or refused room on its way back to the queue — releases its id again, because nothing went on the air that a later copy could duplicate.
 
 What this means for an app: a message is not lost when this happens, but it can be slow. Treat delivery as settled by the acknowledgement, never by elapsed time.
 
@@ -541,9 +541,17 @@ What this means for an app: a message is not lost when this happens, but it can 
 - `forwarded` — messages moved on someone else's behalf, counted once each. This is the contribution figure to show a user.
 - `transmissions` — times a frame was put on a link, counting each link separately and including the device handing over its own messages. This is what the per-second budget bounds, so it is the one to compare against the ceiling.
 
-`rateDeferred` rising means forwarding is hitting that ceiling — those frames are delayed, not dropped. `peerRateLimited` means a single neighbor is sending more than its share. `droppedForCapacity` should stay at zero; anything else means the device is seeing more traffic than it can remember having handled.
+`rate_deferred` rising means forwarding is hitting that ceiling — those frames are delayed, not dropped. `peer_rate_limited` means a single neighbor is sending more than its share. `dropped_for_capacity` should stay at zero; anything else means the device is seeing more traffic than it can remember having handled.
 
-Tunables live in `ProtocolConfig::mesh_relay`.
+The device's own sends draw on the same per-second budget — it is one radio — but keep a small reserve that forwarding never touches, so a device carrying a busy neighborhood can still get its own messages and acknowledgements out.
+
+Tunables live in `ProtocolConfig::mesh_relay`. Both the tunables and these counters are **Rust-core surfaces today**: neither is mirrored over UniFFI or React Native yet, so apps get the defaults and cannot read the counters from JS or native.
+
+#### What forwarding does not cover
+
+A device offers frames to its neighbors only when it holds no other way to reach the recipient. If any carrier that does its own routing is up — Internet, Nostr, Reticulum — that counts as reachable for **every** recipient, and nothing is handed to the mesh.
+
+That is right for the case this is built for, where nobody has infrastructure, but it leaves a gap in a mixed neighborhood: a device with internet will send to the relay rather than across the mesh, even when the recipient is reachable only by a multi-hop mesh path. It applies to acknowledgements too, so an online recipient answers a mesh-delivered message over the relay, where an offline sender cannot see it. Closing this means letting the relay's own "recipient unreachable" verdict fall back to the mesh, which is future work.
 
 ### Path Scoring
 

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -524,9 +524,26 @@ Every frame passing through runs the same sequence before it goes anywhere, and 
 5. **Sent to a few, never backwards** — the frame goes to a bounded number of neighbors chosen by signal strength and capacity, never to the device it came from or the one that wrote it. If the recipient is a neighbor, it goes straight there instead.
 6. **Within budget** — a device caps how many frames it forwards per second. The steps above assume frames are what they appear to be; this one holds regardless. Whatever arrives, a device cannot be made to transmit faster than its budget, so the failure mode under overload or attack is added delay rather than a radio that never goes quiet.
 
-Carrying traffic is subject to the same relay policy as everything else (`allowRelay`, battery floors): a device that declines carries nothing, while still sending and receiving its own messages.
+Carrying traffic is subject to the same relay policy as everything else (`allowRelay`, battery floors): a device that declines carries nothing, while still sending and receiving its own messages. Handing over its *own* messages — an acknowledgement above all — is deliberately not gated on that setting, or a device that declined to carry traffic could never answer anything that reached it across the mesh, and its sender would report a failure for a message that was delivered and read.
 
-Tunables live in `ProtocolConfig::mesh_relay`, and `mesh_relay_stats()` reports what a device has been carrying.
+#### What "handled once" costs
+
+Step 1 is what keeps a message from multiplying, and it has a price worth knowing. Once a device takes a frame on, it ignores that id for the next ten minutes — including the sender's own retransmissions of it. So if the device that accepted a frame then fails to pass it on (it walks out of range, its battery drops below the floor, its queue is full of newer traffic), that particular route is closed for the rest of the window, and the message has to arrive some other way: through a device that never accepted it, or over the internet relay once one of the two comes back online.
+
+This is the trade every controlled flood makes — the alternative is a device re-forwarding the same message each time a copy reaches it, which is exactly the storm the step exists to prevent. Two things keep the cost bounded in practice: a frame is handed to several neighbors at once, so a single carrier walking away rarely closes every route; and a device only records an id once it has genuinely *accepted* the frame, so one turned away for rate, hop budget or queue space leaves the way open for the next copy.
+
+What this means for an app: a message is not lost when this happens, but it can be slow. Treat delivery as settled by the acknowledgement, never by elapsed time.
+
+#### Reading the numbers
+
+`mesh_relay_stats()` reports what a device has been carrying. Two counters are easy to confuse:
+
+- `forwarded` — messages moved on someone else's behalf, counted once each. This is the contribution figure to show a user.
+- `transmissions` — times a frame was put on a link, counting each link separately and including the device handing over its own messages. This is what the per-second budget bounds, so it is the one to compare against the ceiling.
+
+`rateDeferred` rising means forwarding is hitting that ceiling — those frames are delayed, not dropped. `peerRateLimited` means a single neighbor is sending more than its share. `droppedForCapacity` should stay at zero; anything else means the device is seeing more traffic than it can remember having handled.
+
+Tunables live in `ProtocolConfig::mesh_relay`.
 
 ### Path Scoring
 

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -184,15 +184,20 @@ Periodically (default: every 15 seconds), the mesh evaluates whether to swap con
 When an application sends a message:
 1. The message is assigned a unique ID, TTL, and timestamp
 2. DORS selects the best transport (BLE, Wi-Fi Direct, or Internet)
-3. The message is sent to all connected peers on that transport
+3. The message is sent to its recipient over that transport; if the recipient
+   is out of range, it is handed to nearby devices to carry
 4. The message is tracked for acknowledgment
 
 ### Receiving Messages
 When a device receives a message:
-1. Check deduplication (skip if already seen)
-2. If the message is addressed to this device, deliver to the application
-3. Send an acknowledgment back to the sender
-4. Increment hop count (for tracking)
+1. If it is addressed to someone else, consider carrying it onward (see
+   [What a device does with a frame for someone else](#what-a-device-does-with-a-frame-for-someone-else))
+   and stop — a message passing through is not part of this device's own
+   exchange
+2. Check deduplication (skip if already seen)
+3. Deliver to the application
+4. Send an acknowledgment back to the sender, which travels through the mesh if
+   the sender is not directly reachable
 
 ### Message Metadata
 Each message includes:
@@ -506,15 +511,22 @@ This provides:
 
 ## Rust Core: Path Selection and Routing
 
-The Rust `offline-protocol-router` crate implements path selection using gossip-based probabilistic forwarding to prevent broadcast storms in large networks. The system also includes a gradient routing table for directed message delivery when routes are known.
+A message addressed to a device that is out of range is carried by the devices in between. Each one that receives it hands it onward to a bounded set of its own neighbors, until it reaches its recipient or runs out of hops. The recipient's acknowledgement travels back the same way.
 
-### Path Selection Overview
+### What a device does with a frame for someone else
 
-The router uses a multi-factor scoring system to select the best neighbors for message forwarding:
+Every frame passing through runs the same sequence before it goes anywhere, and each step covers something the others cannot:
 
-1. **Gossip-Based Forwarding**: In large networks, messages are forwarded probabilistically to a subset of neighbors to prevent broadcast storms
-2. **Top-K Selection**: Selects the top K neighbors (default: configurable via `forwardToTopK`) based on path scores
-3. **Gradient Routing**: When routes are known, uses directed delivery; otherwise falls back to flooding
+1. **Handled once** — an id a device has already dealt with is ignored. Without this, copies circulate until their hop budget runs out and every device repeats every copy.
+2. **Accepted from this neighbor?** — each link has its own allowance, so one noisy or hostile neighbor cannot consume the device's whole capacity for carrying traffic.
+3. **Hop budget** — the remaining budget a frame claims is cut down to what local policy would have issued, then spent. Nothing authenticates that claim, so it is never taken at face value. In a dense neighborhood the ceiling is lower: with more devices in range, a message covers the same ground in fewer hops.
+4. **Held briefly, and dropped if covered** — a frame waits a short randomized moment before going out, and is dropped if the same frame arrives again while it waits. In a crowded room the first device to transmit covers everyone in earshot and the rest stand down. This is what keeps cost tied to coverage rather than to the number of links, and it adapts as a room fills without any threshold to tune.
+5. **Sent to a few, never backwards** — the frame goes to a bounded number of neighbors chosen by signal strength and capacity, never to the device it came from or the one that wrote it. If the recipient is a neighbor, it goes straight there instead.
+6. **Within budget** — a device caps how many frames it forwards per second. The steps above assume frames are what they appear to be; this one holds regardless. Whatever arrives, a device cannot be made to transmit faster than its budget, so the failure mode under overload or attack is added delay rather than a radio that never goes quiet.
+
+Carrying traffic is subject to the same relay policy as everything else (`allowRelay`, battery floors): a device that declines carries nothing, while still sending and receiving its own messages.
+
+Tunables live in `ProtocolConfig::mesh_relay`, and `mesh_relay_stats()` reports what a device has been carrying.
 
 ### Path Scoring
 
@@ -596,10 +608,21 @@ When sending to a known destination:
 2. Sort by quality score
 3. Return the highest-quality route
 
-### Usage Example (Swift)
+### Do apps need to do any of this?
+
+No. Carrying messages for nearby devices is handled inside the SDK — an app
+sends a message and the SDK works out whether it can be delivered directly,
+handed to a neighbor to carry, or held for retry. There is no app-side
+forwarding to write, and writing one is a mistake: a second forwarder would
+transmit copies the SDK's own accounting knows nothing about, so neither the
+handled-once check nor the per-second budgets would cover it.
+
+The routing-table calls below remain available over UniFFI for native code that
+wants its own view of reachability. They are read-and-record only; nothing an
+app does with them changes what the SDK forwards.
 
 ```swift
-// On message receive - learn route to sender through delivering neighbor:
+// Record what a neighbor can reach, from a message it delivered:
 protocol.learnRoute(
     destination: message.sender,
     nextHop: neighborId,
@@ -608,14 +631,8 @@ protocol.learnRoute(
     sequenceNumber: message.sequenceNumber ?? 0
 )
 
-// On send - use directed delivery if route known:
-if let route = protocol.getBestRoute(destination: recipient) {
-    // Forward via learned route
-    sendToNeighbor(route.nextHop, message: data)
-} else {
-    // Fall back to flooding
-    broadcastToAllNeighbors(message: data)
-}
+// Look up what is known about reaching someone:
+let route = protocol.getBestRoute(destination: recipient)
 
 // On peer disconnect - cleanup stale routes:
 protocol.removeNeighborRoutes(neighborId: disconnectedPeerId)
@@ -624,10 +641,7 @@ protocol.removeNeighborRoutes(neighborId: disconnectedPeerId)
 protocol.cleanupExpiredRoutes()
 ```
 
-### Usage Example (Kotlin)
-
 ```kotlin
-// On message receive - learn route to sender through delivering neighbor:
 protocol.learnRoute(
     destination = message.sender,
     nextHop = neighborId,
@@ -636,33 +650,19 @@ protocol.learnRoute(
     sequenceNumber = (message.sequenceNumber ?: 0).coerceAtLeast(0).toUInt()
 )
 
-// On send - use directed delivery if route known:
 val route = protocol.getBestRoute(destination = recipient)
-if (route != null) {
-    // Forward via learned route
-    sendToNeighbor(route.nextHop, message = data)
-} else {
-    // Fall back to flooding
-    broadcastToAllNeighbors(message = data)
-}
 
-// On peer disconnect - cleanup stale routes:
 protocol.removeNeighborRoutes(neighborId = disconnectedPeerId)
-
-// Periodic maintenance (e.g., every 30 seconds):
 protocol.cleanupExpiredRoutes()
 ```
-
-### Cleanup Operations
-
-- **removeNeighborRoutes()**: Called on disconnect, removes all routes through that neighbor
-- **cleanupExpiredRoutes()**: Periodic cleanup of stale routes (recommended: every 30 seconds)
 
 ### Gradient Routing Table
 
 The gradient routing table learns routes from incoming messages. When a message arrives from a neighbor, we record that neighbor as a route to the message's original sender. Over time, this builds a map of how to reach known destinations.
 
-**Current Status**: The gradient routing table is available via UniFFI bindings and can be used by native implementations for directed delivery when routes are known. The Rust router supports both gradient routing (when routes exist) and gossip-based flooding (when routes are unknown).
+Routes are learned from the link a frame arrived on, which is the neighbor that can be addressed to reach back toward its sender — not the sender itself, who may be several devices away.
+
+**Current status**: forwarding decisions are made from live neighbor state rather than from this table, and that is deliberate. In the environments this is built for — a crowd, a venue, a march — links appear and vanish in seconds, so a remembered route is usually stale by the time it would be used, while a fresh choice among current neighbors never is. The table is also exposed over UniFFI for native code that wants it.
 
 ### Monitoring
 


### PR DESCRIPTION
Messages can now travel between devices that cannot hear each other. A message addressed to someone out of radio range is handed to nearby devices and carried onward until it arrives or runs out of hops, and the recipient's acknowledgement comes back the same way — so a message that crossed several devices is not mistaken for a lost one.

This is the case the SDK is built for: a crowded room, a venue, a march, an internet shutdown. Until now delivery worked when the recipient was within radio range or reachable over the internet relay, and messages to anyone else were queued for retry.

## What was missing

Three seams, none of them in the routing code:

- **The arriving link was discarded.** `Message::transport_peer_id` existed, but the BLE and Wi-Fi Direct bridges dropped the peer id before it reached the protocol layer, so a device could not tell who handed it a frame from who wrote it. Without that distinction there is no split horizon and no correct route learning.
- **Acknowledgements could not travel back.** `handle_ack_message` ran on any frame carrying an ACK key regardless of who it was addressed to, so a third party's acknowledgement was consumed rather than passed on. Multi-hop delivery would have looked like failure to every sender.
- **Wi-Fi Direct had no addressable peer set.** Its peer map is keyed by hardware address and is never populated in production — the bridge only ever reported peers by user id through a different callback.

`offline-protocol-router`'s gossip and gradient-routing code is not used for forwarding decisions. It was never wired to begin with (`git log -S` shows each symbol in a single commit across all history), and live neighbor state is the better input here: in these environments links appear and vanish in seconds, so a remembered route is usually stale by the time it would be used. The routing table is still learned and still exposed over UniFFI.

## Keeping a crowded room usable

Every frame passing through a device runs the same sequence, and each step covers something the others cannot:

1. **Handled once** — an id a device has already taken on is ignored. Recording happens only when a frame is *accepted*, so a frame turned away for rate or hop reasons does not suppress the copy arriving over a healthy link a moment later.
2. **Accepted from this neighbor?** — each link has its own allowance, so one noisy or hostile neighbor cannot consume a device's whole capacity.
3. **Hop budget** — the reach a frame claims is cut to local policy before being spent. Nothing authenticates that claim. The ceiling drops in a dense neighborhood, where a message covers the same ground in fewer hops.
4. **Held briefly, dropped if covered** — a frame waits a short randomized moment and is dropped if the same frame arrives meanwhile. In a crowded room the first device to transmit covers everyone in earshot and the rest stand down. This ties cost to coverage rather than to link count, and adapts as a room fills with no threshold to tune. It does *not* apply at the last hop, where no other device can be assumed to hold the link to the recipient.
5. **Sent to a few, never backwards** — up to three neighbors, chosen by link quality, never the device it came from or the one that wrote it.
6. **Within budget** — a hard per-second ceiling, overall and per neighbor, charged per link a frame crosses. The steps above assume frames are what they appear to be; this one holds regardless. No arrival pattern can make a device transmit faster than its budget, so the failure mode under overload or attack is added delay rather than a radio that never goes quiet.

Carrying traffic also respects the existing relay policy and battery floors. A device that declines carries nothing while still sending and receiving its own messages — including acknowledgements, which is why handing our own frames to neighbors is deliberately not gated on that setting.

## Verification

`crates/offline-protocol/tests/mesh_forwarding.rs` builds several protocol instances, wires them by topology, and moves frames between them the way a radio would. It asserts both halves — that a message reaches someone no single device can see, and that it does so without the network transmitting more than the topology needs:

- a line of five devices, a ring that settles instead of circulating, a diamond where two paths deliver exactly once
- a seven-device cluster where every device hears every other and the recipient sits outside it: one message costs fewer transmissions than the cluster has links
- the device holding the only link to the recipient does not stand down for a neighbor
- a carrier walking away mid-transfer, with the sender's own retry still delivering
- a device that declines to carry traffic, and a frame claiming an implausible reach

Full workspace suite green (`cargo test --workspace`), clippy clean.

## Review notes

An adversarial review pass after the first green run found five defects, all fixed in `242c901` and each now pinned by a regression test. Two are worth calling out because they were reachable in normal operation:

- An id was recorded as handled *before* the admission checks. A frame refused for rate, queue space or hop budget left its id suppressed for the full retention window, so a copy arriving over a healthy link was discarded. Reachable with a single frame whose hop budget was rewritten to nothing.
- Standing down for a neighbor is sound in the middle of a network and wrong at the last hop, where dropping the copy lost the delivery outright and the suppressed id blocked the sender's retries too.

Also corrected there: transmission budget is charged per link crossed rather than per frame released from the queue (real spend had been up to three times the stated ceiling), handing our own messages to neighbors is metered against the same ceiling instead of bypassing it, and the battery floors and link-quality selection that the docs already described are now actually applied.

One change was tried and **reverted**: suppressing duplicate acknowledgements. The window would have to sit below the 10-second acknowledgement timeout to avoid silencing a sender's retransmissions, and the re-ACK path is load-bearing for delivery in three documented places. The redundant answers are bounded and already rate-capped, so the saving was not worth the risk.

## Not in this change

- Neither the forwarding tunables (`ProtocolConfig::mesh_relay`) nor the counters (`mesh_relay_stats()`) are mirrored over the FFI/RN surface yet — defaults apply, which are sensible, but apps can neither tune forwarding nor observe what their device is carrying. Tracked in #325.
- A device only offers frames to its neighbors when it holds no other way to reach the recipient, so anything with a routing carrier up (Internet, Nostr, Reticulum) sends to the relay even when the recipient is reachable only across the mesh. Acknowledgements included, which is the half that bites: an online recipient answers over a relay an offline sender cannot see. Right for the shutdown case this is built for, a real gap in a mixed neighborhood — documented in `docs/mesh.md` and tracked in #326.
- Group messages travel as one addressed frame per member rather than a single mesh broadcast. Each frame gets the full carrying path, so group messaging works across hops; a genuine mesh broadcast would cost less.
- The simulation runs with the pre-transmit hold set to zero and steps in lock-step, which disables the cancel-on-duplicate behaviour entirely. Its transmission counts are therefore worst-case, and only a real multi-device test will show what the density control buys in a room.



## Review round two

An independent review pass after the first found six more items, all fixed here and each pinned by a test (six mutations run across the two behavioural fixes and the battery gate; every one kills its test).

Two were reachable in normal operation:

- **An id could be blackholed for ten minutes by a frame nobody ever heard.** Admission is careful never to record a frame it refuses, but three *later* drops — displaced by an urgent frame, abandoned for waiting too long, refused room on the way back — dropped the frame with its id still recorded. None had gone on the air, so the device closed a route through itself for the full retention window, against the sender's own retransmissions too. Ids are now released at exactly those three sites, and nowhere else.
- **A busy carrier could starve its own acknowledgements.** Own traffic and forwarded traffic share one budget, correctly, but with no precedence — so a device forwarding at its ceiling could fail to get its own answer out, and its sender would report a delivered message as failed. Own traffic now spends from a small reserve carved out of the burst that forwarding never touches. The ceiling is unchanged and forwarding loses no throughput.

Also in this round: the critical battery floor is now one constant shared with the relay role instead of three copies held together by a comment; the battery gate has tests for all four of its branches (it had none); `can_reach_without_carrying` is now tested for staying quiet as well as for firing; delivered ids are no longer written into the forwarding suppression cache, where they could only pollute a capacity signal documented to stay at zero; and `docs/mesh.md` no longer documents camelCase counter names for a JS surface that does not exist.
