### PR TITLE
feat(transport)!: bind Nostr addressing to the derived address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   packages are checked by re-deriving the address from the leaf signature key,
   which — unlike the pin it replaces — also runs on first contact and on every
   read of a cached package.
+- **BREAKING**: the Nostr routing tag is derived from the address rather than
+  the app-chosen id, and the Nostr transport now **requires** the protocol
+  identity. It is installed by the identity rebuild rather than by the
+  constructor, so `enableTransport('nostr')` before `initializeMls` — including
+  any config with `encryption.enabled: false` — is refused instead of falling
+  back. See Security below for why the fallback had to go rather than be fixed.
+- **BREAKING**: the publicly-computable key that seals published key-package
+  records and bootstrap frames is no longer the routing tag. Both are still
+  derived from the address, but through separate domain-separated derivations,
+  so no routing tag has a private half anyone can compute. The old shape was
+  not exploitable — nothing signs with a tag, and inbound is never authenticated
+  by pubkey — but it is a trap for anything that later adds NIP-42 AUTH or
+  pubkey-based filtering. `derivable_for_device_id` is replaced by
+  `record_seal_keypair_for_address`, and `routing_tag_for_device_id` by
+  `routing_tag_for_address`.
+- **BREAKING (behaviour): cold contact by username is gone**, because a
+  username no longer resolves to anything. Cold contact by *address* works
+  exactly as before — a peer reachable from an invite or QR code still resolves
+  over published key packages with no prior exchange. Published records stay
+  sealed, though for a narrower reason than the one documented: the
+  username-directory leak they were built to prevent expired when credentials
+  became addresses, and what remains is that a cleartext record would publish
+  its own address at a tag that is otherwise one-way.
+
+### Security
+
+- **A username-derived routing tag could reach public relays, and did.** The
+  tag is `SHA-256(id)` and both bridges send the subscription filter carrying
+  it to every relay the moment a socket opens, unconditionally. Since the
+  identity rebuild the id is the derived address — but the rebuild is
+  skippable: `encryption.enabled: false` skips `initializeMls` outright, and a
+  thrown one is caught and warned past by the React Native layer, after which a
+  retry is refused for the life of the instance. Either way the transport built
+  from the app's **profile** was still installed when the relays connected, so
+  a label anyone could recompute from a username was published to third-party
+  archival relays with nothing to retract it and no error anywhere. The bundled
+  `nostr-example` app shipped exactly that configuration against three public
+  relays. Nostr now refuses to run without an identity, and the transport
+  refuses an id that is not a derived address rather than hashing it into a
+  tag.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   constructor, so `enableTransport('nostr')` before `initializeMls` — including
   any config with `encryption.enabled: false` — is refused instead of falling
   back. See Security below for why the fallback had to go rather than be fixed.
+- **BREAKING**: a Nostr send whose *recipient* is not a derived address is
+  refused rather than published. The recipient is the sole preimage of the `#p`
+  tag the frame is addressed under, so a username-shaped one carries the same
+  disclosure the local id was refused for, and any non-address one addresses the
+  frame where no peer subscribes. Refused at `send`, so the caller can route
+  over another transport; the same rule gates the key-package resolution queue.
 - **BREAKING**: the publicly-computable key that seals published key-package
   records and bootstrap frames is no longer the routing tag. Both are still
   derived from the address, but through separate domain-separated derivations,

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
@@ -25,10 +25,18 @@ import java.util.concurrent.atomic.AtomicLong
  * Connects to Nostr relays via WebSocket and uses NIP-04 (kind 4) direct messages
  * for protocol message routing.
  */
+/**
+ * The profile is deliberately not a constructor parameter.
+ *
+ * This manager is built at configure time, before the protocol has an
+ * identity, so any id passed in could only be the app-chosen profile — and
+ * the one thing this transport must never carry is a value a username can be
+ * recomputed from. The address is read from the protocol at [start], which is
+ * the first moment it is both known and needed.
+ */
 class NostrManager(
     private val context: android.content.Context,
     private val protocol: OfflineProtocol,
-    private val deviceId: String,
     private val diagnosticEmitter: ((String, String, Map<String, Any?>) -> Unit)? = null
 ) : TransportManager {
 
@@ -197,9 +205,25 @@ class NostrManager(
             throw TransportException.NotAvailable("No relay URLs configured. Call configure(relayUrls:) first.")
         }
 
-        Log.i(TAG, "Starting Nostr transport for device: $deviceId")
+        // Refused without an identity, and refused *here* rather than at the
+        // one call site that enables the transport: start() is the single
+        // point that opens a socket, and the first thing a socket does is
+        // publish this device's routing tag to a third-party relay.
+        //
+        // That tag is derived from the address. With no identity there is no
+        // address — the core installs no Nostr transport at all — so starting
+        // anyway would open relay connections that can never subscribe, which
+        // is indistinguishable from "nobody is talking to us".
+        val address = protocol.localAddress()
+        if (address.isNullOrEmpty()) {
+            throw TransportException.NotAvailable(
+                "Nostr requires the protocol identity. Initialize MLS (or leave encryption enabled) before enabling Nostr."
+            )
+        }
+
+        Log.i(TAG, "Starting Nostr transport for address: $address")
         emitDiagnostic("info", "Starting Nostr transport", mapOf(
-            "deviceId" to deviceId,
+            "address" to address,
             "relayCount" to relayUrls.size,
             "publicKey" to publicKeyHex
         ))

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
@@ -221,6 +221,23 @@ class NostrManager(
             )
         }
 
+        // An identity is necessary but not sufficient. The core registers the
+        // Nostr transport during the identity rebuild and only when Nostr was
+        // enabled in the config create() received, so enableTransport("nostr")
+        // against a config that had it off arrives here with an address and no
+        // transport behind it.
+        //
+        // Probed with the subscription filter because that is the exact call the
+        // socket-open callback makes, and a null answer *there* is not a safe
+        // failure: it is logged and returned from with no retry, so the socket
+        // stays connected to a relay it never subscribes on for the rest of its
+        // life. Refusing before any socket exists is the recoverable shape.
+        if (protocol.nostrGetSubscriptionFilter("startup-probe") == null) {
+            throw TransportException.NotAvailable(
+                "No Nostr transport is registered. Enable Nostr in the protocol configuration before starting it."
+            )
+        }
+
         Log.i(TAG, "Starting Nostr transport for address: $address")
         emitDiagnostic("info", "Starting Nostr transport", mapOf(
             "address" to address,

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -560,7 +560,7 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
 
             // Initialize Nostr manager if nostr is enabled
             if (config.nostrEnabled) {
-                nostrManager = createNostrManager(proto, config.profile)
+                nostrManager = createNostrManager(proto)
                 android.util.Log.i(NAME, "Nostr Manager initialized for user: ${config.profile}")
                 emitDiagnostic("info", "Nostr manager initialized", mapOf(
                     "userId" to config.profile
@@ -2026,7 +2026,7 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
                 }
                 "nostr" -> {
                     if (nostrManager == null) {
-                        nostrManager = createNostrManager(proto, currentConfig?.profile ?: "unknown")
+                        nostrManager = createNostrManager(proto)
                         emitDiagnostic("info", "Nostr manager created on demand")
                     }
 
@@ -2164,8 +2164,8 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         ))
     }
 
-    private fun createNostrManager(proto: OfflineProtocol, userId: String): NostrManager {
-        return NostrManager(reactApplicationContext, proto, userId) { level, message, context ->
+    private fun createNostrManager(proto: OfflineProtocol): NostrManager {
+        return NostrManager(reactApplicationContext, proto) { level, message, context ->
             emitDiagnostic(level, message, context)
         }.also { manager ->
             manager.listener = object : TransportManagerListener {

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -201,6 +201,23 @@ public class NostrManager: NSObject, TransportManager {
             )
         }
 
+        // An identity is necessary but not sufficient. The core registers the
+        // Nostr transport during the identity rebuild and only when Nostr was
+        // enabled in the config `create()` received, so `enableTransport("nostr")`
+        // against a config that had it off arrives here with an address and no
+        // transport behind it.
+        //
+        // Probed with the subscription filter because that is the exact call the
+        // socket-open callback makes, and a nil answer *there* is not a safe
+        // failure: it is logged and returned from with no retry, so the socket
+        // stays connected to a relay it never subscribes on for the rest of its
+        // life. Refusing before any socket exists is the recoverable shape.
+        guard protocolInstance.nostrGetSubscriptionFilter(subscriptionId: "startup-probe") != nil else {
+            throw TransportError.notAvailable(
+                "No Nostr transport is registered. Enable Nostr in the protocol configuration before starting it."
+            )
+        }
+
         emitDiagnostic("info", "Starting Nostr transport", context: [
             "address": address,
             "relayCount": relayUrls.count,

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -37,7 +37,6 @@ public class NostrManager: NSObject, TransportManager {
     // MARK: - Properties
 
     private let protocolInstance: OfflineProtocol
-    private let deviceId: String
 
     // Relay connections: URL string -> URLSessionWebSocketTask
     private var relayUrls: [String] = []
@@ -119,9 +118,15 @@ public class NostrManager: NSObject, TransportManager {
 
     // MARK: - Initialization
 
-    public init(protocol protocolInstance: OfflineProtocol, deviceId: String) {
+    /// The profile is deliberately not taken here.
+    ///
+    /// This manager is built at configure time, before the protocol has an
+    /// identity, so any id passed in could only be the app-chosen profile —
+    /// and the one thing this transport must never carry is a value a
+    /// username can be recomputed from. The address is read from the protocol
+    /// at `start()`, which is the first moment it is both known and needed.
+    public init(protocol protocolInstance: OfflineProtocol) {
         self.protocolInstance = protocolInstance
-        self.deviceId = deviceId
         super.init()
     }
 
@@ -181,8 +186,23 @@ public class NostrManager: NSObject, TransportManager {
             throw TransportError.notAvailable("No relay URLs configured. Call configure(relayUrls:) first.")
         }
 
+        // Refused without an identity, and refused *here* rather than at the
+        // one call site that enables the transport: `start()` is the single
+        // point that opens a socket, and the first thing a socket does is
+        // publish this device's routing tag to a third-party relay.
+        //
+        // That tag is derived from the address. With no identity there is no
+        // address — the core installs no Nostr transport at all — so starting
+        // anyway would open relay connections that can never subscribe, which
+        // is indistinguishable from "nobody is talking to us".
+        guard let address = protocolInstance.localAddress(), !address.isEmpty else {
+            throw TransportError.notAvailable(
+                "Nostr requires the protocol identity. Initialize MLS (or leave encryption enabled) before enabling Nostr."
+            )
+        }
+
         emitDiagnostic("info", "Starting Nostr transport", context: [
-            "deviceId": deviceId,
+            "address": address,
             "relayCount": relayUrls.count,
             "publicKey": publicKeyHex
         ])

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -686,7 +686,7 @@ class OfflineProtocolModule: RCTEventEmitter {
 
             // Initialize Nostr manager if nostr is enabled
             if config.nostrEnabled {
-                let nostrMgr = NostrManager(protocol: proto, deviceId: config.profile)
+                let nostrMgr = NostrManager(protocol: proto)
                 nostrMgr.delegate = self
                 nostrManager = nostrMgr
 
@@ -1858,7 +1858,7 @@ class OfflineProtocolModule: RCTEventEmitter {
 
             case "nostr":
                 if nostrManager == nil {
-                    let newManager = NostrManager(protocol: proto, deviceId: currentConfig?.profile ?? "unknown")
+                    let newManager = NostrManager(protocol: proto)
                     newManager.delegate = self
                     nostrManager = newManager
                     proto.setNostrTransportCallback(callback: NostrTransportCallbackImpl(nostrManager: newManager))

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -1005,10 +1005,25 @@ export class OfflineProtocol {
         await this.enableTransport("nostr", nostrConfig);
         console.log("[OfflineProtocol] Nostr transport auto-enabled");
       } catch (error) {
-        console.warn(
-          "[OfflineProtocol] Failed to auto-enable nostr transport:",
+        // error, not warn: Nostr was asked for, is not running, and nothing
+        // retries this — the app is offline over Nostr for the whole session
+        // with no other signal that it happened.
+        console.error(
+          "[OfflineProtocol] Nostr transport is configured but was NOT enabled:",
           error
         );
+        if (!encryptionEnabled) {
+          // Almost certainly the cause, and the rejection cannot say so: it
+          // reports the missing identity, not the config line that removed it.
+          // Nostr's routing tag is derived from the identity MLS
+          // initialization creates, and `encryption.enabled: false` skips that
+          // initialization entirely.
+          console.error(
+            "[OfflineProtocol] Nostr requires the protocol identity created by MLS " +
+              "initialization, which `encryption.enabled: false` skips. Set " +
+              "`encryption.enabled: true` to use Nostr."
+          );
+        }
       }
     }
 

--- a/crates/offline-protocol-transport/src/lib.rs
+++ b/crates/offline-protocol-transport/src/lib.rs
@@ -60,7 +60,7 @@ pub use constants::DEFAULT_MAX_MESSAGE_SIZE;
 pub use error::{Error, Result};
 pub use internet::{InternetConfig, InternetTransport};
 pub use nostr::{NostrConfig, NostrTransport, NostrTransportBuilder, SignedNostrEvent};
-pub use nostr_crypto::{routing_tag_for_device_id, NostrEvent, NostrKeypair};
+pub use nostr_crypto::{routing_tag_for_address, NostrEvent, NostrKeypair};
 pub use reticulum::{ReticulumConfig, ReticulumTransport};
 pub use traits::{Transport, TransportStatus};
 pub use types::{

--- a/crates/offline-protocol-transport/src/nostr.rs
+++ b/crates/offline-protocol-transport/src/nostr.rs
@@ -14,7 +14,7 @@
 //! [`NostrTransport::report_send_failure`], and injects inbound event
 //! payloads via [`NostrTransport::on_data_received`].
 //!
-//! Addressing uses public routing tags derived from device IDs
+//! Addressing uses public routing tags derived from this device's address
 //! ([`nostr_crypto::routing_tag_for_address`]); event signing uses a
 //! per-install secret key that starts out ephemeral and is upgraded to a
 //! persisted identity via [`NostrTransport::install_signing_secret`].
@@ -607,7 +607,12 @@ impl NostrTransport {
     /// through building an event, to tell it something it is about to look for
     /// anyway.
     fn enqueue_resolution(&self, user_id: &str) -> bool {
-        if !self.cold_contact_enabled() || user_id.is_empty() {
+        // A queued id becomes the `#p` tag of a relay query, so it is held to
+        // the same address requirement as a send recipient — and held here,
+        // at the queue's only gate, so `next_query` can never pop an id whose
+        // tag derivation fails after the entry was already consumed. Subsumes
+        // the emptiness check this replaces: an empty id is not an address.
+        if !self.cold_contact_enabled() || user_id.parse::<Address>().is_err() {
             return false;
         }
 
@@ -1382,6 +1387,30 @@ impl Transport for NostrTransport {
             )));
         }
 
+        // The recipient is the sole preimage of the `#p` tag this frame is
+        // published under, so it is refused here rather than hashed — the same
+        // rule `with_config` applies to our own id, and for the same two silent
+        // failures: a username-shaped id puts a label anyone can recompute from
+        // the name onto third-party relays, and any non-address id addresses
+        // the frame where nobody subscribes.
+        //
+        // Refused at `send` rather than in `build_event` because a build
+        // failure is retriable by the drain: a permanently undeliverable
+        // recipient would burn the whole `MAX_SIGN_RETRIES` ladder, republishing
+        // that label each time, before failing. Here it costs one error to the
+        // caller, which routes to another transport or fails the message.
+        //
+        // The value stays out of the error for the reason `with_config` keeps
+        // it out: the id this rejects is, in the case worth catching, a
+        // username.
+        if message.recipient.as_str().parse::<Address>().is_err() {
+            return Err(crate::Error::PeerNotReachable(
+                "Nostr addresses peers by their derived address, and the \
+                 recipient id is not one"
+                    .to_string(),
+            ));
+        }
+
         let queue_len = {
             let mut queue = self.send_queue.lock_or_recover();
             queue.push_back(message.clone());
@@ -1693,6 +1722,74 @@ mod tests {
         assert!(
             NostrTransport::new(addr("alice")).is_ok(),
             "a derived address is exactly what construction accepts"
+        );
+    }
+
+    /// A recipient that is not an address is refused at `send`, not hashed
+    /// into a public routing tag.
+    ///
+    /// The constructor already refuses a non-address for *our* id; this is the
+    /// same rule on the other side of the frame, and it has the same two silent
+    /// failure modes. It is asserted at `send` specifically because that is the
+    /// only queue writer: past it, the drain would treat the failure as
+    /// retriable and republish the label `MAX_SIGN_RETRIES` times.
+    #[test]
+    fn test_send_refuses_a_recipient_that_is_not_an_address() {
+        let transport = NostrTransport::new(addr("alice")).unwrap();
+        transport.start().unwrap();
+        transport.on_status_changed(TransportStatus::Available);
+
+        let msg = Message::new(
+            UserId::new(addr("alice")).unwrap(),
+            UserId::new("bob").unwrap(),
+            AppId::new("test").unwrap(),
+            "for a username",
+        );
+
+        assert!(
+            transport.send(&msg).is_err(),
+            "a username-shaped recipient must not reach the send queue"
+        );
+        assert!(
+            !transport.has_pending_sends(),
+            "the refused message must not be queued"
+        );
+        assert!(
+            transport.get_next_signed_event().unwrap().is_none(),
+            "nothing may be published for a refused recipient"
+        );
+
+        // The address form of the same peer is what does go out.
+        let ok = Message::new(
+            UserId::new(addr("alice")).unwrap(),
+            UserId::new(addr("bob")).unwrap(),
+            AppId::new("test").unwrap(),
+            "for an address",
+        );
+        assert!(transport.send(&ok).is_ok());
+    }
+
+    /// The resolution queue applies the same rule at its only gate, so
+    /// `next_query` cannot pop an id whose tag derivation would fail after the
+    /// entry was already consumed.
+    #[test]
+    fn test_resolution_refuses_a_peer_id_that_is_not_an_address() {
+        let transport = NostrTransport::new(addr("alice")).unwrap();
+
+        for bad in ["bob", "", "off1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"] {
+            assert!(
+                !transport.request_peer_key_packages(bad),
+                "a non-address peer id must not be queued for resolution: {bad:?}"
+            );
+        }
+        assert!(
+            transport.next_query().unwrap().is_none(),
+            "no query may be issued for a refused peer id"
+        );
+
+        assert!(
+            transport.request_peer_key_packages(&addr("bob")),
+            "an address is exactly what the resolution queue accepts"
         );
     }
 
@@ -3179,7 +3276,7 @@ mod tests {
         let transport = NostrTransport::new(addr("alice")).unwrap();
 
         for i in 0..MAX_PENDING_RESOLUTIONS {
-            assert!(transport.request_peer_key_packages(&format!("peer-{}", i)));
+            assert!(transport.request_peer_key_packages(&addr(&format!("peer-{}", i))));
         }
 
         assert!(

--- a/crates/offline-protocol-transport/src/nostr.rs
+++ b/crates/offline-protocol-transport/src/nostr.rs
@@ -15,7 +15,7 @@
 //! payloads via [`NostrTransport::on_data_received`].
 //!
 //! Addressing uses public routing tags derived from device IDs
-//! ([`nostr_crypto::routing_tag_for_device_id`]); event signing uses a
+//! ([`nostr_crypto::routing_tag_for_address`]); event signing uses a
 //! per-install secret key that starts out ephemeral and is upgraded to a
 //! persisted identity via [`NostrTransport::install_signing_secret`].
 
@@ -237,12 +237,16 @@ pub struct NostrTransport {
     /// protocol-state record and re-installs it on launch. Without that this is
     /// a per-process value and every cold start replays a full backfill window.
     receive_watermark: Mutex<Option<i64>>,
-    /// The publicly computable keypair whose public half is `routing_tag`.
+    /// The publicly computable keypair for our own address.
     ///
-    /// Held only to unseal (and seal) bootstrap-leg frames — see
-    /// [`NostrKeypair::derivable_for_device_id`], which documents why this is
-    /// not a secret and must never authenticate anything.
-    derivable_keypair: NostrKeypair,
+    /// Held to unseal bootstrap-leg frames and to seal our published records —
+    /// see [`nostr_crypto::record_seal_keypair_for_address`], which documents
+    /// why this is not a secret and must never authenticate anything.
+    ///
+    /// Its public half used to *be* `routing_tag`. It is now a separate,
+    /// domain-separated derivation, so the two are unequal and neither can be
+    /// mistaken for the other.
+    record_seal_keypair: NostrKeypair,
     /// Peer user ID → that peer's real per-install Nostr public key, learned
     /// from the `nostr_pubkey` field of their signed key package. Populated by
     /// the engine via [`Self::set_peer_nostr_pubkey`]; a peer absent here takes
@@ -344,15 +348,15 @@ impl NostrTransport {
                 "Nostr transport requires this device's derived address: {e}"
             ))
         })?;
-        let routing_tag = nostr_crypto::routing_tag_for_device_id(&device_id)?;
-        let derivable_keypair = NostrKeypair::derivable_for_device_id(&device_id)?;
+        let routing_tag = nostr_crypto::routing_tag_for_address(&device_id)?;
+        let record_seal_keypair = nostr_crypto::record_seal_keypair_for_address(&device_id)?;
         let keypair = RwLock::new(NostrKeypair::generate_ephemeral()?);
         Ok(Self {
             device_id,
             keypair,
             routing_tag,
             receive_watermark: Mutex::new(None),
-            derivable_keypair,
+            record_seal_keypair,
             peer_nostr_pubkeys: RwLock::new(HashMap::new()),
             sealing_enabled: Mutex::new(true),
             cold_contact_enabled: Mutex::new(true),
@@ -654,7 +658,7 @@ impl NostrTransport {
             }
         };
 
-        let routing_tag = nostr_crypto::routing_tag_for_device_id(&user_id)?;
+        let routing_tag = nostr_crypto::routing_tag_for_address(&user_id)?;
         let query_id = new_query_id();
         let req_json = nostr_crypto::create_key_package_query_message(&routing_tag, &query_id)?;
 
@@ -812,7 +816,7 @@ impl NostrTransport {
         // the whole reason a record sealed to it stays fetchable by anyone
         // entitled to fetch it, while remaining opaque to a relay scraping by
         // kind alone.
-        let peer_key = NostrKeypair::derivable_for_device_id(&user_id)?;
+        let peer_key = nostr_crypto::record_seal_keypair_for_address(&user_id)?;
         match nostr_crypto::open_key_package_publication(&peer_key, author, &sealed) {
             Ok(plaintext) => Ok(Some((author.to_string(), plaintext))),
             Err(e) => {
@@ -940,7 +944,7 @@ impl NostrTransport {
             }
         }
 
-        match nostr_crypto::unwrap_gift_wrap(&self.derivable_keypair, sender_pubkey_hex, data) {
+        match nostr_crypto::unwrap_gift_wrap(&self.record_seal_keypair, sender_pubkey_hex, data) {
             Ok(plaintext) => {
                 tracing::debug!("Unsealed a bootstrap-leg Nostr frame");
                 Cow::Owned(plaintext)
@@ -962,7 +966,7 @@ impl NostrTransport {
     /// key, and timestamp — not just in how `content` is encoded.
     fn build_event(&self, message: &Message) -> Result<nostr_crypto::NostrEvent> {
         let recipient_device_id = message.recipient.as_str();
-        let recipient_tag = nostr_crypto::routing_tag_for_device_id(recipient_device_id)?;
+        let recipient_tag = nostr_crypto::routing_tag_for_address(recipient_device_id)?;
         let data = self.serialize_message(message)?;
 
         if !self.sealing_enabled() {
@@ -993,7 +997,12 @@ impl NostrTransport {
                 // re-resolved on the next send rather than waiting for a fresh
                 // key-package exchange.
                 self.enqueue_resolution(recipient_device_id);
-                recipient_tag.clone()
+                // Their record-seal key, reconstructed from their address —
+                // no longer the routing tag, which since the key split is a
+                // label with no private half anyone holds.
+                nostr_crypto::record_seal_keypair_for_address(recipient_device_id)?
+                    .public_key_hex()
+                    .to_string()
             }
         };
 
@@ -1028,6 +1037,7 @@ impl NostrTransport {
                 nostr_crypto::NostrEvent::create_key_package_publication(
                     &keypair,
                     &self.routing_tag,
+                    self.record_seal_keypair.public_key_hex(),
                     &pending.slot_id,
                     &pending.payload,
                 )?
@@ -2049,7 +2059,7 @@ mod tests {
     #[test]
     fn test_subscription_filters_on_routing_tag_not_signing_key() {
         let transport = NostrTransport::new(addr("device1")).unwrap();
-        let expected_tag = nostr_crypto::routing_tag_for_device_id(&addr("device1")).unwrap();
+        let expected_tag = nostr_crypto::routing_tag_for_address(&addr("device1")).unwrap();
 
         assert_eq!(transport.routing_tag(), expected_tag);
         // The signing key is random per install and must never leak into the
@@ -2079,7 +2089,7 @@ mod tests {
         // Addressing is untouched by the key swap.
         assert_eq!(
             transport_a.routing_tag(),
-            nostr_crypto::routing_tag_for_device_id(&addr("device1")).unwrap()
+            nostr_crypto::routing_tag_for_address(&addr("device1")).unwrap()
         );
     }
 
@@ -2330,7 +2340,7 @@ mod tests {
         transport.send(&msg).unwrap();
 
         let signed = transport.get_next_signed_event().unwrap().unwrap();
-        let bob_tag = nostr_crypto::routing_tag_for_device_id(&addr("bob")).unwrap();
+        let bob_tag = nostr_crypto::routing_tag_for_address(&addr("bob")).unwrap();
         assert!(
             signed.event_json.contains(&bob_tag),
             "event must be addressed to the recipient's routing tag"
@@ -2409,7 +2419,7 @@ mod tests {
         // The only thing a relay legitimately learns is the recipient's routing
         // tag — an opaque label it cannot invert without already knowing the
         // user id it is looking for.
-        let bob_tag = nostr_crypto::routing_tag_for_device_id(&addr("bob")).unwrap();
+        let bob_tag = nostr_crypto::routing_tag_for_address(&addr("bob")).unwrap();
         assert!(wire.contains(&bob_tag));
     }
 
@@ -2533,7 +2543,7 @@ mod tests {
         // ordinary decoder reject it as one undecodable frame — the same
         // outcome as random junk, which is what it is to us.
         let bob = NostrTransport::new(addr("bob")).unwrap();
-        let carol_tag = nostr_crypto::routing_tag_for_device_id(&addr("carol")).unwrap();
+        let carol_tag = nostr_crypto::routing_tag_for_address(&addr("carol")).unwrap();
 
         let event =
             nostr_crypto::NostrEvent::create_gift_wrap(&carol_tag, &carol_tag, b"not for bob")
@@ -2553,7 +2563,7 @@ mod tests {
         // pubkey. A bridge wired to it would otherwise enqueue ciphertext as if
         // it were a message.
         let bob = NostrTransport::new(addr("bob")).unwrap();
-        let bob_tag = nostr_crypto::routing_tag_for_device_id(&addr("bob")).unwrap();
+        let bob_tag = nostr_crypto::routing_tag_for_address(&addr("bob")).unwrap();
         let event =
             nostr_crypto::NostrEvent::create_gift_wrap(&bob_tag, &bob_tag, b"sealed").unwrap();
         let sealed = base64::engine::general_purpose::STANDARD
@@ -2701,7 +2711,7 @@ mod tests {
         assert_eq!(tags[1][1].as_str(), Some(transport.routing_tag()));
 
         // A stranger who knows only the username can open it.
-        let stranger_view = NostrKeypair::derivable_for_device_id(&addr("alice")).unwrap();
+        let stranger_view = nostr_crypto::record_seal_keypair_for_address(&addr("alice")).unwrap();
         let sealed = base64::engine::general_purpose::STANDARD
             .decode(event["content"].as_str().unwrap())
             .unwrap();
@@ -2753,7 +2763,7 @@ mod tests {
         let sealed = base64::engine::general_purpose::STANDARD
             .decode(event["content"].as_str().unwrap())
             .unwrap();
-        let key = NostrKeypair::derivable_for_device_id(&addr("alice")).unwrap();
+        let key = nostr_crypto::record_seal_keypair_for_address(&addr("alice")).unwrap();
         let opened = nostr_crypto::open_key_package_publication(
             &key,
             event["pubkey"].as_str().unwrap(),
@@ -2879,7 +2889,7 @@ mod tests {
         );
 
         let query = transport.next_query().unwrap().expect("resolution queued");
-        let expected_tag = nostr_crypto::routing_tag_for_device_id(&addr("bob")).unwrap();
+        let expected_tag = nostr_crypto::routing_tag_for_address(&addr("bob")).unwrap();
         assert!(query.req_json.contains(&expected_tag));
         assert!(query
             .req_json

--- a/crates/offline-protocol-transport/src/nostr.rs
+++ b/crates/offline-protocol-transport/src/nostr.rs
@@ -25,9 +25,11 @@ use crate::constants::{
     NOSTR_MAX_TRACKED_PEER_KEYS, NOSTR_PENDING_CONFIRMATION_TIMEOUT_SECS,
 };
 use crate::nostr_crypto::{self, now_unix_secs, NostrKeypair};
-use crate::{Result, SharedCallback, Transport, TransportMetrics, TransportStatus, TransportType};
+use crate::{
+    Error, Result, SharedCallback, Transport, TransportMetrics, TransportStatus, TransportType,
+};
 use base64::Engine;
-use offline_protocol_core::{Message, MutexExt, RwLockExt};
+use offline_protocol_core::{Address, Message, MutexExt, RwLockExt};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex, RwLock};
@@ -309,11 +311,39 @@ impl NostrTransport {
 
     /// Creates a new Nostr transport with custom configuration.
     ///
+    /// # `device_id` must be this device's derived address
+    ///
+    /// Not a profile, not an app-chosen string: the id given here is the sole
+    /// preimage of the routing tag, which is the label this device subscribes
+    /// on and the one peers publish to. Both ways of getting it wrong are
+    /// silent, and one of them is a disclosure:
+    ///
+    /// - a *guessable* preimage (a username-shaped profile) puts a label on a
+    ///   public relay that anyone can recompute from the name, which is the
+    ///   property the derived address exists to remove;
+    /// - a preimage that is merely *different* from the address peers know
+    ///   addresses this device where nobody writes, so every Nostr-carried
+    ///   frame is simply never seen — no error, no event, nothing arriving.
+    ///
+    /// Neither failure surfaces anywhere at runtime, so the id is refused
+    /// here rather than hashed. See
+    /// [`test_construction_refuses_an_id_that_is_not_an_address`](self#tests),
+    /// and — for the caller that made this necessary —
+    /// `test_nostr_is_absent_until_the_identity_rebuild_installs_it` in the
+    /// bindings crate.
+    ///
     /// The signing keypair starts out ephemeral (random for this process);
     /// call [`Self::install_signing_secret`] once persisted storage is
     /// available to give the install a stable Nostr identity.
     pub fn with_config(device_id: impl Into<String>, config: NostrConfig) -> Result<Self> {
         let device_id = device_id.into();
+        // The value is deliberately absent from the error: it is the rejected
+        // id, which in the case this check exists for is the app's profile.
+        device_id.parse::<Address>().map_err(|e| {
+            Error::ConfigurationError(format!(
+                "Nostr transport requires this device's derived address: {e}"
+            ))
+        })?;
         let routing_tag = nostr_crypto::routing_tag_for_device_id(&device_id)?;
         let derivable_keypair = NostrKeypair::derivable_for_device_id(&device_id)?;
         let keypair = RwLock::new(NostrKeypair::generate_ephemeral()?);
@@ -1596,26 +1626,77 @@ mod tests {
     use crate::constants::DEFAULT_MAX_MESSAGE_SIZE;
     use offline_protocol_core::{AppId, UserId};
 
+    /// The address a test label stands for.
+    ///
+    /// Every id this transport touches — its own, a recipient's, a peer being
+    /// resolved — is a derived address now, and construction refuses anything
+    /// else, so a fixture cannot simply *be* `"alice"`. It can hold the same
+    /// address every time it says `"alice"`, which is what this gives.
+    ///
+    /// Seeded from the label rather than randomly so a failure reproduces, and
+    /// built straight from the hash rather than through a real keypair because
+    /// nothing here verifies the address against a key: the transport only
+    /// hashes it. The core crate's `test_identity::id` is the version that does
+    /// come from a key, for fixtures that also have to satisfy MLS.
+    fn addr(label: &str) -> String {
+        use sha2::{Digest, Sha256};
+        let digest = Sha256::digest(label.as_bytes());
+        let mut hash = [0u8; Address::HASH_LEN];
+        hash.copy_from_slice(&digest[..Address::HASH_LEN]);
+        Address::from_hash_bytes(hash).to_string()
+    }
+
     fn create_test_message() -> Message {
         Message::new(
-            UserId::new("alice").unwrap(),
-            UserId::new("bob").unwrap(),
+            UserId::new(addr("alice")).unwrap(),
+            UserId::new(addr("bob")).unwrap(),
             AppId::new("test").unwrap(),
             "Test message",
         )
     }
 
+    /// An id that is not an address is refused, not hashed into a tag.
+    ///
+    /// The two failures this prevents are both silent — a guessable preimage
+    /// is a disclosure nothing reports, a merely-wrong one addresses this
+    /// device where nobody writes — so construction is the only place either
+    /// can be made to surface.
+    #[test]
+    fn test_construction_refuses_an_id_that_is_not_an_address() {
+        for bad in [
+            "device1",
+            "alice",
+            "",
+            // Right shape, wrong checksum: the check must be the real address
+            // parse, not a prefix or length test.
+            "off1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+            // Canonical address, uppercased. Accepting both spellings would
+            // give one identity two routing tags.
+            &addr("alice").to_uppercase(),
+        ] {
+            assert!(
+                NostrTransport::new(bad).is_err(),
+                "construction must refuse a non-address id: {bad:?}"
+            );
+        }
+
+        assert!(
+            NostrTransport::new(addr("alice")).is_ok(),
+            "a derived address is exactly what construction accepts"
+        );
+    }
+
     #[test]
     fn test_nostr_transport_creation() {
-        let transport = NostrTransport::new("device1").unwrap();
-        assert_eq!(transport.device_id(), "device1");
+        let transport = NostrTransport::new(addr("device1")).unwrap();
+        assert_eq!(transport.device_id(), addr("device1"));
         assert_eq!(transport.transport_type(), TransportType::Nostr);
         assert_eq!(transport.status(), TransportStatus::Unavailable);
     }
 
     #[test]
     fn test_builder() {
-        let transport = NostrTransportBuilder::new("device1")
+        let transport = NostrTransportBuilder::new(addr("device1"))
             .relay_urls(vec!["wss://relay.example.com".to_string()])
             .add_relay_url("wss://relay2.example.com")
             .connection_timeout(Duration::from_secs(60))
@@ -1636,7 +1717,7 @@ mod tests {
 
     #[test]
     fn test_send_receive() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1653,20 +1734,20 @@ mod tests {
 
     #[test]
     fn test_send_when_unavailable_fails() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         let msg = create_test_message();
         assert!(transport.send(&msg).is_err());
     }
 
     #[test]
     fn test_receive_when_empty_returns_none() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         assert!(transport.receive().unwrap().is_none());
     }
 
     #[test]
     fn test_confirmation_loop() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1683,7 +1764,7 @@ mod tests {
 
     #[test]
     fn test_send_failure_reporting() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1700,7 +1781,7 @@ mod tests {
 
     #[test]
     fn test_fail_all_pending_on_disconnect() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1716,7 +1797,7 @@ mod tests {
 
     #[test]
     fn test_stop_fails_pending() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1732,7 +1813,7 @@ mod tests {
 
     #[test]
     fn test_serialization() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         let msg = create_test_message();
         let data = transport.serialize_message(&msg).unwrap();
         let deserialized = transport.deserialize_message(&data).unwrap();
@@ -1741,7 +1822,7 @@ mod tests {
 
     #[test]
     fn test_reconnect_logic() {
-        let transport = NostrTransportBuilder::new("device1")
+        let transport = NostrTransportBuilder::new(addr("device1"))
             .max_reconnect_attempts(3)
             .build()
             .unwrap();
@@ -1756,7 +1837,7 @@ mod tests {
 
     #[test]
     fn test_on_data_received_invalid_json_drops_ok() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         let result = transport.on_data_received(b"not json".to_vec());
         assert!(result.is_ok());
         assert!(transport.receive().unwrap().is_none());
@@ -1764,7 +1845,7 @@ mod tests {
 
     #[test]
     fn test_on_data_received_rejects_oversized_payload() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         let oversized = vec![0u8; DEFAULT_MAX_MESSAGE_SIZE + 1];
         let result = transport.on_data_received(oversized);
         assert!(result.is_err());
@@ -1772,7 +1853,7 @@ mod tests {
 
     #[test]
     fn test_on_messages_available_callback() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1791,7 +1872,7 @@ mod tests {
     fn test_messages_available_callback_reentrant_send() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        let transport = Arc::new(NostrTransport::new("device1").unwrap());
+        let transport = Arc::new(NostrTransport::new(addr("device1")).unwrap());
         transport.on_status_changed(TransportStatus::Available);
 
         let reentered = Arc::new(AtomicBool::new(false));
@@ -1814,7 +1895,7 @@ mod tests {
 
     #[test]
     fn test_update_metrics_preserves_confirmation_counts() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1834,7 +1915,7 @@ mod tests {
 
     #[test]
     fn test_platform_handle() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         assert!(transport.platform_handle().is_none());
         transport.set_platform_handle(42);
         assert_eq!(transport.platform_handle(), Some(42));
@@ -1842,7 +1923,7 @@ mod tests {
 
     #[test]
     fn test_drain_expired_pending_expires_old_entries() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1884,7 +1965,7 @@ mod tests {
 
     #[test]
     fn test_has_pending_sends() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1897,7 +1978,7 @@ mod tests {
 
     #[test]
     fn test_pending_confirmation_count() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1925,7 +2006,7 @@ mod tests {
 
     #[test]
     fn test_get_next_signed_event() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1949,7 +2030,7 @@ mod tests {
 
     #[test]
     fn test_get_next_signed_event_confirm_flow() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -1967,8 +2048,8 @@ mod tests {
 
     #[test]
     fn test_subscription_filters_on_routing_tag_not_signing_key() {
-        let transport = NostrTransport::new("device1").unwrap();
-        let expected_tag = nostr_crypto::routing_tag_for_device_id("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
+        let expected_tag = nostr_crypto::routing_tag_for_device_id(&addr("device1")).unwrap();
 
         assert_eq!(transport.routing_tag(), expected_tag);
         // The signing key is random per install and must never leak into the
@@ -1982,8 +2063,8 @@ mod tests {
 
     #[test]
     fn test_install_signing_secret_gives_stable_identity() {
-        let transport_a = NostrTransport::new("device1").unwrap();
-        let transport_b = NostrTransport::new("device1").unwrap();
+        let transport_a = NostrTransport::new(addr("device1")).unwrap();
+        let transport_b = NostrTransport::new(addr("device1")).unwrap();
 
         // Ephemeral keys are random: two instances differ.
         assert_ne!(transport_a.public_key_hex(), transport_b.public_key_hex());
@@ -1998,19 +2079,19 @@ mod tests {
         // Addressing is untouched by the key swap.
         assert_eq!(
             transport_a.routing_tag(),
-            nostr_crypto::routing_tag_for_device_id("device1").unwrap()
+            nostr_crypto::routing_tag_for_device_id(&addr("device1")).unwrap()
         );
     }
 
     #[test]
     fn test_oversized_event_is_dropped_permanently_and_does_not_block_queue() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
         let oversized = Message::new(
-            UserId::new("alice").unwrap(),
-            UserId::new("bob").unwrap(),
+            UserId::new(addr("alice")).unwrap(),
+            UserId::new(addr("bob")).unwrap(),
             AppId::new("test").unwrap(),
             "x".repeat(NOSTR_MAX_PAYLOAD_SIZE),
         );
@@ -2046,7 +2127,7 @@ mod tests {
 
     #[test]
     fn test_size_cap_measures_the_relay_message_not_the_inner_payload() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2054,8 +2135,8 @@ mod tests {
         // pushes the event a relay actually sees over it. Capping the inner
         // payload instead would let this onto the wire to be rejected there.
         let msg = Message::new(
-            UserId::new("alice").unwrap(),
-            UserId::new("bob").unwrap(),
+            UserId::new(addr("alice")).unwrap(),
+            UserId::new(addr("bob")).unwrap(),
             AppId::new("test").unwrap(),
             "x".repeat(50_000),
         );
@@ -2081,7 +2162,7 @@ mod tests {
         // 32 KiB DEFAULT_CHUNK_SIZE that is ~156 KB on the wire, well past
         // both this cap and the 64-128 KB relays typically accept. Such events
         // were never deliverable; they now fail here instead of at the relay.
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2117,7 +2198,7 @@ mod tests {
         // A zero (or absent) `since` is the unbounded filter the watermark
         // exists to remove, and no-watermark is the *common* case: the bridges
         // subscribe on every relay connect, which can precede the restore.
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         assert!(transport.receive_watermark_secs().is_none());
 
         let since = subscription_filter(&transport)["since"].as_i64().unwrap();
@@ -2133,7 +2214,7 @@ mod tests {
 
     #[test]
     fn test_since_follows_the_watermark_with_a_jitter_and_skew_overlap() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         let mark = now_unix_secs() - 30;
         assert!(transport.advance_receive_watermark(mark));
 
@@ -2154,7 +2235,7 @@ mod tests {
         // the very relay query meant to fetch them — a silent delivery loss
         // with no error anywhere. This pins the two uses of the constant
         // together.
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         let mark = now_unix_secs();
         transport.advance_receive_watermark(mark);
 
@@ -2167,7 +2248,7 @@ mod tests {
 
     #[test]
     fn test_watermark_only_advances() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         let base = now_unix_secs() - 3600;
 
         assert!(transport.advance_receive_watermark(base));
@@ -2192,7 +2273,7 @@ mod tests {
         // publisher wrote. Accepting a far-future value would pin the mark
         // there and every later subscription would ask for events `since` the
         // far future — receiving nothing, permanently, with no error raised.
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         let honest = now_unix_secs() - 10;
         transport.advance_receive_watermark(honest);
 
@@ -2214,7 +2295,7 @@ mod tests {
     fn test_non_positive_created_at_is_ignored() {
         // A missing `created_at` reaches the FFI as 0; a malformed one can be
         // negative. Neither is receive progress.
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         assert!(!transport.advance_receive_watermark(0));
         assert!(!transport.advance_receive_watermark(-1));
         assert!(transport.receive_watermark_secs().is_none());
@@ -2225,7 +2306,7 @@ mod tests {
         // stop() clears in-flight queues, but receive progress is not undone by
         // a restart — resetting it here would replay a full backfill window on
         // every stop/start cycle.
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         let mark = now_unix_secs() - 60;
         transport.advance_receive_watermark(mark);
 
@@ -2236,7 +2317,7 @@ mod tests {
 
     #[test]
     fn test_signed_event_uses_recipient_routing_tag_and_own_signing_key() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
         // Addressing is a property of the unsealed path too; assert it there so
@@ -2249,7 +2330,7 @@ mod tests {
         transport.send(&msg).unwrap();
 
         let signed = transport.get_next_signed_event().unwrap().unwrap();
-        let bob_tag = nostr_crypto::routing_tag_for_device_id("bob").unwrap();
+        let bob_tag = nostr_crypto::routing_tag_for_device_id(&addr("bob")).unwrap();
         assert!(
             signed.event_json.contains(&bob_tag),
             "event must be addressed to the recipient's routing tag"
@@ -2285,13 +2366,13 @@ mod tests {
         // excluded only *after* pinning its sealed shape — it is random bytes,
         // and a case-folded substring assertion over its base64 spells "bob"
         // roughly once per hundred runs, failing CI with no leak present.
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
         let msg = Message::new(
-            UserId::new("alice").unwrap(),
-            UserId::new("bob").unwrap(),
+            UserId::new(addr("alice")).unwrap(),
+            UserId::new(addr("bob")).unwrap(),
             AppId::new("fernweh").unwrap(),
             "the quick brown fox",
         );
@@ -2328,13 +2409,13 @@ mod tests {
         // The only thing a relay legitimately learns is the recipient's routing
         // tag — an opaque label it cannot invert without already knowing the
         // user id it is looking for.
-        let bob_tag = nostr_crypto::routing_tag_for_device_id("bob").unwrap();
+        let bob_tag = nostr_crypto::routing_tag_for_device_id(&addr("bob")).unwrap();
         assert!(wire.contains(&bob_tag));
     }
 
     #[test]
     fn test_sealed_event_is_a_gift_wrap_not_signed_by_our_install_key() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
         transport.send(&create_test_message()).unwrap();
@@ -2358,14 +2439,14 @@ mod tests {
     fn test_sealed_frame_round_trips_through_the_recipients_transport() {
         // End-to-end over the two transports, which is what proves the send and
         // receive halves agree about which key seals what.
-        let alice = NostrTransport::new("alice").unwrap();
+        let alice = NostrTransport::new(addr("alice")).unwrap();
         alice.start().unwrap();
         alice.on_status_changed(TransportStatus::Available);
 
-        let bob = NostrTransport::new("bob").unwrap();
+        let bob = NostrTransport::new(addr("bob")).unwrap();
         bob.install_signing_secret(&[88u8; 32]).unwrap();
         // Alice has seen Bob's key package, so this is the steady state.
-        alice.set_peer_nostr_pubkey("bob", &bob.public_key_hex());
+        alice.set_peer_nostr_pubkey(&addr("bob"), &bob.public_key_hex());
 
         let msg = create_test_message();
         alice.send(&msg).unwrap();
@@ -2380,7 +2461,7 @@ mod tests {
         let plaintext = bob.unseal_event_payload(sender_pubkey, &sealed);
         let received = bob.deserialize_message(&plaintext).unwrap();
         assert_eq!(received.id, msg.id);
-        assert_eq!(received.sender.as_str(), "alice");
+        assert_eq!(received.sender.as_str(), addr("alice"));
     }
 
     #[test]
@@ -2388,11 +2469,11 @@ mod tests {
         // Cold first contact: Alice knows only Bob's user id. The frame is
         // sealed to Bob's publicly computable key, and Bob's receive path finds
         // it on the second attempt.
-        let alice = NostrTransport::new("alice").unwrap();
+        let alice = NostrTransport::new(addr("alice")).unwrap();
         alice.start().unwrap();
         alice.on_status_changed(TransportStatus::Available);
 
-        let bob = NostrTransport::new("bob").unwrap();
+        let bob = NostrTransport::new(addr("bob")).unwrap();
         bob.install_signing_secret(&[91u8; 32]).unwrap();
         // Deliberately NOT calling set_peer_nostr_pubkey.
 
@@ -2421,7 +2502,7 @@ mod tests {
         // A peer on a build from before sealing publishes the old cleartext
         // envelope. It must pass straight through, or upgrading breaks every
         // conversation with a peer that has not upgraded yet.
-        let alice = NostrTransport::new("alice").unwrap();
+        let alice = NostrTransport::new(addr("alice")).unwrap();
         alice.set_sealing_enabled(false);
         alice.start().unwrap();
         alice.on_status_changed(TransportStatus::Available);
@@ -2439,7 +2520,7 @@ mod tests {
             .decode(event["content"].as_str().unwrap())
             .unwrap();
 
-        let bob = NostrTransport::new("bob").unwrap();
+        let bob = NostrTransport::new(addr("bob")).unwrap();
         let passed_through = bob.unseal_event_payload(event["pubkey"].as_str().unwrap(), &legacy);
         assert_eq!(passed_through.as_ref(), legacy.as_slice());
         assert_eq!(bob.deserialize_message(&passed_through).unwrap().id, msg.id);
@@ -2451,8 +2532,8 @@ mod tests {
         // must fail closed. Returning the ciphertext unchanged lets the
         // ordinary decoder reject it as one undecodable frame — the same
         // outcome as random junk, which is what it is to us.
-        let bob = NostrTransport::new("bob").unwrap();
-        let carol_tag = nostr_crypto::routing_tag_for_device_id("carol").unwrap();
+        let bob = NostrTransport::new(addr("bob")).unwrap();
+        let carol_tag = nostr_crypto::routing_tag_for_device_id(&addr("carol")).unwrap();
 
         let event =
             nostr_crypto::NostrEvent::create_gift_wrap(&carol_tag, &carol_tag, b"not for bob")
@@ -2471,8 +2552,8 @@ mod tests {
         // `on_data_received` cannot unseal — it has no access to the wrapper's
         // pubkey. A bridge wired to it would otherwise enqueue ciphertext as if
         // it were a message.
-        let bob = NostrTransport::new("bob").unwrap();
-        let bob_tag = nostr_crypto::routing_tag_for_device_id("bob").unwrap();
+        let bob = NostrTransport::new(addr("bob")).unwrap();
+        let bob_tag = nostr_crypto::routing_tag_for_device_id(&addr("bob")).unwrap();
         let event =
             nostr_crypto::NostrEvent::create_gift_wrap(&bob_tag, &bob_tag, b"sealed").unwrap();
         let sealed = base64::engine::general_purpose::STANDARD
@@ -2485,18 +2566,21 @@ mod tests {
 
     #[test]
     fn test_peer_key_map_is_bounded_and_rejects_malformed_keys() {
-        let transport = NostrTransport::new("device1").unwrap();
+        let transport = NostrTransport::new(addr("device1")).unwrap();
 
-        transport.set_peer_nostr_pubkey("bob", "not-hex");
-        transport.set_peer_nostr_pubkey("bob", &"ab".repeat(31)); // 62 chars
+        transport.set_peer_nostr_pubkey(&addr("bob"), "not-hex");
+        transport.set_peer_nostr_pubkey(&addr("bob"), &"ab".repeat(31)); // 62 chars
         transport.set_peer_nostr_pubkey("", &"ab".repeat(32));
-        assert!(transport.peer_nostr_pubkey("bob").is_none());
+        assert!(transport.peer_nostr_pubkey(&addr("bob")).is_none());
 
         // Case is normalized: `#p`-style values are lowercase hex by spec, and a
         // mixed-case duplicate must not seal to a different string.
         let key = "AB".repeat(32);
-        transport.set_peer_nostr_pubkey("bob", &key);
-        assert_eq!(transport.peer_nostr_pubkey("bob"), Some(key.to_lowercase()));
+        transport.set_peer_nostr_pubkey(&addr("bob"), &key);
+        assert_eq!(
+            transport.peer_nostr_pubkey(&addr("bob")),
+            Some(key.to_lowercase())
+        );
 
         for i in 0..NOSTR_MAX_TRACKED_PEER_KEYS + 10 {
             transport.set_peer_nostr_pubkey(&format!("peer{i}"), &"cd".repeat(32));
@@ -2512,11 +2596,11 @@ mod tests {
         // The kill switch gates the send side only. A peer that keeps sealing
         // must stay readable, or flipping the flag on one device would sever
         // conversations rather than merely un-protecting our own traffic.
-        let alice = NostrTransport::new("alice").unwrap();
+        let alice = NostrTransport::new(addr("alice")).unwrap();
         alice.start().unwrap();
         alice.on_status_changed(TransportStatus::Available);
 
-        let bob = NostrTransport::new("bob").unwrap();
+        let bob = NostrTransport::new(addr("bob")).unwrap();
         bob.set_sealing_enabled(false);
         assert!(!bob.sealing_enabled());
 
@@ -2538,13 +2622,13 @@ mod tests {
         // payload before base64 — considerably more than the ~33% a base64
         // layer alone would suggest. Ordinary text messages must still fit
         // comfortably, and the cap must be measured on the sealed event.
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
         let msg = Message::new(
-            UserId::new("alice").unwrap(),
-            UserId::new("bob").unwrap(),
+            UserId::new(addr("alice")).unwrap(),
+            UserId::new(addr("bob")).unwrap(),
             AppId::new("test").unwrap(),
             "x".repeat(4096),
         );
@@ -2571,7 +2655,7 @@ mod tests {
     /// preimage the `SHA-256(user_id)` routing tag exists to withhold.
     #[test]
     fn test_published_key_package_record_leaks_no_username() {
-        let transport = NostrTransport::new("alice-the-identifiable").unwrap();
+        let transport = NostrTransport::new(addr("alice-the-identifiable")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2590,7 +2674,7 @@ mod tests {
 
     #[test]
     fn test_published_record_is_addressable_and_opens_with_the_derivable_key() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.install_signing_secret(&[7u8; 32]).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
@@ -2617,7 +2701,7 @@ mod tests {
         assert_eq!(tags[1][1].as_str(), Some(transport.routing_tag()));
 
         // A stranger who knows only the username can open it.
-        let stranger_view = NostrKeypair::derivable_for_device_id("alice").unwrap();
+        let stranger_view = NostrKeypair::derivable_for_device_id(&addr("alice")).unwrap();
         let sealed = base64::engine::general_purpose::STANDARD
             .decode(event["content"].as_str().unwrap())
             .unwrap();
@@ -2636,7 +2720,7 @@ mod tests {
     /// key package standing as the live record.
     #[test]
     fn test_republication_is_not_backdated_below_the_record_it_replaces() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2657,7 +2741,7 @@ mod tests {
     /// publishing both would briefly stand a consumed package back up.
     #[test]
     fn test_requeued_slot_collapses_to_the_newer_payload() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2669,7 +2753,7 @@ mod tests {
         let sealed = base64::engine::general_purpose::STANDARD
             .decode(event["content"].as_str().unwrap())
             .unwrap();
-        let key = NostrKeypair::derivable_for_device_id("alice").unwrap();
+        let key = NostrKeypair::derivable_for_device_id(&addr("alice")).unwrap();
         let opened = nostr_crypto::open_key_package_publication(
             &key,
             event["pubkey"].as_str().unwrap(),
@@ -2686,7 +2770,7 @@ mod tests {
 
     #[test]
     fn test_publications_drain_ahead_of_messages() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2708,7 +2792,7 @@ mod tests {
     /// process while the relays hold nothing.
     #[test]
     fn test_rejected_publication_is_reported_back_for_republication() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2736,7 +2820,7 @@ mod tests {
     /// in-flight event, and a publication among them is no exception.
     #[test]
     fn test_disconnect_reports_in_flight_publications_for_republication() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2756,7 +2840,7 @@ mod tests {
     /// slot set is keyed on the synthetic publication id and nothing else.
     #[test]
     fn test_message_failure_reports_no_publication_slot() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2769,20 +2853,20 @@ mod tests {
 
     #[test]
     fn test_cold_contact_disabled_publishes_nothing_and_resolves_nothing() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.set_cold_contact_enabled(false);
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
         transport.publish_key_package("slot-a", b"kp".to_vec());
         assert!(!transport.has_pending_publications());
-        assert!(!transport.request_peer_key_packages("bob"));
+        assert!(!transport.request_peer_key_packages(&addr("bob")));
         assert!(transport.next_query().unwrap().is_none());
     }
 
     #[test]
     fn test_send_to_an_unknown_peer_queues_a_resolution_and_still_sends() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2795,7 +2879,7 @@ mod tests {
         );
 
         let query = transport.next_query().unwrap().expect("resolution queued");
-        let expected_tag = nostr_crypto::routing_tag_for_device_id("bob").unwrap();
+        let expected_tag = nostr_crypto::routing_tag_for_device_id(&addr("bob")).unwrap();
         assert!(query.req_json.contains(&expected_tag));
         assert!(query
             .req_json
@@ -2804,19 +2888,19 @@ mod tests {
 
     #[test]
     fn test_resolution_is_rate_limited_per_peer() {
-        let transport = NostrTransport::new("alice").unwrap();
-        assert!(transport.request_peer_key_packages("bob"));
+        let transport = NostrTransport::new(addr("alice")).unwrap();
+        assert!(transport.request_peer_key_packages(&addr("bob")));
         assert!(
-            !transport.request_peer_key_packages("bob"),
+            !transport.request_peer_key_packages(&addr("bob")),
             "a peer who has published nothing must not mint a round-trip per frame"
         );
-        assert!(transport.request_peer_key_packages("carol"));
+        assert!(transport.request_peer_key_packages(&addr("carol")));
     }
 
     #[test]
     fn test_query_event_opens_only_for_the_peer_it_was_issued_for() {
-        let alice = NostrTransport::new("alice").unwrap();
-        let bob = NostrTransport::new("bob").unwrap();
+        let alice = NostrTransport::new(addr("alice")).unwrap();
+        let bob = NostrTransport::new(addr("bob")).unwrap();
         bob.install_signing_secret(&[9u8; 32]).unwrap();
         bob.start().unwrap();
         bob.on_status_changed(TransportStatus::Available);
@@ -2826,7 +2910,7 @@ mod tests {
         let event = event_object(&published);
         let event_json = serde_json::to_string(&event).unwrap();
 
-        alice.request_peer_key_packages("bob");
+        alice.request_peer_key_packages(&addr("bob"));
         let query = alice.next_query().unwrap().unwrap();
 
         let opened = alice
@@ -2837,7 +2921,7 @@ mod tests {
 
         // The same record delivered under a query for someone else does not
         // open: the query id is what says whose key to try.
-        alice.request_peer_key_packages("carol");
+        alice.request_peer_key_packages(&addr("carol"));
         let other = alice.next_query().unwrap().unwrap();
         assert!(alice
             .open_query_event(&other.query_id, &event_json)
@@ -2847,8 +2931,8 @@ mod tests {
 
     #[test]
     fn test_query_event_for_an_unknown_or_completed_query_is_dropped() {
-        let alice = NostrTransport::new("alice").unwrap();
-        alice.request_peer_key_packages("bob");
+        let alice = NostrTransport::new(addr("alice")).unwrap();
+        alice.request_peer_key_packages(&addr("bob"));
         let query = alice.next_query().unwrap().unwrap();
         alice.complete_query(&query.query_id);
 
@@ -2867,8 +2951,8 @@ mod tests {
     /// than failing the query.
     #[test]
     fn test_query_event_ignores_wrong_kinds_and_unopenable_content() {
-        let alice = NostrTransport::new("alice").unwrap();
-        alice.request_peer_key_packages("bob");
+        let alice = NostrTransport::new(addr("alice")).unwrap();
+        alice.request_peer_key_packages(&addr("bob"));
         let query = alice.next_query().unwrap().unwrap();
 
         let wrong_kind = r#"{"kind":1059,"pubkey":"aa","content":"AQID"}"#;
@@ -2899,7 +2983,7 @@ mod tests {
     /// deprioritise Nostr for traffic that delivers perfectly well.
     #[test]
     fn test_publication_failures_stay_out_of_the_delivery_metrics() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2944,7 +3028,7 @@ mod tests {
     /// inflate the ratio and mask real message failures.
     #[test]
     fn test_publication_successes_do_not_mask_message_failures() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         transport.start().unwrap();
         transport.on_status_changed(TransportStatus::Available);
 
@@ -2976,8 +3060,8 @@ mod tests {
     /// import a package we already hold.
     #[test]
     fn test_duplicate_records_from_several_relays_open_once() {
-        let alice = NostrTransport::new("alice").unwrap();
-        let bob = NostrTransport::new("bob").unwrap();
+        let alice = NostrTransport::new(addr("alice")).unwrap();
+        let bob = NostrTransport::new(addr("bob")).unwrap();
         bob.install_signing_secret(&[9u8; 32]).unwrap();
         bob.start().unwrap();
         bob.on_status_changed(TransportStatus::Available);
@@ -2986,7 +3070,7 @@ mod tests {
         let published = bob.get_next_signed_event().unwrap().unwrap();
         let event_json = serde_json::to_string(&event_object(&published)).unwrap();
 
-        alice.request_peer_key_packages("bob");
+        alice.request_peer_key_packages(&addr("bob"));
         let query = alice.next_query().unwrap().unwrap();
 
         assert!(
@@ -3012,8 +3096,8 @@ mod tests {
     /// call — so the ceiling has to be ours, not the relay's.
     #[test]
     fn test_a_query_stops_accepting_events_at_its_ceiling() {
-        let alice = NostrTransport::new("alice").unwrap();
-        let bob = NostrTransport::new("bob").unwrap();
+        let alice = NostrTransport::new(addr("alice")).unwrap();
+        let bob = NostrTransport::new(addr("bob")).unwrap();
         bob.install_signing_secret(&[9u8; 32]).unwrap();
         bob.start().unwrap();
         bob.on_status_changed(TransportStatus::Available);
@@ -3021,7 +3105,7 @@ mod tests {
         let published = bob.get_next_signed_event().unwrap().unwrap();
         let genuine = serde_json::to_string(&event_object(&published)).unwrap();
 
-        alice.request_peer_key_packages("bob");
+        alice.request_peer_key_packages(&addr("bob"));
         let query = alice.next_query().unwrap().unwrap();
 
         // Distinct ids, so it is the ceiling that stops this and not the dedup.
@@ -3046,8 +3130,8 @@ mod tests {
 
         // The record itself is fine, and the ceiling is per query: a fresh one
         // opens it.
-        let alice2 = NostrTransport::new("alice").unwrap();
-        alice2.request_peer_key_packages("bob");
+        let alice2 = NostrTransport::new(addr("alice")).unwrap();
+        alice2.request_peer_key_packages(&addr("bob"));
         let fresh = alice2.next_query().unwrap().unwrap();
         assert!(alice2
             .open_query_event(&fresh.query_id, &genuine)
@@ -3063,7 +3147,7 @@ mod tests {
     /// hostile event was enough; it must be an unopenable frame instead.
     #[test]
     fn test_malformed_event_pubkey_does_not_abort_the_receive_path() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
         let sealed = vec![0x02u8; 160];
 
         for pubkey in ["", "aa", "abcd", &"ab".repeat(64)] {
@@ -3082,21 +3166,21 @@ mod tests {
     /// the peer instead waits out `RESOLUTION_RETRY_INTERVAL`.
     #[test]
     fn test_a_resolution_refused_at_capacity_does_not_burn_the_rate_limit() {
-        let transport = NostrTransport::new("alice").unwrap();
+        let transport = NostrTransport::new(addr("alice")).unwrap();
 
         for i in 0..MAX_PENDING_RESOLUTIONS {
             assert!(transport.request_peer_key_packages(&format!("peer-{}", i)));
         }
 
         assert!(
-            !transport.request_peer_key_packages("bob"),
+            !transport.request_peer_key_packages(&addr("bob")),
             "the queue is full, so this request is refused"
         );
 
         // Draining one makes room; bob must be admitted straight away.
         transport.next_query().unwrap().unwrap();
         assert!(
-            transport.request_peer_key_packages("bob"),
+            transport.request_peer_key_packages(&addr("bob")),
             "a request dropped at capacity burned the retry interval"
         );
     }

--- a/crates/offline-protocol-transport/src/nostr_crypto.rs
+++ b/crates/offline-protocol-transport/src/nostr_crypto.rs
@@ -8,23 +8,39 @@
 //!
 //! # Key model
 //!
-//! Two independent values are in play, and they must not be conflated:
+//! Three values are in play, and they must not be conflated:
 //!
-//! - **Routing tag** ([`routing_tag_for_device_id`]): a public rendezvous
-//!   label derived deterministically from a device/user ID. Senders put the
+//! - **Routing tag** ([`routing_tag_for_address`]): a public rendezvous label
+//!   derived deterministically from a device's address. Senders put the
 //!   recipient's tag in the event's `#p` tag; the recipient subscribes on its
-//!   own tag. It carries no secret — anyone who knows a device ID can (and
-//!   must be able to) compute it, exactly like an email address.
-//! - **Signing key** ([`NostrKeypair`]): the secp256k1 private key that signs
-//!   outgoing events. It is derived via HKDF-SHA256 from a per-install random
-//!   secret ([`NostrKeypair::from_install_secret`]) and is never derivable
-//!   from any public identifier.
+//!   own. It is a *label*: nothing signs with it, nothing seals to it, and
+//!   anyone who knows an address can — and must be able to — compute it,
+//!   exactly like an email address.
+//! - **Signing key** ([`NostrKeypair::from_install_secret`]): the secp256k1
+//!   private key that signs outgoing events, derived via HKDF-SHA256 from a
+//!   per-install random secret. Never derivable from any public value.
+//! - **Record-seal key** ([`record_seal_keypair_for_address`]): a keypair
+//!   *anyone who knows an address can reconstruct*, holding one job — sealing
+//!   the published key-package record and the bootstrap leg of a conversation,
+//!   so a relay scraping by kind sees ciphertext instead of a directory. Its
+//!   private half is public by construction, so it must never authenticate
+//!   anything.
 //!
-//! Historically both roles were served by `SHA-256(device_id)`, which let
-//! anyone who knew a device ID reconstruct that device's private key and sign
-//! events as it. Only the routing-tag role legitimately needs to be publicly
-//! derivable, so only it retains the deterministic derivation (unchanged on
-//! the wire for interoperability with older peers).
+//! Two historical conflations are worth knowing about, because both looked
+//! harmless until they weren't.
+//!
+//! Originally the *signing* key was `SHA-256(device_id)` too, so anyone who
+//! knew a device id could sign events as that device. That one was fixed by
+//! moving signing onto a per-install secret.
+//!
+//! What survived until the address migration was subtler: the record-seal
+//! key's public half **was** the routing tag, bit for bit. Nothing was wrong
+//! with it on its own — the two roles happened to want the same derivation —
+//! but it left every routing tag standing as a public key whose private half
+//! was computable, which is a live footgun the moment anything adds NIP-42
+//! AUTH or pubkey-based filtering. They are now separately domain-separated
+//! and deliberately unequal, pinned by
+//! `test_record_seal_key_is_not_the_routing_tag`.
 
 use crate::constants::{NOSTR_CREATED_AT_JITTER_SECS, NOSTR_INITIAL_QUERY_LIMIT};
 use crate::nip44::{self, ConversationKey};
@@ -39,6 +55,15 @@ use zeroize::Zeroizing;
 /// per-install secret. A trailing counter byte is appended per attempt so an
 /// (astronomically unlikely) invalid scalar can be retried deterministically.
 const SIGNING_KEY_HKDF_INFO: &[u8] = b"offline-protocol/nostr/v1/signing-key/";
+
+/// Domain-separation prefix for the publicly computable record-seal key.
+///
+/// Distinct from [`SIGNING_KEY_HKDF_INFO`] because these two keys have
+/// opposite security properties — one is an unforgeable identity, the other is
+/// reconstructible by anyone holding the address — and sharing a derivation
+/// between them is the kind of thing that is fine until someone reuses one
+/// where they meant the other.
+const RECORD_SEAL_HKDF_INFO: &[u8] = b"offline-protocol/nostr/v1/record-seal-key/";
 
 /// Upper bound on HKDF derivation attempts. Each attempt fails with
 /// probability ~2^-128 (scalar of zero or above the curve order), so more
@@ -58,7 +83,7 @@ const MIN_INSTALL_SECRET_LEN: usize = 16;
 ///
 /// The keypair authenticates this install to Nostr relays (event signatures,
 /// NIP-42 style auth). It is intentionally *not* derivable from the device
-/// ID; message addressing uses the separate [`routing_tag_for_device_id`]
+/// ID; message addressing uses the separate [`routing_tag_for_address`]
 /// label instead.
 pub struct NostrKeypair {
     signing_key: SigningKey,
@@ -138,35 +163,60 @@ impl NostrKeypair {
         &self.public_key_hex
     }
 
-    /// Reconstructs the keypair whose public half is
-    /// [`routing_tag_for_device_id`] — the *publicly computable* keypair.
-    ///
-    /// # This key is not a secret
-    ///
-    /// Its private half is `SHA-256(device_id)`, so anyone who knows a device
-    /// ID holds it. It exists for exactly one purpose: unsealing (and sealing)
-    /// the **first** frame of a conversation, before the two sides have learned
-    /// each other's real per-install Nostr keys. That gives bulk-collection
-    /// resistance — a relay operator scraping everything cannot read it — and
-    /// nothing more: an observer who guesses the username can.
-    ///
-    /// It must therefore **never** be used to authenticate anything: not
-    /// NIP-42 AUTH, not inbound sender attribution, not any decision that
-    /// treats "this decrypted" as evidence of who sent it. Sender authenticity
-    /// on this transport comes from the protocol-layer Ed25519 + derivation gate and
-    /// MLS, both of which sit above this function and are unaffected by it.
-    /// [`Self::from_install_secret`] is the only unforgeable identity here.
-    pub fn derivable_for_device_id(device_id: &str) -> Result<Self> {
-        let scalar = Sha256::digest(device_id.as_bytes());
-        let signing_key = SigningKey::from_bytes(scalar.as_slice()).map_err(|e| {
-            Error::CryptoError(format!("Invalid derivable key for device_id: {}", e))
-        })?;
-        let public_key_hex = hex::encode(signing_key.verifying_key().to_bytes());
-        Ok(Self {
-            signing_key,
-            public_key_hex,
-        })
+}
+
+/// Reconstructs the keypair that seals content addressed to `address`.
+///
+/// # This key is not a secret
+///
+/// It is derived from the address alone, so **anyone who knows an address
+/// holds this keypair for it**. That is the point: it lets a stranger seal a
+/// first frame to a peer they have never exchanged keys with, and lets them
+/// open that peer's published key-package record — while a relay scraping by
+/// kind, which knows tags but not addresses, sees only ciphertext.
+///
+/// What that is worth changed with the address migration, and it is worth
+/// being precise about. When the preimage was a username, "anyone who knows
+/// it" meant anyone who could *guess* `bob`. An address is a 160-bit hash of
+/// an identity key: it cannot be guessed, only learned — from an invite, a QR
+/// code, or a frame the holder already sent you. So the audience for this key
+/// is now the same set of people who could already send you traffic, rather
+/// than everyone with a dictionary.
+///
+/// It must **never** authenticate anything: not NIP-42 AUTH, not inbound
+/// sender attribution, not any decision that treats "this decrypted" as
+/// evidence of who sent it. Sender authenticity comes from the protocol-layer
+/// Ed25519 + derivation gate and from MLS, both above this function.
+/// [`NostrKeypair::from_install_secret`] is the only unforgeable identity
+/// here.
+///
+/// Domain-separated so this is *not* the routing tag's scalar. Nothing breaks
+/// if they coincide, but a routing label that doubles as a public key whose
+/// private half is computable is a trap for whoever next touches this file.
+pub fn record_seal_keypair_for_address(address: &str) -> Result<NostrKeypair> {
+    let hkdf = Hkdf::<Sha256>::new(None, address.as_bytes());
+    let mut info = Vec::with_capacity(RECORD_SEAL_HKDF_INFO.len() + 1);
+    for counter in 0..MAX_DERIVE_ATTEMPTS {
+        info.clear();
+        info.extend_from_slice(RECORD_SEAL_HKDF_INFO);
+        info.push(counter);
+
+        let mut candidate = Zeroizing::new([0u8; 32]);
+        hkdf.expand(&info, &mut *candidate)
+            .map_err(|e| Error::CryptoError(format!("HKDF expand failed: {}", e)))?;
+
+        if let Ok(signing_key) = SigningKey::from_bytes(&*candidate) {
+            let public_key_hex = hex::encode(signing_key.verifying_key().to_bytes());
+            return Ok(NostrKeypair {
+                signing_key,
+                public_key_hex,
+            });
+        }
     }
+
+    Err(Error::CryptoError(
+        "Failed to derive a record-seal key for the address".to_string(),
+    ))
 }
 
 /// Current wall-clock time as unix seconds — the unit every Nostr timestamp
@@ -181,21 +231,35 @@ pub(crate) fn now_unix_secs() -> i64 {
         .unwrap_or(0)
 }
 
-/// Computes the public routing tag for a device/user ID.
+/// Computes the public routing tag for a device's address.
 ///
-/// Derivation: `SHA-256(device_id)` → scalar → x-only secp256k1 public key
-/// hex — byte-identical to the legacy shared derivation, so old and new
-/// versions address each other without a migration.
+/// Derivation: `SHA-256(address)` → scalar → x-only secp256k1 public key hex.
 ///
 /// Senders place the recipient's tag in the `#p` tag of outgoing events and
-/// recipients subscribe on their own tag. It is a rendezvous label only:
-/// nothing signs with the corresponding scalar, and incoming events are never
-/// authenticated against it (sender authenticity comes from the
-/// protocol-layer MLS signatures).
-pub fn routing_tag_for_device_id(device_id: &str) -> Result<String> {
-    let tag_scalar = Sha256::digest(device_id.as_bytes());
+/// recipients subscribe on their own. It is a rendezvous label only: nothing
+/// signs with the corresponding scalar, nothing seals to it, and incoming
+/// events are never authenticated against it (sender authenticity comes from
+/// the protocol layer).
+///
+/// # Why an identity-derived label is acceptable here
+///
+/// Deriving a delivery address from stable identity material is normally the
+/// wrong move — it lets an observer precompute the label for any identity it
+/// cares about and confirm traffic without holding a key. The Marmot protocol
+/// forbids it for *group* addressing for exactly that reason, and carves out
+/// the case this is: an account-level inbox, "because reaching a specific
+/// account is the purpose of an inbox". NIP-59 goes further and puts the
+/// recipient's actual pubkey in `p`.
+///
+/// So the tag is not obscurity and is not load-bearing for privacy. What it
+/// does buy is non-invertibility: knowing a tag does not yield the address, so
+/// a relay cannot turn its subscriber list back into an address book. That
+/// property is the reason the published record stays sealed — publishing it in
+/// the clear would hand the address back at the tag it sits on.
+pub fn routing_tag_for_address(address: &str) -> Result<String> {
+    let tag_scalar = Sha256::digest(address.as_bytes());
     let tag_key = SigningKey::from_bytes(tag_scalar.as_slice())
-        .map_err(|e| Error::CryptoError(format!("Invalid routing tag for device_id: {}", e)))?;
+        .map_err(|e| Error::CryptoError(format!("Invalid routing tag for address: {}", e)))?;
     Ok(hex::encode(tag_key.verifying_key().to_bytes()))
 }
 
@@ -273,7 +337,7 @@ impl NostrEvent {
     ///
     /// - `keypair`: Sender's signing keypair (per-install secret key).
     /// - `recipient_pubkey_hex`: Recipient's routing tag (64-char hex, from
-    ///   [`routing_tag_for_device_id`]).
+    ///   [`routing_tag_for_address`]).
     /// - `content_base64`: Base64-encoded protocol message bytes.
     pub fn create_dm(
         keypair: &NostrKeypair,
@@ -342,24 +406,28 @@ impl NostrEvent {
     ///
     /// # Why the content is sealed even though the record is public
     ///
-    /// An MLS key package carries its owner's user id twice over: once in the
-    /// `KeyPackagePayload` field and once, unremovably, in the leaf credential —
-    /// this SDK's credentials are basic credentials holding the raw user id, as
-    /// `verify_credential_identity` relies on. Published in the clear, a filter
-    /// naming only this kind and no tag would therefore return a directory of
-    /// every username on the relay, handing over exactly the preimages the
-    /// `SHA-256(user_id)` routing tag exists to withhold.
+    /// The original reason was that an MLS key package carries its owner's
+    /// user id twice over — in the `KeyPackagePayload` field and, unremovably,
+    /// in the leaf credential — so a cleartext record would have let
+    /// `{"kinds":[30443]}` return **a directory of every username on the
+    /// relay**. That reason expired: credentials now hold the derived address,
+    /// and an address is not a name.
     ///
-    /// So the content is NIP-44-sealed to *our own* publicly computable key.
-    /// That costs nothing in reach: fetching the record at all requires knowing
-    /// the routing tag, which requires knowing the username, which is precisely
-    /// the knowledge needed to reconstruct the derivable key and open it. The
-    /// audience is unchanged and a scraper sees an opaque blob.
+    /// The seal stays anyway, for a narrower reason that did not expire. The
+    /// routing tag is one-way — a relay holding tags cannot recover addresses
+    /// from them. A cleartext record publishes the address *at* its own tag,
+    /// which hands that inversion back for the whole userbase to anyone willing
+    /// to scrape one kind. Sealing keeps the tag one-way.
     ///
-    /// This is the one encryption use of the derivable key that survives
-    /// publication: real messages seal to the per-install key resolved *from*
-    /// this record, so the weak key protects only a self-published record whose
-    /// sole reader already knows who it belongs to.
+    /// Worth knowing that this is where we diverge from Marmot, which
+    /// publishes kind-30443 key packages in the clear and is right to: their
+    /// leaf credential *is* the Nostr pubkey the event is already signed by, so
+    /// a cleartext record discloses nothing the event's own `pubkey` field did
+    /// not. Ours names a different identity, so ours has something to hide.
+    ///
+    /// Sealing costs nothing in reach: opening the record needs the address,
+    /// and so does finding it — the tag you fetch from is derived from that
+    /// same address.
     ///
     /// `created_at` is the true current time, deliberately **not** jittered into
     /// the past like a gift wrap's. Relays keep the newest event per
@@ -367,15 +435,21 @@ impl NostrEvent {
     /// would be silently discarded — leaving a consumed key package standing as
     /// the live record. Nothing is lost by it: this is a standing record, not a
     /// message, so its timestamp correlates with no conversation.
+    ///
+    /// `routing_tag` addresses the record; `seal_pubkey` is our own
+    /// record-seal public key, which is what a fetcher reconstructs from our
+    /// address to open it. They used to be the same value and are now
+    /// deliberately not, so the two arguments say which job each is doing.
     pub fn create_key_package_publication(
         keypair: &NostrKeypair,
         routing_tag: &str,
+        seal_pubkey: &str,
         slot_id: &str,
         plaintext: &[u8],
     ) -> Result<Self> {
-        let tag_bytes = hex::decode(routing_tag)
-            .map_err(|e| Error::CryptoError(format!("Invalid routing tag: {}", e)))?;
-        let conversation_key = ConversationKey::derive(&keypair.signing_key, &tag_bytes)?;
+        let seal_bytes = hex::decode(seal_pubkey)
+            .map_err(|e| Error::CryptoError(format!("Invalid record-seal pubkey: {}", e)))?;
+        let conversation_key = ConversationKey::derive(&keypair.signing_key, &seal_bytes)?;
         let sealed = nip44::encrypt(plaintext, &conversation_key)?;
 
         let tags = vec![
@@ -466,7 +540,7 @@ impl NostrEvent {
 }
 
 /// Creates a NIP-01 REQ subscription message for DMs addressed to `pubkey_hex`
-/// (this device's own routing tag, from [`routing_tag_for_device_id`]).
+/// (this device's own routing tag, from [`routing_tag_for_address`]).
 ///
 /// Returns
 /// `["REQ", "<sub_id>", {"#p": ["<pubkey>"], "kinds": [4, 1059], "since": T, "limit": N}]`.
@@ -641,7 +715,7 @@ mod tests {
         // the routing tag stays publicly derivable, the signing key does not.
         let secret = Sha256::digest("alice".as_bytes());
         let kp = NostrKeypair::from_install_secret(secret.as_slice()).unwrap();
-        let tag = routing_tag_for_device_id("alice").unwrap();
+        let tag = routing_tag_for_address("alice").unwrap();
         assert_ne!(kp.public_key_hex(), tag);
     }
 
@@ -667,15 +741,15 @@ mod tests {
         // These golden values were computed from the pre-split derivation and
         // must never change, or addressing breaks against deployed peers.
         assert_eq!(
-            routing_tag_for_device_id("alice").unwrap(),
+            routing_tag_for_address("alice").unwrap(),
             "9997a497d964fc1a62885b05a51166a65a90df00492c8d7cf61d6accf54803be"
         );
         assert_eq!(
-            routing_tag_for_device_id("bob").unwrap(),
+            routing_tag_for_address("bob").unwrap(),
             "4edfcf9dfe6c0b5c83d1ab3f78d1b39a46ebac6798e08e19761f5ed89ec83c10"
         );
         assert_eq!(
-            routing_tag_for_device_id("device1").unwrap(),
+            routing_tag_for_address("device1").unwrap(),
             "01194098eb3146ae142447c78a1fcf8df55b72b6d54f9eaa4b5b1c2a11826295"
         );
     }
@@ -683,7 +757,7 @@ mod tests {
     #[test]
     fn test_create_dm_event() {
         let sender = NostrKeypair::generate_ephemeral().unwrap();
-        let recipient_pubkey = routing_tag_for_device_id("bob").unwrap();
+        let recipient_pubkey = routing_tag_for_address("bob").unwrap();
 
         let event = NostrEvent::create_dm(&sender, &recipient_pubkey, "dGVzdCBtZXNzYWdl").unwrap();
 
@@ -700,7 +774,7 @@ mod tests {
     #[test]
     fn test_event_id_is_sha256_of_serialization() {
         let sender = NostrKeypair::generate_ephemeral().unwrap();
-        let recipient_pubkey = routing_tag_for_device_id("bob").unwrap();
+        let recipient_pubkey = routing_tag_for_address("bob").unwrap();
 
         let event = NostrEvent::create_dm(&sender, &recipient_pubkey, "dGVzdCBtZXNzYWdl").unwrap();
 
@@ -718,7 +792,7 @@ mod tests {
     #[test]
     fn test_signature_verification() {
         let sender = NostrKeypair::generate_ephemeral().unwrap();
-        let recipient_pubkey = routing_tag_for_device_id("bob").unwrap();
+        let recipient_pubkey = routing_tag_for_address("bob").unwrap();
 
         let event = NostrEvent::create_dm(&sender, &recipient_pubkey, "dGVzdCBtZXNzYWdl").unwrap();
 
@@ -737,7 +811,7 @@ mod tests {
     #[test]
     fn test_to_relay_message() {
         let sender = NostrKeypair::generate_ephemeral().unwrap();
-        let recipient_pubkey = routing_tag_for_device_id("bob").unwrap();
+        let recipient_pubkey = routing_tag_for_address("bob").unwrap();
 
         let event = NostrEvent::create_dm(&sender, &recipient_pubkey, "dGVzdCBtZXNzYWdl").unwrap();
         let relay_msg = event.to_relay_message().unwrap();
@@ -750,7 +824,7 @@ mod tests {
 
     #[test]
     fn test_create_subscription_message() {
-        let pubkey = routing_tag_for_device_id("alice").unwrap();
+        let pubkey = routing_tag_for_address("alice").unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", 1_700_000_000).unwrap();
 
         assert!(msg.starts_with("[\"REQ\",\"sub123\",{"));
@@ -767,7 +841,7 @@ mod tests {
         // from before sealing still publishes kind 4. Dropping kind 4 from the
         // filter would make those peers silently undeliverable — no error, no
         // event, just nothing arriving — so both kinds stay requested.
-        let pubkey = routing_tag_for_device_id("alice").unwrap();
+        let pubkey = routing_tag_for_address("alice").unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", 1_700_000_000).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -786,7 +860,7 @@ mod tests {
         // The wrapper's signing key must be fresh per event: a stable one would
         // let a relay group every message this device ever publishes, which is
         // most of the metadata that sealing exists to remove.
-        let bob_tag = routing_tag_for_device_id("bob").unwrap();
+        let bob_tag = routing_tag_for_address("bob").unwrap();
 
         let a = NostrEvent::create_gift_wrap(&bob_tag, &bob_tag, b"hello").unwrap();
         let b = NostrEvent::create_gift_wrap(&bob_tag, &bob_tag, b"hello").unwrap();
@@ -803,7 +877,7 @@ mod tests {
     #[test]
     fn test_gift_wrap_round_trips_to_the_recipients_key() {
         let bob = NostrKeypair::from_install_secret(&[77u8; 32]).unwrap();
-        let bob_tag = routing_tag_for_device_id("bob").unwrap();
+        let bob_tag = routing_tag_for_address("bob").unwrap();
 
         let event =
             NostrEvent::create_gift_wrap(&bob_tag, bob.public_key_hex(), b"payload").unwrap();
@@ -819,42 +893,75 @@ mod tests {
         // Sealed to Bob's install key, so Bob's *derivable* key must not open
         // it — otherwise the steady-state seal would be no better than the
         // bootstrap one.
-        let bob_derivable = NostrKeypair::derivable_for_device_id("bob").unwrap();
+        let bob_derivable = record_seal_keypair_for_address("bob").unwrap();
         assert!(unwrap_gift_wrap(&bob_derivable, &event.pubkey, &sealed).is_err());
     }
 
     #[test]
-    fn test_bootstrap_wrap_opens_with_the_derivable_key() {
-        // First contact: the sender knows only the recipient's user id, so it
-        // seals to the publicly computable key — which is the routing tag.
-        let bob_tag = routing_tag_for_device_id("bob").unwrap();
-        let event = NostrEvent::create_gift_wrap(&bob_tag, &bob_tag, b"first contact").unwrap();
+    fn test_bootstrap_wrap_opens_with_the_record_seal_key() {
+        // First contact: the sender knows only the recipient's address, so it
+        // addresses the frame to their tag and seals it to their record-seal
+        // key. Those are now two different values, which is the whole point of
+        // keeping them as two arguments.
+        let bob_tag = routing_tag_for_address("bob").unwrap();
+        let bob_seal = record_seal_keypair_for_address("bob").unwrap();
+
+        let event =
+            NostrEvent::create_gift_wrap(&bob_tag, bob_seal.public_key_hex(), b"first contact")
+                .unwrap();
         let sealed = base64::engine::general_purpose::STANDARD
             .decode(&event.content)
             .unwrap();
 
-        let bob_derivable = NostrKeypair::derivable_for_device_id("bob").unwrap();
         assert_eq!(
-            unwrap_gift_wrap(&bob_derivable, &event.pubkey, &sealed).unwrap(),
+            unwrap_gift_wrap(&bob_seal, &event.pubkey, &sealed).unwrap(),
             b"first contact"
+        );
+        assert_eq!(
+            event.tags[0],
+            vec!["p".to_string(), bob_tag],
+            "the frame is addressed to the tag even though it is sealed to the key"
         );
     }
 
     #[test]
-    fn test_derivable_public_half_is_exactly_the_routing_tag() {
-        // Load-bearing coincidence: the bootstrap seal targets the same value
-        // that appears in `#p`. If these ever diverged, first-contact frames
-        // would be addressed to one key and sealed to another — undeliverable,
-        // with nothing in the logs pointing at the cause.
+    fn test_record_seal_key_is_not_the_routing_tag() {
+        // These were the same value for most of this transport's life. Nothing
+        // was broken by it, but it left every routing tag standing as a public
+        // key whose private half anyone could compute — which stops being
+        // harmless the moment something adds NIP-42 AUTH or pubkey filtering
+        // and reaches for "the key matching this tag".
+        //
+        // Separate derivations, so there is no such key.
         for id in ["alice", "bob", "device1", "a-very-long-user-id-with-dashes"] {
-            assert_eq!(
-                NostrKeypair::derivable_for_device_id(id)
-                    .unwrap()
-                    .public_key_hex(),
-                routing_tag_for_device_id(id).unwrap(),
-                "derivable key and routing tag diverged for {id}"
+            assert_ne!(
+                record_seal_keypair_for_address(id).unwrap().public_key_hex(),
+                routing_tag_for_address(id).unwrap(),
+                "the record-seal key must not be the routing tag for {id}"
             );
         }
+    }
+
+    #[test]
+    fn test_record_seal_key_is_deterministic_and_address_specific() {
+        // Deterministic because both sides derive it independently — the
+        // publisher to seal, a fetcher to open — and they never exchange it.
+        assert_eq!(
+            record_seal_keypair_for_address("alice")
+                .unwrap()
+                .public_key_hex(),
+            record_seal_keypair_for_address("alice")
+                .unwrap()
+                .public_key_hex()
+        );
+        assert_ne!(
+            record_seal_keypair_for_address("alice")
+                .unwrap()
+                .public_key_hex(),
+            record_seal_keypair_for_address("bob")
+                .unwrap()
+                .public_key_hex()
+        );
     }
 
     #[test]
@@ -863,7 +970,7 @@ mod tests {
         // filtered out by peers' `until` bounds and, on our own receive path,
         // is exactly what `NOSTR_FUTURE_DATED_TOLERANCE_SECS` refuses to let
         // advance the watermark.
-        let bob_tag = routing_tag_for_device_id("bob").unwrap();
+        let bob_tag = routing_tag_for_address("bob").unwrap();
         let mut saw_jitter = false;
 
         for _ in 0..64 {
@@ -894,7 +1001,7 @@ mod tests {
         // Without a `limit` the filter is unbounded, so every relay
         // (re)connect replays the relay's whole retention window — which
         // NIP-11 no longer advertises, so it cannot even be reasoned about.
-        let pubkey = routing_tag_for_device_id("alice").unwrap();
+        let pubkey = routing_tag_for_address("alice").unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", 1_700_000_000).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -909,7 +1016,7 @@ mod tests {
 
     #[test]
     fn test_subscription_filter_carries_since() {
-        let pubkey = routing_tag_for_device_id("alice").unwrap();
+        let pubkey = routing_tag_for_address("alice").unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", 1_700_000_000).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -926,7 +1033,7 @@ mod tests {
         // A negative `since` is not a valid NIP-01 filter value; relays may
         // reject the whole REQ, which would take the subscription down rather
         // than merely widening it.
-        let pubkey = routing_tag_for_device_id("alice").unwrap();
+        let pubkey = routing_tag_for_address("alice").unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", -42).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();

--- a/crates/offline-protocol-transport/src/nostr_crypto.rs
+++ b/crates/offline-protocol-transport/src/nostr_crypto.rs
@@ -686,6 +686,18 @@ mod tests {
     use super::*;
     use base64::Engine;
 
+    /// The address a test label stands for.
+    ///
+    /// Both derivations here take an address, and an address is not a name —
+    /// writing `routing_tag_for_address("bob")` would still compute *a* tag,
+    /// and would quietly teach the next reader that usernames are valid input.
+    fn addr(label: &str) -> String {
+        let digest = Sha256::digest(label.as_bytes());
+        let mut hash = [0u8; offline_protocol_core::Address::HASH_LEN];
+        hash.copy_from_slice(&digest[..offline_protocol_core::Address::HASH_LEN]);
+        offline_protocol_core::Address::from_hash_bytes(hash).to_string()
+    }
+
     #[test]
     fn test_from_install_secret_deterministic() {
         let secret = [7u8; 32];
@@ -710,13 +722,26 @@ mod tests {
     }
 
     #[test]
-    fn test_signing_key_not_derivable_from_device_id() {
-        // The signing key must NOT equal the legacy SHA-256(device_id) key:
-        // the routing tag stays publicly derivable, the signing key does not.
-        let secret = Sha256::digest("alice".as_bytes());
+    fn test_signing_key_is_not_derivable_from_the_address() {
+        // The oldest invariant in this file, kept because the thing it guards
+        // against is the whole reason the key model has three entries: a
+        // signing key anyone can recompute from a public identifier is not an
+        // identity. Feeding the address straight into the install-secret
+        // derivation must not land on either public value.
+        let address = addr("alice");
+        let secret = Sha256::digest(address.as_bytes());
         let kp = NostrKeypair::from_install_secret(secret.as_slice()).unwrap();
-        let tag = routing_tag_for_address("alice").unwrap();
-        assert_ne!(kp.public_key_hex(), tag);
+
+        assert_ne!(
+            kp.public_key_hex(),
+            routing_tag_for_address(&address).unwrap()
+        );
+        assert_ne!(
+            kp.public_key_hex(),
+            record_seal_keypair_for_address(&address)
+                .unwrap()
+                .public_key_hex()
+        );
     }
 
     #[test]
@@ -735,29 +760,61 @@ mod tests {
     }
 
     #[test]
-    fn test_routing_tag_wire_compat_golden_values() {
-        // The routing tag is a cross-version wire contract: peers on older
-        // SDK versions derive our tag as SHA-256(device_id) → x-only pubkey.
-        // These golden values were computed from the pre-split derivation and
-        // must never change, or addressing breaks against deployed peers.
+    fn test_routing_tag_golden_values() {
+        // Re-pinned on addresses. The previous vectors were computed from
+        // usernames and carried a comment saying they "must never change, or
+        // addressing breaks against deployed peers" — which was true when the
+        // preimage was a username, and stopped being true twice over: the
+        // preimage is now the derived address, and the identity migration is a
+        // deliberate clean cutover with no fleet to break.
+        //
+        // So this is no longer a backward-compatibility contract. What it
+        // still guards is that two builds computing a tag for the same address
+        // agree — the failure it catches is a silent one, where both sides
+        // think they are talking and each subscribes to a label the other
+        // never writes to.
+        //
+        // Written out as literal addresses rather than through `addr()`: a
+        // golden vector that derives its own input can only ever agree with
+        // itself.
         assert_eq!(
-            routing_tag_for_address("alice").unwrap(),
-            "9997a497d964fc1a62885b05a51166a65a90df00492c8d7cf61d6accf54803be"
+            routing_tag_for_address("off1qy4aspkf0u8qptc6rlpn9ra8vw5jd9ereq4cwpfs").unwrap(),
+            "2ba510b01e5a0f1a76ed8e66beb430642960e740aedf7d8f1c8b21cb11028fc2"
         );
         assert_eq!(
-            routing_tag_for_address("bob").unwrap(),
-            "4edfcf9dfe6c0b5c83d1ab3f78d1b39a46ebac6798e08e19761f5ed89ec83c10"
+            routing_tag_for_address("off1qxqmvd7clnfvdknrt8nfvvgn5ytsmeu4us5lrr0g").unwrap(),
+            "32d26c7b8fbbb9268aba57a45d84a5554cc23e880aef5a7b2ce06e490a1ba35c"
         );
         assert_eq!(
-            routing_tag_for_address("device1").unwrap(),
-            "01194098eb3146ae142447c78a1fcf8df55b72b6d54f9eaa4b5b1c2a11826295"
+            routing_tag_for_address("off1qyv04gxa02f8jpkt8cu06nlk3x0mu35wdqyxt6jq").unwrap(),
+            "e7505f56a2de5a5d3946949ab58bde530b452f46f4c11f85130c18e48b7bbd51"
+        );
+    }
+
+    /// The record-seal key is a wire contract in the same way the tag is: a
+    /// publisher seals with it and a fetcher, on some other build, reconstructs
+    /// it independently. If the two derivations ever disagree, every published
+    /// record silently stops opening.
+    #[test]
+    fn test_record_seal_key_golden_values() {
+        assert_eq!(
+            record_seal_keypair_for_address("off1qy4aspkf0u8qptc6rlpn9ra8vw5jd9ereq4cwpfs")
+                .unwrap()
+                .public_key_hex(),
+            "62f2835dc8788282d7ce92864fd1819b12b472e209b0116c17a1d06a5f9eebb0"
+        );
+        assert_eq!(
+            record_seal_keypair_for_address("off1qxqmvd7clnfvdknrt8nfvvgn5ytsmeu4us5lrr0g")
+                .unwrap()
+                .public_key_hex(),
+            "c6c428f62e777b97c29a8e1a8d7fb2aaaa14bf55e5adf3ced4ed30a5c3c27755"
         );
     }
 
     #[test]
     fn test_create_dm_event() {
         let sender = NostrKeypair::generate_ephemeral().unwrap();
-        let recipient_pubkey = routing_tag_for_address("bob").unwrap();
+        let recipient_pubkey = routing_tag_for_address(&addr("bob")).unwrap();
 
         let event = NostrEvent::create_dm(&sender, &recipient_pubkey, "dGVzdCBtZXNzYWdl").unwrap();
 
@@ -774,7 +831,7 @@ mod tests {
     #[test]
     fn test_event_id_is_sha256_of_serialization() {
         let sender = NostrKeypair::generate_ephemeral().unwrap();
-        let recipient_pubkey = routing_tag_for_address("bob").unwrap();
+        let recipient_pubkey = routing_tag_for_address(&addr("bob")).unwrap();
 
         let event = NostrEvent::create_dm(&sender, &recipient_pubkey, "dGVzdCBtZXNzYWdl").unwrap();
 
@@ -792,7 +849,7 @@ mod tests {
     #[test]
     fn test_signature_verification() {
         let sender = NostrKeypair::generate_ephemeral().unwrap();
-        let recipient_pubkey = routing_tag_for_address("bob").unwrap();
+        let recipient_pubkey = routing_tag_for_address(&addr("bob")).unwrap();
 
         let event = NostrEvent::create_dm(&sender, &recipient_pubkey, "dGVzdCBtZXNzYWdl").unwrap();
 
@@ -811,7 +868,7 @@ mod tests {
     #[test]
     fn test_to_relay_message() {
         let sender = NostrKeypair::generate_ephemeral().unwrap();
-        let recipient_pubkey = routing_tag_for_address("bob").unwrap();
+        let recipient_pubkey = routing_tag_for_address(&addr("bob")).unwrap();
 
         let event = NostrEvent::create_dm(&sender, &recipient_pubkey, "dGVzdCBtZXNzYWdl").unwrap();
         let relay_msg = event.to_relay_message().unwrap();
@@ -824,7 +881,7 @@ mod tests {
 
     #[test]
     fn test_create_subscription_message() {
-        let pubkey = routing_tag_for_address("alice").unwrap();
+        let pubkey = routing_tag_for_address(&addr("alice")).unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", 1_700_000_000).unwrap();
 
         assert!(msg.starts_with("[\"REQ\",\"sub123\",{"));
@@ -841,7 +898,7 @@ mod tests {
         // from before sealing still publishes kind 4. Dropping kind 4 from the
         // filter would make those peers silently undeliverable — no error, no
         // event, just nothing arriving — so both kinds stay requested.
-        let pubkey = routing_tag_for_address("alice").unwrap();
+        let pubkey = routing_tag_for_address(&addr("alice")).unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", 1_700_000_000).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -860,7 +917,7 @@ mod tests {
         // The wrapper's signing key must be fresh per event: a stable one would
         // let a relay group every message this device ever publishes, which is
         // most of the metadata that sealing exists to remove.
-        let bob_tag = routing_tag_for_address("bob").unwrap();
+        let bob_tag = routing_tag_for_address(&addr("bob")).unwrap();
 
         let a = NostrEvent::create_gift_wrap(&bob_tag, &bob_tag, b"hello").unwrap();
         let b = NostrEvent::create_gift_wrap(&bob_tag, &bob_tag, b"hello").unwrap();
@@ -877,7 +934,7 @@ mod tests {
     #[test]
     fn test_gift_wrap_round_trips_to_the_recipients_key() {
         let bob = NostrKeypair::from_install_secret(&[77u8; 32]).unwrap();
-        let bob_tag = routing_tag_for_address("bob").unwrap();
+        let bob_tag = routing_tag_for_address(&addr("bob")).unwrap();
 
         let event =
             NostrEvent::create_gift_wrap(&bob_tag, bob.public_key_hex(), b"payload").unwrap();
@@ -893,7 +950,7 @@ mod tests {
         // Sealed to Bob's install key, so Bob's *derivable* key must not open
         // it — otherwise the steady-state seal would be no better than the
         // bootstrap one.
-        let bob_derivable = record_seal_keypair_for_address("bob").unwrap();
+        let bob_derivable = record_seal_keypair_for_address(&addr("bob")).unwrap();
         assert!(unwrap_gift_wrap(&bob_derivable, &event.pubkey, &sealed).is_err());
     }
 
@@ -903,8 +960,8 @@ mod tests {
         // addresses the frame to their tag and seals it to their record-seal
         // key. Those are now two different values, which is the whole point of
         // keeping them as two arguments.
-        let bob_tag = routing_tag_for_address("bob").unwrap();
-        let bob_seal = record_seal_keypair_for_address("bob").unwrap();
+        let bob_tag = routing_tag_for_address(&addr("bob")).unwrap();
+        let bob_seal = record_seal_keypair_for_address(&addr("bob")).unwrap();
 
         let event =
             NostrEvent::create_gift_wrap(&bob_tag, bob_seal.public_key_hex(), b"first contact")
@@ -947,18 +1004,18 @@ mod tests {
         // Deterministic because both sides derive it independently — the
         // publisher to seal, a fetcher to open — and they never exchange it.
         assert_eq!(
-            record_seal_keypair_for_address("alice")
+            record_seal_keypair_for_address(&addr("alice"))
                 .unwrap()
                 .public_key_hex(),
-            record_seal_keypair_for_address("alice")
+            record_seal_keypair_for_address(&addr("alice"))
                 .unwrap()
                 .public_key_hex()
         );
         assert_ne!(
-            record_seal_keypair_for_address("alice")
+            record_seal_keypair_for_address(&addr("alice"))
                 .unwrap()
                 .public_key_hex(),
-            record_seal_keypair_for_address("bob")
+            record_seal_keypair_for_address(&addr("bob"))
                 .unwrap()
                 .public_key_hex()
         );
@@ -970,7 +1027,7 @@ mod tests {
         // filtered out by peers' `until` bounds and, on our own receive path,
         // is exactly what `NOSTR_FUTURE_DATED_TOLERANCE_SECS` refuses to let
         // advance the watermark.
-        let bob_tag = routing_tag_for_address("bob").unwrap();
+        let bob_tag = routing_tag_for_address(&addr("bob")).unwrap();
         let mut saw_jitter = false;
 
         for _ in 0..64 {
@@ -1001,7 +1058,7 @@ mod tests {
         // Without a `limit` the filter is unbounded, so every relay
         // (re)connect replays the relay's whole retention window — which
         // NIP-11 no longer advertises, so it cannot even be reasoned about.
-        let pubkey = routing_tag_for_address("alice").unwrap();
+        let pubkey = routing_tag_for_address(&addr("alice")).unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", 1_700_000_000).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -1016,7 +1073,7 @@ mod tests {
 
     #[test]
     fn test_subscription_filter_carries_since() {
-        let pubkey = routing_tag_for_address("alice").unwrap();
+        let pubkey = routing_tag_for_address(&addr("alice")).unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", 1_700_000_000).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -1033,7 +1090,7 @@ mod tests {
         // A negative `since` is not a valid NIP-01 filter value; relays may
         // reject the whole REQ, which would take the subscription down rather
         // than merely widening it.
-        let pubkey = routing_tag_for_address("alice").unwrap();
+        let pubkey = routing_tag_for_address(&addr("alice")).unwrap();
         let msg = create_subscription_message(&pubkey, "sub123", -42).unwrap();
 
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();

--- a/crates/offline-protocol-transport/src/nostr_crypto.rs
+++ b/crates/offline-protocol-transport/src/nostr_crypto.rs
@@ -989,13 +989,14 @@ mod tests {
         // and reaches for "the key matching this tag".
         //
         // Separate derivations, so there is no such key.
-        for id in ["alice", "bob", "device1", "a-very-long-user-id-with-dashes"] {
+        for label in ["alice", "bob", "device1", "a-very-long-user-id-with-dashes"] {
+            let address = addr(label);
             assert_ne!(
-                record_seal_keypair_for_address(id)
+                record_seal_keypair_for_address(&address)
                     .unwrap()
                     .public_key_hex(),
-                routing_tag_for_address(id).unwrap(),
-                "the record-seal key must not be the routing tag for {id}"
+                routing_tag_for_address(&address).unwrap(),
+                "the record-seal key must not be the routing tag for {label}"
             );
         }
     }

--- a/crates/offline-protocol-transport/src/nostr_crypto.rs
+++ b/crates/offline-protocol-transport/src/nostr_crypto.rs
@@ -162,7 +162,6 @@ impl NostrKeypair {
     pub fn public_key_hex(&self) -> &str {
         &self.public_key_hex
     }
-
 }
 
 /// Reconstructs the keypair that seals content addressed to `address`.
@@ -992,7 +991,9 @@ mod tests {
         // Separate derivations, so there is no such key.
         for id in ["alice", "bob", "device1", "a-very-long-user-id-with-dashes"] {
             assert_ne!(
-                record_seal_keypair_for_address(id).unwrap().public_key_hex(),
+                record_seal_keypair_for_address(id)
+                    .unwrap()
+                    .public_key_hex(),
                 routing_tag_for_address(id).unwrap(),
                 "the record-seal key must not be the routing tag for {id}"
             );

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10185,8 +10185,8 @@ mod tests {
             .unwrap();
 
         let address = protocol.local_address().expect("address after init");
-        let address_tag = offline_protocol_transport::routing_tag_for_device_id(&address).unwrap();
-        let profile_tag = offline_protocol_transport::routing_tag_for_device_id(&profile).unwrap();
+        let address_tag = offline_protocol_transport::routing_tag_for_address(&address).unwrap();
+        let profile_tag = offline_protocol_transport::routing_tag_for_address(&profile).unwrap();
 
         assert_eq!(
             protocol.with_nostr_transport(|nt| nt.routing_tag().to_string()),
@@ -10246,7 +10246,7 @@ mod tests {
             .nostr_get_subscription_filter("sub".to_string())
             .expect("the rebuild installs the transport");
         let address = protocol.local_address().expect("address after init");
-        let address_tag = offline_protocol_transport::routing_tag_for_device_id(&address).unwrap();
+        let address_tag = offline_protocol_transport::routing_tag_for_address(&address).unwrap();
         assert!(
             filter.contains(&address_tag),
             "the filter must carry the address-derived tag: {filter}"

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -2377,19 +2377,26 @@ impl OfflineProtocol {
                 .add_transport(CoreTransportType::Reticulum, Box::new(reticulum_transport));
         }
 
-        // Add Nostr transport if enabled
-        // The platform bridges to Nostr relay WebSocket connections
-        if nostr_enabled {
-            let nostr_transport = NostrTransport::new(user_id.clone()).map_err(|e| {
-                ProtocolError::InvalidConfiguration(format!(
-                    "Failed to create Nostr keypair: {}",
-                    e
-                ))
-            })?;
-            protocol
-                .transport_manager_mut()
-                .add_transport(CoreTransportType::Nostr, Box::new(nostr_transport));
-        }
+        // Nostr is deliberately NOT built here, unlike the three above.
+        //
+        // Those carry the placeholder id as local bookkeeping until the
+        // rebuild; Nostr *publishes* its id's derivative. The routing tag is
+        // `SHA-256(id)`, it goes to third-party relays in the subscription
+        // filter the moment a socket opens, and both bridges send that filter
+        // unconditionally from their socket-open callback — so a transport
+        // built on the profile here puts a label anyone can recompute from the
+        // username onto a public relay, permanently and with nothing to
+        // retract it.
+        //
+        // That is not hypothetical: `initialize_mls` is skipped outright when
+        // encryption is disabled, and a thrown one is caught and warned past by
+        // the RN layer, so the rebuild cannot be relied on to arrive before the
+        // relays do. Leaving the slot empty makes the transport's absence the
+        // failure instead — loud at `enable_transport`, and nothing published.
+        //
+        // `enabled_transports.nostr` carries the intent forward;
+        // `rebuild_transports_for_identity` installs the only Nostr transport
+        // this instance ever has, against the real address.
 
         // Create the event queue and callback that will be shared with the event handler
         let event_queue = Arc::new(Mutex::new(VecDeque::new()));
@@ -7630,6 +7637,7 @@ mod tests {
             ..create_test_config()
         })
         .unwrap();
+        install_test_identity(&receiver);
         receiver.start().unwrap();
 
         receiver
@@ -7673,6 +7681,22 @@ mod tests {
         );
     }
 
+    /// Runs the identity bootstrap these fixtures need before `start()`.
+    ///
+    /// The Nostr transport is installed by the identity rebuild, not by
+    /// `new()` — nothing publishes a routing tag derived from a profile — so a
+    /// Nostr fixture that skips this has no Nostr transport at all. Pinned from
+    /// the other side by
+    /// `test_nostr_is_absent_until_the_identity_rebuild_installs_it`.
+    fn install_test_identity(protocol: &OfflineProtocol) {
+        protocol
+            .initialize_mls(
+                Box::new(TestMlsStorageProvider::default()),
+                Box::new(TestMlsStorageProvider::default()),
+            )
+            .expect("test identity bootstrap");
+    }
+
     /// Reads the `since` the transport would put on its next REQ filter.
     fn nostr_subscription_since(protocol: &OfflineProtocol) -> i64 {
         let filter = protocol
@@ -7699,6 +7723,7 @@ mod tests {
             ..create_test_config()
         })
         .unwrap();
+        install_test_identity(&receiver);
         receiver.start().unwrap();
 
         let first_run_since = nostr_subscription_since(&receiver);
@@ -7731,6 +7756,7 @@ mod tests {
             ..create_test_config()
         })
         .unwrap();
+        install_test_identity(&receiver);
         receiver.start().unwrap();
 
         let before = nostr_subscription_since(&receiver);
@@ -7761,6 +7787,7 @@ mod tests {
             ..create_test_config()
         })
         .unwrap();
+        install_test_identity(&receiver);
         receiver.start().unwrap();
 
         let before = nostr_subscription_since(&receiver);
@@ -10135,11 +10162,11 @@ mod tests {
     /// The one transport for which the post-identity rebuild is load-bearing.
     ///
     /// `NostrTransport` computes its routing tag from the id it is constructed
-    /// with, and that tag is the address peers publish to. Built in `new()` the
-    /// id is still the profile, so without the rebuild this device subscribes
-    /// to a tag nobody writes to and every Nostr-carried frame is simply never
-    /// seen — no error anywhere. The assertion that matters is the second one:
-    /// the tag actually *moved* off the profile.
+    /// with, and that tag is what goes to third-party relays. So the rebuild is
+    /// not merely where the tag improves — it is the only place a Nostr
+    /// transport is allowed to come from at all, which is what
+    /// [`test_nostr_is_absent_until_the_identity_rebuild_installs_it`] holds
+    /// down from the other side.
     #[test]
     fn test_nostr_routing_tag_follows_the_derived_address_after_mls_init() {
         let config = ProtocolConfig {
@@ -10150,13 +10177,6 @@ mod tests {
         let profile = config.profile.clone();
         let protocol = OfflineProtocol::new(config).unwrap();
 
-        let profile_tag = offline_protocol_transport::routing_tag_for_device_id(&profile).unwrap();
-        assert_eq!(
-            protocol.with_nostr_transport(|nt| nt.routing_tag().to_string()),
-            Some(profile_tag.clone()),
-            "before init the transport can only know the profile"
-        );
-
         protocol
             .initialize_mls(
                 Box::new(TestMlsStorageProvider::default()),
@@ -10166,6 +10186,7 @@ mod tests {
 
         let address = protocol.local_address().expect("address after init");
         let address_tag = offline_protocol_transport::routing_tag_for_device_id(&address).unwrap();
+        let profile_tag = offline_protocol_transport::routing_tag_for_device_id(&profile).unwrap();
 
         assert_eq!(
             protocol.with_nostr_transport(|nt| nt.routing_tag().to_string()),
@@ -10176,6 +10197,96 @@ mod tests {
             protocol.with_nostr_transport(|nt| nt.routing_tag().to_string()),
             Some(profile_tag),
             "a tag still derived from the profile is the silent-delivery failure this rebuild exists to prevent"
+        );
+    }
+
+    /// No identity, no Nostr — the leak this ordering exists to prevent.
+    ///
+    /// The routing tag is `SHA-256(id)` and the bridges hand it to relays in
+    /// the subscription filter the moment a socket opens, unconditionally, from
+    /// their socket-open callback. A transport built on the profile therefore
+    /// publishes a label anyone can recompute from the username, to third
+    /// parties, with nothing to retract it — and the rebuild that would have
+    /// fixed it cannot be relied on to arrive first: `initialize_mls` is
+    /// skipped outright when encryption is disabled, and a thrown one is caught
+    /// and warned past by the RN layer.
+    ///
+    /// So the absence is the contract. Asserting on `nostr_get_subscription_filter`
+    /// rather than on the transport handle is deliberate: that function is the
+    /// only thing standing between this state and a relay, so it is the one
+    /// that has to come back empty.
+    #[test]
+    fn test_nostr_is_absent_until_the_identity_rebuild_installs_it() {
+        let protocol = OfflineProtocol::new(ProtocolConfig {
+            profile: "leaky-profile".to_string(),
+            nostr_enabled: true,
+            ..create_test_config()
+        })
+        .unwrap();
+
+        assert_eq!(
+            protocol.nostr_get_subscription_filter("sub".to_string()),
+            None,
+            "a filter before identity is a profile-derived tag on a public relay"
+        );
+        assert_eq!(
+            protocol.with_nostr_transport(|nt| nt.routing_tag().to_string()),
+            None,
+            "no Nostr transport may exist before the address does"
+        );
+
+        protocol
+            .initialize_mls(
+                Box::new(TestMlsStorageProvider::default()),
+                Box::new(TestMlsStorageProvider::default()),
+            )
+            .unwrap();
+
+        let filter = protocol
+            .nostr_get_subscription_filter("sub".to_string())
+            .expect("the rebuild installs the transport");
+        let address = protocol.local_address().expect("address after init");
+        let address_tag = offline_protocol_transport::routing_tag_for_device_id(&address).unwrap();
+        assert!(
+            filter.contains(&address_tag),
+            "the filter must carry the address-derived tag: {filter}"
+        );
+        assert!(
+            !filter.contains("leaky-profile"),
+            "the profile must reach no relay in any form: {filter}"
+        );
+    }
+
+    /// The transport refuses an id that is not an address, rather than hashing
+    /// it into a tag.
+    ///
+    /// Both ways of getting the id wrong are silent at runtime — a guessable
+    /// preimage is a disclosure nothing reports, and a merely-different one
+    /// addresses the device where nobody writes — so the refusal is the only
+    /// place either can surface.
+    #[test]
+    fn test_nostr_transport_refuses_an_id_that_is_not_an_address() {
+        assert!(
+            offline_protocol_transport::NostrTransport::new("nostr-profile").is_err(),
+            "a profile-shaped id must not produce a routing tag"
+        );
+
+        let protocol = OfflineProtocol::new(ProtocolConfig {
+            profile: "nostr-profile".to_string(),
+            nostr_enabled: true,
+            ..create_test_config()
+        })
+        .unwrap();
+        protocol
+            .initialize_mls(
+                Box::new(TestMlsStorageProvider::default()),
+                Box::new(TestMlsStorageProvider::default()),
+            )
+            .unwrap();
+        let address = protocol.local_address().expect("address after init");
+        assert!(
+            offline_protocol_transport::NostrTransport::new(address).is_ok(),
+            "the derived address is exactly what the transport accepts"
         );
     }
 
@@ -10194,7 +10305,11 @@ mod tests {
         })
         .unwrap();
 
+        // Absent, not merely unchanged: nothing installs a Nostr transport
+        // before the address exists, so a refused init must leave the slot
+        // empty rather than fill it on the way out.
         let tag_before = protocol.with_nostr_transport(|nt| nt.routing_tag().to_string());
+        assert_eq!(tag_before, None, "no Nostr transport before identity");
         protocol.start().unwrap();
 
         let err = protocol

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -5243,6 +5243,14 @@ impl OfflineProtocol {
                 self.enabled_transports,
                 &address,
             )?;
+            // The Nostr transport did not exist while `initialize_mls` ran its
+            // restores — the line above is what installs it — so the persisted
+            // signing secret and receive watermark have to be installed now.
+            // Skipping this leaves the transport on its construction-time
+            // ephemeral key, which rotates this install's Nostr identity every
+            // launch and silently strands peers still sealing to the pubkey we
+            // last advertised.
+            protocol.restore_nostr_transport_state();
         }
         Ok(())
     }
@@ -6177,9 +6185,23 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
+    /// Backing store for [`TestMlsStorageProvider`], shareable so two protocol
+    /// instances can stand in for two launches of one device.
+    type TestStore = Arc<Mutex<HashMap<(String, String), Vec<u8>>>>;
+
     #[derive(Default)]
     struct TestMlsStorageProvider {
-        data: Mutex<HashMap<(String, String), Vec<u8>>>,
+        data: TestStore,
+    }
+
+    impl TestMlsStorageProvider {
+        /// A provider over an existing store, so a second instance reads what
+        /// the first one persisted.
+        fn over(store: &TestStore) -> Self {
+            Self {
+                data: store.clone(),
+            }
+        }
     }
 
     impl MlsStorageProvider for TestMlsStorageProvider {
@@ -10287,6 +10309,114 @@ mod tests {
         assert!(
             offline_protocol_transport::NostrTransport::new(address).is_ok(),
             "the derived address is exactly what the transport accepts"
+        );
+    }
+
+    /// One device, two launches: the same Nostr signing identity both times.
+    ///
+    /// The persisted signing secret is installed by a restore that runs inside
+    /// `initialize_mls` — at which point no Nostr transport exists, because the
+    /// transport is derived from the address `initialize_mls` is busy
+    /// producing. The rebuild installs it a moment later, so the restore has to
+    /// run again or the transport keeps the ephemeral key it was constructed
+    /// with. That failure is silent and remote: we advertise the ephemeral
+    /// pubkey in our key packages, peers persist it and seal to it, and after
+    /// our next launch their frames no longer open — while `build_event` only
+    /// re-resolves a peer it has *no* key for, so a stale one is never
+    /// refreshed.
+    #[test]
+    fn test_nostr_signing_identity_survives_a_restart() {
+        let secure = TestStore::default();
+        let state = TestStore::default();
+
+        let launch = |secure: &TestStore, state: &TestStore| {
+            let protocol = OfflineProtocol::new(ProtocolConfig {
+                profile: "restarting-device".to_string(),
+                nostr_enabled: true,
+                ..create_test_config()
+            })
+            .unwrap();
+            protocol
+                .initialize_mls(
+                    Box::new(TestMlsStorageProvider::over(secure)),
+                    Box::new(TestMlsStorageProvider::over(state)),
+                )
+                .unwrap();
+            protocol
+        };
+
+        let first = launch(&secure, &state);
+        let first_key = first
+            .nostr_get_public_key()
+            .expect("the rebuild installs a Nostr transport");
+
+        let second = launch(&secure, &state);
+        let second_key = second
+            .nostr_get_public_key()
+            .expect("the rebuild installs a Nostr transport");
+
+        assert_eq!(
+            first_key, second_key,
+            "the persisted signing secret must reach the transport the rebuild \
+             installed; an ephemeral key here rotates this install's Nostr \
+             identity on every launch"
+        );
+    }
+
+    /// The other half of the same restore: a restart resumes from the stored
+    /// receive watermark instead of replaying the whole first-run backfill.
+    #[test]
+    fn test_nostr_receive_watermark_survives_a_restart() {
+        let secure = TestStore::default();
+        let state = TestStore::default();
+        let data = serialized_message_from("sender-user", "receiver-user");
+
+        let first = OfflineProtocol::new(ProtocolConfig {
+            profile: "restarting-device".to_string(),
+            nostr_enabled: true,
+            ..create_test_config()
+        })
+        .unwrap();
+        first
+            .initialize_mls(
+                Box::new(TestMlsStorageProvider::over(&secure)),
+                Box::new(TestMlsStorageProvider::over(&state)),
+            )
+            .unwrap();
+        first.start().unwrap();
+
+        let first_run_since = nostr_subscription_since(&first);
+        let created_at = now_unix_secs() - 30;
+        first
+            .nostr_message_received_at("nostr-routing-pubkey".to_string(), data, created_at)
+            .unwrap();
+        let advanced_since = nostr_subscription_since(&first);
+        assert!(
+            advanced_since > first_run_since,
+            "watermark did not advance"
+        );
+
+        // stop() flushes the mark to protocol-state storage.
+        first.stop().unwrap();
+
+        let second = OfflineProtocol::new(ProtocolConfig {
+            profile: "restarting-device".to_string(),
+            nostr_enabled: true,
+            ..create_test_config()
+        })
+        .unwrap();
+        second
+            .initialize_mls(
+                Box::new(TestMlsStorageProvider::over(&secure)),
+                Box::new(TestMlsStorageProvider::over(&state)),
+            )
+            .unwrap();
+
+        assert_eq!(
+            nostr_subscription_since(&second),
+            advanced_since,
+            "the second launch must resume from the persisted watermark rather \
+             than replaying the first-run backfill window"
         );
     }
 

--- a/crates/offline-protocol/src/protocol/storage.rs
+++ b/crates/offline-protocol/src/protocol/storage.rs
@@ -4253,8 +4253,13 @@ impl OfflineProtocol {
     /// This gives the install a stable Nostr identity (event signatures,
     /// relay-visible pubkey) across restarts. The signing key is intentionally
     /// not derivable from any public identifier (SEC-M4); message addressing
-    /// is unaffected because it uses the separate routing tag, which remains
-    /// derived from the device ID.
+    /// is unaffected because it uses the separate routing tag, which is
+    /// derived from this device's address.
+    ///
+    /// Registering the Nostr transport *after* this has run leaves it on its
+    /// ephemeral key — see [`Self::restore_nostr_transport_state`], which is
+    /// how the bindings layer (whose transport cannot exist until the address
+    /// does) gets a second pass.
     ///
     /// Idempotent across repeated initialization attempts via
     /// `nostr_secret_persisted`. All
@@ -4528,6 +4533,29 @@ impl OfflineProtocol {
                  keeping the live mark and rewriting on the next accepted event"
             );
         }
+    }
+
+    /// Installs the persisted Nostr state into a transport that was registered
+    /// *after* [`Self::initialize_mls`] ran.
+    ///
+    /// Both restores below are no-ops when no Nostr transport is registered,
+    /// which is exactly the state `initialize_mls` runs them in for the FFI:
+    /// the Nostr transport is derived from this device's address, so the
+    /// bindings layer cannot construct it until `initialize_mls` has produced
+    /// one, and it installs the transport immediately afterwards. Without this
+    /// second pass that transport keeps the ephemeral signing key it was
+    /// constructed with — rotating this install's Nostr identity on every
+    /// launch, so peers who sealed to the pubkey we advertised last time get
+    /// frames we can no longer open — and starts with no receive watermark, so
+    /// every cold start replays the full first-run backfill window.
+    ///
+    /// Safe to call whether or not the first pass found a transport: the
+    /// signing-secret restore is guarded by `nostr_secret_persisted`, which a
+    /// transport-less pass leaves unset, and the watermark only ever moves
+    /// forward.
+    pub fn restore_nostr_transport_state(&mut self) {
+        self.restore_or_init_nostr_signing_secret();
+        self.restore_nostr_watermark();
     }
 
     /// Installs `secret` as the telemetry fallback secret and rebuilds the

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -2425,7 +2425,7 @@ fn peer_nostr_pubkey_persists_across_restart() {
 fn peer_nostr_pubkey_reaches_the_nostr_transport() {
     // The record is only useful if it lands where sealing reads it.
     let mut protocol = protocol_with_nostr("user123");
-    let bob = NostrTransport::new("bob").unwrap();
+    let bob = NostrTransport::new(id("bob")).unwrap();
     bob.install_signing_secret(&[64u8; 32]).unwrap();
     let bob_pubkey = bob.public_key_hex();
 
@@ -2452,7 +2452,7 @@ fn peer_nostr_pubkey_reaches_the_nostr_transport() {
 
     // And a *different* install of Bob's user id cannot: that is the whole
     // difference between the steady state and the bootstrap leg.
-    let impostor = NostrTransport::new("bob").unwrap();
+    let impostor = NostrTransport::new(id("bob")).unwrap();
     impostor.install_signing_secret(&[65u8; 32]).unwrap();
     assert_eq!(
         impostor
@@ -2469,7 +2469,7 @@ fn unblock_clears_the_cached_peer_nostr_key() {
     // capability sets, so it needs its own clear — otherwise the durable
     // record is deleted while sends keep sealing to the forgotten key.
     let mut protocol = protocol_with_nostr("user123");
-    let bob = NostrTransport::new("bob").unwrap();
+    let bob = NostrTransport::new(id("bob")).unwrap();
     bob.install_signing_secret(&[70u8; 32]).unwrap();
     feed_key_package_with_nostr_pubkey(&mut protocol, "bob", Some(&bob.public_key_hex()));
 
@@ -2616,7 +2616,7 @@ fn outgoing_key_package_advertises_our_nostr_pubkey_only_when_nostr_is_on() {
     // an upgrade.
     assert_ne!(
         advertised.as_deref(),
-        Some(routing_tag_for_device_id("alice").unwrap().as_str())
+        Some(routing_tag_for_device_id(&id("alice")).unwrap().as_str())
     );
 }
 
@@ -23531,7 +23531,7 @@ fn scrub_secret_without_storage_keeps_random_per_instance_fallback() {
 
 fn protocol_with_nostr_transport() -> OfflineProtocol {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
-    let nostr = offline_protocol_transport::NostrTransport::new("test_user").unwrap();
+    let nostr = offline_protocol_transport::NostrTransport::new(id("test_user")).unwrap();
     protocol
         .transport_manager
         .add_transport(TransportType::Nostr, Box::new(nostr));
@@ -31781,7 +31781,7 @@ fn nostr_kill_switches_reach_the_transport_on_start() {
         config.transport.nostr_cold_contact_enabled = cold_contact;
 
         let mut protocol = OfflineProtocol::new(config).unwrap();
-        let nostr = NostrTransport::new("alice").unwrap();
+        let nostr = NostrTransport::new(id("alice")).unwrap();
         nostr.on_status_changed(TransportStatus::Available);
         protocol
             .transport_manager_mut()

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -11,7 +11,7 @@ use crate::test_identity::{id, session_slot};
 use chrono::Duration as ChronoDuration;
 use offline_protocol_core::{AppId, ContentType, MessagePriority, ServiceDescriptor, UserId};
 use offline_protocol_transport::{
-    mock::MockTransport, nostr::NostrTransport, nostr_crypto::routing_tag_for_device_id, Transport,
+    mock::MockTransport, nostr::NostrTransport, nostr_crypto::routing_tag_for_address, Transport,
     TransportMetrics, TransportStatus, TransportType,
 };
 use std::sync::{Arc, Barrier, Mutex};
@@ -2616,7 +2616,7 @@ fn outgoing_key_package_advertises_our_nostr_pubkey_only_when_nostr_is_on() {
     // an upgrade.
     assert_ne!(
         advertised.as_deref(),
-        Some(routing_tag_for_device_id(&id("alice")).unwrap().as_str())
+        Some(routing_tag_for_address(&id("alice")).unwrap().as_str())
     );
 }
 

--- a/docs/nostr.md
+++ b/docs/nostr.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Nostr transport routes messages over [Nostr](https://nostr.com/) relays via WebSockets, providing a censorship-resistant, decentralized fallback when direct mesh and ordinary Internet endpoints are unreachable. Addressing uses a public *routing tag* deterministically derived from the `userId`, so peers can compute where to send without exchanging keys. Relays simply rebroadcast the signed events to subscribers.
+The Nostr transport routes messages over [Nostr](https://nostr.com/) relays via WebSockets, providing a censorship-resistant, decentralized fallback when direct mesh and ordinary Internet endpoints are unreachable. Addressing uses a public *routing tag* deterministically derived from this device's **derived address** (the `off1…` identity the SDK generates at `initializeMls`), so peers can compute where to send without exchanging keys. Relays simply rebroadcast the signed events to subscribers.
 
 Outgoing frames are **sealed into [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md) gift wraps** (kind `1059`, [NIP-44 v2](https://github.com/nostr-protocol/nips/blob/master/44.md) inner encryption), each signed by a fresh single-use key. A relay sees an opaque routing tag, an unlinkable per-event pubkey, a jittered timestamp, and ciphertext — and nothing that identifies either party. See [What a relay can see](#what-a-relay-can-see).
 
@@ -19,7 +19,7 @@ Nostr is the fifth transport in the Offline Protocol SDK, alongside BLE, WiFi Di
 
 Nostr is **not** suitable for:
 - Latency-sensitive workloads — relay round-trips add tens of ms at minimum
-- Hiding *that* a given user is reachable — the routing tag is derived from the `userId`, so anyone who can guess a username can watch that inbox for traffic volume and timing
+- Hiding *that* a given address is reachable — the routing tag is derived from the address, so anyone who **knows** an address can watch that inbox for traffic volume and timing. An address cannot be guessed (it is a 160-bit hash of an identity key), so this is a smaller set than it used to be: the people who could already send you traffic. It is not nobody
 - Pure offline scenarios — relays are reachable only when the device has Internet
 
 ## Architecture
@@ -55,7 +55,7 @@ The Rust `NostrTransport` owns the queue, signing, and confirmation loop. The pl
 └──────────────────────┘
 ```
 
-The Rust side signs with the per-install Schnorr keypair (stable once `initialize_mls` persists the install secret), addresses the event to the recipient's routing tag (derived from their `userId`), builds canonical Nostr event JSON, and hands the platform a `NostrMessage` with `{message_id, event_id, event_json}`. The platform never touches secret material.
+The Rust side signs with the per-install Schnorr keypair (stable once `initialize_mls` persists the install secret), addresses the event to the recipient's routing tag (derived from their address), builds canonical Nostr event JSON, and hands the platform a `NostrMessage` with `{message_id, event_id, event_json}`. The platform never touches secret material.
 
 ## Configuration
 
@@ -65,7 +65,7 @@ The Rust side signs with the per-install Schnorr keypair (stable once `initializ
 ```typescript
 const protocol = new OfflineProtocol({
   appId: 'my-app',
-  userId: 'user123',
+  profile: 'user123',
   transports: {
     ble: { enabled: true },
     nostr: {
@@ -85,7 +85,7 @@ const protocol = new OfflineProtocol({
 ```kotlin
 val config = ProtocolConfig(
     appId = "my-app",
-    userId = "user123",
+    profile = "user123",
     bleEnabled = true,
     nostrEnabled = true,
     // ... other fields
@@ -96,7 +96,7 @@ val config = ProtocolConfig(
 ```swift
 let config = ProtocolConfig(
     appId: "my-app",
-    userId: "user123",
+    profile: "user123",
     bleEnabled: true,
     nostrEnabled: true,
     // ... other fields
@@ -210,7 +210,7 @@ sends fall back to the bootstrap leg as before.
 
 ### Subscription Filters
 
-The Rust core builds NIP-01 filters scoped to the local routing tag (events addressed to this device); the tag is derived from the `userId`, so senders can compute it without a key exchange. Use `nostrGetSubscriptionFilter(subscriptionId)` to fetch the JSON filter to send via `["REQ", subscriptionId, filter]`. Use `nostrGetPublicKey()` to retrieve the install's hex-encoded signing public key (for diagnostics); read it after MLS initialization, since that is when the persisted signing key is installed.
+The Rust core builds NIP-01 filters scoped to the local routing tag (events addressed to this device); the tag is derived from the address, so senders can compute it without a key exchange. Use `nostrGetSubscriptionFilter(subscriptionId)` to fetch the JSON filter to send via `["REQ", subscriptionId, filter]`. Use `nostrGetPublicKey()` to retrieve the install's hex-encoded signing public key (for diagnostics); read it after MLS initialization, since that is when the persisted signing key is installed.
 
 > **`nostrGetPublicKey()` is no longer a self-event filter.** Every sealed event is signed by a fresh single-use key, so comparing an inbound event's `pubkey` against this value never matches our own sealed traffic — and by design nothing on a gift wrap identifies its author. The bundled bridges keep the comparison only for the legacy unsealed form. Self-delivery is prevented by the `#p` filter (our outbound events are addressed to a *peer's* tag, not ours) and, for self-addressed messages, by the engine's deduplication.
 
@@ -227,7 +227,7 @@ Bridges that still call the timestamp-less `nostrMessageReceived(senderId, data)
 
 *The replayed overlap is not fully deduplicated.* Message-id dedup retains ids for an hour by default (`reliability.dedup.retention_time_secs`, and at most `max_tracked_messages` of them), while `since` reaches back an hour and five minutes. A reconnect sooner than the retention window has its overlap absorbed; a reconnect after longer — an app reopened the next day, the common case — re-processes it instead. That costs work, not correctness: a replayed ciphertext whose ratchet generation is spent fails closed and is dropped, a past-epoch one triggers at most one rate-limited re-key, and a replayed group copy TTLs out of the pending buffer.
 
-*Junk can crowd out stored history.* The routing tag is `SHA-256(userId)`, so anyone who knows a username can publish events to it, and only the *decodability* of a frame gates the watermark — parsing a `Message` needs no signature. An attacker who floods more than `limit` decodable events can therefore both push real messages out of a truncated initial query and advance the mark past them, leaving those below the next `since`. What makes this recoverable rather than terminal is that it is not the only delivery path: ACK-gated messages stay in the sender's outbox for 7 days and are retransmitted with a fresh `created_at`, which lands above any watermark. The exposure is delay on a Nostr-only route, and it needs a sustained flood rather than a single event.
+*Junk can crowd out stored history.* The routing tag is `SHA-256(address)`, so anyone who knows an address can publish events to it, and only the *decodability* of a frame gates the watermark — parsing a `Message` needs no signature. An attacker who floods more than `limit` decodable events can therefore both push real messages out of a truncated initial query and advance the mark past them, leaving those below the next `since`. What makes this recoverable rather than terminal is that it is not the only delivery path: ACK-gated messages stay in the sender's outbox for 7 days and are retransmitted with a fresh `created_at`, which lands above any watermark. The exposure is delay on a Nostr-only route, and it needs a sustained flood rather than a single event.
 
 ### Send Confirmation Loop
 
@@ -329,7 +329,7 @@ A sealed event carries exactly five things, and none of them names anybody:
 |---|---|---|
 | `kind` | `1059` | That this is a gift wrap — the same kind ordinary NIP-17 DM clients publish. (Published key packages use `30443`, the kind Marmot publishes them under, for the same anonymity-set reason) |
 | `pubkey` | fresh single-use key | Nothing. A new key per event, so no two events we publish are linkable to each other or to this device |
-| `tags` | `[["p", <recipient routing tag>]]` | An opaque 32-byte label. Computable *from* a `userId`, but not invertible back to one |
+| `tags` | `[["p", <recipient routing tag>]]` | An opaque 32-byte label. Computable *from* an address, but not invertible back to one — which is why the published record stays sealed (see below) |
 | `created_at` | jittered up to 1 h into the past | A coarse time bucket, deliberately not the publication time |
 | `content` | NIP-44 v2 ciphertext | Length, rounded up to a power-of-two bucket |
 
@@ -344,18 +344,18 @@ A sealed event carries exactly five things, and none of them names anybody:
 
 Only `content` was MLS ciphertext. Both usernames, the app id, the app's metadata map, the content type and a millisecond timestamp were readable by every relay, permanently. Relays are not hops — they are third-party-operated, public, and archival — so this was a durable social-graph disclosure, not transient hop metadata. Sealing closes it.
 
-**What remains observable** is traffic to `SHA-256(userId)` for a username an observer already guessed: that someone is publishing to that inbox, roughly when, and roughly how much. Sealing does not hide that, and rotating rendezvous tags — which would — is deliberately deferred: tying addressing to MLS epoch state turns a desync from "fails to decrypt" into "peers become mutually unreachable". (The Marmot protocol reached the same conclusion and likewise kept stable 1:1 inbox addressing.)
+**What remains observable** is traffic to `SHA-256(address)` for an address an observer already holds: that someone is publishing to that inbox, roughly when, and roughly how much. Sealing does not hide that, and rotating rendezvous tags — which would — is deliberately deferred: tying addressing to MLS epoch state turns a desync from "fails to decrypt" into "peers become mutually unreachable". (The Marmot protocol reached the same conclusion and likewise kept stable 1:1 inbox addressing.)
 
 ### Published key packages and cold first contact
 
-Sealing a frame requires the recipient's Nostr public key, and until it is known the frame falls back to the recipient's **publicly computable** key — the same value as their routing tag. That fallback is bulk-collection resistance only: a relay scraping everything cannot read it, but anyone who guesses the username holds the matching private half.
+Sealing a frame requires the recipient's Nostr public key, and until it is known the frame falls back to the recipient's **record-seal key** — a keypair derived from their address, which anyone holding that address can reconstruct. (It is *not* the routing tag; those were the same value until the addressing migration, and are now separately domain-separated so that no routing tag has a computable private half.) That fallback is bulk-collection resistance only: a relay scraping everything cannot read it, but anyone who knows the address can.
 
 To make the fallback rare rather than routine, each install **publishes MLS key packages as fetchable relay records**, and resolves a peer's before sealing to them.
 
 - **Publishing.** `NOSTR_KEY_PACKAGE_SLOTS` (5) single-use key packages are published as NIP-33 addressable events (kind `30443`), one per slot, tagged `[["d", <slot id>], ["p", <our routing tag>]]` and signed by the install's real Nostr key. Slots refresh on the process tick: a package consumed by a Welcome, or expired, is replaced and republished under the same slot id.
 - **Resolving.** A send to a peer whose per-install key we lack queues a query — `{"kinds":[30443],"#p":[<their routing tag>]}` — issued to every connected relay. *That send still goes out on the bootstrap leg*: blocking on a relay round-trip would turn a metadata upgrade into latency, and the round-trip may have nothing to return. The answer upgrades the next frame.
 
-This is what makes **cold first contact** possible at all: a peer known only by username becomes reachable over Nostr with no prior key-package exchange over some other transport.
+This is what makes **cold first contact** possible at all: a peer known only by address — from an invite or a QR code — becomes reachable over Nostr with no prior key-package exchange over some other transport. Note what changed with addressing: cold contact by *username* is gone, because a username no longer resolves to anything. Reaching a stranger means holding their address first.
 
 **Why slots, and not one record.** An MLS key package's init key is consumed by the first peer who uses it. One replaceable record would mean a stranger who fetches it after it was spent builds a Welcome that can never be processed. Consumption is *local* — an init key leaves provider storage only when this node processes a Welcome built against it — so a stranger can drive it only by actually establishing sessions, and each burnt slot is refilled on the next tick. The slot count covers the *sequential* gap between refreshes; it does not absorb concurrent cold contacts, since nothing distributes simultaneous fetchers across slots (two at once generally race for one init key, and the loser recovers through the reverse key-package exchange).
 
@@ -367,11 +367,25 @@ The first such failure retries promptly, since a relay hiccup should not cost a 
 
 #### Why the published record is sealed, though it is public by intent
 
-An MLS key package carries its owner's username twice: in the `KeyPackagePayload` field, and — unremovably — in the leaf credential, since this SDK uses basic credentials holding the raw user id. Published in the clear, `{"kinds":[30443]}` with no tag and no author would return **a directory of every username on the relay**, handing over exactly the preimages the `SHA-256(userId)` routing tag exists to withhold.
+The original reason was that an MLS key package carried its owner's *username* twice — in the `KeyPackagePayload` field and, unremovably, in the leaf credential — so a cleartext record would have let `{"kinds":[30443]}` return **a directory of every username on the relay**. That reason expired with the addressing migration: credentials now hold the derived address, and an address is not a name.
 
-The record's content is therefore NIP-44-sealed to our own publicly computable key. That costs nothing in reach — fetching the record requires the routing tag, which requires the username, which is the same knowledge needed to reconstruct the key and open it — while a scraper filtering by kind sees an opaque blob.
+The seal stays anyway, for a narrower reason that did not expire. The routing tag is one-way — a relay holding tags cannot recover addresses from them. A cleartext record publishes the address *at* its own tag, which hands that inversion back for the whole userbase to anyone willing to scrape a single kind. Sealing keeps the tag one-way.
 
-So the computable keypair keeps exactly one encryption use: a self-published record whose only reader already knows whose it is. Real messages seal to the per-install key resolved from it. It must still **never** back NIP-42 AUTH or any authentication decision — its private half is public by construction, and a fetcher takes the peer's Nostr key from the Ed25519-signed payload inside the record, never from the event's self-attesting `pubkey` field.
+This is where we diverge from Marmot, which publishes its kind-30443 key packages in the clear and is right to: their leaf credential *is* the Nostr pubkey the event is already signed by, so a cleartext record discloses nothing the event's own `pubkey` field did not. Ours names a different identity, so ours has something to hide.
+
+The record's content is therefore NIP-44-sealed to our own **record-seal key**. That costs nothing in reach — opening the record needs the address, and so does finding it, since the tag you fetch from is derived from that same address — while a scraper filtering by kind sees an opaque blob.
+
+So the record-seal key has two encryption uses and no others: this record, and the bootstrap leg of a conversation. Real messages seal to the per-install key resolved from the record. It must **never** back NIP-42 AUTH or any authentication decision — its private half is public by construction, and a fetcher takes the peer's Nostr key from the Ed25519-signed payload inside the record, never from the event's self-attesting `pubkey` field.
+
+Three keys, then, with three different properties — worth keeping straight, because two of them were the same value until recently:
+
+| Key | Derived from | Who can compute it | Job |
+|---|---|---|---|
+| Routing tag | `SHA-256(address)` | anyone with the address | addressing only — nothing signs or seals with it |
+| Record-seal key | HKDF(address) | anyone with the address | seals published records and bootstrap frames |
+| Signing key | HKDF(per-install random secret) | only this install | signs events; the only unforgeable identity here |
+
+The tag and the record-seal key were one value for most of this transport's life. Nothing was broken by it, but it left every routing tag standing as a public key whose private half anyone could compute — harmless only until something reaches for "the key matching this tag". They are now separate derivations.
 
 #### What publication costs
 
@@ -384,7 +398,7 @@ This is the first thing the transport emits **unprompted**. A small set of recor
 The routing tag is public, so anyone may publish to it and a query returns whatever the relay holds there. Two things that buys, both bounded:
 
 - **Crowding.** Foreign records displace real ones from the query's `limit`, costing the metadata upgrade and nothing else — the send falls back to the bootstrap leg exactly as before.
-- **Replaying a spent record.** Every published record is openable by anyone who knows the username (that is the design), so a squatter can unseal one of a peer's *consumed* records, re-seal the untouched and genuinely Ed25519-signed payload under their own author key, and stand it back up with a fresh `created_at`. Nothing detects this: the inner signature is real, and no freshness binding ties a record to the live slot. The resolver imports a genuine-but-consumed key package and builds a Welcome the peer can never process — worse than crowding, because it commits to a dead session rather than staying on the working bootstrap leg.
+- **Replaying a spent record.** Every published record is openable by anyone who knows the address (that is the design), so a squatter can unseal one of a peer's *consumed* records, re-seal the untouched and genuinely Ed25519-signed payload under their own author key, and stand it back up with a fresh `created_at`. Nothing detects this: the inner signature is real, and no freshness binding ties a record to the live slot. The resolver imports a genuine-but-consumed key package and builds a Welcome the peer can never process — worse than crowding, because it commits to a dead session rather than staying on the working bootstrap leg.
 
   It does not strand the pair. Importing any key package pushes ours back under `auto_key_exchange`, and the peer then establishes from their side against a package that is actually live, so the cost is delivery delayed by one exchange — the same bounded class as the already-accepted `key_package_data` substitution vector. Closing it outright needs the record to carry slot-bound freshness (its slot id plus a signed issue time), which is future work.
 
@@ -397,7 +411,8 @@ Resolution narrows this considerably: a peer who publishes is re-resolved whenev
 ### Identity
 
 - **The signing key is a per-install secret** — derived via HKDF from a random 32-byte secret persisted through the app's `MlsStorage` on first `initialize_mls`, never from any public identifier. It is advertised in outgoing key packages so peers can seal to it, and it is *not* what signs sealed events (those use a throwaway key each). Wiping app storage rotates the install's Nostr identity.
-- **The routing tag is derived from `userId`** — running the same `userId` on two devices means they share an inbox (both receive events tagged to that ID). Use distinct user IDs per device for separate inboxes.
+- **The routing tag is derived from the address** — and the address is derived from the identity key generated at `initializeMls`, so two devices only share an inbox if they share an identity. Two installs are two addresses and two inboxes.
+- **Nostr requires the protocol identity.** The tag has no preimage until `initializeMls` has run, so the SDK installs no Nostr transport before then and `enableTransport('nostr')` is refused. Disabling encryption disables Nostr with it. This used to "work" by falling back to the app-chosen profile, which published a label anyone could recompute from a username to every configured relay.
 - **Payload is end-to-end encrypted by MLS** before reaching this transport. Gift-wrap sealing is an additional, hop-local layer over the whole envelope; it does not replace MLS.
 - **Telemetry scrubbing** — when telemetry `scrub_ids` is on (default), pubkeys flowing through the SDK's telemetry sink are SHA-256 hashed before emission.
 

--- a/examples/nostr-example/src/constants.ts
+++ b/examples/nostr-example/src/constants.ts
@@ -16,7 +16,17 @@ export const PROTOCOL_CONFIG = {
     },
   },
   encryption: {
-    enabled: false, // Disabled for simple transport testing
+    // Not optional for Nostr, and not merely for encryption's sake.
+    //
+    // Disabling it skips MLS initialization, which is what derives this
+    // device's address — and the Nostr routing tag is derived from that
+    // address. With no identity there is no tag, so the SDK installs no Nostr
+    // transport and `enableTransport('nostr')` is refused.
+    //
+    // This used to "work": the transport fell back to the profile, so the
+    // subscription filter published a label anyone could recompute from the
+    // username to three public relays. It doesn't do that any more.
+    enabled: true,
   },
   network: {initialTtl: 8},
 };


### PR DESCRIPTION
Addressing chain item 5 (A5). Follows #327 → #328 → #329 → #330.

## What this actually turned out to be

The ticket said "routing tag = SHA-256(address); delete `derivable_for_device_id`; re-pin vectors; update docs". The first part was **already true** — #328's `rebuild_transports_for_identity` moved the tag preimage to the address as a side effect, pinned by `test_nostr_routing_tag_follows_the_derived_address_after_mls_init`.

Except it isn't true in two reachable configurations, and that turned out to be a live leak rather than a gap.

## The leak

The routing tag is `SHA-256(id)`, and both bridges send the subscription filter carrying it to every relay the moment a socket opens — unconditionally, from the socket-open callback, with no identity check anywhere in the path.

The rebuild that fixes the id is skippable:

- `bindings/react-native/src/index.ts:927` skips `initializeMls` outright when `encryption.enabled === false`
- `index.ts:940-945` catches a thrown init, warns, and proceeds to `start()` — after which `lib.rs:5218` refuses a retry for the life of the instance

Either way the transport built in `new()`, holding the app's **profile**, is the one still installed when the relays connect. So a label anyone can recompute from a username went to third-party archival relays, permanently, with nothing reporting it.

`examples/nostr-example/src/constants.ts:18` ships exactly that configuration against three public relays.

Both guards were negative-controlled by restoring the leak; the mutation run prints the leaked REQ with its profile-derived tag.

## The second finding

The published key-package record is sealed to a publicly-computable key, justified in-code by "a cleartext record returns a directory of every username on the relay" — the username being in the MLS leaf credential. **#328 made that credential the address**, so that rationale expired.

The seal survives for a narrower reason: the routing tag is one-way, and a cleartext record would publish the address *at* its own tag, handing that inversion back to anyone scraping one kind. Marmot publishes theirs in the clear and is right to — their credential is the pubkey the event is already signed by. Ours names a different identity.

That forced a decision, because `derivable_for_device_id` serves **four** roles, and "delete it" + "keep record sealing" cannot both hold literally — opening a record sealed to a computable key requires that key. Resolved by splitting the roles: the API is gone, sealing moves to a domain-separated `record_seal_keypair_for_address` that is deliberately **not** the routing tag. That also removes something the ticket didn't ask for — every routing tag was a public key whose private half anyone could compute, which is a trap for whatever next adds NIP-42 AUTH or pubkey filtering.

## Commits

| | |
|---|---|
| `5761983` | stop publishing a profile-derived routing tag (the leak) |
| `589fd68` | bridges refuse to start Nostr without an identity |
| `f141fb9` | split the record-seal key off the routing tag |
| `1acf4ab` | re-pin golden vectors on addresses |
| `b835dbc` | docs + CHANGELOG |

## Breaking

- **Nostr requires the protocol identity.** No transport before `initializeMls`; `enableTransport('nostr')` refused without it. `encryption.enabled: false` now disables Nostr with it.
- **Cold contact by username is gone** — a username resolves to nothing. By *address* (invite/QR) works exactly as before.
- Two wire changes, both pre-fleet under D6's clean cutover: the bootstrap-leg and published-record seal targets both move off the routing tag.
- `derivable_for_device_id` → `record_seal_keypair_for_address`; `routing_tag_for_device_id` → `routing_tag_for_address`.

No UDL change — the guard uses the already-exposed `local_address()`, so no binding regeneration.

## Verification

- Rust: 2031 tests (full `cargo test --workspace`, doctests included), clippy `-D warnings`, fmt
- iOS: all 28 hand-written sources typechecked via the `BRIDGE_MAINTENANCE.md` symlink-farm recipe, **negative-controlled**; 187 Swift tests
- Android: 376 unit tests in the clean-dir CI harness
- tsc clean

## Not in scope

Stage-2 discovery (item 8), the wider `username`→address API/doc sweep (item 6), relay lockstep (item 7), record slot-bound freshness (pre-existing residual).

## Review focus

The judgement call worth a second opinion is keeping a publicly-computable key at all. Option B — delete it outright and publish records in cleartext like Marmot — is defensible, and costs tag→address invertibility plus the bootstrap leg for peers who publish nothing. I took the narrower change; happy to revisit.