### PR TITLE
fix(bindings): teach the relay group adapter who it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **The relay group control plane no longer recognized this device, so it added
+  itself to its own groups and never left them.** The React Native bridges tell
+  their relay adapter who "self" is with the `profile`, and compare that against
+  ids that arrive from two different places: group rosters and leave
+  notifications come from the core and name members by `off1…` address, while
+  the relay's own role-change answer names accounts by their relay username.
+  Since the identity change the profile matched neither reliably, so all three
+  self-checks were dead. The SDK sent the relay an `AddGroupMember` naming its
+  own address; leaving a group never sent the relay-native `LeaveGroup`, so the
+  relay kept fanning that group out to a device that had left; and being
+  promoted to admin mid-connection never re-enabled the membership sync an
+  earlier denial had suppressed. The adapter now recognizes itself by profile
+  *or* address, resolved fresh on each use so it works across MLS
+  initialization and identity rebuilds, and the role-change answer is read from
+  the field the relay actually sends. The same two-namespace fix is applied to
+  the presence self-filters, which could otherwise put this device in its own
+  presence watch set. No configuration, and nothing for an app to call.
+
 - **No MLS session could be established over the relay, and `off1…` recipients
   were unreachable through it.** The relay knows a connection by the account
   name it authenticated, and stamps that name on every frame it forwards. Since

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -154,7 +154,20 @@ class InternetManager(
 
     // Translates core-tagged server-plane control frames (control_op on
     // InternetMessage) into relay-native ops.
-    private val controlOpTranslator = RelayControlOpTranslator(deviceId)
+    //
+    // Two identities, deliberately: `deviceId` is the profile (the relay
+    // username by convention) and matches relay-fed answers, while the lambda
+    // resolves the derived address that core-fed roster payloads are named in.
+    // Resolved per call, never captured: MLS identity may not exist yet at
+    // construction and an identity rebuild replaces the address. See
+    // RelayControlOpTranslator's namespace note.
+    private val controlOpTranslator = RelayControlOpTranslator(deviceId) {
+        try {
+            protocol.localAddress()
+        } catch (e: Exception) {
+            null
+        }
+    }
 
     // Client-side mirror of the relay's token bucket: every relay-bound
     // frame takes a token before the socket write (a server-side drop after
@@ -1629,9 +1642,15 @@ class InternetManager(
             "GroupRoleChanged" -> {
                 // A promotion of this device to admin re-enables member
                 // deltas an earlier denial suppressed.
+                // The relay names the promoted account in `username` (its
+                // group path is username-keyed). `user_id` is kept only as a
+                // fallback for a future relay that renames the field —
+                // reading it FIRST was the defect: the relay never emits it,
+                // so the self-check compared against an empty string and no
+                // promotion ever landed.
                 controlOpTranslator.onRoleChanged(
                     json.safeOptString("group_id"),
-                    json.safeOptString("user_id"),
+                    json.safeOptString("username", json.safeOptString("user_id")),
                     json.safeOptString("new_role", json.safeOptString("role"))
                 )
                 serverMessageEmitter?.invoke(rawText)
@@ -2168,7 +2187,7 @@ class InternetManager(
         // occupy a rotation slot until the idle TTL and could surface a
         // presence_updated(self, offline) to the app. (The core drops self
         // presence too — this just keeps the bridge honest at the source.)
-        if (recipient != deviceId) {
+        if (!isSelfPeer(recipient)) {
             presenceWatch.watch(recipient, now)
             try {
                 protocol.internetPeerPresence(recipient, false, null)
@@ -2182,6 +2201,22 @@ class InternetManager(
             "source" to source,
             "failedInFlight" to failedIds.size
         ))
+    }
+
+    /**
+     * True when [peerId] names this device in either namespace — the profile
+     * (relay username by convention) or the derived address the core stamps
+     * on its own frames. Peer ids reaching the presence plane come from both
+     * sides, and a profile-only test lets self through on every core-fed one.
+     */
+    private fun isSelfPeer(peerId: String): Boolean {
+        if (peerId.isEmpty()) return false
+        if (peerId == deviceId) return true
+        return try {
+            peerId == protocol.localAddress()
+        } catch (e: Exception) {
+            false
+        }
     }
 
     private fun startPresenceWatch() {
@@ -2206,7 +2241,20 @@ class InternetManager(
             val now = monotonicNowMs()
             // Self is filtered BEFORE the merge so it can never enter the
             // watch set and pin a rotation slot until the idle TTL.
-            val peers = presenceWatch.peersToQuery(coreWatchlist.filter { it != deviceId }, now)
+            // Resolved once per tick rather than per entry: the watchlist
+            // comes from the core in address space, so a profile-only filter
+            // lets self into the watch set.
+            // Empty folds to null so an absent address never matches an
+            // empty watchlist entry.
+            val selfAddress = try {
+                protocol.localAddress()?.takeIf { it.isNotEmpty() }
+            } catch (e: Exception) {
+                null
+            }
+            val peers = presenceWatch.peersToQuery(
+                coreWatchlist.filter { it != deviceId && it != selfAddress },
+                now
+            )
             var queried = 0
             for (peer in peers) {
                 // Presence queries yield to data traffic under rate

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/RelayControlOpTranslator.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/RelayControlOpTranslator.kt
@@ -45,15 +45,41 @@ import org.json.JSONObject
  * RateLimited) cannot write a phantom snapshot into the next connection's
  * diff base.
  *
+ * SELF-IDENTITY SPANS TWO NAMESPACES — that is why [isSelf] matches a pair
+ * rather than one string. The frames this translator reads come from two
+ * different sides, and they name this device differently:
+ *
+ * - core-fed control payloads (`members`, `leaving_member`) carry the MLS
+ *   roster, which since the self-certifying addressing change is `off1…`
+ *   ADDRESS space;
+ * - relay-fed answers (`GroupRoleChanged`) name members by the relay's
+ *   account key, which is USERNAME space (the relay stays username-keyed on
+ *   the group path by design).
+ *
+ * [selfId] is the app-chosen profile, conventionally the relay username;
+ * [selfAddress] resolves the derived address lazily, because MLS identity is
+ * not necessarily initialized when this translator is constructed and the
+ * address can change across an identity rebuild. A comparison against only
+ * one of the two silently never matches on the other side's frames, which is
+ * what made all three self-checks dead: the SDK named its own address in
+ * `AddGroupMember`, never sent a relay-native `LeaveGroup`, and ignored its
+ * own admin promotion.
+ *
  * Known v1 limitation: a group rename re-registers, but the relay's
  * idempotent sync never updates the stored name (`ON CONFLICT DO NOTHING`).
  *
  * State is per-connection: call [reset] on disconnect.
  * Thread-safe: relay answers (`onGroupError`) arrive on OkHttp's reader
  * thread while `translate` runs on the main handler's poll loop, so all
- * state is guarded by an internal lock.
+ * state is guarded by an internal lock. [selfAddress] is always invoked
+ * OUTSIDE that lock: it reaches into the protocol's own mutex, and the core
+ * never calls back into the translator, so keeping the ordering
+ * one-directional is what makes that safe.
  */
-class RelayControlOpTranslator(private val selfId: String) {
+class RelayControlOpTranslator(
+    private val selfId: String,
+    private val selfAddress: () -> String?
+) {
 
     companion object {
         /**
@@ -154,14 +180,35 @@ class RelayControlOpTranslator(private val selfId: String) {
     /** Groups for which a relay-native LeaveGroup was already committed. */
     private val leaveSent = HashSet<String>()
 
+    /**
+     * True when [id] names this device in either namespace.
+     * [resolvedAddress] is the value of [selfAddress] sampled once by the
+     * caller before it took the lock — a null (or empty) address degrades to
+     * profile-only matching, which is exactly the behavior that predates
+     * addressing.
+     */
+    private fun isSelf(id: String, resolvedAddress: String?): Boolean =
+        id == selfId || (!resolvedAddress.isNullOrEmpty() && id == resolvedAddress)
+
     fun translate(
         controlOp: String,
         controlPayload: String,
         recipientId: String
+    ): Translation {
+        // Sampled before the lock: resolving the address takes the protocol's
+        // mutex, and this translator must never hold its own lock across that.
+        val resolvedAddress = selfAddress()
+        return translateLocked(controlOp, controlPayload, resolvedAddress)
+    }
+
+    private fun translateLocked(
+        controlOp: String,
+        controlPayload: String,
+        resolvedAddress: String?
     ): Translation = synchronized(lock) {
         try {
             when (controlOp) {
-                "group_relay_register" -> translateRegister(controlPayload)
+                "group_relay_register" -> translateRegister(controlPayload, resolvedAddress)
 
                 "group_relay_broadcast" -> {
                     val payload = JSONObject(controlPayload)
@@ -204,8 +251,15 @@ class RelayControlOpTranslator(private val selfId: String) {
                 "group_mls_leave" -> {
                     val payload = JSONObject(controlPayload)
                     val groupId = payload.optString("group_id")
+                    // `leaving_member` is the core's `local_id` — address
+                    // space. A profile-only comparison here never fires,
+                    // which left the relay holding us in the group registry
+                    // after we left.
                     val leavingMember = payload.optString("leaving_member")
-                    if (groupId.isEmpty() || leavingMember != selfId || leaveSent.contains(groupId)) {
+                    if (groupId.isEmpty() ||
+                        !isSelf(leavingMember, resolvedAddress) ||
+                        leaveSent.contains(groupId)
+                    ) {
                         Translation.Tap(emptyList())
                     } else {
                         val gen = generation
@@ -228,7 +282,10 @@ class RelayControlOpTranslator(private val selfId: String) {
         }
     }
 
-    private fun translateRegister(controlPayload: String): Translation {
+    private fun translateRegister(
+        controlPayload: String,
+        resolvedAddress: String?
+    ): Translation {
         val payload = JSONObject(controlPayload)
         val groupId = payload.optString("group_id")
         if (groupId.isEmpty()) return Translation.PassThrough
@@ -264,9 +321,13 @@ class RelayControlOpTranslator(private val selfId: String) {
         // Member deltas: the relay adds the creator itself, and self-adds are
         // redundant, so the self id never appears in a delta. Sorted for a
         // deterministic wire order across platforms.
+        //
+        // `members` is the MLS roster — address space. Filtering it against
+        // the profile alone strips nothing, which is how the SDK ended up
+        // sending an AddGroupMember naming its own address.
         var commit: (() -> Unit)? = null
         if (!notAdmin && !memberDeltasDenied.contains(groupId)) {
-            val desired = members.filter { it != selfId }.toSet()
+            val desired = members.filter { !isSelf(it, resolvedAddress) }.toSet()
             val known = registeredMembers[groupId] ?: emptySet()
             for (added in (desired - known).sorted()) {
                 frames.add(JSONObject().apply {
@@ -367,10 +428,22 @@ class RelayControlOpTranslator(private val selfId: String) {
      * the relay until the next reconnect. (The denial already dropped the
      * group's committed snapshot, so the next register recomputes the full
      * delta set.)
+     *
+     * [member] is the relay's own naming of the promoted account — username
+     * space today (the relay's group path stays username-keyed), which is
+     * why [selfId] is the load-bearing half of the match here. The address
+     * half costs nothing and keeps this correct if the relay's group naming
+     * later moves to address space.
+     *
+     * Residual, accepted: an app whose relay username differs from its
+     * `profile` still fails this match and falls back to re-learning the
+     * denial each connection — noisy but safe, the same degradation a
+     * reworded denial marker produces.
      */
-    fun onRoleChanged(groupId: String, userId: String, newRole: String) {
-        if (groupId.isEmpty() || userId != selfId) return
+    fun onRoleChanged(groupId: String, member: String, newRole: String) {
+        if (groupId.isEmpty()) return
         if (!newRole.equals("admin", ignoreCase = true)) return
+        if (!isSelf(member, selfAddress())) return
         synchronized(lock) {
             memberDeltasDenied.remove(groupId)
         }

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/RelayControlOpTranslatorTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/RelayControlOpTranslatorTest.kt
@@ -31,7 +31,7 @@ class RelayControlOpTranslatorTest {
      */
     @Test
     fun connectionOpsPassThroughVerbatim() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
         val cases = listOf(
             "conn_req" to """{"sender_name":"Alice","timestamp_ms":1,"key_package":[1,2,3]}""",
             "conn_acc" to """{"accepted_by_name":"Alice","timestamp_ms":1}""",
@@ -49,7 +49,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun registerTranslatesToCreateGroupPlusMemberDeltas() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
 
         val firstTranslation = translator.translate(
             "group_relay_register",
@@ -89,7 +89,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun uncommittedRegistrationResendsDeltas() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
 
         // The frames were produced but never fully written (a best-effort
         // delta dropped): the commit must not run, so the next registration
@@ -116,7 +116,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun adminDeniedGroupsStopProducingMemberDeltas() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
 
         commit(
             translator.translate(
@@ -142,7 +142,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun notAdminHintSkipsMemberDeltasUpFront() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
 
         // The core's is_admin=false hint: no deltas are ever attempted, so
         // the relay never answers the group-scoped denials that would revoke
@@ -172,7 +172,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun numericAndStringIsAdminHintsMatchSwiftSemantics() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
 
         // Numeric 0 is honored as not-admin (NSNumber.boolValue parity with
         // the Swift translator) even though serde emits real booleans.
@@ -210,7 +210,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun leaveAfterRejoinSendsLeaveGroupAgain() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
 
         commit(
             translator.translate(
@@ -243,7 +243,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun adminDenialDuringFlightWinsOverCommit() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
 
         // Frames produced, but the relay's denial lands before the caller
         // commits (reader thread races the send loop): the commit must not
@@ -270,7 +270,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun broadcastTranslatesToSendGroupMessage() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
         val bcast = frames(
             translator.translate(
                 "group_relay_broadcast",
@@ -289,7 +289,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun broadcastStampsLogicalMessageId() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
         val bcast = frames(
             translator.translate(
                 "group_relay_broadcast",
@@ -309,7 +309,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun broadcastOmitsMessageIdWhenAbsent() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
         val bcast = frames(
             translator.translate(
                 "group_relay_broadcast",
@@ -322,7 +322,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun broadcastForwardsForwardInfo() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
         val bcast = frames(
             translator.translate(
                 "group_relay_broadcast",
@@ -338,7 +338,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun broadcastOmitsForwardInfoWhenAbsent() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
         val bcast = frames(
             translator.translate(
                 "group_relay_broadcast",
@@ -351,7 +351,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun leaveIsATapSentOncePerGroupForSelfOnly() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
 
         val tap = translator.translate(
             "group_mls_leave",
@@ -393,7 +393,7 @@ class RelayControlOpTranslatorTest {
      */
     @Test
     fun everyCoreControlOpTranslatesToRelayNative() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
 
         // Ordered: g1 is registered before the ops that reference it.
         val cases = listOf(
@@ -422,7 +422,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun malformedPayloadAndUnknownOpFallBackToPassThrough() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
         assertTrue(
             translator.translate("group_relay_broadcast", "not-json", "alice")
                 is RelayControlOpTranslator.Translation.PassThrough
@@ -439,7 +439,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun resetForgetsRegistrationDiffState() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
         commit(
             translator.translate(
                 "group_relay_register",
@@ -464,7 +464,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun registerCommitAfterResetIsANoOp() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
 
         // A chain that settles after a disconnect reset must not commit a
         // phantom snapshot into the NEXT connection's diff base — the relay
@@ -492,7 +492,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun leaveCommitAfterResetIsANoOp() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
 
         val staleTranslation = translator.translate(
             "group_mls_leave",
@@ -517,7 +517,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun nonAdminReasonGroupErrorDoesNotSuppressDeltas() {
-        val translator = RelayControlOpTranslator("alice")
+        val translator = RelayControlOpTranslator("alice") { null }
 
         // Only the relay's admin-denial wording flips the suppression, even
         // when the error correlates to outstanding deltas; an unrelated
@@ -546,7 +546,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun rolePromotionReenablesMemberDeltas() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
         // The denial answers an outstanding member delta (the correlation
         // window — see onGroupError).
         translator.translate(
@@ -596,7 +596,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun uncorrelatedAdminDenialDoesNotSuppressDeltas() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
 
         // An admin-denial GroupError with NO member deltas outstanding from
         // this translator answers someone else's operation (an app
@@ -619,7 +619,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun requestIdCarryingDenialIsNeverOurs() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
 
         // The translator never tags request_id, so a request_id-echoing
         // GroupError answers an app raw-channel frame — even mid-window it
@@ -659,7 +659,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun deltaWindowClosesOnFirstGroupScopedAnswer() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
 
         // One answer per window: the first group-scoped GroupError closes
         // it, so a later admin-denial with nothing outstanding is
@@ -689,7 +689,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun successAnswerClosesTheDenialWindow() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
 
         // The register succeeded (GroupCreated answered it): the success
         // answer must close the delta window too, or it stays armed for the
@@ -720,7 +720,7 @@ class RelayControlOpTranslatorTest {
 
     @Test
     fun resetClosesTheDenialWindow() {
-        val translator = RelayControlOpTranslator("bob")
+        val translator = RelayControlOpTranslator("bob") { null }
 
         translator.translate(
             "group_relay_register",
@@ -742,6 +742,240 @@ class RelayControlOpTranslatorTest {
         )
         assertEquals(2, after.size)
         assertEquals("AddGroupMember", after[1].getString("type"))
+    }
+
+    // ---- Self-identity across both namespaces -------------------------
+    //
+    // Core-fed payloads (members, leaving_member) name this device by its
+    // derived `off1…` address; relay-fed answers (GroupRoleChanged) name it
+    // by account name. Every test above pins the profile half with a null
+    // address; these pin the address half and the interaction.
+    // Mirrors ios/tests/RelayControlOpTranslatorTests.swift.
+
+    private val selfAddr = "off1qqqqself0000000000000000000000000000000000000000000000000"
+    private val peerAddr = "off1qqqqpeer00000000000000000000000000000000000000000000000000"
+
+    /**
+     * The registration roster is the MLS roster — addresses. Filtering it
+     * against the profile alone strips nothing, so the SDK emitted an
+     * AddGroupMember naming its own address: self-add, wrong under every
+     * namespace the relay might settle on.
+     */
+    @Test
+    fun registerStripsSelfByAddressNotJustProfile() {
+        val translator = RelayControlOpTranslator("alice") { selfAddr }
+
+        val sent = frames(
+            translator.translate(
+                "group_relay_register",
+                """{"group_id":"g1","members":["$selfAddr","$peerAddr"]}""",
+                selfAddr
+            )
+        )
+        val delta = sent.drop(1).map { it.getString("username") }
+        assertEquals(
+            "self must be stripped from the roster by address; only the peer is a real delta",
+            listOf(peerAddr),
+            delta
+        )
+        assertFalse(
+            "the SDK must never send an AddGroupMember naming its own address",
+            delta.contains(selfAddr)
+        )
+    }
+
+    /**
+     * The profile half must survive the address half: a roster still naming
+     * this device by profile (a relay-shaped roster) strips too.
+     */
+    @Test
+    fun registerStillStripsSelfByProfileWhenAddressIsKnown() {
+        val translator = RelayControlOpTranslator("alice") { selfAddr }
+        val sent = frames(
+            translator.translate(
+                "group_relay_register",
+                """{"group_id":"g1","members":["alice","bob"]}""",
+                "alice"
+            )
+        )
+        assertEquals(listOf("bob"), sent.drop(1).map { it.getString("username") })
+    }
+
+    /**
+     * `leaving_member` is the core's local_id — an address. Without the
+     * address half this never fired, so the relay kept us in the group
+     * registry after we left and went on fanning the group out to us.
+     */
+    @Test
+    fun leaveFiresWhenLeavingMemberIsOurAddress() {
+        val translator = RelayControlOpTranslator("alice") { selfAddr }
+
+        val tap = translator.translate(
+            "group_mls_leave",
+            """{"group_id":"g1","leaving_member":"$selfAddr"}""",
+            peerAddr
+        )
+        val leaveFrames = frames(tap)
+        assertEquals(
+            "our own leave must produce a relay-native LeaveGroup",
+            1,
+            leaveFrames.size
+        )
+        assertEquals("LeaveGroup", leaveFrames[0].getString("type"))
+        commit(tap)
+
+        // Another member's leave — named by address — is still not ours to
+        // send. Widening the match must not have widened it to everyone.
+        val other = translator.translate(
+            "group_mls_leave",
+            """{"group_id":"g2","leaving_member":"$peerAddr"}""",
+            peerAddr
+        )
+        assertTrue(
+            "third-party leave must stay a tap",
+            other is RelayControlOpTranslator.Translation.Tap
+        )
+        assertTrue(
+            "a peer's address must never be read as self — that would deregister us " +
+                "from a group we are still in",
+            frames(other).isEmpty()
+        )
+    }
+
+    /**
+     * The relay names the promoted account by username, so the profile half
+     * carries this site; the address half is forward-compatibility for a
+     * relay whose group path later moves to address space.
+     */
+    @Test
+    fun rolePromotionMatchesSelfInEitherNamespace() {
+        for ((label, promoted) in listOf("profile" to "bob", "address" to selfAddr)) {
+            val translator = RelayControlOpTranslator("bob") { selfAddr }
+            commit(
+                translator.translate(
+                    "group_relay_register",
+                    """{"group_id":"g1","members":["alice","bob"]}""",
+                    "bob"
+                )
+            )
+            translator.onGroupError("g1", "Only admins can add members")
+            assertEquals(
+                "$label: denial must suppress deltas first",
+                1,
+                frames(
+                    translator.translate(
+                        "group_relay_register",
+                        """{"group_id":"g1","members":["alice","bob"]}""",
+                        "bob"
+                    )
+                ).size
+            )
+
+            translator.onRoleChanged("g1", promoted, "admin")
+            assertEquals(
+                "$label: our own promotion must re-enable member deltas",
+                2,
+                frames(
+                    translator.translate(
+                        "group_relay_register",
+                        """{"group_id":"g1","members":["alice","bob"]}""",
+                        "bob"
+                    )
+                ).size
+            )
+        }
+    }
+
+    /**
+     * An unrelated account's promotion must not re-enable our deltas, in
+     * either namespace.
+     */
+    @Test
+    fun rolePromotionOfAnotherAddressIsIgnored() {
+        val translator = RelayControlOpTranslator("bob") { selfAddr }
+        commit(
+            translator.translate(
+                "group_relay_register",
+                """{"group_id":"g1","members":["alice","bob"]}""",
+                "bob"
+            )
+        )
+        translator.onGroupError("g1", "Only admins can add members")
+
+        translator.onRoleChanged("g1", peerAddr, "admin")
+        assertEquals(
+            "another member's promotion must leave our denial in place",
+            1,
+            frames(
+                translator.translate(
+                    "group_relay_register",
+                    """{"group_id":"g1","members":["alice","bob"]}""",
+                    "bob"
+                )
+            ).size
+        )
+    }
+
+    /**
+     * Before MLS identity exists (encryption disabled, or pre-init) the
+     * provider returns null and the translator must behave exactly as it did
+     * when it only knew the profile — no crash, no accidental self-match.
+     */
+    @Test
+    fun absentAddressDegradesToProfileOnlyMatching() {
+        for (provider in listOf<() -> String?>({ null }, { "" })) {
+            val translator = RelayControlOpTranslator("alice", provider)
+            val sent = frames(
+                translator.translate(
+                    "group_relay_register",
+                    """{"group_id":"g1","members":["alice","bob"]}""",
+                    "alice"
+                )
+            )
+            assertEquals(listOf("bob"), sent.drop(1).map { it.getString("username") })
+
+            // An empty roster id must not match an empty address. (Empty
+            // members are dropped upstream too — this pins both guards.)
+            val withEmpty = frames(
+                translator.translate(
+                    "group_relay_register",
+                    """{"group_id":"g2","members":["alice","","bob"]}""",
+                    "alice"
+                )
+            )
+            assertEquals(listOf("bob"), withEmpty.drop(1).map { it.getString("username") })
+        }
+    }
+
+    /**
+     * The address is resolved per call, never captured at construction: the
+     * translator outlives MLS init and identity rebuilds.
+     */
+    @Test
+    fun addressIsResolvedPerCallNotCachedAtConstruction() {
+        var current: String? = null
+        val translator = RelayControlOpTranslator("alice") { current }
+
+        // Pre-identity: the address is unknown, so it cannot be stripped.
+        val before = frames(
+            translator.translate(
+                "group_relay_register",
+                """{"group_id":"g1","members":["$selfAddr","$peerAddr"]}""",
+                "alice"
+            )
+        )
+        assertEquals("unknown address cannot be filtered out", 3, before.size)
+
+        // MLS init lands: the very next translation must see it.
+        current = selfAddr
+        val after = frames(
+            translator.translate(
+                "group_relay_register",
+                """{"group_id":"g2","members":["$selfAddr","$peerAddr"]}""",
+                "alice"
+            )
+        )
+        assertEquals(listOf(peerAddr), after.drop(1).map { it.getString("username") })
     }
 
     @Test

--- a/bindings/react-native/ios/InternetManager.swift
+++ b/bindings/react-native/ios/InternetManager.swift
@@ -418,7 +418,16 @@ public class InternetManager: NSObject, TransportManager {
     public init(protocol protocolInstance: OfflineProtocol, deviceId: String, serverUrl: String? = nil) {
         self.protocolInstance = protocolInstance
         self.deviceId = deviceId
-        self.controlOpTranslator = RelayControlOpTranslator(selfId: deviceId)
+        // Two identities, deliberately: `deviceId` is the profile (the relay
+        // username by convention) and matches relay-fed answers, while the
+        // closure resolves the derived address that core-fed roster payloads
+        // are named in. Resolved per call, never captured: MLS identity may
+        // not exist yet at construction and an identity rebuild replaces the
+        // address. See RelayControlOpTranslator's namespace note.
+        self.controlOpTranslator = RelayControlOpTranslator(
+            selfId: deviceId,
+            selfAddress: { [weak protocolInstance] in protocolInstance?.localAddress() }
+        )
         if let urlString = serverUrl, let url = URL(string: urlString) {
             // Stored var, not the guarded accessor: computed setters cannot
             // run before super.init(), and no other thread can see self yet.
@@ -1914,9 +1923,14 @@ public class InternetManager: NSObject, TransportManager {
         case "GroupRoleChanged":
             // A promotion of this device to admin re-enables member deltas
             // an earlier denial suppressed.
+            // The relay names the promoted account in `username` (its group
+            // path is username-keyed). `user_id` is kept only as a fallback
+            // for a future relay that renames the field — reading it FIRST
+            // was the defect: the relay never emits it, so the self-check
+            // compared against an empty string and no promotion ever landed.
             controlOpTranslator.onRoleChanged(
                 groupId: json["group_id"] as? String ?? "",
-                userId: json["user_id"] as? String ?? "",
+                member: json["username"] as? String ?? json["user_id"] as? String ?? "",
                 newRole: json["new_role"] as? String ?? json["role"] as? String ?? ""
             )
             emitServerMessage(rawText)
@@ -2695,7 +2709,7 @@ public class InternetManager: NSObject, TransportManager {
         // occupy a rotation slot until the idle TTL and could surface a
         // presence_updated(self, offline) to the app. (The core drops self
         // presence too — this just keeps the bridge honest at the source.)
-        if recipient != deviceId {
+        if !isSelfPeer(recipient) {
             presenceWatch.watch(recipient, nowMs: now)
             protocolInstance.internetPeerPresence(peerId: recipient, online: false, lastSeenMs: nil)
         }
@@ -2705,6 +2719,16 @@ public class InternetManager: NSObject, TransportManager {
             "source": source,
             "failedInFlight": failedIds.count
         ])
+    }
+
+    /// True when `peerId` names this device in either namespace — the profile
+    /// (relay username by convention) or the derived address the core stamps
+    /// on its own frames. Peer ids reaching the presence plane come from both
+    /// sides, and a profile-only test lets self through on every core-fed one.
+    private func isSelfPeer(_ peerId: String) -> Bool {
+        if peerId.isEmpty { return false }
+        if peerId == deviceId { return true }
+        return peerId == protocolInstance.localAddress()
     }
 
     private func startPresenceWatch() {
@@ -2742,8 +2766,14 @@ public class InternetManager: NSObject, TransportManager {
         let now = monotonicNowMs()
         // Self is filtered BEFORE the merge so it can never enter the watch
         // set and pin a rotation slot until the idle TTL.
+        // Resolved once per tick rather than per entry: the watchlist comes
+        // from the core in address space, so a profile-only filter lets self
+        // into the watch set.
+        let selfAddress = protocolInstance.localAddress()
         let peers = presenceWatch.peersToQuery(
-            coreWatchlist: coreWatchlist.filter { $0 != deviceId },
+            coreWatchlist: coreWatchlist.filter { peer in
+                peer != deviceId && !(peer == selfAddress && !peer.isEmpty)
+            },
             nowMs: now
         )
         var queried = 0

--- a/bindings/react-native/ios/RelayControlOpTranslator.swift
+++ b/bindings/react-native/ios/RelayControlOpTranslator.swift
@@ -19,6 +19,26 @@
 // diff base. A GroupRoleChanged promotion of this device (onRoleChanged)
 // re-enables member deltas an earlier admin denial suppressed.
 //
+// SELF-IDENTITY SPANS TWO NAMESPACES — that is why `isSelf` matches a pair
+// rather than one string. The frames this translator reads come from two
+// different sides, and they name this device differently:
+//
+//   * core-fed control payloads (`members`, `leaving_member`) carry the MLS
+//     roster, which since the self-certifying addressing change is
+//     `off1…` ADDRESS space;
+//   * relay-fed answers (GroupRoleChanged) name members by the relay's
+//     account key, which is USERNAME space (the relay stays username-keyed
+//     on the group path by design).
+//
+// `deviceId` is the app-chosen profile, conventionally the relay username;
+// `selfAddress` resolves the derived address lazily, because MLS identity is
+// not necessarily initialized when this translator is constructed and the
+// address can change across an identity rebuild. A comparison against only
+// one of the two silently never matches on the other side's frames, which
+// is what made all three self-checks dead: the SDK named its own address in
+// AddGroupMember, never sent a relay-native LeaveGroup, and ignored its own
+// admin promotion.
+//
 // Known v1 limitation: a group rename re-registers, but the relay's
 // idempotent sync never updates the stored name (ON CONFLICT DO NOTHING).
 //
@@ -81,7 +101,17 @@ final class RelayControlOpTranslator {
         case passThrough
     }
 
+    /// The app-chosen profile, conventionally this device's relay username.
+    /// Matches relay-fed answers; never matches core-fed roster payloads.
     private let selfId: String
+    /// Resolves this device's derived `off1…` address, or nil before MLS
+    /// identity exists. Read lazily (never cached) because the translator is
+    /// constructed before initialize_mls may have run, and an identity
+    /// rebuild replaces the address underneath us. Always invoked OUTSIDE
+    /// this translator's lock: it reaches into the protocol's own mutex, and
+    /// the core never calls back into the translator, so keeping the
+    /// ordering one-directional is what makes that safe.
+    private let selfAddress: () -> String?
     /// Bumped by reset(). Commit closures capture the generation of their
     /// translation and no-op if it moved: state written after a reset would
     /// describe frames sent on a connection (or inside a rate budget) the
@@ -102,11 +132,26 @@ final class RelayControlOpTranslator {
     private var leaveSent: Set<String> = []
     private let lock = NSLock()
 
-    init(selfId: String) {
+    init(selfId: String, selfAddress: @escaping () -> String?) {
         self.selfId = selfId
+        self.selfAddress = selfAddress
+    }
+
+    /// True when `id` names this device in either namespace. `resolvedAddress`
+    /// is the value of `selfAddress()` sampled once by the caller before it
+    /// took the lock — a nil (or empty) address degrades to profile-only
+    /// matching, which is exactly the behavior that predates addressing.
+    private func isSelf(_ id: String, resolvedAddress: String?) -> Bool {
+        if id == selfId { return true }
+        guard let address = resolvedAddress, !address.isEmpty else { return false }
+        return id == address
     }
 
     func translate(controlOp: String, controlPayload: String, recipientId: String) -> Translation {
+        // Sampled before the lock: resolving the address takes the protocol's
+        // mutex, and this translator must never hold its own lock across that.
+        let resolvedAddress = selfAddress()
+
         lock.lock()
         defer { lock.unlock() }
 
@@ -118,7 +163,11 @@ final class RelayControlOpTranslator {
                   let groupId = payload["group_id"] as? String, !groupId.isEmpty else {
                 return .passThrough
             }
-            return translateRegisterLocked(groupId: groupId, payload: payload)
+            return translateRegisterLocked(
+                groupId: groupId,
+                payload: payload,
+                resolvedAddress: resolvedAddress
+            )
 
         case "group_relay_broadcast":
             guard let payload = payload,
@@ -157,10 +206,13 @@ final class RelayControlOpTranslator {
             return .replace([frame], nil)
 
         case "group_mls_leave":
+            // `leaving_member` is the core's `local_id` — address space. A
+            // profile-only comparison here never fires, which left the relay
+            // holding us in the group registry after we left.
             guard let payload = payload,
                   let groupId = payload["group_id"] as? String, !groupId.isEmpty,
                   let leavingMember = payload["leaving_member"] as? String,
-                  leavingMember == selfId,
+                  isSelf(leavingMember, resolvedAddress: resolvedAddress),
                   !leaveSent.contains(groupId) else {
                 return .tap([], nil)
             }
@@ -221,9 +273,20 @@ final class RelayControlOpTranslator {
     /// the relay until the next reconnect. (The denial already dropped the
     /// group's committed snapshot, so the next register recomputes the full
     /// delta set.)
-    func onRoleChanged(groupId: String, userId: String, newRole: String) {
-        guard !groupId.isEmpty, userId == selfId else { return }
+    /// `member` is the relay's own naming of the promoted account — username
+    /// space today (the relay's group path stays username-keyed), which is
+    /// why `deviceId` is the load-bearing half of the match here. The address
+    /// half costs nothing and keeps this correct if the relay's group naming
+    /// later moves to address space.
+    ///
+    /// Residual, accepted: an app whose relay username differs from its
+    /// `profile` still fails this match and falls back to re-learning the
+    /// denial each connection — noisy but safe, the same degradation a
+    /// reworded denial marker produces.
+    func onRoleChanged(groupId: String, member: String, newRole: String) {
+        guard !groupId.isEmpty else { return }
         guard newRole.caseInsensitiveCompare("admin") == .orderedSame else { return }
+        guard isSelf(member, resolvedAddress: selfAddress()) else { return }
         lock.lock()
         defer { lock.unlock() }
         memberDeltasDenied.remove(groupId)
@@ -240,7 +303,11 @@ final class RelayControlOpTranslator {
         leaveSent.removeAll()
     }
 
-    private func translateRegisterLocked(groupId: String, payload: [String: Any]) -> Translation {
+    private func translateRegisterLocked(
+        groupId: String,
+        payload: [String: Any],
+        resolvedAddress: String?
+    ) -> Translation {
         let rawName = payload["group_name"] as? String
         let name = rawName.flatMap { $0.isEmpty ? nil : $0 } ?? groupId
         let members = (payload["members"] as? [Any])?
@@ -274,9 +341,13 @@ final class RelayControlOpTranslator {
         // Member deltas: the relay adds the creator itself, and self-adds are
         // redundant, so the self id never appears in a delta. Sorted for a
         // deterministic wire order across platforms.
+        //
+        // `members` is the MLS roster — address space. Filtering it against
+        // the profile alone strips nothing, which is how the SDK ended up
+        // sending an AddGroupMember naming its own address.
         var commit: (() -> Void)? = nil
         if !notAdmin && !memberDeltasDenied.contains(groupId) {
-            let desired = Set(members.filter { $0 != selfId })
+            let desired = Set(members.filter { !isSelf($0, resolvedAddress: resolvedAddress) })
             let known = registeredMembers[groupId] ?? []
             for added in desired.subtracting(known).sorted() {
                 frames.append([

--- a/bindings/react-native/ios/tests/RelayControlOpTranslatorTests.swift
+++ b/bindings/react-native/ios/tests/RelayControlOpTranslatorTests.swift
@@ -34,7 +34,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     /// signed SendMessage frames, so the translator must pass them through
     /// untouched (they should never even be tagged by the core).
     func testConnectionOpsPassThroughVerbatim() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
         for (op, payload) in [
             ("conn_req", #"{"sender_name":"Alice","timestamp_ms":1,"key_package":[1,2,3]}"#),
             ("conn_acc", #"{"accepted_by_name":"Alice","timestamp_ms":1}"#),
@@ -54,7 +54,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testRegisterTranslatesToCreateGroupPlusMemberDeltas() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
 
         let firstTranslation = translator.translate(
             controlOp: "group_relay_register",
@@ -89,7 +89,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testAdminDeniedGroupsStopProducingMemberDeltas() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         commit(translator.translate(
             controlOp: "group_relay_register",
@@ -110,7 +110,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testBroadcastTranslatesToSendGroupMessage() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
         let bcast = frames(translator.translate(
             controlOp: "group_relay_broadcast",
             controlPayload: #"{"group_id":"g1","ciphertext":"AAECAw==","epoch":4,"reply_to":"m-9"}"#,
@@ -127,7 +127,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testBroadcastStampsLogicalMessageId() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
         let bcast = frames(translator.translate(
             controlOp: "group_relay_broadcast",
             controlPayload: #"{"group_id":"g1","ciphertext":"AAECAw==","epoch":4,"message_id":"11111111-2222-3333-4444-555555555555"}"#,
@@ -144,7 +144,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testBroadcastOmitsMessageIdWhenAbsent() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
         let bcast = frames(translator.translate(
             controlOp: "group_relay_broadcast",
             controlPayload: #"{"group_id":"g1","ciphertext":"AAECAw==","epoch":4}"#,
@@ -155,7 +155,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testBroadcastForwardsForwardInfo() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
         let bcast = frames(translator.translate(
             controlOp: "group_relay_broadcast",
             controlPayload: #"{"group_id":"g1","ciphertext":"AAECAw==","epoch":4,"forward_info":{"original_sender":"dave","forwarded_at":123}}"#,
@@ -168,7 +168,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testBroadcastOmitsForwardInfoWhenAbsent() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
         let bcast = frames(translator.translate(
             controlOp: "group_relay_broadcast",
             controlPayload: #"{"group_id":"g1","ciphertext":"AAECAw==","epoch":4}"#,
@@ -179,7 +179,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testLeaveIsATapSentOncePerGroupForSelfOnly() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
 
         let tap = translator.translate(
             controlOp: "group_mls_leave",
@@ -219,7 +219,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testNotAdminHintSkipsMemberDeltasUpFront() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         // The core's is_admin=false hint: no deltas are ever attempted, so
         // the relay never answers the group-scoped denials that would revoke
@@ -248,7 +248,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testLeaveAfterRejoinSendsLeaveGroupAgain() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
 
         commit(translator.translate(
             controlOp: "group_mls_leave",
@@ -278,7 +278,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testAdminDenialDuringFlightWinsOverCommit() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         // Frames produced, but the relay's denial lands before the caller
         // commits (delegate queue races the send chain): the commit must not
@@ -309,7 +309,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     /// Kotlin translator AND the spec table before it ships — an unhandled
     /// op degrades to an opaque SendMessage the relay merely echoes/forwards.
     func testEveryCoreControlOpTranslatesToRelayNative() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
 
         // Ordered: g1 is registered before the ops that reference it.
         let cases: [(op: String, payload: String, recipient: String)] = [
@@ -333,7 +333,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testMalformedPayloadAndUnknownOpFallBackToPassThrough() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
         XCTAssertTrue(isPassThrough(
             translator.translate(controlOp: "group_relay_broadcast", controlPayload: "not-json", recipientId: "alice")
         ))
@@ -346,7 +346,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testUncommittedRegistrationResendsDeltas() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
 
         // The frames were produced but never fully written (a best-effort
         // delta dropped): the commit must not run, so the next registration
@@ -368,7 +368,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testResetForgetsRegistrationDiffState() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
         commit(translator.translate(
             controlOp: "group_relay_register",
             controlPayload: #"{"group_id":"g1","members":["alice","bob"]}"#,
@@ -388,7 +388,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testRegisterCommitAfterResetIsANoOp() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
 
         // A chain that settles after a disconnect reset must not commit a
         // phantom snapshot into the NEXT connection's diff base — the relay
@@ -413,7 +413,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testLeaveCommitAfterResetIsANoOp() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
 
         let staleTranslation = translator.translate(
             controlOp: "group_mls_leave",
@@ -435,7 +435,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testNonAdminReasonGroupErrorDoesNotSuppressDeltas() {
-        let translator = RelayControlOpTranslator(selfId: "alice")
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { nil })
 
         // Only the relay's admin-denial wording flips the suppression, even
         // when the error correlates to outstanding deltas; an unrelated group
@@ -459,7 +459,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testUncorrelatedAdminDenialDoesNotSuppressDeltas() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         // An admin-denial GroupError with NO member deltas outstanding from
         // this translator answers someone else's operation (an app
@@ -478,7 +478,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testRequestIdCarryingDenialIsNeverOurs() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         // The translator never tags request_id, so a request_id-echoing
         // GroupError answers an app raw-channel frame — even mid-window it
@@ -517,7 +517,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testDeltaWindowClosesOnFirstGroupScopedAnswer() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         // One answer per window: the first group-scoped GroupError closes it,
         // so a later admin-denial with nothing outstanding is uncorrelated
@@ -542,7 +542,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testSuccessAnswerClosesTheDenialWindow() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         // The register succeeded (GroupCreated answered it): the success
         // answer must close the delta window too, or it stays armed for the
@@ -568,7 +568,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testResetClosesTheDenialWindow() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         _ = translator.translate(
             controlOp: "group_relay_register",
@@ -591,7 +591,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testStringIsAdminHintTreatedAsAbsent() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         // A string encoding is not boolean-like on either platform: treated
         // as an absent hint (send-and-learn), not as a denial — mirrors the
@@ -605,7 +605,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testIsAdminHintAcceptsNumericEncoding() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
 
         // JSON 0/1 arrive as NSNumber integers; the hint must behave like
         // the boolean encoding on both platforms (NSNumber boolValue).
@@ -627,7 +627,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
     }
 
     func testRolePromotionReenablesMemberDeltas() {
-        let translator = RelayControlOpTranslator(selfId: "bob")
+        let translator = RelayControlOpTranslator(selfId: "bob", selfAddress: { nil })
         // The denial must correlate to deltas this translator sent.
         commit(translator.translate(
             controlOp: "group_relay_register",
@@ -645,8 +645,8 @@ final class RelayControlOpTranslatorTests: XCTestCase {
         XCTAssertEqual(denied.count, 1)
 
         // Someone else's promotion — or a demotion — changes nothing.
-        translator.onRoleChanged(groupId: "g1", userId: "carol", newRole: "admin")
-        translator.onRoleChanged(groupId: "g1", userId: "bob", newRole: "member")
+        translator.onRoleChanged(groupId: "g1", member: "carol", newRole: "admin")
+        translator.onRoleChanged(groupId: "g1", member: "bob", newRole: "member")
         XCTAssertEqual(
             frames(translator.translate(
                 controlOp: "group_relay_register",
@@ -657,7 +657,7 @@ final class RelayControlOpTranslatorTests: XCTestCase {
         )
 
         // This device's promotion to admin re-enables the deltas.
-        translator.onRoleChanged(groupId: "g1", userId: "bob", newRole: "admin")
+        translator.onRoleChanged(groupId: "g1", member: "bob", newRole: "admin")
         let promoted = frames(translator.translate(
             controlOp: "group_relay_register",
             controlPayload: #"{"group_id":"g1","members":["alice","bob"]}"#,
@@ -666,6 +666,207 @@ final class RelayControlOpTranslatorTests: XCTestCase {
         XCTAssertEqual(promoted.count, 2)
         XCTAssertEqual(promoted[1]["type"] as? String, "AddGroupMember")
         XCTAssertEqual(promoted[1]["username"] as? String, "alice")
+    }
+
+    // MARK: - Self-identity across both namespaces
+    //
+    // Core-fed payloads (members, leaving_member) name this device by its
+    // derived `off1…` address; relay-fed answers (GroupRoleChanged) name it
+    // by account name. Every test above pins the profile half with a nil
+    // address; these pin the address half and the interaction.
+
+    private static let selfAddr = "off1qqqqself0000000000000000000000000000000000000000000000000"
+    private static let peerAddr = "off1qqqqpeer00000000000000000000000000000000000000000000000000"
+
+    /// The registration roster is the MLS roster — addresses. Filtering it
+    /// against the profile alone strips nothing, so the SDK emitted an
+    /// AddGroupMember naming its own address: self-add, wrong under every
+    /// namespace the relay might settle on.
+    func testRegisterStripsSelfByAddressNotJustProfile() {
+        let translator = RelayControlOpTranslator(
+            selfId: "alice",
+            selfAddress: { Self.selfAddr }
+        )
+
+        let registration = translator.translate(
+            controlOp: "group_relay_register",
+            controlPayload: #"{"group_id":"g1","members":["\#(Self.selfAddr)","\#(Self.peerAddr)"]}"#,
+            recipientId: Self.selfAddr
+        )
+        let sent = frames(registration)
+        let delta = sent.dropFirst().map { $0["username"] as? String ?? "" }
+        XCTAssertEqual(
+            delta, [Self.peerAddr],
+            "self must be stripped from the roster by address; only the peer is a real delta"
+        )
+        XCTAssertFalse(
+            delta.contains(Self.selfAddr),
+            "the SDK must never send an AddGroupMember naming its own address"
+        )
+    }
+
+    /// The profile half must survive the address half: a roster still naming
+    /// this device by profile (a relay-shaped roster) strips too.
+    func testRegisterStillStripsSelfByProfileWhenAddressIsKnown() {
+        let translator = RelayControlOpTranslator(
+            selfId: "alice",
+            selfAddress: { Self.selfAddr }
+        )
+        let sent = frames(translator.translate(
+            controlOp: "group_relay_register",
+            controlPayload: #"{"group_id":"g1","members":["alice","bob"]}"#,
+            recipientId: "alice"
+        ))
+        XCTAssertEqual(sent.dropFirst().map { $0["username"] as? String ?? "" }, ["bob"])
+    }
+
+    /// `leaving_member` is the core's local_id — an address. Without the
+    /// address half this never fired, so the relay kept us in the group
+    /// registry after we left and went on fanning the group out to us.
+    func testLeaveFiresWhenLeavingMemberIsOurAddress() {
+        let translator = RelayControlOpTranslator(
+            selfId: "alice",
+            selfAddress: { Self.selfAddr }
+        )
+
+        let tap = translator.translate(
+            controlOp: "group_mls_leave",
+            controlPayload: #"{"group_id":"g1","leaving_member":"\#(Self.selfAddr)"}"#,
+            recipientId: Self.peerAddr
+        )
+        guard case .tap(let leaveFrames, _) = tap else {
+            return XCTFail("leave must be a tap")
+        }
+        XCTAssertEqual(leaveFrames.count, 1, "our own leave must produce a relay-native LeaveGroup")
+        XCTAssertEqual(leaveFrames[0]["type"] as? String, "LeaveGroup")
+        commit(tap)
+
+        // Another member's leave — named by address — is still not ours to
+        // send. Widening the match must not have widened it to everyone.
+        let other = translator.translate(
+            controlOp: "group_mls_leave",
+            controlPayload: #"{"group_id":"g2","leaving_member":"\#(Self.peerAddr)"}"#,
+            recipientId: Self.peerAddr
+        )
+        guard case .tap(let otherFrames, _) = other else {
+            return XCTFail("third-party leave must stay a tap")
+        }
+        XCTAssertTrue(
+            otherFrames.isEmpty,
+            "a peer's address must never be read as self — that would deregister us from a group we are still in"
+        )
+    }
+
+    /// The relay names the promoted account by username, so the profile half
+    /// carries this site; the address half is forward-compatibility for a
+    /// relay whose group path later moves to address space.
+    func testRolePromotionMatchesSelfInEitherNamespace() {
+        for (label, promoted) in [("profile", "bob"), ("address", Self.selfAddr)] {
+            let translator = RelayControlOpTranslator(
+                selfId: "bob",
+                selfAddress: { Self.selfAddr }
+            )
+            commit(translator.translate(
+                controlOp: "group_relay_register",
+                controlPayload: #"{"group_id":"g1","members":["alice","bob"]}"#,
+                recipientId: "bob"
+            ))
+            translator.onGroupError(groupId: "g1", reason: "Only admins can add members")
+            XCTAssertEqual(
+                frames(translator.translate(
+                    controlOp: "group_relay_register",
+                    controlPayload: #"{"group_id":"g1","members":["alice","bob"]}"#,
+                    recipientId: "bob"
+                )).count,
+                1,
+                "\(label): denial must suppress deltas first"
+            )
+
+            translator.onRoleChanged(groupId: "g1", member: promoted, newRole: "admin")
+            XCTAssertEqual(
+                frames(translator.translate(
+                    controlOp: "group_relay_register",
+                    controlPayload: #"{"group_id":"g1","members":["alice","bob"]}"#,
+                    recipientId: "bob"
+                )).count,
+                2,
+                "\(label): our own promotion must re-enable member deltas"
+            )
+        }
+    }
+
+    /// An unrelated account's promotion must not re-enable our deltas, in
+    /// either namespace.
+    func testRolePromotionOfAnotherAddressIsIgnored() {
+        let translator = RelayControlOpTranslator(
+            selfId: "bob",
+            selfAddress: { Self.selfAddr }
+        )
+        commit(translator.translate(
+            controlOp: "group_relay_register",
+            controlPayload: #"{"group_id":"g1","members":["alice","bob"]}"#,
+            recipientId: "bob"
+        ))
+        translator.onGroupError(groupId: "g1", reason: "Only admins can add members")
+
+        translator.onRoleChanged(groupId: "g1", member: Self.peerAddr, newRole: "admin")
+        XCTAssertEqual(
+            frames(translator.translate(
+                controlOp: "group_relay_register",
+                controlPayload: #"{"group_id":"g1","members":["alice","bob"]}"#,
+                recipientId: "bob"
+            )).count,
+            1,
+            "another member's promotion must leave our denial in place"
+        )
+    }
+
+    /// Before MLS identity exists (encryption disabled, or pre-init) the
+    /// provider returns nil and the translator must behave exactly as it did
+    /// when it only knew the profile — no crash, no accidental self-match.
+    func testAbsentAddressDegradesToProfileOnlyMatching() {
+        for provider in [{ nil as String? }, { "" as String? }] {
+            let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: provider)
+            let sent = frames(translator.translate(
+                controlOp: "group_relay_register",
+                controlPayload: #"{"group_id":"g1","members":["alice","bob"]}"#,
+                recipientId: "alice"
+            ))
+            XCTAssertEqual(sent.dropFirst().map { $0["username"] as? String ?? "" }, ["bob"])
+
+            // An empty roster id must not match an empty address. (Empty
+            // members are dropped upstream too — this pins both guards.)
+            let withEmpty = frames(translator.translate(
+                controlOp: "group_relay_register",
+                controlPayload: #"{"group_id":"g2","members":["alice","","bob"]}"#,
+                recipientId: "alice"
+            ))
+            XCTAssertEqual(withEmpty.dropFirst().map { $0["username"] as? String ?? "" }, ["bob"])
+        }
+    }
+
+    /// The address is resolved per call, never captured at construction:
+    /// the translator outlives MLS init and identity rebuilds.
+    func testAddressIsResolvedPerCallNotCachedAtConstruction() {
+        var current: String? = nil
+        let translator = RelayControlOpTranslator(selfId: "alice", selfAddress: { current })
+
+        // Pre-identity: the address is unknown, so it cannot be stripped.
+        let before = frames(translator.translate(
+            controlOp: "group_relay_register",
+            controlPayload: #"{"group_id":"g1","members":["\#(Self.selfAddr)","\#(Self.peerAddr)"]}"#,
+            recipientId: "alice"
+        ))
+        XCTAssertEqual(before.count, 3, "unknown address cannot be filtered out")
+
+        // MLS init lands: the very next translation must see it.
+        current = Self.selfAddr
+        let after = frames(translator.translate(
+            controlOp: "group_relay_register",
+            controlPayload: #"{"group_id":"g2","members":["\#(Self.selfAddr)","\#(Self.peerAddr)"]}"#,
+            recipientId: "alice"
+        ))
+        XCTAssertEqual(after.dropFirst().map { $0["username"] as? String ?? "" }, [Self.peerAddr])
     }
 
     func testServerPlaneFirewallBlocksRelayAnswerPrefixesOnly() {

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10373,6 +10373,149 @@ mod tests {
         }
     }
 
+    /// The relay group control plane knows itself in BOTH namespaces.
+    ///
+    /// `RelayControlOpTranslator` compares an id against "self" at three
+    /// sites, and the frames carrying those ids come from two different sides
+    /// that name this device differently:
+    ///
+    /// * core-fed control payloads (`members` in the relay registration,
+    ///   `leaving_member` in the leave notification) carry the MLS roster,
+    ///   which is `off1…` ADDRESS space — `members` is `refresh_group_members`
+    ///   and `leaving_member` is `local_id`;
+    /// * the relay's own `GroupRoleChanged` answer names the promoted account
+    ///   in USERNAME space, in a field literally called `username` (the
+    ///   relay's group path stays username-keyed by design).
+    ///
+    /// The bridges construct the translator with `deviceId` — the app-chosen
+    /// profile — which since the addressing change matches neither the roster
+    /// payloads nor, on its own, anything the relay sends under a different
+    /// account name. All three self-checks were therefore dead: the SDK sent
+    /// an `AddGroupMember` naming its OWN address, never sent a relay-native
+    /// `LeaveGroup` when this device left, and ignored its own admin
+    /// promotion. Passing the address *instead* would have been equally
+    /// one-sided — it fixes the two core-fed sites and breaks the relay-fed
+    /// one — which is why the fix is a pair, not a swap.
+    ///
+    /// Pinned as source text for the same reason as the two guards above:
+    /// `InternetManager.swift` is on `Package.swift`'s `exclude:` list and
+    /// `InternetManager.kt` needs a live OkHttp socket, so CI typechecks one
+    /// and executes neither. The translator's own matching logic IS unit-tested
+    /// on both platforms (`registerStripsSelfByAddressNotJustProfile`,
+    /// `leaveFiresWhenLeavingMemberIsOurAddress`,
+    /// `rolePromotionMatchesSelfInEitherNamespace` and their Swift mirrors);
+    /// what no test there can reach is that the bridges *wire* the address in
+    /// and read the field the relay actually sends.
+    #[test]
+    fn react_native_relay_control_translator_knows_self_in_both_namespaces() {
+        let swift = rn_source_code_only("ios/InternetManager.swift");
+        let kotlin =
+            rn_source_code_only("android/src/main/java/com/offlineprotocol/InternetManager.kt");
+
+        // --- 1. The translator is built with a live address provider --------
+        //
+        // Resolved per call rather than captured: the translator is
+        // constructed before `initialize_mls` may have run, and an identity
+        // rebuild replaces the address underneath it. A snapshot taken here
+        // would be empty on every connection that predates MLS init.
+        assert!(
+            swift.contains(
+                "RelayControlOpTranslator( selfId: deviceId, selfAddress: { [weak \
+                 protocolInstance] in protocolInstance?.localAddress() } )"
+            ),
+            "InternetManager.swift must build the control-op translator with BOTH identities: \
+             deviceId (the profile, which matches the relay's own answers) and a lazily \
+             resolved local_address() (which matches the MLS roster the core sends). With only \
+             the profile, the member-delta filter never strips self and the SDK sends an \
+             AddGroupMember naming its own address"
+        );
+        assert!(
+            kotlin.contains(
+                "private val controlOpTranslator = RelayControlOpTranslator(deviceId) { try { \
+                 protocol.localAddress() } catch (e: Exception) { null } }"
+            ),
+            "InternetManager.kt must build the control-op translator with BOTH identities — \
+             same reason as the Swift half above"
+        );
+
+        // A one-argument construction is exactly the pre-fix shape: it
+        // compiles the moment someone gives `selfAddress` a default, and
+        // silently restores profile-only matching.
+        assert!(
+            !swift.contains("RelayControlOpTranslator(selfId: deviceId)"),
+            "InternetManager.swift must not construct the translator with the profile alone — \
+             that is the shape whose three dead self-checks this guard exists to prevent"
+        );
+        // Kotlin passes the provider as a trailing lambda, so the profile-only
+        // call is a textual PREFIX of the correct one: assert instead that
+        // every construction is followed by the lambda that supplies the
+        // address.
+        assert!(
+            kotlin
+                .match_indices("RelayControlOpTranslator(deviceId)")
+                .all(|(at, m)| kotlin[at + m.len()..].starts_with(" {")),
+            "InternetManager.kt must not construct the translator with the profile alone — every \
+             RelayControlOpTranslator(deviceId) must be followed by the trailing lambda that \
+             resolves local_address(); same reason as the Swift half above"
+        );
+
+        // --- 2. The role-change arm reads the field the relay SENDS ---------
+        //
+        // `ServerMessage::GroupRoleChanged` (relay `message.rs`) carries
+        // `username`, pinned there by `group_role_changed_serializes_correctly`.
+        // Both bridges used to read `user_id`, which the relay never emits —
+        // so the self-check compared against an empty string and no promotion
+        // ever re-enabled member deltas. `user_id` survives only as a
+        // second-choice fallback.
+        assert!(
+            swift.contains(
+                "member: json[\"username\"] as? String ?? json[\"user_id\"] as? String ?? \"\""
+            ),
+            "InternetManager.swift must read the promoted account from `username` FIRST — that \
+             is the field the relay's GroupRoleChanged actually carries; reading `user_id` \
+             alone yields an empty string and the promotion is silently ignored"
+        );
+        assert!(
+            kotlin.contains("json.safeOptString(\"username\", json.safeOptString(\"user_id\")),"),
+            "InternetManager.kt must read the promoted account from `username` FIRST — same \
+             reason as the Swift half above"
+        );
+
+        // --- 3. Presence self-filters span both namespaces too --------------
+        //
+        // Same defect, same file: the core's presence watchlist and the
+        // unreachable-recipient path are both address-space, and a
+        // profile-only test lets self into the watch set — where it pins a
+        // rotation slot until the idle TTL and can surface a
+        // presence_updated(self, offline) to the app.
+        for (label, code) in [("ios", &swift), ("android", &kotlin)] {
+            assert!(
+                code.contains("isSelfPeer(recipient)"),
+                "{label} InternetManager must filter the unreachable recipient through a \
+                 two-namespace self test: the core names peers by address, so `!= deviceId` \
+                 never recognizes self on a core-fed id"
+            );
+        }
+        assert!(
+            !swift.contains("if recipient != deviceId {"),
+            "InternetManager.swift must not self-test the recipient against the profile alone"
+        );
+        assert!(
+            !kotlin.contains("if (recipient != deviceId) {"),
+            "InternetManager.kt must not self-test the recipient against the profile alone"
+        );
+        assert!(
+            swift.contains("peer != deviceId && !(peer == selfAddress && !peer.isEmpty)"),
+            "InternetManager.swift must filter the core's presence watchlist by address as well \
+             as profile — the watchlist is core-fed, so it names this device by address"
+        );
+        assert!(
+            kotlin.contains("coreWatchlist.filter { it != deviceId && it != selfAddress }"),
+            "InternetManager.kt must filter the core's presence watchlist by address as well as \
+             profile — same reason as the Swift half above"
+        );
+    }
+
     /// Every hand-written iOS source is listed in the podspec.
     ///
     /// `MeshSdk.podspec` enumerates its Swift sources one by one (only `ble/`


### PR DESCRIPTION
## What

`RelayControlOpTranslator` compares ids against "self" at three sites. The bridges give it one identity — `deviceId`, i.e. `config.profile` — while the ids it compares arrive in **two different namespaces**:

| Site | Id comes from | Namespace | Why it was dead |
|---|---|---|---|
| Member-delta filter | core `members` (the MLS roster) | `off1…` address | address ≠ profile → self never stripped → SDK sent `AddGroupMember` naming **its own address** |
| Self-leave check | core `leaving_member` (`local_id`) | `off1…` address | address ≠ profile → relay-native `LeaveGroup` never sent → relay kept fanning the group to a device that had left |
| Role-change re-enable | relay `GroupRoleChanged` | **username** | both bridges read `json["user_id"]`, a field the relay **never emits** (it sends `username`) → compared against `""` → admin promotion silently ignored |

Not a regression in this code — it was written when `profile` *was* the wire identity, and #328 moved the namespace underneath it.

## The fix

The translator now knows itself as a **pair** (profile ∪ derived address) and matches either. Swapping `selfId` to `local_address()` — the TODO item's own sketch — repairs the two core-fed sites and **breaks** the relay-fed one, so a pair is required, not a swap.

The address is resolved through a closure **per call**, never captured: the translator is constructed before `initialize_mls` may have run, and an identity rebuild replaces the address underneath it. The closure is always invoked *outside* the translator's lock (it takes the protocol mutex; the core never calls back into the translator, so the ordering stays one-directional).

Absent address (encryption disabled, pre-init) degrades to exactly the current profile-only behavior.

**While at it:** the presence self-filters in the same file have the identical bug, and the watchlist they filter is core-fed — so self could enter its own presence watch set and pin a rotation slot until the idle TTL.

## Not in scope

- **Item 21** (relay-side group naming). `AddGroupMember` still names addresses into a username-keyed relay roster. Self-add is wrong under *every* namespace outcome, so this stands alone.
- **`BleManager.swift:1307`** — same defect class (route-learning self-filter), different subsystem, bookkeeping-only impact. Recorded for the BLE/mesh items rather than fixed here.
- **Accepted residual:** an app whose relay username ≠ its `profile` still fails the role-change match and falls back to re-learning the denial each connection — noisy but safe, the same degradation a reworded denial marker produces. Commented at the site.

## Verification

| Check | Result |
|---|---|
| Rust (`--workspace --lib`) | 2036 passed |
| Swift (`swift test`) | 209 passed (+7) |
| Android (CI harness) | 398 passed (+7) |
| clippy `-D warnings` / fmt | clean |
| tsc | clean |
| iOS `swiftc -typecheck` probe | clean |

**Negative controls, all fired and all restored** (scratchpad copies, never `git checkout`):
- Swift `isSelf` address half removed → 35 → 14 passing, new tests red
- Kotlin `isSelf` address half removed → 4 new tests red
- Rust guard × 3: Swift role-change field reverted, Kotlin construction reverted to profile-only, Swift watchlist filter reverted — each failed with its own message

The new Rust guard (`react_native_relay_control_translator_knows_self_in_both_namespaces`) exists because **neither bridge's call sites are reachable from an executing test** — `InternetManager.swift` is on `Package.swift`'s `exclude:` list, `InternetManager.kt` needs a live OkHttp socket. That is the same blind spot that hid the #328 and #330 breaks. It sits next to the two existing guards watching this same file.

## Notes

No UDL change (`localAddress()` was already exposed), no binding regeneration, no TS change, no new files (so no podspec/ci.yml file-list edits), no wire or schema change. No released build ever emitted the broken frames — the whole addressing chain is unreleased.

Fixes part of the relay release-gate audit (TODO item 22).