### PR TITLE
feat(bindings): prove the relay connection's address after auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,7 @@ jobs:
             mesh/Mesh.swift ble/MeshConnectionRegistry.swift \
             ble/BleDiscoveryBootstrapPolicy.swift \
             Generated/offline_protocol.swift ForcedPresenceCheckQueue.swift \
+            AddressDeclarationPolicy.swift \
             PeerIdentityBinding.swift RelayAnswerPrefixes.swift \
             RelayControlOpTranslator.swift RelayGroupSnapshotBridge.swift \
             RelayRateLimiter.swift LegacyRelayMessage.swift MonotonicClock.swift \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **No MLS session could be established over the relay, and `off1…` recipients
+  were unreachable through it.** The relay knows a connection by the account
+  name it authenticated, and stamps that name on every frame it forwards. Since
+  the identity change the core stamps `Message.sender` with the derived address,
+  so the receiver's transport-identity check compared an address against an
+  account name and rejected the frame — which took `__MLS_KEY_PKG__` and
+  `__MLS_WELCOME__` with it, while already-established sessions kept decrypting
+  (`__MLS_ENC__` is data-plane and ungated). Outbound was broken in the same
+  place from the other side: an `off1…` recipient did not exist in a registry
+  keyed by account name. Both bridges now prove their address to the relay
+  immediately after authenticating, by signing a per-connection challenge from
+  the relay's `Authenticated` frame under a dedicated domain, and the relay
+  routes and attributes that connection by address from there on. Requires a
+  relay advertising the `address_routing_v1` capability; against an older one
+  the bridges stay silent and the connection behaves exactly as before. No
+  configuration, and nothing for an app to call.
+
 - **Transport callbacks registered before `initialize_mls` were silently
   dropped.** `set_*_transport_callback` installed onto whichever transport was
   registered at the time, and the identity rebuild replaces those objects — so

--- a/bindings/react-native/MeshSdk.podspec
+++ b/bindings/react-native/MeshSdk.podspec
@@ -27,6 +27,7 @@ Pod::Spec.new do |s|
     "ios/BleManager.swift",
     "ios/InternetManager.swift",
     "ios/ForcedPresenceCheckQueue.swift",
+    "ios/AddressDeclarationPolicy.swift",
     "ios/PeerIdentityBinding.swift",
     "ios/RelayAnswerPrefixes.swift",
     "ios/RelayControlOpTranslator.swift",

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/AddressDeclarationPolicy.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/AddressDeclarationPolicy.kt
@@ -1,0 +1,235 @@
+package com.offlineprotocol
+
+import android.util.Base64
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+
+/**
+ * Builds the `DeclareAddress` proof a relay connection needs to be routed by
+ * address instead of by account name.
+ *
+ * Mirrors iOS's AddressDeclarationPolicy.swift — keep in sync.
+ *
+ * ## Why the declaration exists
+ *
+ * The relay authenticates a JWT and knows the connection by its *account name*,
+ * but since the addressing cutover the core stamps `Message.sender` with
+ * `local_address()`. A relay that attributes an inbound frame by account name
+ * therefore hands the receiver a `transport_peer_id` that cannot match the
+ * sender it is strict-matched against in `validate_transport_sender`, and every
+ * security-gated control frame (`__MLS_KEY_PKG__`, `__MLS_WELCOME__`) is
+ * rejected — no MLS session can be established over the relay at all. Declaring
+ * closes that, and is also what makes an `off1…` recipient resolvable in the
+ * relay's registry.
+ *
+ * ## Why the account name is inside the signed bytes
+ *
+ * The signing key here is the identity key that also signs mesh control frames
+ * under `offline-ctrl-v1`. If the proof were a signature over a bare
+ * relay-chosen challenge, a hostile relay could hand out a challenge shaped
+ * like a control-frame payload and harvest a signature that replays as a
+ * control frame from this peer. Binding the domain **and** the account makes
+ * the signature meaningful only as "this account, on this relay, holds this
+ * key" — it cannot be replayed under another account, nor onto another
+ * connection, since the challenge is minted per connection.
+ *
+ * The layout is fixed by the relay's `address_binding::address_proof_payload`
+ * and pinned there by a hex vector, which
+ * `AddressDeclarationPolicyTest.proofPayloadMatchesThePinnedRelayVector`
+ * mirrors byte for byte. Neither side may change it alone.
+ *
+ * ## Why every failure is a skip rather than an error
+ *
+ * A connection that does not declare keeps working exactly as it did before
+ * addresses existed — the relay attributes it by account name, which is the
+ * legacy path and still the only path an older relay has. So the absence of a
+ * capability, of a challenge, or of a local identity is a reason to stay quiet,
+ * not to fail a connection that is otherwise fine.
+ */
+object AddressDeclarationPolicy {
+
+    /**
+     * The relay capability token gating the whole exchange. A relay that does
+     * not advertise it also omits `address_challenge`, and would parse a
+     * `DeclareAddress` into nothing and answer nothing — so the token is the
+     * tell, not a timeout.
+     */
+    const val CAPABILITY = "address_routing_v1"
+
+    /**
+     * Domain separator prefixing the signed payload. Must not prefix, nor be
+     * prefixed by, the core's `offline-ctrl-v1` control-frame domain; the relay
+     * pins that relation in
+     * `the_proof_domain_cannot_collide_with_control_message_signing`.
+     */
+    const val PROOF_DOMAIN = "offline-relay-addr-v1"
+
+    /**
+     * The relay mints exactly this many challenge bytes. A frame carrying any
+     * other length is malformed, and signing it would produce a proof that
+     * cannot verify — better to skip and say so.
+     */
+    const val CHALLENGE_LENGTH = 32
+
+    /**
+     * Stable diagnostic reasons, shared with the Swift mirror so a field report
+     * reproduces under the same string on both platforms.
+     */
+    object Reason {
+        /**
+         * The relay does not advertise `address_routing_v1` — an older
+         * deployment. Expected, and the reason this is not an error.
+         */
+        const val CAPABILITY_ABSENT = "capability_absent"
+
+        /** Capability advertised but no `address_challenge` came with it. */
+        const val CHALLENGE_ABSENT = "challenge_absent"
+
+        /**
+         * The challenge was not standard base64, or did not decode to exactly
+         * [CHALLENGE_LENGTH] bytes.
+         */
+        const val CHALLENGE_MALFORMED = "challenge_malformed"
+
+        /**
+         * The `Authenticated` frame carried no account name to bind the proof
+         * to. Never sign a locally-chosen substitute here: the relay verifies
+         * against the name *it* resolved, so a guess produces a signature that
+         * cannot verify and is indistinguishable, in the relay's logs, from an
+         * attack.
+         */
+        const val ACCOUNT_ABSENT = "account_absent"
+
+        /**
+         * `localAddress()` was null — MLS is not initialized, so there is no
+         * identity to prove. An app running with encryption disabled stays in
+         * account-name space by construction.
+         */
+        const val ADDRESS_UNAVAILABLE = "address_unavailable"
+
+        /** The identity key or the signature could not be produced. */
+        const val SIGNING_FAILED = "signing_failed"
+
+        /** The proof was built but the frame could not be serialized. */
+        const val FRAME_UNSERIALIZABLE = "frame_unserializable"
+    }
+
+    sealed class Outcome {
+        /** Sign [proofPayload] and send the declaration. */
+        data class Declare(val account: String, val challenge: ByteArray) : Outcome() {
+            // ByteArray needs structural equality by hand, and the tests
+            // compare whole outcomes.
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (other !is Declare) return false
+                return account == other.account && challenge.contentEquals(other.challenge)
+            }
+
+            override fun hashCode(): Int = 31 * account.hashCode() + challenge.contentHashCode()
+        }
+
+        /** Send nothing; [reason] is a [Reason]. */
+        data class Skip(val reason: String) : Outcome()
+    }
+
+    /**
+     * Decides whether this connection can declare, from the `Authenticated`
+     * frame alone.
+     *
+     * Deliberately does **not** take the local address: this runs before any
+     * FFI call so that the common skip (an older relay) costs no acquisition of
+     * the protocol mutex. The caller fetches the address only after a
+     * [Outcome.Declare], and reports [Reason.ADDRESS_UNAVAILABLE] if it is null.
+     *
+     * @param capabilities the `capabilities` array, verbatim.
+     * @param addressChallenge the `address_challenge` field — base64 of the raw
+     *   challenge bytes, absent on relays without the capability.
+     * @param username the `username` field **as the relay sent it**. Callers
+     *   must not substitute a local fallback (see [Reason.ACCOUNT_ABSENT]).
+     */
+    @JvmStatic
+    fun decide(
+        capabilities: List<String>,
+        addressChallenge: String?,
+        username: String?
+    ): Outcome {
+        if (!capabilities.contains(CAPABILITY)) {
+            return Outcome.Skip(Reason.CAPABILITY_ABSENT)
+        }
+        if (addressChallenge.isNullOrEmpty()) {
+            return Outcome.Skip(Reason.CHALLENGE_ABSENT)
+        }
+        // Standard alphabet — the relay encodes with the same, and the
+        // url-safe alphabet's '-'/'_' are rejected outright here. (This decoder
+        // tolerates missing padding where the relay's does not; that can only
+        // make us accept a challenge the relay would never mint, and the length
+        // check below still has to pass.)
+        val challenge = try {
+            Base64.decode(addressChallenge, Base64.NO_WRAP)
+        } catch (e: IllegalArgumentException) {
+            return Outcome.Skip(Reason.CHALLENGE_MALFORMED)
+        }
+        if (challenge.size != CHALLENGE_LENGTH) {
+            return Outcome.Skip(Reason.CHALLENGE_MALFORMED)
+        }
+        if (username.isNullOrEmpty()) {
+            return Outcome.Skip(Reason.ACCOUNT_ABSENT)
+        }
+        return Outcome.Declare(username, challenge)
+    }
+
+    /**
+     * The exact bytes the relay verifies the signature over.
+     *
+     *     "offline-relay-addr-v1" ‖ u32be(account.utf8.size) ‖ account.utf8 ‖ challenge
+     *
+     * No separators, no terminators. The length prefix is what makes the
+     * concatenation unambiguous — without it, an account name ending in bytes
+     * that look like the start of a challenge could be re-split, so two
+     * different (account, challenge) pairs would share one payload.
+     */
+    @JvmStatic
+    fun proofPayload(account: String, challenge: ByteArray): ByteArray {
+        val accountBytes = account.toByteArray(Charsets.UTF_8)
+        val out = ByteArrayOutputStream(
+            PROOF_DOMAIN.length + 4 + accountBytes.size + challenge.size
+        )
+        out.write(PROOF_DOMAIN.toByteArray(Charsets.US_ASCII))
+        // Big-endian, and of the UTF-8 *byte* count — not the character count,
+        // which differs for any non-ASCII account name.
+        val length = accountBytes.size
+        out.write((length ushr 24) and 0xFF)
+        out.write((length ushr 16) and 0xFF)
+        out.write((length ushr 8) and 0xFF)
+        out.write(length and 0xFF)
+        out.write(accountBytes)
+        out.write(challenge)
+        return out.toByteArray()
+    }
+
+    /**
+     * The `DeclareAddress` frame, serialized.
+     *
+     * Owns the base64 encoding so the wire contract lives in one place per
+     * platform: standard alphabet, padded, no line breaks — a 32-byte key
+     * encodes to 44 characters and a 64-byte signature to 88. The relay decodes
+     * with a strict engine and refuses anything else (NO_WRAP matters: the
+     * default flags append a newline, which would not survive its decoder).
+     *
+     * Returns null only if serialization fails, which three `String` values
+     * cannot cause; the caller reports [Reason.FRAME_UNSERIALIZABLE] rather
+     * than putting a malformed frame on the wire.
+     */
+    @JvmStatic
+    fun declarationJson(address: String, publicKey: ByteArray, signature: ByteArray): String? =
+        try {
+            JSONObject().apply {
+                put("type", "DeclareAddress")
+                put("address", address)
+                put("public_key", Base64.encodeToString(publicKey, Base64.NO_WRAP))
+                put("signature", Base64.encodeToString(signature, Base64.NO_WRAP))
+            }.toString()
+        } catch (e: Exception) {
+            null
+        }
+}

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -722,8 +722,9 @@ class InternetManager(
     private fun handleAuthenticated(
         ws: WebSocket,
         userId: String,
-        username: String,
-        capabilities: List<String>
+        username: String?,
+        capabilities: List<String>,
+        addressChallenge: String?
     ) {
         // The whole reaction is ONE main-posted block gated on the socket
         // still being current and the transport not stopping: reacting on
@@ -744,6 +745,23 @@ class InternetManager(
             cancelAuthTimeout()
 
             updateState(TransportState.RUNNING)
+
+            // The address declaration MUST precede both calls below: the relay
+            // attributes each inbound frame by whatever this connection has
+            // proved at the moment it reads that frame, and never re-stamps
+            // retroactively — so a send that leaves before the declaration is
+            // attributed by account name for good, and its `Message.sender`
+            // (an address) then fails the receiver's
+            // `validate_transport_sender`. The status flip below flushes the
+            // outbox, which is exactly what produces those sends.
+            //
+            // Unlike iOS, this whole block runs on main rather than hopping to
+            // a serial queue, so the ordering is simply sequential here — and
+            // the declaration's two FFI calls land on the main looper next to
+            // the far heavier flush that already does. If that flush ever
+            // moves off main (the iOS messageQueue shape), this must move with
+            // it, ahead of it. Mirrors InternetManager.swift — keep in sync.
+            declareAddress(ws, capabilities, addressChallenge, username)
 
             // Capabilities MUST reach the SDK before the status flip: the
             // false→true transition flushes queued sends, and the group
@@ -784,11 +802,96 @@ class InternetManager(
 
             emitDiagnostic("info", "Authenticated with relay server", mapOf(
                 "userId" to userId,
-                "username" to username
+                "username" to (username ?: deviceId)
             ))
         }
     }
-    
+
+    /**
+     * Proves this connection's `off1…` address to the relay, so it is
+     * attributed by address rather than by account name.
+     *
+     * Called from [handleAuthenticated]'s main-posted block and deliberately
+     * the first thing it does: everything the relay attributes downstream —
+     * the outbox flush's sends, and anything the poll loop drains after it —
+     * is stamped with whatever this connection has proved by the time the relay
+     * reads the frame, with no retroactive re-stamping.
+     *
+     * Nothing waits on the answer. The relay binds the address before it reads
+     * the next frame off the socket, so ordering is established by the write
+     * alone; `AddressDeclared` and `AddressError` are reported when they arrive
+     * but gate nothing.
+     *
+     * Every failure path is a diagnostic and a return, never a throw: this runs
+     * immediately before the capability injection and the status flip, and an
+     * undeclared connection is a working connection — the relay simply
+     * attributes it the legacy way. Failing the connection over a refused
+     * declaration would turn a degraded path into no path.
+     */
+    private fun declareAddress(
+        ws: WebSocket,
+        capabilities: List<String>,
+        addressChallenge: String?,
+        username: String?
+    ) {
+        val outcome = AddressDeclarationPolicy.decide(capabilities, addressChallenge, username)
+        val declaration = when (outcome) {
+            is AddressDeclarationPolicy.Outcome.Declare -> outcome
+            is AddressDeclarationPolicy.Outcome.Skip -> {
+                emitDiagnostic("debug", "Not declaring an address to the relay", mapOf(
+                    "reason" to outcome.reason
+                ))
+                return
+            }
+        }
+
+        val frame = try {
+            val address = protocol.localAddress()
+            if (address.isNullOrEmpty()) {
+                emitDiagnostic("debug", "Not declaring an address to the relay", mapOf(
+                    "reason" to AddressDeclarationPolicy.Reason.ADDRESS_UNAVAILABLE
+                ))
+                return
+            }
+            // UniFFI carries `sequence<u8>` as List<UByte> in Kotlin; the
+            // policy speaks ByteArray on both platforms.
+            val publicKey = protocol.getIdentityPublicKey()
+            val signature = protocol.signData(
+                AddressDeclarationPolicy.proofPayload(
+                    declaration.account,
+                    declaration.challenge
+                ).map { it.toUByte() }
+            )
+            AddressDeclarationPolicy.declarationJson(
+                address,
+                publicKey.map { it.toByte() }.toByteArray(),
+                signature.map { it.toByte() }.toByteArray()
+            )
+        } catch (e: Exception) {
+            emitDiagnostic("error", "Could not sign the address declaration", mapOf(
+                "reason" to AddressDeclarationPolicy.Reason.SIGNING_FAILED,
+                "error" to (e.message ?: e.toString())
+            ))
+            return
+        }
+
+        if (frame == null) {
+            emitDiagnostic("error", "Could not build the address declaration", mapOf(
+                "reason" to AddressDeclarationPolicy.Reason.FRAME_UNSERIALIZABLE
+            ))
+            return
+        }
+
+        // Unmetered, like the authentication frame this follows: both are
+        // one-per-connection handshake frames, and the client limiter's
+        // headroom under the relay's own bucket is sized for exactly the two
+        // (see RelayRateLimiter). Metering it would let a full bucket defer the
+        // one frame every later send's attribution depends on.
+        if (!ws.send(frame)) {
+            emitDiagnostic("warning", "Address declaration write failed", emptyMap())
+        }
+    }
+
     /**
      * The transport's reaction to a dead socket. Only reachable through
      * [terminateSocket]'s detach-first funnel, so it runs on main and at
@@ -1090,15 +1193,54 @@ class InternetManager(
             "Authenticated" -> {
                 // Handle authentication success
                 val userId = json.safeOptString("user_id", deviceId)
-                val username = json.safeOptString("username", deviceId)
+                // Kept RAW — no deviceId fallback. This is the account name the
+                // relay resolved for the connection, and it is signed into the
+                // address proof: the relay verifies against its own copy, so a
+                // local substitute would produce a signature that cannot
+                // verify. Its only other use is the diagnostic in
+                // handleAuthenticated, which falls back there instead.
+                val username = json.optNullableString("username")
                 // Capability tokens this relay deployment supports (e.g.
                 // "group_delivery_v2"). Older relays omit the field → empty.
                 val capabilities = json.optJSONArray("capabilities")?.let { arr ->
                     (0 until arr.length()).mapNotNull { i -> arr.optString(i).takeIf { it.isNotEmpty() } }
                 } ?: emptyList()
-                handleAuthenticated(ws, userId, username, capabilities)
+                // Base64 challenge for the optional address declaration,
+                // present only on relays advertising `address_routing_v1`.
+                val addressChallenge = json.optNullableString("address_challenge")
+                handleAuthenticated(ws, userId, username, capabilities, addressChallenge)
             }
-            
+
+            "AddressDeclared" -> {
+                // The relay bound this connection to the address we proved.
+                // From its next inbound frame on, it attributes us by address
+                // instead of account name. Informational: the binding took
+                // effect before the relay answered (its frame loop is
+                // sequential), so nothing waits on this, and the frame is
+                // forwarded like any other.
+                emitDiagnostic("info", "Relay accepted the address declaration", mapOf(
+                    "address" to json.safeOptString("address", "")
+                ))
+                serverMessageEmitter?.invoke(rawText)
+            }
+
+            "AddressError" -> {
+                // The declaration was refused. Non-fatal by contract: the
+                // connection stays authenticated and keeps working in
+                // account-name space, which is exactly how it behaved before
+                // addresses existed. No retry here — a refusal is either
+                // permanent for this connection (bad material, or a different
+                // address already declared) or means this socket was displaced
+                // by a newer login, in which case the successor declares for
+                // itself. The next reconnect re-declares from scratch.
+                emitDiagnostic(
+                    "error",
+                    "Relay refused the address declaration; staying in account-name space",
+                    mapOf("reason" to json.safeOptString("reason", "Unknown error"))
+                )
+                serverMessageEmitter?.invoke(rawText)
+            }
+
             "AuthError" -> {
                 // Handle authentication error
                 val reason = json.safeOptString("reason", "Unknown error")

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/RelayRateLimiter.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/RelayRateLimiter.kt
@@ -9,10 +9,15 @@ package com.offlineprotocol
  * "succeeded", which would let the bridge confirm (and the translator
  * commit) state the relay never recorded.
  *
- * Capacity/refill sit slightly under the relay's documented budget so a
- * frame this limiter doesn't meter (authentication) never tips the server
- * bucket. A `false` from [tryAcquire] always means "defer the frame to a
- * later tick", never "drop it".
+ * Capacity/refill sit slightly under the relay's documented budget so the
+ * frames this limiter doesn't meter never tip the server bucket. There are
+ * exactly two, both one-per-connection handshake frames sent back to back
+ * before anything else: `Authenticate`, and the `DeclareAddress` that proves
+ * this connection's address. 2 unmetered + a 28 burst is the relay's 30, and
+ * 9/s stays under its 10/s from there. Neither may be metered: a full bucket
+ * would defer the frame the whole connection's identity depends on. A `false`
+ * from [tryAcquire] always means "defer the frame to a later tick", never
+ * "drop it".
  *
  * Callers pass `nowMs` explicitly (testability). Thread-safe. Mirrors
  * ios/RelayRateLimiter.swift — keep in sync.

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/AddressDeclarationPolicyTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/AddressDeclarationPolicyTest.kt
@@ -1,0 +1,308 @@
+package com.offlineprotocol
+
+import android.util.Base64
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the relay address declaration: the exact bytes signed, and the four
+ * conditions under which a connection stays in account-name space.
+ *
+ * Mirrors iOS's AddressDeclarationPolicyTests — keep in sync.
+ *
+ * The payload test is a cross-repo pin. Its expected value is copied from the
+ * relay's own `address_proof_payload_matches_the_pinned_vector` (relay-server
+ * src/address_binding.rs), so the two implementations cannot drift apart
+ * silently — which matters more than usual here, because a wrong payload is not
+ * a compile error or a parse error on either side. It is a signature that
+ * simply does not verify, reported by the relay as `AddressError`, and
+ * indistinguishable in its logs from an attack.
+ */
+/// Robolectric, not plain JUnit: `android.util.Base64` is a framework class and
+/// the policy owns the encoding on purpose (it is half the wire contract), so a
+/// stubbed one would leave that half untested. Pinned to this module's
+/// `minSdkVersion` like the other Robolectric suites here.
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [24])
+class AddressDeclarationPolicyTest {
+
+    /** A real derivation from the core's address golden vectors. */
+    private val address = "off1qysluvwl5922yctzd0u9gpr06gn3k7ldfvgtwgvn"
+
+    /** The challenge from the relay's pinned vector: bytes 0x00…0x1f. */
+    private val vectorChallenge = ByteArray(32) { it.toByte() }
+
+    private fun hex(bytes: ByteArray): String =
+        bytes.joinToString("") { String.format("%02x", it) }
+
+    private fun b64(bytes: ByteArray): String = Base64.encodeToString(bytes, Base64.NO_WRAP)
+
+    private fun capabilities(vararg extra: String): List<String> =
+        listOf("group_delivery_v2") + extra
+
+    // ---- The signed bytes ----
+
+    /**
+     * Byte-for-byte against the relay's pinned vector. Any drift in the domain
+     * string, the length prefix's width or endianness, the UTF-8 encoding, or
+     * the concatenation order fails here rather than in the field.
+     */
+    @Test
+    fun proofPayloadMatchesThePinnedRelayVector() {
+        assertEquals(
+            "6f66666c696e652d72656c61792d616464722d7631" +
+                "00000005" +
+                "616c696365" +
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            hex(AddressDeclarationPolicy.proofPayload("alice", vectorChallenge))
+        )
+    }
+
+    /**
+     * The length prefix is big-endian. A little-endian bridge writes `05000000`
+     * here and produces a signature the relay refuses — the one error the
+     * pinned vector exists to catch, isolated so a failure names it.
+     */
+    @Test
+    fun accountLengthPrefixIsBigEndian() {
+        val payload = AddressDeclarationPolicy.proofPayload("alice", vectorChallenge)
+        val domainLength = AddressDeclarationPolicy.PROOF_DOMAIN.length
+        assertEquals("00000005", hex(payload.copyOfRange(domainLength, domainLength + 4)))
+    }
+
+    /**
+     * The prefix counts UTF-8 bytes, not characters. The relay reads the same
+     * bytes back out, so a character count silently mis-frames every account
+     * name outside ASCII.
+     */
+    @Test
+    fun accountLengthCountsUtf8BytesNotCharacters() {
+        val account = "zoë" // 3 characters, 4 UTF-8 bytes
+        val payload = AddressDeclarationPolicy.proofPayload(account, vectorChallenge)
+        val domainLength = AddressDeclarationPolicy.PROOF_DOMAIN.length
+        assertEquals("00000004", hex(payload.copyOfRange(domainLength, domainLength + 4)))
+        assertEquals(domainLength + 4 + 4 + 32, payload.size)
+    }
+
+    /**
+     * The domain must not prefix, nor be prefixed by, the core's control-frame
+     * domain. If either did, a relay-chosen challenge could steer this
+     * signature into the control-message domain and replay as a frame from this
+     * peer. The relay pins the same relation from its side.
+     */
+    @Test
+    fun proofDomainCannotCollideWithControlFrameSigning() {
+        val controlDomain = "offline-ctrl-v1"
+        val proofDomain = AddressDeclarationPolicy.PROOF_DOMAIN
+        assertFalse(proofDomain.startsWith(controlDomain))
+        assertFalse(controlDomain.startsWith(proofDomain))
+    }
+
+    /**
+     * The payload starts with the domain, so a signature over the bare
+     * challenge — the naive implementation — can never equal it. The relay
+     * refuses that shape explicitly (`a_bare_challenge_signature_is_refused`).
+     */
+    @Test
+    fun payloadIsNeverTheBareChallenge() {
+        val payload = AddressDeclarationPolicy.proofPayload("alice", vectorChallenge)
+        assertFalse(payload.contentEquals(vectorChallenge))
+        assertTrue(
+            hex(payload).startsWith(
+                hex(AddressDeclarationPolicy.PROOF_DOMAIN.toByteArray(Charsets.US_ASCII))
+            )
+        )
+    }
+
+    // ---- The decision ----
+
+    /**
+     * The happy path: capability, a well-formed challenge, and an account name
+     * the relay itself supplied.
+     */
+    @Test
+    fun declaresWhenCapabilityChallengeAndAccountArePresent() {
+        assertEquals(
+            AddressDeclarationPolicy.Outcome.Declare("alice", vectorChallenge),
+            AddressDeclarationPolicy.decide(
+                capabilities(AddressDeclarationPolicy.CAPABILITY),
+                b64(vectorChallenge),
+                "alice"
+            )
+        )
+    }
+
+    /**
+     * An older relay. It omits the capability, would parse a `DeclareAddress`
+     * into nothing and answer nothing at all — so the token is what gates the
+     * send, and its absence is expected rather than exceptional.
+     */
+    @Test
+    fun skipsWhenRelayLacksTheCapability() {
+        assertEquals(
+            AddressDeclarationPolicy.Outcome.Skip(
+                AddressDeclarationPolicy.Reason.CAPABILITY_ABSENT
+            ),
+            AddressDeclarationPolicy.decide(capabilities(), b64(vectorChallenge), "alice")
+        )
+    }
+
+    /** Capability without a challenge: nothing to sign. */
+    @Test
+    fun skipsWhenChallengeIsAbsent() {
+        assertEquals(
+            AddressDeclarationPolicy.Outcome.Skip(
+                AddressDeclarationPolicy.Reason.CHALLENGE_ABSENT
+            ),
+            AddressDeclarationPolicy.decide(
+                capabilities(AddressDeclarationPolicy.CAPABILITY),
+                null,
+                "alice"
+            )
+        )
+    }
+
+    /** Not base64 at all. */
+    @Test
+    fun skipsWhenChallengeIsNotBase64() {
+        assertEquals(
+            AddressDeclarationPolicy.Outcome.Skip(
+                AddressDeclarationPolicy.Reason.CHALLENGE_MALFORMED
+            ),
+            AddressDeclarationPolicy.decide(
+                capabilities(AddressDeclarationPolicy.CAPABILITY),
+                "not base64!!",
+                "alice"
+            )
+        )
+    }
+
+    /**
+     * Decodes, but not to 32 bytes. Signing it would produce a proof that
+     * cannot verify, so it is refused before the FFI is touched.
+     */
+    @Test
+    fun skipsWhenChallengeIsWrongLength() {
+        assertEquals(
+            AddressDeclarationPolicy.Outcome.Skip(
+                AddressDeclarationPolicy.Reason.CHALLENGE_MALFORMED
+            ),
+            AddressDeclarationPolicy.decide(
+                capabilities(AddressDeclarationPolicy.CAPABILITY),
+                b64(ByteArray(16) { 7 }),
+                "alice"
+            )
+        )
+    }
+
+    /**
+     * The relay decodes with a strict standard-alphabet engine, so a base64url
+     * spelling of the same 32 bytes is not interchangeable.
+     */
+    @Test
+    fun skipsWhenChallengeIsBase64Url() {
+        // A 32-byte value whose standard encoding contains both '+' and '/'.
+        val raw = ByteArray(32)
+        raw[0] = 0xFB.toByte()
+        raw[1] = 0xF0.toByte()
+        val standard = b64(raw)
+        val urlSafe = standard.replace('+', '-').replace('/', '_').trimEnd('=')
+        assertFalse("the fixture must actually differ between alphabets", standard == urlSafe)
+        assertEquals(
+            AddressDeclarationPolicy.Outcome.Skip(
+                AddressDeclarationPolicy.Reason.CHALLENGE_MALFORMED
+            ),
+            AddressDeclarationPolicy.decide(
+                capabilities(AddressDeclarationPolicy.CAPABILITY),
+                urlSafe,
+                "alice"
+            )
+        )
+    }
+
+    /**
+     * No account name on the frame. The proof binds the name the relay
+     * resolved, so there is nothing local that could stand in: signing a
+     * substitute (the profile, a device id) yields a signature that cannot
+     * verify and reads as an attack in the relay's logs.
+     */
+    @Test
+    fun skipsWhenAccountIsAbsent() {
+        assertEquals(
+            AddressDeclarationPolicy.Outcome.Skip(
+                AddressDeclarationPolicy.Reason.ACCOUNT_ABSENT
+            ),
+            AddressDeclarationPolicy.decide(
+                capabilities(AddressDeclarationPolicy.CAPABILITY),
+                b64(vectorChallenge),
+                null
+            )
+        )
+    }
+
+    @Test
+    fun skipsWhenAccountIsEmpty() {
+        assertEquals(
+            AddressDeclarationPolicy.Outcome.Skip(
+                AddressDeclarationPolicy.Reason.ACCOUNT_ABSENT
+            ),
+            AddressDeclarationPolicy.decide(
+                capabilities(AddressDeclarationPolicy.CAPABILITY),
+                b64(vectorChallenge),
+                ""
+            )
+        )
+    }
+
+    // ---- The frame ----
+
+    /**
+     * Field names and the frame tag are the relay's `ClientMessage` variant;
+     * all three values are base64 standard *with* padding, which is what the
+     * relay's decoder requires.
+     */
+    @Test
+    fun declarationFrameShape() {
+        val publicKey = ByteArray(32) { 0xAB.toByte() }
+        val signature = ByteArray(64) { 0xCD.toByte() }
+        val json = AddressDeclarationPolicy.declarationJson(address, publicKey, signature)
+        assertNotNull(json)
+        val parsed = JSONObject(json!!)
+        assertEquals("DeclareAddress", parsed.getString("type"))
+        assertEquals(address, parsed.getString("address"))
+        assertEquals(b64(publicKey), parsed.getString("public_key"))
+        assertEquals(b64(signature), parsed.getString("signature"))
+        assertEquals(4, parsed.length())
+    }
+
+    /**
+     * Length and padding of the encoded material, as the relay expects to find
+     * it: 32 bytes → 44 characters, 64 bytes → 88. NO_WRAP is what keeps the
+     * newline `Base64.DEFAULT` would append off the wire.
+     */
+    @Test
+    fun encodedMaterialIsPaddedStandardBase64() {
+        val json = AddressDeclarationPolicy.declarationJson(
+            address,
+            ByteArray(32) { 0xAB.toByte() },
+            ByteArray(64) { 0xCD.toByte() }
+        )
+        val parsed = JSONObject(json!!)
+        val publicKey = parsed.getString("public_key")
+        val signature = parsed.getString("signature")
+        assertEquals(44, publicKey.length)
+        assertTrue(publicKey.endsWith("="))
+        assertEquals(88, signature.length)
+        assertTrue(signature.endsWith("="))
+        assertFalse(publicKey.contains("-") || publicKey.contains("_"))
+        assertFalse(signature.contains("-") || signature.contains("_"))
+        assertFalse(publicKey.contains("\n") || signature.contains("\n"))
+    }
+}

--- a/bindings/react-native/ios/AddressDeclarationPolicy.swift
+++ b/bindings/react-native/ios/AddressDeclarationPolicy.swift
@@ -1,0 +1,185 @@
+//
+// AddressDeclarationPolicy.swift
+// OfflineProtocol
+//
+// Whether this connection proves its `off1…` address to the relay, and the
+// exact bytes it signs to do it.
+// Mirrors android/src/main/java/com/offlineprotocol/AddressDeclarationPolicy.kt
+// — keep in sync.
+//
+
+import Foundation
+
+/// Builds the `DeclareAddress` proof a relay connection needs to be routed by
+/// address instead of by account name.
+///
+/// # Why the declaration exists
+///
+/// The relay authenticates a JWT and knows the connection by its *account
+/// name*, but since the addressing cutover the core stamps `Message.sender`
+/// with `local_address()`. A relay that attributes an inbound frame by account
+/// name therefore hands the receiver a `transport_peer_id` that cannot match
+/// the sender it is strict-matched against in `validate_transport_sender`, and
+/// every security-gated control frame (`__MLS_KEY_PKG__`, `__MLS_WELCOME__`)
+/// is rejected — no MLS session can be established over the relay at all.
+/// Declaring closes that, and is also what makes an `off1…` recipient
+/// resolvable in the relay's registry.
+///
+/// # Why the account name is inside the signed bytes
+///
+/// The signing key here is the identity key that also signs mesh control
+/// frames under `offline-ctrl-v1`. If the proof were a signature over a bare
+/// relay-chosen challenge, a hostile relay could hand out a challenge shaped
+/// like a control-frame payload and harvest a signature that replays as a
+/// control frame from this peer. Binding the domain **and** the account makes
+/// the signature meaningful only as "this account, on this relay, holds this
+/// key" — it cannot be replayed under another account, nor onto another
+/// connection, since the challenge is minted per connection.
+///
+/// The layout is fixed by the relay's `address_binding::address_proof_payload`
+/// and pinned there by a hex vector, which
+/// `AddressDeclarationPolicyTests.proofPayloadMatchesThePinnedRelayVector`
+/// mirrors byte for byte. Neither side may change it alone.
+///
+/// # Why every failure is a skip rather than an error
+///
+/// A connection that does not declare keeps working exactly as it did before
+/// addresses existed — the relay attributes it by account name, which is the
+/// legacy path and still the only path an older relay has. So the absence of
+/// a capability, of a challenge, or of a local identity is a reason to stay
+/// quiet, not to fail a connection that is otherwise fine.
+enum AddressDeclarationPolicy {
+
+    /// The relay capability token gating the whole exchange. A relay that does
+    /// not advertise it also omits `address_challenge`, and would parse a
+    /// `DeclareAddress` into nothing and answer nothing — so the token is the
+    /// tell, not a timeout.
+    static let CAPABILITY = "address_routing_v1"
+
+    /// Domain separator prefixing the signed payload. Must not prefix, nor be
+    /// prefixed by, the core's `offline-ctrl-v1` control-frame domain; the
+    /// relay pins that relation in
+    /// `the_proof_domain_cannot_collide_with_control_message_signing`.
+    static let PROOF_DOMAIN = "offline-relay-addr-v1"
+
+    /// The relay mints exactly this many challenge bytes. A frame carrying any
+    /// other length is malformed, and signing it would produce a proof that
+    /// cannot verify — better to skip and say so.
+    static let CHALLENGE_LENGTH = 32
+
+    /// Stable diagnostic reasons, shared with the Kotlin mirror so a field
+    /// report reproduces under the same string on both platforms.
+    enum Reason {
+        /// The relay does not advertise `address_routing_v1` — an older
+        /// deployment. Expected, and the reason this is not an error.
+        static let capabilityAbsent = "capability_absent"
+        /// Capability advertised but no `address_challenge` came with it.
+        static let challengeAbsent = "challenge_absent"
+        /// The challenge was not standard base64, or did not decode to
+        /// exactly `CHALLENGE_LENGTH` bytes.
+        static let challengeMalformed = "challenge_malformed"
+        /// The `Authenticated` frame carried no account name to bind the
+        /// proof to. Never sign a locally-chosen substitute here: the relay
+        /// verifies against the name *it* resolved, so a guess produces a
+        /// signature that cannot verify and is indistinguishable, in the
+        /// relay's logs, from an attack.
+        static let accountAbsent = "account_absent"
+        /// `local_address()` was nil — MLS is not initialized, so there is no
+        /// identity to prove. An app running with encryption disabled stays in
+        /// account-name space by construction.
+        static let addressUnavailable = "address_unavailable"
+        /// The identity key or the signature could not be produced.
+        static let signingFailed = "signing_failed"
+        /// The proof was built but the frame could not be serialized.
+        static let frameUnserializable = "frame_unserializable"
+    }
+
+    enum Outcome: Equatable {
+        /// Sign `proofPayload(account:challenge:)` and send the declaration.
+        case declare(account: String, challenge: Data)
+        /// Send nothing; the string is a `Reason`.
+        case skip(reason: String)
+    }
+
+    /// Decides whether this connection can declare, from the `Authenticated`
+    /// frame alone.
+    ///
+    /// Deliberately does **not** take the local address: this runs before any
+    /// FFI call so that the common skip (an older relay) costs no acquisition
+    /// of the protocol mutex. The caller fetches the address only after a
+    /// `declare`, and reports `Reason.addressUnavailable` if it is nil.
+    ///
+    /// - Parameters:
+    ///   - capabilities: the `capabilities` array, verbatim.
+    ///   - addressChallenge: the `address_challenge` field — base64 of the raw
+    ///     challenge bytes, absent on relays without the capability.
+    ///   - username: the `username` field **as the relay sent it**. Callers
+    ///     must not substitute a local fallback (see `Reason.accountAbsent`).
+    static func decide(
+        capabilities: [String],
+        addressChallenge: String?,
+        username: String?
+    ) -> Outcome {
+        guard capabilities.contains(CAPABILITY) else {
+            return .skip(reason: Reason.capabilityAbsent)
+        }
+        guard let challengeBase64 = addressChallenge, !challengeBase64.isEmpty else {
+            return .skip(reason: Reason.challengeAbsent)
+        }
+        // Standard alphabet, padding required — the relay decodes with the
+        // same, and rejects base64url or unpadded input.
+        guard let challenge = Data(base64Encoded: challengeBase64),
+              challenge.count == CHALLENGE_LENGTH else {
+            return .skip(reason: Reason.challengeMalformed)
+        }
+        guard let account = username, !account.isEmpty else {
+            return .skip(reason: Reason.accountAbsent)
+        }
+        return .declare(account: account, challenge: challenge)
+    }
+
+    /// The exact bytes the relay verifies the signature over.
+    ///
+    ///     "offline-relay-addr-v1" ‖ u32be(account.utf8.count) ‖ account.utf8 ‖ challenge
+    ///
+    /// No separators, no terminators. The length prefix is what makes the
+    /// concatenation unambiguous — without it, an account name ending in bytes
+    /// that look like the start of a challenge could be re-split, so two
+    /// different (account, challenge) pairs would share one payload.
+    static func proofPayload(account: String, challenge: Data) -> Data {
+        let accountBytes = Array(account.utf8)
+        var payload = Data()
+        payload.append(contentsOf: Array(PROOF_DOMAIN.utf8))
+        // Big-endian, and of the UTF-8 *byte* count — not the character count,
+        // which differs for any non-ASCII account name.
+        var length = UInt32(accountBytes.count).bigEndian
+        withUnsafeBytes(of: &length) { payload.append(contentsOf: $0) }
+        payload.append(contentsOf: accountBytes)
+        payload.append(challenge)
+        return payload
+    }
+
+    /// The `DeclareAddress` frame, serialized.
+    ///
+    /// Owns the base64 encoding so the wire contract lives in one place per
+    /// platform: standard alphabet, padded, no line breaks — a 32-byte key
+    /// encodes to 44 characters and a 64-byte signature to 88. The relay
+    /// decodes with a strict engine and refuses anything else.
+    ///
+    /// Returns nil only if serialization fails, which three `String` values
+    /// cannot cause; the caller reports `Reason.frameUnserializable` rather
+    /// than putting a malformed frame on the wire.
+    static func declarationJson(address: String, publicKey: Data, signature: Data) -> String? {
+        let frame: [String: Any] = [
+            "type": "DeclareAddress",
+            "address": address,
+            "public_key": publicKey.base64EncodedString(),
+            "signature": signature.base64EncodedString()
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: frame, options: []),
+              let json = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return json
+    }
+}

--- a/bindings/react-native/ios/InternetManager.swift
+++ b/bindings/react-native/ios/InternetManager.swift
@@ -1040,18 +1040,29 @@ public class InternetManager: NSObject, TransportManager {
     /// connection that no longer exists.
     private func handleAuthenticated(
         userId: String,
-        username: String,
+        username: String?,
         capabilities: [String],
+        addressChallenge: String?,
         task: URLSessionWebSocketTask
     ) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self, !self.isStale(task) else { return }
             self.handleAuthenticatedOnMain(
-                userId: userId, username: username, capabilities: capabilities)
+                userId: userId,
+                username: username,
+                capabilities: capabilities,
+                addressChallenge: addressChallenge,
+                task: task)
         }
     }
 
-    private func handleAuthenticatedOnMain(userId: String, username: String, capabilities: [String]) {
+    private func handleAuthenticatedOnMain(
+        userId: String,
+        username: String?,
+        capabilities: [String],
+        addressChallenge: String?,
+        task: URLSessionWebSocketTask
+    ) {
         isAuthenticated = true
         emitConnectionStatus()
         cancelAuthTimeout()
@@ -1078,14 +1089,32 @@ public class InternetManager: NSObject, TransportManager {
         // component, never `self`): a teardown racing this hop must not
         // swallow the status change while the Rust instance lives on.
         //
-        // In-block order is load-bearing twice over. Capabilities MUST reach
-        // the SDK before the status flip: the flush reads the group
-        // broadcast gate's capability set (an older relay omits the field;
-        // the empty list is still injected so a stale set from a previous
-        // relay can never leak across connections). And the immediate poll
-        // MUST follow the flip on the same queue: the flush is what fills
-        // the internet send queue that poll drains — messages queued during
-        // disconnection go out promptly, not on the next timer tick.
+        // In-block order is load-bearing three times over. The address
+        // declaration MUST precede both: the relay attributes each inbound
+        // frame by whatever this connection has proved at the moment it
+        // reads that frame, and never re-stamps retroactively — so a send
+        // that leaves before the declaration is attributed by account name
+        // for good, and its `Message.sender` (an address) then fails the
+        // receiver's `validate_transport_sender`. The flush the status flip
+        // performs is exactly what produces those sends, so the declaration
+        // goes out first, on the same serial queue that orders them.
+        // Capabilities MUST reach the SDK before the status flip: the flush
+        // reads the group broadcast gate's capability set (an older relay
+        // omits the field; the empty list is still injected so a stale set
+        // from a previous relay can never leak across connections). And the
+        // immediate poll MUST follow the flip on the same queue: the flush is
+        // what fills the internet send queue that poll drains — messages
+        // queued during disconnection go out promptly, not on the next timer
+        // tick.
+        //
+        // The decision itself is made here on main because it is pure and
+        // cheap; only the signing and the write happen on messageQueue, since
+        // `signData` and `getIdentityPublicKey` take the protocol mutex.
+        let declaration = AddressDeclarationPolicy.decide(
+            capabilities: capabilities,
+            addressChallenge: addressChallenge,
+            username: username
+        )
         let pausedNow = isPaused
         messageQueue.async { [weak self, proto = self.protocolInstance] in
             // The `true` is asymmetric to the `false` blocks on purpose: those
@@ -1107,6 +1136,7 @@ public class InternetManager: NSObject, TransportManager {
             // survive to the next auth, and parked forced checks stay parked
             // (serviced by that auth, or drained by stop()).
             guard let self = self, self.isAuthenticated else { return }
+            self.declareAddress(declaration, proto: proto, task: task)
             try? proto.internetRelayCapabilities(capabilities: capabilities)
             try? proto.internetStatusChanged(isConnected: true)
             if !pausedNow {
@@ -1145,10 +1175,99 @@ public class InternetManager: NSObject, TransportManager {
 
         emitDiagnostic("info", "Authenticated with relay server", context: [
             "userId": userId,
-            "username": username
+            "username": username ?? deviceId
         ])
     }
     
+    /// Proves this connection's `off1…` address to the relay, so it is
+    /// attributed by address rather than by account name.
+    ///
+    /// messageQueue only, and deliberately the first thing that queue does for
+    /// a new connection: everything the relay attributes downstream — the
+    /// outbox flush's sends, and anything the poll loop drains after it — is
+    /// stamped with whatever this connection has proved by the time the relay
+    /// reads the frame, with no retroactive re-stamping.
+    ///
+    /// Nothing waits on the answer. The relay binds the address before it
+    /// reads the next frame off the socket, so ordering is established by the
+    /// write alone; `AddressDeclared` and `AddressError` are reported when
+    /// they arrive but gate nothing.
+    ///
+    /// Every failure path is a diagnostic and a return, never a throw or a
+    /// teardown: this runs immediately before the capability injection and the
+    /// status flip, and an undeclared connection is a working connection —
+    /// the relay simply attributes it the legacy way. Failing the connection
+    /// over a refused declaration would turn a degraded path into no path.
+    private func declareAddress(
+        _ outcome: AddressDeclarationPolicy.Outcome,
+        proto: OfflineProtocol,
+        task: URLSessionWebSocketTask
+    ) {
+        let account: String
+        let challenge: Data
+        switch outcome {
+        case let .declare(declaredAccount, declaredChallenge):
+            account = declaredAccount
+            challenge = declaredChallenge
+        case let .skip(reason):
+            emitDiagnostic("debug", "Not declaring an address to the relay", context: [
+                "reason": reason
+            ])
+            return
+        }
+
+        // The declaration belongs to the connection that was handed the
+        // challenge. A socket replaced between the main hop and this queue has
+        // its own `Authenticated` (and its own challenge) coming.
+        guard task === webSocketTask else { return }
+
+        guard let address = proto.localAddress(), !address.isEmpty else {
+            emitDiagnostic("debug", "Not declaring an address to the relay", context: [
+                "reason": AddressDeclarationPolicy.Reason.addressUnavailable
+            ])
+            return
+        }
+
+        let frame: String
+        do {
+            let publicKey = try proto.getIdentityPublicKey()
+            let signature = try proto.signData(
+                data: [UInt8](
+                    AddressDeclarationPolicy.proofPayload(account: account, challenge: challenge)
+                )
+            )
+            guard let json = AddressDeclarationPolicy.declarationJson(
+                address: address,
+                publicKey: Data(publicKey),
+                signature: Data(signature)
+            ) else {
+                emitDiagnostic("error", "Could not build the address declaration", context: [
+                    "reason": AddressDeclarationPolicy.Reason.frameUnserializable
+                ])
+                return
+            }
+            frame = json
+        } catch {
+            emitDiagnostic("error", "Could not sign the address declaration", context: [
+                "reason": AddressDeclarationPolicy.Reason.signingFailed,
+                "error": error.localizedDescription
+            ])
+            return
+        }
+
+        // Unmetered, like the authentication frame this follows: both are
+        // one-per-connection handshake frames, and the client limiter's
+        // headroom under the relay's own bucket is sized for exactly the two
+        // (see RelayRateLimiter). Metering it would let a full bucket defer
+        // the one frame every later send's attribution depends on.
+        task.send(.string(frame)) { [weak self] error in
+            guard let error = error else { return }
+            self?.emitDiagnostic("warning", "Address declaration write failed", context: [
+                "error": error.localizedDescription
+            ])
+        }
+    }
+
     /// Marks the connection displaced by the relay and latches it stopped:
     /// cancels any pending reconnect, latches `supersedeLatch` so auto- and
     /// force-reconnect refuse until the next start(), and fires the one-shot
@@ -1397,12 +1516,51 @@ public class InternetManager: NSObject, TransportManager {
         case "Authenticated":
             // Handle authentication success
             let userId = json["user_id"] as? String ?? deviceId
-            let username = json["username"] as? String ?? deviceId
+            // Kept RAW — no deviceId fallback. This is the account name the
+            // relay resolved for the connection, and it is signed into the
+            // address proof: the relay verifies against its own copy, so a
+            // local substitute would produce a signature that cannot verify.
+            // Its only other use is the diagnostic below, which falls back
+            // there instead.
+            let username = json["username"] as? String
             // Capability tokens this relay deployment supports (e.g.
             // "group_delivery_v2"). Older relays omit the field → empty.
             let capabilities = json["capabilities"] as? [String] ?? []
+            // Base64 challenge for the optional address declaration, present
+            // only on relays advertising `address_routing_v1`.
+            let addressChallenge = json["address_challenge"] as? String
             handleAuthenticated(
-                userId: userId, username: username, capabilities: capabilities, task: task)
+                userId: userId,
+                username: username,
+                capabilities: capabilities,
+                addressChallenge: addressChallenge,
+                task: task)
+
+        case "AddressDeclared":
+            // The relay bound this connection to the address we proved. From
+            // its next inbound frame on, it attributes us by address instead
+            // of account name. Informational: the binding took effect before
+            // the relay answered (its frame loop is sequential), so nothing
+            // waits on this, and the frame is forwarded like any other.
+            emitDiagnostic("info", "Relay accepted the address declaration", context: [
+                "address": json["address"] as? String ?? ""
+            ])
+            emitServerMessage(rawText)
+
+        case "AddressError":
+            // The declaration was refused. Non-fatal by contract: the
+            // connection stays authenticated and keeps working in
+            // account-name space, which is exactly how it behaved before
+            // addresses existed. No retry here — a refusal is either
+            // permanent for this connection (bad material, or a different
+            // address already declared) or means this socket was displaced by
+            // a newer login, in which case the successor declares for itself.
+            // The next reconnect re-declares from scratch.
+            let addressErrorReason = json["reason"] as? String ?? "Unknown error"
+            emitDiagnostic("error", "Relay refused the address declaration; staying in account-name space", context: [
+                "reason": addressErrorReason
+            ])
+            emitServerMessage(rawText)
             
         case "AuthError":
             // Handle authentication error

--- a/bindings/react-native/ios/Package.swift
+++ b/bindings/react-native/ios/Package.swift
@@ -57,6 +57,7 @@ let package = Package(
                 "tests"
             ],
             sources: [
+                "AddressDeclarationPolicy.swift",
                 "EncryptionConfigReader.swift",
                 "ForcedPresenceCheckQueue.swift",
                 "ForegroundReconnectPolicy.swift",
@@ -92,6 +93,7 @@ let package = Package(
                 "ProtocolErrorBridgeTests.swift"
             ],
             sources: [
+                "AddressDeclarationPolicyTests.swift",
                 "EncryptionConfigReaderTests.swift",
                 "ForcedPresenceCheckQueueTests.swift",
                 "ForegroundReconnectPolicyTests.swift",

--- a/bindings/react-native/ios/RelayRateLimiter.swift
+++ b/bindings/react-native/ios/RelayRateLimiter.swift
@@ -10,10 +10,15 @@
 // local write "succeeded", which would let the bridge confirm (and the
 // translator commit) state the relay never recorded.
 //
-// Capacity/refill sit slightly under the relay's documented budget so a
-// frame this limiter doesn't meter (authentication) never tips the server
-// bucket. A `false` from tryAcquire always means "defer the frame to a
-// later tick", never "drop it".
+// Capacity/refill sit slightly under the relay's documented budget so the
+// frames this limiter doesn't meter never tip the server bucket. There are
+// exactly two, both one-per-connection handshake frames sent back to back
+// before anything else: `Authenticate`, and the `DeclareAddress` that proves
+// this connection's address. 2 unmetered + a 28 burst is the relay's 30, and
+// 9/s stays under its 10/s from there. Neither may be metered: a full bucket
+// would defer the frame the whole connection's identity depends on. A `false`
+// from tryAcquire always means "defer the frame to a later tick", never
+// "drop it".
 //
 // Callers pass `nowMs` explicitly (testability). Thread-safe. Mirrors
 // android RelayRateLimiter.kt — keep in sync.

--- a/bindings/react-native/ios/tests/AddressDeclarationPolicyTests.swift
+++ b/bindings/react-native/ios/tests/AddressDeclarationPolicyTests.swift
@@ -1,0 +1,273 @@
+//
+// AddressDeclarationPolicyTests.swift
+//
+// Pins the relay address declaration: the exact bytes signed, and the four
+// conditions under which a connection stays in account-name space.
+// Mirrors android's AddressDeclarationPolicyTest — keep in sync.
+//
+// The payload test is a cross-repo pin. Its expected value is copied from the
+// relay's own `address_proof_payload_matches_the_pinned_vector`
+// (relay-server src/address_binding.rs), so the two implementations cannot
+// drift apart silently — which matters more than usual here, because a wrong
+// payload is not a compile error or a parse error on either side. It is a
+// signature that simply does not verify, reported by the relay as
+// `AddressError`, and indistinguishable in its logs from an attack.
+//
+
+import XCTest
+@testable import OfflineProtocol
+
+final class AddressDeclarationPolicyTests: XCTestCase {
+
+    /// A real derivation from the core's address golden vectors.
+    private let address = "off1qysluvwl5922yctzd0u9gpr06gn3k7ldfvgtwgvn"
+
+    /// The challenge from the relay's pinned vector: bytes 0x00…0x1f.
+    private let vectorChallenge = Data((0..<32).map { UInt8($0) })
+
+    private func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - The signed bytes
+
+    /// Byte-for-byte against the relay's pinned vector. Any drift in the
+    /// domain string, the length prefix's width or endianness, the UTF-8
+    /// encoding, or the concatenation order fails here rather than in the
+    /// field.
+    func testProofPayloadMatchesThePinnedRelayVector() {
+        let payload = AddressDeclarationPolicy.proofPayload(
+            account: "alice",
+            challenge: vectorChallenge
+        )
+        XCTAssertEqual(
+            hex(payload),
+            "6f66666c696e652d72656c61792d616464722d7631"
+                + "00000005"
+                + "616c696365"
+                + "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        )
+    }
+
+    /// The length prefix is big-endian. A little-endian bridge writes
+    /// `05000000` here and produces a signature the relay refuses — the one
+    /// error the pinned vector exists to catch, isolated so a failure names it.
+    func testAccountLengthPrefixIsBigEndian() {
+        let payload = AddressDeclarationPolicy.proofPayload(
+            account: "alice",
+            challenge: vectorChallenge
+        )
+        let domainLength = AddressDeclarationPolicy.PROOF_DOMAIN.utf8.count
+        XCTAssertEqual(
+            hex(payload.subdata(in: domainLength..<(domainLength + 4))),
+            "00000005"
+        )
+    }
+
+    /// The prefix counts UTF-8 bytes, not characters. The relay reads the same
+    /// bytes back out, so a character count silently mis-frames every account
+    /// name outside ASCII.
+    func testAccountLengthCountsUtf8BytesNotCharacters() {
+        let account = "zoë"  // 3 characters, 4 UTF-8 bytes
+        let payload = AddressDeclarationPolicy.proofPayload(
+            account: account,
+            challenge: vectorChallenge
+        )
+        let domainLength = AddressDeclarationPolicy.PROOF_DOMAIN.utf8.count
+        XCTAssertEqual(
+            hex(payload.subdata(in: domainLength..<(domainLength + 4))),
+            "00000004"
+        )
+        XCTAssertEqual(payload.count, domainLength + 4 + 4 + 32)
+    }
+
+    /// The domain must not prefix, nor be prefixed by, the core's
+    /// control-frame domain. If either did, a relay-chosen challenge could
+    /// steer this signature into the control-message domain and replay as a
+    /// frame from this peer. The relay pins the same relation from its side.
+    func testProofDomainCannotCollideWithControlFrameSigning() {
+        let controlDomain = "offline-ctrl-v1"
+        let proofDomain = AddressDeclarationPolicy.PROOF_DOMAIN
+        XCTAssertFalse(proofDomain.hasPrefix(controlDomain))
+        XCTAssertFalse(controlDomain.hasPrefix(proofDomain))
+    }
+
+    /// The payload starts with the domain, so a signature over the bare
+    /// challenge — the naive implementation — can never equal it. The relay
+    /// refuses that shape explicitly (`a_bare_challenge_signature_is_refused`).
+    func testPayloadIsNeverTheBareChallenge() {
+        let payload = AddressDeclarationPolicy.proofPayload(
+            account: "alice",
+            challenge: vectorChallenge
+        )
+        XCTAssertNotEqual(payload, vectorChallenge)
+        XCTAssertTrue(hex(payload).hasPrefix(hex(Data(AddressDeclarationPolicy.PROOF_DOMAIN.utf8))))
+    }
+
+    // MARK: - The decision
+
+    private func capabilities(_ extra: String...) -> [String] {
+        ["group_delivery_v2"] + extra
+    }
+
+    /// The happy path: capability, a well-formed challenge, and an account
+    /// name the relay itself supplied.
+    func testDeclaresWhenCapabilityChallengeAndAccountArePresent() {
+        let outcome = AddressDeclarationPolicy.decide(
+            capabilities: capabilities(AddressDeclarationPolicy.CAPABILITY),
+            addressChallenge: vectorChallenge.base64EncodedString(),
+            username: "alice"
+        )
+        XCTAssertEqual(outcome, .declare(account: "alice", challenge: vectorChallenge))
+    }
+
+    /// An older relay. It omits the capability, would parse a `DeclareAddress`
+    /// into nothing and answer nothing at all — so the token is what gates the
+    /// send, and its absence is expected rather than exceptional.
+    func testSkipsWhenRelayLacksTheCapability() {
+        XCTAssertEqual(
+            AddressDeclarationPolicy.decide(
+                capabilities: capabilities(),
+                addressChallenge: vectorChallenge.base64EncodedString(),
+                username: "alice"
+            ),
+            .skip(reason: AddressDeclarationPolicy.Reason.capabilityAbsent)
+        )
+    }
+
+    /// Capability without a challenge: nothing to sign.
+    func testSkipsWhenChallengeIsAbsent() {
+        XCTAssertEqual(
+            AddressDeclarationPolicy.decide(
+                capabilities: capabilities(AddressDeclarationPolicy.CAPABILITY),
+                addressChallenge: nil,
+                username: "alice"
+            ),
+            .skip(reason: AddressDeclarationPolicy.Reason.challengeAbsent)
+        )
+    }
+
+    /// Not base64 at all.
+    func testSkipsWhenChallengeIsNotBase64() {
+        XCTAssertEqual(
+            AddressDeclarationPolicy.decide(
+                capabilities: capabilities(AddressDeclarationPolicy.CAPABILITY),
+                addressChallenge: "not base64!!",
+                username: "alice"
+            ),
+            .skip(reason: AddressDeclarationPolicy.Reason.challengeMalformed)
+        )
+    }
+
+    /// Decodes, but not to 32 bytes. Signing it would produce a proof that
+    /// cannot verify, so it is refused before the FFI is touched.
+    func testSkipsWhenChallengeIsWrongLength() {
+        XCTAssertEqual(
+            AddressDeclarationPolicy.decide(
+                capabilities: capabilities(AddressDeclarationPolicy.CAPABILITY),
+                addressChallenge: Data(repeating: 7, count: 16).base64EncodedString(),
+                username: "alice"
+            ),
+            .skip(reason: AddressDeclarationPolicy.Reason.challengeMalformed)
+        )
+    }
+
+    /// The relay decodes with a strict standard-alphabet engine, so a
+    /// base64url spelling of the same 32 bytes is not interchangeable.
+    func testSkipsWhenChallengeIsBase64Url() {
+        // A 32-byte value whose standard encoding contains both '+' and '/'.
+        var raw = Data(repeating: 0, count: 32)
+        raw[0] = 0xFB
+        raw[1] = 0xF0
+        raw[2] = 0x00
+        let standard = raw.base64EncodedString()
+        let urlSafe = standard.replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        XCTAssertNotEqual(standard, urlSafe, "the fixture must actually differ between alphabets")
+        XCTAssertEqual(
+            AddressDeclarationPolicy.decide(
+                capabilities: capabilities(AddressDeclarationPolicy.CAPABILITY),
+                addressChallenge: urlSafe,
+                username: "alice"
+            ),
+            .skip(reason: AddressDeclarationPolicy.Reason.challengeMalformed)
+        )
+    }
+
+    /// No account name on the frame. The proof binds the name the relay
+    /// resolved, so there is nothing local that could stand in: signing a
+    /// substitute (the profile, a device id) yields a signature that cannot
+    /// verify and reads as an attack in the relay's logs.
+    func testSkipsWhenAccountIsAbsent() {
+        XCTAssertEqual(
+            AddressDeclarationPolicy.decide(
+                capabilities: capabilities(AddressDeclarationPolicy.CAPABILITY),
+                addressChallenge: vectorChallenge.base64EncodedString(),
+                username: nil
+            ),
+            .skip(reason: AddressDeclarationPolicy.Reason.accountAbsent)
+        )
+    }
+
+    func testSkipsWhenAccountIsEmpty() {
+        XCTAssertEqual(
+            AddressDeclarationPolicy.decide(
+                capabilities: capabilities(AddressDeclarationPolicy.CAPABILITY),
+                addressChallenge: vectorChallenge.base64EncodedString(),
+                username: ""
+            ),
+            .skip(reason: AddressDeclarationPolicy.Reason.accountAbsent)
+        )
+    }
+
+    // MARK: - The frame
+
+    /// Field names and the frame tag are the relay's `ClientMessage` variant;
+    /// all three values are base64 standard *with* padding, which is what the
+    /// relay's decoder requires.
+    func testDeclarationFrameShape() throws {
+        let publicKey = Data(repeating: 0xAB, count: 32)
+        let signature = Data(repeating: 0xCD, count: 64)
+        let json = try XCTUnwrap(
+            AddressDeclarationPolicy.declarationJson(
+                address: address,
+                publicKey: publicKey,
+                signature: signature
+            )
+        )
+        let parsed = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: XCTUnwrap(json.data(using: .utf8)))
+                as? [String: Any]
+        )
+        XCTAssertEqual(parsed["type"] as? String, "DeclareAddress")
+        XCTAssertEqual(parsed["address"] as? String, address)
+        XCTAssertEqual(parsed["public_key"] as? String, publicKey.base64EncodedString())
+        XCTAssertEqual(parsed["signature"] as? String, signature.base64EncodedString())
+        XCTAssertEqual(parsed.count, 4)
+    }
+
+    /// Length and padding of the encoded material, as the relay expects to
+    /// find it: 32 bytes → 44 characters, 64 bytes → 88.
+    func testEncodedMaterialIsPaddedStandardBase64() throws {
+        let json = try XCTUnwrap(
+            AddressDeclarationPolicy.declarationJson(
+                address: address,
+                publicKey: Data(repeating: 0xAB, count: 32),
+                signature: Data(repeating: 0xCD, count: 64)
+            )
+        )
+        let parsed = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: XCTUnwrap(json.data(using: .utf8)))
+                as? [String: Any]
+        )
+        let publicKey = try XCTUnwrap(parsed["public_key"] as? String)
+        let signature = try XCTUnwrap(parsed["signature"] as? String)
+        XCTAssertEqual(publicKey.count, 44)
+        XCTAssertTrue(publicKey.hasSuffix("="))
+        XCTAssertEqual(signature.count, 88)
+        XCTAssertTrue(signature.hasSuffix("="))
+        XCTAssertFalse(publicKey.contains("-") || publicKey.contains("_"))
+        XCTAssertFalse(signature.contains("-") || signature.contains("_"))
+    }
+}

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10174,6 +10174,107 @@ mod tests {
         );
     }
 
+    /// The relay connection proves its address before it sends anything else.
+    ///
+    /// The relay attributes each inbound frame by whatever the connection has
+    /// proved at the moment it reads that frame, and never re-stamps
+    /// retroactively. So a frame written before the `DeclareAddress` is
+    /// attributed by *account name* permanently — and since the core stamps
+    /// `Message.sender` with `local_address()`, the receiver's
+    /// [`validate_transport_sender`] strict-match then rejects it. The
+    /// outbound flush that `internet_status_changed(true)` performs is exactly
+    /// what produces those frames, which is what makes this an ordering
+    /// invariant rather than a preference.
+    ///
+    /// Neither platform can test this itself: `InternetManager.swift` is on
+    /// `Package.swift`'s `exclude:` list and `InternetManager.kt` needs a live
+    /// OkHttp socket, so CI typechecks one and executes neither. The *decision*
+    /// and the signed bytes are unit-tested on both sides
+    /// (`AddressDeclarationPolicyTests` / `AddressDeclarationPolicyTest`); what
+    /// no test there can reach is that the call sites run in this order.
+    ///
+    /// The capabilities-before-status half of the chain was comment-only on
+    /// every surface until this guard — see `internet_relay_capabilities`.
+    #[test]
+    fn react_native_relay_declares_its_address_before_it_flushes() {
+        let swift = rn_source_code_only("ios/InternetManager.swift");
+        let kotlin =
+            rn_source_code_only("android/src/main/java/com/offlineprotocol/InternetManager.kt");
+
+        // --- 1. Both bridges declare, and build the proof from the policy ----
+        //
+        // The payload layout is a cross-repo contract with the relay's
+        // `address_binding::address_proof_payload`, pinned to a hex vector on
+        // both sides. A hand-rolled payload at the call site would be a
+        // signature that simply fails to verify — no compile error, no parse
+        // error, just a connection that silently stays in account-name space.
+        for (label, code) in [("ios", &swift), ("android", &kotlin)] {
+            assert!(
+                code.contains("AddressDeclarationPolicy.proofPayload("),
+                "{label} InternetManager must build the address proof through \
+                 AddressDeclarationPolicy.proofPayload — the byte layout is pinned against the \
+                 relay's own vector, and a hand-rolled copy cannot be"
+            );
+            assert!(
+                code.contains("AddressDeclarationPolicy.declarationJson("),
+                "{label} InternetManager must build the DeclareAddress frame through the policy, \
+                 which owns the padded-standard base64 the relay's decoder requires"
+            );
+        }
+
+        // --- 2. The signed account name is the relay's, never a local one ----
+        //
+        // The relay verifies the proof against the account name *it* resolved.
+        // Both bridges used to read `username` with a `deviceId` fallback —
+        // the app-chosen profile — which would produce a signature that cannot
+        // verify and reads as an attack in the relay's logs.
+        assert!(
+            !swift.contains("let username = json[\"username\"] as? String ?? deviceId"),
+            "InternetManager.swift must read the Authenticated username RAW: the deviceId \
+             fallback is the local profile, and signing it produces an unverifiable proof"
+        );
+        assert!(
+            !kotlin.contains("val username = json.safeOptString(\"username\", deviceId)"),
+            "InternetManager.kt must read the Authenticated username RAW: the deviceId fallback \
+             is the local profile, and signing it produces an unverifiable proof"
+        );
+
+        // --- 3. ORDERING: declare → capabilities → status flip ---------------
+        let swift_declare = swift
+            .find("self.declareAddress(declaration, proto: proto, task: task)")
+            .expect("InternetManager.swift must declare its address on the authenticated path");
+        let swift_caps = swift
+            .find("proto.internetRelayCapabilities(capabilities: capabilities)")
+            .expect("InternetManager.swift must inject relay capabilities");
+        let swift_status = swift
+            .find("proto.internetStatusChanged(isConnected: true)")
+            .expect("InternetManager.swift must flip the internet status true");
+        assert!(
+            swift_declare < swift_caps && swift_caps < swift_status,
+            "ORDERING INVARIANT: InternetManager.swift must send DeclareAddress BEFORE \
+             internetRelayCapabilities, which must precede internetStatusChanged(true). The \
+             status flip flushes the outbox, and every frame it produces is attributed by \
+             whatever this connection proved first — declare late and those sends are stamped \
+             with the account name, failing the receiver's validate_transport_sender"
+        );
+
+        let kotlin_declare = kotlin
+            .find("declareAddress(ws, capabilities, addressChallenge, username)")
+            .expect("InternetManager.kt must declare its address on the authenticated path");
+        let kotlin_caps = kotlin
+            .find("protocol.internetRelayCapabilities(capabilities)")
+            .expect("InternetManager.kt must inject relay capabilities");
+        let kotlin_status = kotlin
+            .find("protocol.internetStatusChanged(true)")
+            .expect("InternetManager.kt must flip the internet status true");
+        assert!(
+            kotlin_declare < kotlin_caps && kotlin_caps < kotlin_status,
+            "ORDERING INVARIANT: InternetManager.kt must send DeclareAddress BEFORE \
+             internetRelayCapabilities, which must precede internetStatusChanged(true) — same \
+             reason as the Swift half above"
+        );
+    }
+
     /// Wi-Fi Direct announces nothing, because it can name nobody.
     ///
     /// Both managers used to pass a transport-level string — a TCP endpoint on

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10275,6 +10275,53 @@ mod tests {
         );
     }
 
+    /// Every hand-written iOS source is listed in the podspec.
+    ///
+    /// `MeshSdk.podspec` enumerates its Swift sources one by one (only `ble/`
+    /// and `mesh/` are globbed), and the pod — not `Package.swift` — is what
+    /// ships. A new file that nothing lists compiles in both CI checks anyway:
+    /// the SwiftPM harness has its own `sources:` list, and the `swiftc
+    /// -typecheck` probe takes an explicit file list on the command line. So
+    /// the omission surfaces only when an app builds the pod, as an undefined
+    /// symbol for a type that is right there in the directory.
+    ///
+    /// Directory-driven rather than list-driven on purpose: a guard that
+    /// compared two hand-maintained lists would need editing by the same person
+    /// who forgot the podspec.
+    #[test]
+    fn react_native_podspec_ships_every_hand_written_ios_source() {
+        let root =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../bindings/react-native");
+        let podspec_path = root.join("MeshSdk.podspec");
+        let podspec = std::fs::read_to_string(&podspec_path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", podspec_path.display()));
+
+        let ios = root.join("ios");
+        let mut missing: Vec<String> = std::fs::read_dir(&ios)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", ios.display()))
+            .map(|entry| entry.expect("directory entry").file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            // Package.swift is the SwiftPM test harness's manifest, not a
+            // source the pod could compile.
+            .filter(|name| name.ends_with(".swift") && name != "Package.swift")
+            .filter(|name| {
+                let stem = name.trim_end_matches(".swift");
+                !podspec.contains(&format!("\"ios/{name}\""))
+                    // OfflineProtocolModule rides the `{m,swift}` brace form,
+                    // which pairs it with its ObjC bridging file.
+                    && !podspec.contains(&format!("\"ios/{stem}.{{m,swift}}\""))
+            })
+            .collect();
+        missing.sort();
+
+        assert!(
+            missing.is_empty(),
+            "MeshSdk.podspec does not list {missing:?} — the pod is what ships, so an unlisted \
+             source is absent from every app build while both CI checks (the SwiftPM harness and \
+             the swiftc typecheck probe) keep passing on their own file lists"
+        );
+    }
+
     /// Wi-Fi Direct announces nothing, because it can name nobody.
     ///
     /// Both managers used to pass a transport-level string — a TCP endpoint on

--- a/docs/message-delivery.md
+++ b/docs/message-delivery.md
@@ -128,6 +128,42 @@ When `internet_status_changed(true)` is called after a disconnection:
 
 Both flush methods cap at 20 messages per invocation to prevent blocking. If more messages are pending, the remainder stays in the retry queue and will be picked up on the next `process()` tick or the next flush.
 
+### Relay identity: the address declaration
+
+The relay authenticates a JWT and knows the connection by the **account name**
+behind it. The SDK, meanwhile, stamps every frame's sender with this device's
+`off1…` address, and the receiver strict-matches the two — so a relay that
+attributes a frame by account name hands the receiver a mismatch and the frame
+is rejected. That rejection applies to the security-gated control prefixes
+(`__MLS_KEY_PKG__`, `__MLS_WELCOME__`), which is what establishes a session; an
+already-established session keeps working, because `__MLS_ENC__` is data-plane
+and ungated.
+
+So, on every connection, immediately after the relay's `Authenticated` answer
+and **before** any queued message is flushed, each bridge proves its address:
+it signs the per-connection `address_challenge` from that frame — bound to a
+dedicated domain and to the relay-resolved account name — with the same
+identity key the address derives from, and sends a `DeclareAddress`. The relay
+verifies the signature, re-derives the address from the presented key, and from
+its next inbound frame onward attributes *and* routes that connection by
+address. This also makes an `off1…` recipient resolvable: the relay's registry
+is keyed by account name, and the declaration is what maps one to the other.
+
+The ordering is load-bearing. A frame written before the declaration is
+attributed by account name permanently — the relay does not re-stamp
+retroactively — so the declaration precedes the reconnect flush described
+above, not merely the first send an app makes.
+
+This is automatic and unconfigurable. It happens only against a relay
+advertising the `address_routing_v1` capability; against an older relay, or
+before MLS holds an identity (an app running with `encryption.enabled: false`
+never has one), the bridges send nothing and the connection behaves exactly as
+it did before addresses existed. A refusal is non-fatal for the same reason:
+the relay answers `AddressError`, the connection stays up in account-name
+space, and the next reconnect declares again from scratch. Both the acceptance
+and the refusal also reach the app verbatim as `internet_server_message`
+events, and the bridge diagnostics name the reason it skipped.
+
 ## Outbox
 
 The outbox persists messages that require acknowledgment. It serves as the source of truth for "what messages are in flight."


### PR DESCRIPTION
Closes the client half of the relay address-routing contract. Relay PR
[#27](https://github.com/Offline-Protocol/relay-server/pull/27) (merged 2026-08-11) taught the relay to accept a proved
`off1…` address, but the relay learns nothing until a client declares — so
this is the last thing standing between `main` and a releasable relay path.

## The break this closes

The relay knows a connection by the account name behind its JWT and stamps
that name on every frame it forwards. Since #328 the core stamps
`Message.sender` with the derived address, and the receiver strict-matches the
two in `validate_transport_sender`.

So on `main` today, **no MLS session can be established over the relay at
all**: `__MLS_KEY_PKG__` and `__MLS_WELCOME__` are security-gated and hit the
mismatch, while already-established sessions keep working because `__MLS_ENC__`
is data-plane and ungated — the transport looks healthy right up until someone
new tries to talk to you. Outbound was broken in the same place from the other
side: an `off1…` recipient does not exist in a registry keyed by account name.

The seam itself was pinned from both ends before this PR — SDK #333, and the
relay's `a_declared_sender_is_attributed_by_its_address` mirror.

## What this does

On every connection, immediately after the relay's `Authenticated` frame and
**before** the capability injection and the false→true status flush, each
bridge signs that frame's per-connection `address_challenge` and sends
`DeclareAddress`.

- **Ordering is load-bearing, not a preference.** The relay attributes each
  frame by whatever the connection has proved at the moment it reads it, and
  never re-stamps retroactively. The status flip flushes the outbox, which is
  exactly what produces those frames. Nothing waits for the ack — the relay
  binds the address before reading the next frame off the socket, so the write
  alone establishes the order.
- **The payload is domain-separated and binds the account name.** Signing a
  bare challenge would let a hostile relay hand out bytes shaped like a control
  frame and harvest a signature that replays as one (the same identity key
  signs `offline-ctrl-v1`). The relay refuses that shape explicitly.
- **Every failure is a skip.** No capability, no challenge, no local identity
  (`encryption.enabled: false` never has one), or a refused declaration — all
  leave a working connection the relay attributes the legacy way. Failing a
  connection over this would turn a degraded path into no path.

Gated on `address_routing_v1`; against an older relay the bridges stay silent.
**No UDL change** — `sign_data`, `get_identity_public_key` and `local_address()`
were already exposed, so no bindings were regenerated.

## Three things found while implementing

1. **The podspec would have silently dropped the new file.** `MeshSdk.podspec`
   enumerates iOS sources one by one and is what actually ships, while *both*
   CI checks (the SwiftPM harness and the `swiftc -typecheck` probe) carry
   their own file lists — so the omission is invisible to CI and surfaces as an
   undefined symbol in an app build. Nothing pinned that invariant for any of
   the 29 sources; the second commit adds a directory-driven guard.
2. **Both bridges read the `Authenticated` username with a `deviceId`
   fallback** — the app-chosen *profile*. Signing that would produce a
   permanently unverifiable proof that reads as an attack in the relay's logs.
   Both parse sites now keep it raw; the fallback survives only in the
   diagnostic, and the Rust guard pins its absence.
3. UniFFI carries `sequence<u8>` as `List<UByte>` in Kotlin — caught only by
   the Android compile.

## Design notes

The decision and the byte layout live in a dispatch-free `AddressDeclarationPolicy`
per platform (the established `SupersededLatchPolicy` pattern), because
`InternetManager` is untestable on both: it is on `Package.swift`'s `exclude:`
list, and the Kotlin needs a live socket. What the policy tests still cannot
reach is that the *call sites* run in the right order — hence the source-text
guard in the uniffi crate. The capabilities-before-status half of that chain
had been comment-only on every surface until now.

Decisions taken: `AddressError` degrades with no retry (relay-side non-fatal; a
refusal is either permanent for the connection or means a displaced socket
whose successor declares for itself, and every reconnect re-declares);
no kill-switch, since the capability *is* the gate and an opt-out would only
re-create the broken username space; `AddressDeclared` is logged, not verified
(the echo-vs-`local_address()` hard check stays with item 7 and wants a
dedicated FFI entry, per the `internet_group_report_received` precedent); the
frame goes out unmetered like `Authenticate` — 2 unmetered + a 28 burst is
exactly the relay's 30, then 9/s stays under its 10/s, so both `RelayRateLimiter`
headers were corrected (they described the reserve as covering one frame).

## Verification

202 Swift · 391 Android (+15 each — the two suites mirror the relay's own
pinned hex vector byte for byte) · 2029 Rust · clippy `-D warnings`, fmt, tsc
and the iOS `swiftc -typecheck` probe all clean.

**Four independent negative controls**, all fired and all restored:
little-endian length prefix (3 tests red on *each* platform), dropped
capability gate, reordered declare-vs-flush, and a removed podspec entry.

## Not covered — please read before merging

Nothing here ran against a live relay. The relay's own tests call
`handle_declare_address` directly and there is no socket-level JSON test on
either side, so the untested layer is exactly the one that hid the #328 and
#330 breaks.

Fold a relay leg into the release-gate device pass item 4 already asks for:
new-SDK client → deployed relay, asserting `AddressDeclared` arrives and an MLS
session actually **establishes over the relay**, plus one legacy-relay peer to
confirm the silent-skip path.

Residual, pre-existing and documented rather than fixed: `isReady()` flips the
instant `isAuthenticated` does — before capabilities and before the declaration
— so an app writing raw frames via `sendRawServerCommand` in that window is
account-name-attributed for the life of the connection.
