### PR TITLE
test(protocol): pin the relay attribution seam

### DIFF
--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -19077,6 +19077,91 @@ fn test_validate_transport_sender_hop_zero_mismatch_still_rejected() {
     assert!(!protocol.validate_transport_sender(&msg));
 }
 
+/// The relay must attribute an uploader by the address it runs as, not by the
+/// account name it authenticated under.
+///
+/// This pins, from the SDK side, the contract relay work (TODO item 18) has to
+/// satisfy. Since #328 a frame's `sender` is the uploader's derived `off1…`
+/// address — `initialize_mls` takes `local_id` from the identity key — while
+/// the relay stamps its envelope `sender` from `resolve_username`, a username.
+/// The two meet here, at the `hop_count == 0` strict match, so a username
+/// attribution refuses every control frame the relay carries: `__MLS_KEY_PKG__`
+/// and `__MLS_WELCOME__` never land, and no new session can be established over
+/// the relay. `__MLS_ENC__` is data-plane and skips the gate entirely, which is
+/// why already-established sessions keep working and the break stays quiet.
+///
+/// This is deliberately *not* the same case as
+/// `test_validate_transport_sender_mismatch`, which names a different **peer**
+/// (`id("eve")`) — an impostor, correctly refused. Here both arms name the same
+/// peer and differ only in **namespace**: `id("alice")` is what alice's device
+/// signs as, `"alice"` is what the relay knows her as. Refusing the second is
+/// right for a frame that proves nothing, and is exactly why the relay cannot
+/// keep attributing in username space.
+///
+/// Neither assertion changes when item 18 ships. What changes is which arm
+/// production reaches: the relay starts stamping the address, so real traffic
+/// lands on the first arm instead of the second. The gate's contract is what is
+/// pinned here, not the relay's current behaviour, so this test stays green
+/// across the transition and fails loudly if the strict match is ever loosened
+/// to paper over the mismatch instead of fixing the attribution.
+#[test]
+fn test_relay_attribution_must_be_the_address_not_the_profile() {
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+
+    // A gated prefix, deliberately: `security_gate_control_message` returns
+    // `Proceed` immediately for anything `is_security_gated_prefix` does not
+    // cover, so a frame carrying ordinary text would make both arms below pass
+    // without the identity check ever running. `KEY_PACKAGE` is also the frame
+    // the break actually blocks.
+    let control = format!("{}{{\"data\":\"test\"}}", internal_prefixes::KEY_PACKAGE);
+
+    // `signed_frame` signs only when the content is a gated prefix. Assert the
+    // signature is really there: unsigned control traffic is refused outright,
+    // so an unsigned frame would reject on *both* arms and the test would pass
+    // while proving nothing about transport identity.
+    let signed = signed_frame(&id("alice"), &id("user123"), &control);
+    assert!(
+        signed.metadata.contains_key(CTRL_SIG_META_KEY),
+        "the frame under test must actually be signed, or both arms reject for \
+         the unrelated unsigned-control reason"
+    );
+
+    // The two namespaces this whole item is about.
+    assert_ne!(
+        id("alice"),
+        "alice",
+        "the fixture must give alice an address distinct from her label, or \
+         this test cannot tell the two namespaces apart"
+    );
+
+    // What the relay must stamp after item 18: the uploader's address.
+    let mut as_address = signed.clone();
+    as_address.set_transport_peer_id(id("alice")).unwrap();
+    assert!(
+        matches!(
+            protocol.security_gate_control_message(&as_address, Some(TransportType::Internet)),
+            ControlGateOutcome::Proceed { signed: true }
+        ),
+        "a relay that attributes by address must let alice's own signed control \
+         frame through"
+    );
+
+    // What the relay stamps today: the account name. Same peer, same frame,
+    // same signature — refused, because the claim is unproven in this namespace.
+    let mut as_profile = signed;
+    as_profile
+        .set_transport_peer_id("alice".to_string())
+        .unwrap();
+    assert!(
+        matches!(
+            protocol.security_gate_control_message(&as_profile, Some(TransportType::Internet)),
+            ControlGateOutcome::Rejected(InternalMessageResult::SecurityRejected)
+        ),
+        "a username attribution must be refused: this is the relay break, and \
+         loosening the gate is not the fix — item 18 changes the attribution"
+    );
+}
+
 #[test]
 fn test_relayed_control_message_with_carrier_identity_not_security_rejected() {
     let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();


### PR DESCRIPTION
Pins, from the SDK side, the contract the relay has to satisfy — and the break it does not satisfy today.

## The break this pins

Since #328 a frame's `sender` is the uploader's derived `off1…` address (`initialize_mls` takes `local_id` from the identity key; `send.rs` builds `sender` from it). The relay stamps its envelope `sender` from `resolve_username` — a username. The two meet at `validate_transport_sender`'s `hop_count == 0` strict match, so a username attribution refuses every control frame the relay carries: `__MLS_KEY_PKG__` and `__MLS_WELCOME__` never land and **no new MLS session can be established over the relay**.

`__MLS_ENC__` is data-plane and skips the gate entirely, which is why already-established sessions keep working and this has stayed quiet.

Same class as the BLE break #330 found: #328 moved `Message.sender` to the address and left an identity plane behind.

**Not in production.** The whole addressing chain (#327–#332) is unreleased — last tag `v0.20.1` is 2026-08-07, all six merged 2026-08-09/10, `git tag --contains` on the earliest is empty. fernweh_v2 ships `mesh-sdk@^0.20.1`, which predates #328. This is a release gate, not an outage.

## Why a test and not a fix

The fix is in the relay repo (https://github.com/Offline-Protocol/relay-server/pull/27). So this pins the gate's **contract** rather than the bug:

- address attribution → `Proceed`
- username attribution → `Rejected(SecurityRejected)`

Neither assertion changes when the relay ships addresses. What changes is which arm production reaches. The test stays green across the transition, and fails loudly if anyone ever "fixes" this by loosening the strict match instead of correcting the attribution.

## Why the suite missed this

Existing coverage (`test_validate_transport_sender_mismatch`) only ever compares two *addresses* — `id("alice")` against `id("eve")`. That is an impostor, and refusing it is obviously right. Nobody tested alice against alice spelled the other way, which is a **namespace** mismatch, not an impostor.

## Verification

Mutation-checked with three independent sabotages, each killing a different assertion:

| Sabotage | Kills |
|---|---|
| `validate_transport_sender` → `true` | the username-attribution arm |
| `is_security_gated_prefix` → `false` | the signature guard (gate short-circuits) |
| `verify_control_message` → `Ok(false)` | the address-attribution arm |

Test-only change; no production code touched. `cargo test --workspace --lib` 2027 passing, clippy `-D warnings` and fmt clean.

TODO item 7 / A7.
