### PR TITLE
fix(bindings,uniffi): move the remaining transports off the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -393,10 +393,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   stop and exited, and the freshly bound socket leaked with the port still
   held — the next `start()` failed with `BindException`. The accept task now
   closes the socket it bound on every exit, and the field is published safely
-  across the two threads that touch it. Separately, each `start()` created a
-  `WifiP2pManager` channel that nothing ever released; `stop()` now closes it
-  on API 27+. Both pre-existing, and low real-world impact while this
-  transport stays unregistered.
+  across the two threads that touch it. The accept loop also stops when *its
+  own* socket closes rather than only when the transport flag clears: a
+  restart that set the flag back while the old task was still waking from the
+  close left it spinning at full tilt on a dead socket, emitting a diagnostic
+  per turn. Separately, each `start()` created a `WifiP2pManager` channel that
+  nothing ever released; `stop()` now closes it on API 27+. All pre-existing,
+  and low real-world impact while this transport stays unregistered.
+
+  Two smaller ones in the same file: the P2P state-change broadcast no longer
+  makes its protocol call inside the receiver's dispatch window (it hands it to
+  the same queue and returns, which is what the send drain's batch budget is
+  for), and `resume()` clears the previous poll before posting one, so a resume
+  that does not follow a pause no longer leaves two polling loops running.
 
 - **Android: Nostr's reconnect bookkeeping was three plain maps crossed by two
   threads.** OkHttp's reader thread reset a relay's attempt counter and delay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   resolved. Recoverable, since the following attempt corrects the status and
   the core retries the sends, but self-inflicted.
 
+  Two of those checks sit inside the lock that owns what they guard, rather
+  than beside it, because a check next to the write it protects is still a
+  check followed by an act on another thread. The consequential one was the
+  connected flags: a teardown landing between the check and the write was
+  simply overwritten, leaving the transport marked connected against a socket
+  that teardown had already closed — and since a connect refuses to start while
+  that flag is set, the next `start()` returned having done nothing until the
+  orphaned reader errored and the reconnect ladder picked it up.
+
+  Tearing down now also ends a connect that has nothing to publish yet. Only
+  closing the socket ends a blocked connect — it ignores interruption — and the
+  thread it runs on is shared and outlives the session, so an attempt left
+  running against an unreachable daemon held the *next* session's connect
+  behind it for the rest of the 60s timeout. The per-session thread this
+  replaced never had that coupling: it was abandoned mid-call and the restart
+  got a fresh one.
+
 - **Android: Wi-Fi Direct teardown could strand port 8988, and every session
   leaked a framework channel.** A `stop()` racing the server socket's bind
   closed a still-null field; the bind then completed, the accept loop saw the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,6 +312,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   socket work now has its own thread, and `stop()` closes the socket rather
   than waiting for whatever is on it.
 
+- **Android: a Reticulum connect that failed never retried.** The failure path
+  cleared its own in-flight flag before handing off, and the handler that
+  receives the failure decides whether to react by reading exactly that flag —
+  so it saw nothing to do and returned before scheduling anything. The 1s→30s
+  reconnect ladder was therefore dead for the case it exists for: a daemon
+  that is not running. The transport sat in `STARTING`, where `start()` throws
+  `AlreadyRunning`, until the app stopped and started it by hand. iOS was
+  unaffected. Configuration set by `configure()` is also now published safely
+  to the threads that read it, so a mid-session reconfigure cannot leave a
+  reconnect dialling the previous host or relay set.
+
+- **Android: stopping and restarting Reticulum while it was connecting could
+  leave a second connection live and unowned.** Tearing down clears the
+  in-flight flag while the connect is still blocked inside the socket call, so
+  the restart opened a second connection without the first being closed.
+  Whichever lost the race was left with a live reader that still believed it
+  was connected — and when it eventually failed it tore down the connection
+  that had replaced it. Attempts are now versioned, so one that outlives its
+  session closes what it opened instead of publishing it.
+
 - **A relay-delivered group message could be lost silently while the sender saw
   it delivered.** The relay's group path names senders by relay-account
   username, while the MLS credential inside the ciphertext is the sender's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,9 +291,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   it had been told it was down — with nothing left that would ever tear it down
   again, and the next `start()` failing with `AlreadyRunning`. All four now
   check for the stop before announcing and close the connection they opened
-  instead; on iOS the check sits ahead of the queue hop, which is the boundary
-  the stop would otherwise slip through. The relay transport already guarded
-  its posted blocks this way on both platforms.
+  instead. The relay transport already guarded its posted blocks this way on
+  both platforms.
+
+  The two platforms need different amounts of machinery for it. On Android the
+  gate, the state write, the status call and `stop()` all run on the one
+  transport thread, so a plain check is already atomic against a teardown. On
+  iOS they are spread over three queues, so a check followed by a write is two
+  steps with a `stop()` free to land between them: the announcement claims
+  `.running` in one operation instead, and the status call — which on Reticulum
+  is a further queue hop away, the wider of the two windows — is ordered
+  against `stop()`'s own call by a lock rather than by proximity to a check.
+  Without that a torn-down transport could still be reported to the core as
+  connected, and the core would route to a transport that never drains.
 
 - **A Reticulum daemon that was unreachable or had stopped reading could stall
   `stop()`.** Its connect (up to 60s) and its TCP writes (no timeout at all)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,7 +276,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   `stop()` is no longer cut off by a timeout (it is the caller that needs the
   stop to have finished), while a main-thread caller now gives up rather than
   parking behind the mutex. `internetForceReconnect` no longer waits at all;
-  it already resolved "accepted", not "reconnected".
+  it already resolved "accepted", not "reconnected". `pause()` and `resume()`
+  went the other way — on Nostr and Reticulum they used to hand the work to a
+  handler and return, which paused nothing, so the core could pause underneath
+  a transport still calling into it. Both now wait, and the module's pause and
+  resume run their fan-out the way the stop paths already do: every transport
+  is still paused (or resumed) even if one of them throws, and the first
+  failure is reported once the rest are done rather than skipping them.
 
   Also fixed while in these files: iOS `stop()` and `destroy()` never stopped
   the Wi-Fi Direct manager, leaving a live send path holding a protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   instance the caller had released; and that manager's session and peer map
   were read and written from three threads without synchronisation.
 
+- **A Reticulum daemon that was unreachable or had stopped reading could stall
+  `stop()`.** Its connect (up to 60s) and its TCP writes (no timeout at all)
+  shared the thread that lifecycle calls wait on, so tearing the transport down
+  queued behind them — and with it the React Native bridge thread. The blocking
+  socket work now has its own thread, and `stop()` closes the socket rather
+  than waiting for whatever is on it.
+
 - **A relay-delivered group message could be lost silently while the sender saw
   it delivered.** The relay's group path names senders by relay-account
   username, while the MLS credential inside the ciphertext is the sender's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,6 +336,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   that had replaced it. Attempts are now versioned, so one that outlives its
   session closes what it opened instead of publishing it.
 
+  The version is checked everywhere a retired attempt could still act, not
+  only before it publishes. Publishing the connection, claiming the connected
+  flags and announcing the connection are three steps with a scheduling gap
+  after each, and the stopped-transport check that guards the announcement is
+  blind to precisely this case — after a stop *and* a restart the transport is
+  legitimately starting again, so the check passes and the announcement
+  reports a connection the teardown had already closed. The core would route
+  to a transport with no socket, and the send loop that announcement starts
+  drained the outbox straight into send failures until the next attempt
+  resolved. Recoverable, since the following attempt corrects the status and
+  the core retries the sends, but self-inflicted.
+
 - **Android: Wi-Fi Direct teardown could strand port 8988, and every session
   leaked a framework channel.** A `stop()` racing the server socket's bind
   closed a still-null field; the bind then completed, the accept loop saw the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,6 +336,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   that had replaced it. Attempts are now versioned, so one that outlives its
   session closes what it opened instead of publishing it.
 
+- **Android: Wi-Fi Direct teardown could strand port 8988, and every session
+  leaked a framework channel.** A `stop()` racing the server socket's bind
+  closed a still-null field; the bind then completed, the accept loop saw the
+  stop and exited, and the freshly bound socket leaked with the port still
+  held — the next `start()` failed with `BindException`. The accept task now
+  closes the socket it bound on every exit, and the field is published safely
+  across the two threads that touch it. Separately, each `start()` created a
+  `WifiP2pManager` channel that nothing ever released; `stop()` now closes it
+  on API 27+. Both pre-existing, and low real-world impact while this
+  transport stays unregistered.
+
 - **A relay-delivered group message could be lost silently while the sender saw
   it delivered.** The relay's group path names senders by relay-account
   username, while the MLS credential inside the ciphertext is the sender's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,14 +284,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   were read and written from three threads without synchronisation.
 
 - **Stopping the Reticulum or Nostr transport while it was still connecting
-  could leave it permanently wedged.** Both announce a new connection from a
-  posted block, so a `stop()` could land in between. The announcement then ran
-  against a stopped transport: it put the state back to `RUNNING` and told the
-  core the transport was up moments after it had been told it was down — with
-  nothing left that would ever tear it down again, and the next `start()`
-  failing with `AlreadyRunning`. Both now check for the stop before announcing
-  and close the connection they opened instead. The relay transport already
-  guarded its posted blocks this way.
+  could leave it permanently wedged, on both platforms.** All four managers
+  announce a new connection from a posted block, so a `stop()` could land in
+  between. The announcement then ran against a stopped transport: it put the
+  state back to `RUNNING` and told the core the transport was up moments after
+  it had been told it was down — with nothing left that would ever tear it down
+  again, and the next `start()` failing with `AlreadyRunning`. All four now
+  check for the stop before announcing and close the connection they opened
+  instead; on iOS the check sits ahead of the queue hop, which is the boundary
+  the stop would otherwise slip through. The relay transport already guarded
+  its posted blocks this way on both platforms.
 
 - **A Reticulum daemon that was unreachable or had stopped reading could stall
   `stop()`.** Its connect (up to 60s) and its TCP writes (no timeout at all)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,6 +415,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   fixed while there: `stop()` never shut down the OkHttp dispatcher (the relay
   manager already did), so its threads outlived every stop/start cycle.
 
+- **Nostr could report itself connected with no relay connected, on both
+  platforms.** Deciding whether the relay set had just come up sampled "is any
+  relay connected" and published the answer as two separate steps, so two
+  relays transitioning at once could interleave and let the later writer
+  publish the earlier reader's stale answer. The core was then told the
+  transport was up against an empty relay set, and every message the send loop
+  drained came straight back as a send failure until a relay genuinely
+  reconnected. Both halves now happen under one lock, so the last writer always
+  reflects the final state. Pre-existing on both platforms.
+
 - **A relay-delivered group message could be lost silently while the sender saw
   it delivered.** The relay's group path names senders by relay-account
   username, while the MLS credential inside the ciphertext is the sender's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   instance the caller had released; and that manager's session and peer map
   were read and written from three threads without synchronisation.
 
+- **Stopping the Reticulum or Nostr transport while it was still connecting
+  could leave it permanently wedged.** Both announce a new connection from a
+  posted block, so a `stop()` could land in between. The announcement then ran
+  against a stopped transport: it put the state back to `RUNNING` and told the
+  core the transport was up moments after it had been told it was down — with
+  nothing left that would ever tear it down again, and the next `start()`
+  failing with `AlreadyRunning`. Both now check for the stop before announcing
+  and close the connection they opened instead. The relay transport already
+  guarded its posted blocks this way.
+
 - **A Reticulum daemon that was unreachable or had stopped reading could stall
   `stop()`.** Its connect (up to 60s) and its TCP writes (no timeout at all)
   shared the thread that lifecycle calls wait on, so tearing the transport down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,6 +375,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   replaced never had that coupling: it was abandoned mid-call and the restart
   got a fresh one.
 
+  The version guards the teardown as well as the connect, which is the half
+  with a permanent consequence. Every way a disconnect gets *observed* — a
+  failed connect, a dead receive loop, a send budget exhausted — is noticed on
+  one thread and handled on another, so each can arrive after the session it
+  describes is over. The handler's own duplicate check could not tell: it asks
+  whether *a* connection is live, never whether it is *that* one, so after a
+  stop and a restart it read the new session's flags and passed. The stale
+  report then marked a healthy connection down, told the core so, and started
+  a reconnect ladder against it — while the connection that was actually live
+  was left open with its reader parked on a socket nothing would ever close,
+  leaking a thread and a descriptor for the life of the process.
+
 - **Android: Wi-Fi Direct teardown could strand port 8988, and every session
   leaked a framework channel.** A `stop()` racing the server socket's bind
   closed a still-null field; the bind then completed, the accept loop saw the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   every authenticate; Wi-Fi Direct added an unbounded drain and its
   framework callbacks; Nostr and Reticulum polled off main already but kept
   their lifecycle and connect/disconnect status calls on it. Each manager now
-  confines itself to a private looper. On iOS only Reticulum was still
+  confines itself to a private looper, and Wi-Fi Direct's drain sends in
+  batches rather than in one pass — that looper now also carries the P2P
+  framework callbacks, and a broadcast that waits out its dispatch budget is
+  an ANR wherever its receiver runs. On iOS only Reticulum was still
   affected, and its connected-edge status call is the expensive one — it
   flushes the entire outbox under the mutex — so both edges move to the
   queue the rest of that file already uses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   on API 27+. Both pre-existing, and low real-world impact while this
   transport stays unregistered.
 
+- **Android: Nostr's reconnect bookkeeping was three plain maps crossed by two
+  threads.** OkHttp's reader thread reset a relay's attempt counter and delay
+  on every successful connect while the transport thread structurally modified
+  the same maps scheduling reconnects — a plain `HashMap` read racing a resize
+  is the classic corruption case. All three are `ConcurrentHashMap` now. Also
+  fixed while there: `stop()` never shut down the OkHttp dispatcher (the relay
+  manager already did), so its threads outlived every stop/start cycle.
+
 - **A relay-delivered group message could be lost silently while the sender saw
   it delivered.** The relay's group path names senders by relay-account
   username, while the MLS credential inside the ciphertext is the sender's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,8 +280,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
   Also fixed while in these files: iOS `stop()` and `destroy()` never stopped
   the Wi-Fi Direct manager, leaving a live send path holding a protocol
-  instance the caller had released; and that manager's session and peer map
-  were read and written from three threads without synchronisation.
+  instance the caller had released; that manager's session and peer map were
+  read and written from three threads without synchronisation; and its send
+  drain, which is deliberately unbounded, now re-reads the transport state each
+  time round rather than only before it starts — a `stop()` landing mid-drain
+  left the rest of the queue being fetched under the core's mutex and dropped
+  for want of a session.
 
 - **Stopping the Reticulum or Nostr transport while it was still connecting
   could leave it permanently wedged, on both platforms.** All four managers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,7 +303,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   is a further queue hop away, the wider of the two windows — is ordered
   against `stop()`'s own call by a lock rather than by proximity to a check.
   Without that a torn-down transport could still be reported to the core as
-  connected, and the core would route to a transport that never drains.
+  connected, and the core would route to a transport that never drains. The
+  announcement also refuses once the connection it was announcing has died,
+  which no teardown check can see: a link that opens and immediately fails
+  reports itself down over a shorter path than the announcement travels, so
+  the two would otherwise reach the core in the wrong order.
 
 - **A Reticulum daemon that was unreachable or had stopped reading could stall
   `stop()`.** Its connect (up to 60s) and its TCP writes (no timeout at all)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **The remaining transports no longer run protocol calls on the app's main
+  thread.** Completing what the BLE fixes started: on Android all four
+  non-BLE transport managers took their ordering from the app's main looper,
+  so every call into the core — which serialises on one global mutex held
+  across MLS work and AndroidKeyStore access — was charged to the thread
+  Android watches for ANRs. The relay transport was the worst of them, at
+  10Hz for any connected session plus a keystore-backed signing burst on
+  every authenticate; Wi-Fi Direct added an unbounded drain and its
+  framework callbacks; Nostr and Reticulum polled off main already but kept
+  their lifecycle and connect/disconnect status calls on it. Each manager now
+  confines itself to a private looper. On iOS only Reticulum was still
+  affected, and its connected-edge status call is the expensive one — it
+  flushes the entire outbox under the mutex — so both edges move to the
+  queue the rest of that file already uses.
+
+  Two lifecycle waits changed shape as part of this. A background caller of
+  `stop()` is no longer cut off by a timeout (it is the caller that needs the
+  stop to have finished), while a main-thread caller now gives up rather than
+  parking behind the mutex. `internetForceReconnect` no longer waits at all;
+  it already resolved "accepted", not "reconnected".
+
+  Also fixed while in these files: iOS `stop()` and `destroy()` never stopped
+  the Wi-Fi Direct manager, leaving a live send path holding a protocol
+  instance the caller had released; and that manager's session and peer map
+  were read and written from three threads without synchronisation.
+
 - **A relay-delivered group message could be lost silently while the sender saw
   it delivered.** The relay's group path names senders by relay-account
   username, while the MLS credential inside the ciphertext is the sender's

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -1,11 +1,8 @@
 package com.offlineprotocol
 
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
 import okhttp3.*
 import uniffi.offline_protocol.OfflineProtocol
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -25,7 +22,7 @@ class InternetManager(
     
     override val transportId = "internet"
     override val transportName = "Internet (WebSocket)"
-    // Volatile: written on main (updateState) but read from RN threads.
+    // Volatile: written on the transport thread (updateState) but read from RN threads.
     @Volatile override var state: TransportState = TransportState.UNAVAILABLE
         private set
     override var listener: TransportManagerListener? = null
@@ -65,16 +62,20 @@ class InternetManager(
         // to the FFI as a senderId. See injectGroupInternalMessage. Mirrors
         // InternetManager.swift — keep in sync.
         private const val RELAY_PLACEHOLDER_SENDER = "relay"
+        // Name of the private looper this manager confines itself to. Shared
+        // process-wide under this key, so a manager rebuilt after stop()
+        // inherits the same ordered queue.
+        private const val CONFINEMENT_THREAD = "offline-internet"
     }
     
     // MARK: - Properties
     
     // Written by configure()/setAuthToken() on the RN bridge thread; read on
-    // main (connect/scheduleReconnect) and on the OkHttp reader thread
-    // (sendAuthentication after a reconnect's onOpen). First-start flows get
-    // happens-before from the start() main-sync, but a mid-session token
-    // rotation or reconfigure has no such edge — volatile so a reconnect
-    // can't re-authenticate with a stale token.
+    // the transport thread (connect/scheduleReconnect) and on the OkHttp reader
+    // thread (sendAuthentication after a reconnect's onOpen). First-start
+    // flows get happens-before from the start() transport-sync, but a
+    // mid-session token rotation or reconfigure has no such edge — volatile so
+    // a reconnect can't re-authenticate with a stale token.
     @Volatile private var serverUrl: String? = null
     @Volatile private var autoReconnect = true
     @Volatile private var maxReconnectAttempts = 0 // 0 = infinite
@@ -82,33 +83,37 @@ class InternetManager(
     
     // OkHttp components
     private var okHttpClient: OkHttpClient? = null
-    // Written ONLY on main (connect/disconnect/terminateSocket — every
-    // terminal signal posts to main); read from the OkHttp reader thread and
+    // Written ONLY on the transport thread (connect/disconnect/terminateSocket —
+    // every terminal signal posts to it); read from the OkHttp reader thread and
     // RN bridge threads (sendRawCommand, checkPresence). Volatile for those
     // reads; the single-writer rule is what makes terminateSocket's
     // compare-then-detach race-free.
     @Volatile private var webSocket: WebSocket? = null
     
-    // Handler for main thread operations.
+    // The one thread this manager runs on.
     //
-    // NOTE (residual OFF-2123 surface, tracked separately): this manager is
-    // still main-affine, and [messagePollingRunnable] below re-enters UniFFI
-    // every MESSAGE_POLL_INTERVAL_MS (100ms) from it. Every one of those calls
-    // waits on the same global protocol mutex that made the BLE facade's
-    // main-looper residency an ANR source, so for a relay-connected session the
-    // mechanic OFF-2123 fixed for BLE is still live here at 10Hz. The BLE
-    // facade's remedy applies directly — see [com.offlineprotocol.ble.
-    // BleTransportFacade.bleLooper] for why a private looper preserves the
-    // ordering this design depends on — but the swap was deliberately left out
-    // of that change to keep its blast radius to one transport.
-    private val mainHandler = Handler(Looper.getMainLooper())
+    // This used to be the app's main looper, and that was the largest
+    // remaining OFF-2123 surface: [messagePollingRunnable] below re-enters
+    // UniFFI every MESSAGE_POLL_INTERVAL_MS (100ms), and every one of those
+    // calls waits on the same global protocol mutex that made the BLE facade's
+    // main-looper residency an ANR source — so a relay-connected session drove
+    // the mechanic at 10Hz, next to a keystore-backed signing burst on every
+    // authenticate. Nothing here touches the UI; main was only ever the
+    // ordering primitive, and [TransportConfinement] is that primitive without
+    // the app's responsiveness behind it.
+    //
+    // "Transport-thread only" below means this thread, and it is the same
+    // confinement iOS gets from its messageQueue. The single-writer rules the
+    // comments describe are unchanged — only which thread is the writer.
+    private val confinement = TransportConfinement.shared(CONFINEMENT_THREAD)
+    private val transportHandler = confinement.handler
 
     // Message polling runnable
     private val messagePollingRunnable = object : Runnable {
         override fun run() {
             pollAndSendMessages()
             if (state == TransportState.RUNNING && isConnected.get()) {
-                mainHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
+                transportHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
             }
         }
     }
@@ -121,7 +126,7 @@ class InternetManager(
         override fun run() {
             presenceWatchTick()
             if (state == TransportState.RUNNING && isConnected.get()) {
-                mainHandler.postDelayed(this, PresenceWatchPolicy.DEFAULT_TICK_INTERVAL_MS)
+                transportHandler.postDelayed(this, PresenceWatchPolicy.DEFAULT_TICK_INTERVAL_MS)
             }
         }
     }
@@ -137,19 +142,20 @@ class InternetManager(
     // on the current socket). While latched, auto- AND force-reconnect refuse
     // until an explicit start() — a blind reconnect just re-displaces the peer
     // socket in a tight loop. Owns the boolean + decision; this manager owns
-    // the threading (every call on main, the single writer). Mirrors
-    // InternetManager.swift's supersedeLatch.
+    // the threading (every call on the transport thread, the single writer).
+    // Mirrors InternetManager.swift's supersedeLatch.
     private val supersedeLatch = SupersededLatchPolicy()
     private var reconnectAttempts = AtomicInteger(0)
-    // Atomic for cross-thread reads; written only on main (scheduleReconnect
-    // grows it, handleAuthenticated's posted reaction resets it).
+    // Atomic for cross-thread reads; written only on the transport thread
+    // (scheduleReconnect grows it, handleAuthenticated's posted reaction
+    // resets it).
     private val currentReconnectDelay =
         java.util.concurrent.atomic.AtomicLong(RECONNECT_INITIAL_DELAY_MS)
     private var reconnectRunnable: Runnable? = null
     // Watchdog for a relay that opens the socket but never answers
     // Authenticate: with isConnected already true, connect() short-circuits
     // and no timer ever starts — a permanently wedged transport without
-    // this. Main-thread only.
+    // this. Transport-thread only.
     private var authTimeoutRunnable: Runnable? = null
     private var transportStartAt: Long = 0L
     
@@ -190,9 +196,10 @@ class InternetManager(
     // the socket is still resuming or the token bucket is momentarily
     // empty. The park/expire/fail-fast/drain policy lives in the Looper-free
     // ForcedPresenceCheckQueue (JVM-tested); only the Handler shell — the
-    // retry tick and its no-stacking flag — is here. Main-confined (like the
-    // rest of the timer state). Never bypasses the rate limiter — the client
-    // bucket mirrors the relay's server bucket, and an over-budget frame is
+    // retry tick and its no-stacking flag — is here. Transport-thread
+    // confined (like the rest of the timer state). Never bypasses the rate
+    // limiter — the client bucket mirrors the relay's server bucket, and an
+    // over-budget frame is
     // dropped server-side *after* the local write "succeeded", which is
     // strictly worse than deferring.
     private val forcedChecks = ForcedPresenceCheckQueue()
@@ -217,7 +224,7 @@ class InternetManager(
     /**
      * Control-op frames deferred by the rate limiter, drained (oldest first)
      * at the start of each poll tick. A translation's commit closure runs
-     * only after its LAST frame is written. Main-thread only; cleared on
+     * only after its LAST frame is written. Transport-thread only; cleared on
      * disconnect/stop/RateLimited — the frames are per-connection and their
      * commits are generation-guarded anyway.
      */
@@ -259,7 +266,7 @@ class InternetManager(
 
     /**
      * Last (connected, authenticated) pair published, or null before the
-     * first. All mutation funnels run on the main handler (or, for
+     * first. All mutation funnels run on the transport handler (or, for
      * [disconnect], are serialized against it by the stop path), matching
      * the single-writer rule the state flags already follow.
      */
@@ -299,31 +306,18 @@ class InternetManager(
 
     // MARK: - Helper
     
-    private fun <T> runOnMainSync(action: () -> T): T {
-        if (Looper.myLooper() == Looper.getMainLooper()) {
-            return action()
-        }
-        
-        val latch = CountDownLatch(1)
-        var outcome: Result<T>? = null
-        mainHandler.post {
-            outcome = try {
-                Result.success(action())
-            } catch (t: Throwable) {
-                Result.failure(t)
-            }
-            latch.countDown()
-        }
-        
-        try {
-            latch.await()
-        } catch (ie: InterruptedException) {
-            Thread.currentThread().interrupt()
-            throw RuntimeException("Interrupted while executing on main thread", ie)
-        }
-        
-        return outcome!!.getOrThrow()
-    }
+    /**
+     * Runs [action] on the transport thread and waits for it — the lifecycle
+     * entry points' way onto the single writer.
+     *
+     * The wait used to be unbounded for every caller, which was safe only
+     * because the target was main. Against a thread that can sit inside a
+     * UniFFI call it is not: a main-thread caller would park behind the
+     * protocol mutex, rebuilding OFF-2123 through the lifecycle door. The
+     * bound now applies to main alone — see [TransportConfinement.runSync] for
+     * why background callers keep waiting indefinitely.
+     */
+    private fun <T> runConfinedSync(action: () -> T): T = confinement.runSync(action)
     
     // MARK: - Configuration
     
@@ -373,7 +367,7 @@ class InternetManager(
     }
     
     override fun start() {
-        runOnMainSync {
+        runConfinedSync {
             startUnsafe()
         }
     }
@@ -430,7 +424,7 @@ class InternetManager(
     }
     
     override fun stop() {
-        runOnMainSync {
+        runConfinedSync {
             stopUnsafe()
         }
     }
@@ -448,7 +442,7 @@ class InternetManager(
         }
 
         // Cancel reconnect attempts
-        reconnectRunnable?.let { mainHandler.removeCallbacks(it) }
+        reconnectRunnable?.let { transportHandler.removeCallbacks(it) }
         reconnectRunnable = null
 
         cancelAuthTimeout()
@@ -476,7 +470,7 @@ class InternetManager(
         // explicit stop() ends the session, and dangling their RN promises
         // until the deadline helps nobody. (A mere disconnect keeps them —
         // the deadline gives the reconnect its chance.)
-        mainHandler.removeCallbacks(forcedCheckRetryRunnable)
+        transportHandler.removeCallbacks(forcedCheckRetryRunnable)
         forcedCheckRetryScheduled = false
         forcedChecks.drainAll()
 
@@ -500,7 +494,7 @@ class InternetManager(
     }
     
     override fun pause() {
-        runOnMainSync {
+        runConfinedSync {
             // The flag makes the pause durable: a background network blip
             // reconnects and re-authenticates, and handleAuthenticated must
             // not restart the timers the app paused.
@@ -515,8 +509,8 @@ class InternetManager(
             // stranded until resume(). The module pauses the core right
             // after the transports, so the remaining window — a send racing
             // pause() itself — is bounded to sends already in flight.
-            // (Safe to run inline here: polling and pause share the main
-            // handler, unlike the iOS bridge's messageQueue confinement.)
+            // (Safe to run inline here: polling and pause share the transport
+            // handler, the same confinement iOS gets from its messageQueue.)
             if (state == TransportState.RUNNING && isConnected.get()) {
                 pollAndSendMessages()
             }
@@ -524,7 +518,7 @@ class InternetManager(
     }
 
     override fun resume() {
-        runOnMainSync {
+        runConfinedSync {
             isPaused = false
             if (state == TransportState.RUNNING && isConnected.get()) {
                 startMessagePolling()
@@ -547,16 +541,26 @@ class InternetManager(
      * enable/disable lifecycle). The actual reconnect honors [autoReconnect];
      * with it disabled this tears the socket down without rebuilding it.
      * Emits a transient `internet_status_changed` down→up.
+     *
+     * Posted, not awaited, and that matters for the caller that motivated this
+     * method: `onHostResume` runs on main, and main is the one thread the
+     * transport thread will not let block on it. Waiting here would either
+     * park the foreground behind the protocol mutex — the defect this whole
+     * confinement exists to remove — or, with the bound, throw
+     * [TransportConfinement.MainThreadSyncTimeout] into a lifecycle callback
+     * that has no [TeardownSequence] around it to absorb it. Nothing reads a
+     * return value: the RN entry point already resolves "accepted", never
+     * "reconnected", and the outcome arrives as `internet_status_changed`.
      */
     fun forceReconnect() {
-        runOnMainSync {
-            if (state != TransportState.RUNNING && state != TransportState.STARTING) return@runOnMainSync
+        confinement.run {
+            if (state != TransportState.RUNNING && state != TransportState.STARTING) return@run
 
             // A forced reconnect is a fresh attempt: cancel any pending
             // backoff-scheduled reconnect and reset the backoff so this
             // reconnect (and any that follow it) starts from the initial delay
             // instead of a stale 30s ceiling.
-            reconnectRunnable?.let { mainHandler.removeCallbacks(it) }
+            reconnectRunnable?.let { transportHandler.removeCallbacks(it) }
             reconnectRunnable = null
             currentReconnectDelay.set(RECONNECT_INITIAL_DELAY_MS)
             reconnectAttempts.set(0)
@@ -646,14 +650,14 @@ class InternetManager(
     }
     
     private fun handleConnectionOpened(ws: WebSocket) {
-        // ONE main-posted block gated on the socket still being current,
+        // ONE posted block gated on the socket still being current,
         // like handleAuthenticated and terminateSocket: mutating the flags
         // on the reader thread races stopUnsafe() — an onOpen that passed
         // the listener's staleness pre-check, was preempted by disconnect()
         // (webSocket=null, flags cleared), and then resumed would latch
         // isConnected=true with no socket alive to ever clear it, and every
         // future connect() would early-return — a wedged transport.
-        mainHandler.post {
+        transportHandler.post {
             if (ws !== webSocket) return@post
             if (state == TransportState.STOPPING || state == TransportState.STOPPED) return@post
 
@@ -688,7 +692,7 @@ class InternetManager(
      * funnel itself cancels it).
      */
     private fun scheduleAuthTimeout(ws: WebSocket) {
-        mainHandler.post {
+        transportHandler.post {
             if (ws !== webSocket) return@post
             cancelAuthTimeout()
             val runnable = object : Runnable {
@@ -702,13 +706,13 @@ class InternetManager(
                 }
             }
             authTimeoutRunnable = runnable
-            mainHandler.postDelayed(runnable, AUTH_RESPONSE_TIMEOUT_MS)
+            transportHandler.postDelayed(runnable, AUTH_RESPONSE_TIMEOUT_MS)
         }
     }
 
-    /** Main-thread only. */
+    /** Transport-thread only. */
     private fun cancelAuthTimeout() {
-        authTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+        authTimeoutRunnable?.let { transportHandler.removeCallbacks(it) }
         authTimeoutRunnable = null
     }
     
@@ -750,13 +754,13 @@ class InternetManager(
         capabilities: List<String>,
         addressChallenge: String?
     ) {
-        // The whole reaction is ONE main-posted block gated on the socket
+        // The whole reaction is ONE posted block gated on the socket
         // still being current and the transport not stopping: reacting on
         // the reader thread would race stopUnsafe() — the core would be told
         // internet is up and route to a transport whose poll loop never
         // starts, and the unguarded RUNNING write would wedge state so the
         // next start() throws AlreadyRunning.
-        mainHandler.post {
+        transportHandler.post {
             if (ws !== webSocket) return@post
             if (state == TransportState.STOPPING || state == TransportState.STOPPED) return@post
 
@@ -779,12 +783,14 @@ class InternetManager(
             // `validate_transport_sender`. The status flip below flushes the
             // outbox, which is exactly what produces those sends.
             //
-            // Unlike iOS, this whole block runs on main rather than hopping to
-            // a serial queue, so the ordering is simply sequential here — and
-            // the declaration's two FFI calls land on the main looper next to
-            // the far heavier flush that already does. If that flush ever
-            // moves off main (the iOS messageQueue shape), this must move with
-            // it, ahead of it. Mirrors InternetManager.swift — keep in sync.
+            // This whole block runs on the transport thread, so the ordering
+            // is simply sequential here: the declaration's two FFI calls and
+            // the far heavier flush below are posted work on one serial
+            // looper, exactly like iOS's messageQueue confinement. That is
+            // what the previous note here asked for — the flush moved off
+            // main, and the declaration moved with it, ahead of it, in the
+            // same block rather than in a second post that could interleave.
+            // Mirrors InternetManager.swift — keep in sync.
             declareAddress(ws, capabilities, addressChallenge, username)
 
             // Capabilities MUST reach the SDK before the status flip: the
@@ -835,7 +841,7 @@ class InternetManager(
      * Proves this connection's `off1…` address to the relay, so it is
      * attributed by address rather than by account name.
      *
-     * Called from [handleAuthenticated]'s main-posted block and deliberately
+     * Called from [handleAuthenticated]'s posted block and deliberately
      * the first thing it does: everything the relay attributes downstream —
      * the outbox flush's sends, and anything the poll loop drains after it —
      * is stamped with whatever this connection has proved by the time the relay
@@ -918,9 +924,9 @@ class InternetManager(
 
     /**
      * The transport's reaction to a dead socket. Only reachable through
-     * [terminateSocket]'s detach-first funnel, so it runs on main and at
-     * most once per socket — a queued send-failure teardown racing an
-     * organic onFailure used to run it twice, double-incrementing the
+     * [terminateSocket]'s detach-first funnel, so it runs on the transport
+     * thread and at most once per socket — a queued send-failure teardown
+     * racing an organic onFailure used to run it twice, double-incrementing the
      * reconnect attempt and double-doubling the backoff.
      */
     private fun handleConnectionClosed(code: Int, reason: String?) {
@@ -1011,7 +1017,7 @@ class InternetManager(
      * force-reconnect refuse until the next start(), and fires the one-shot
      * superseded event. Idempotent (via [SupersededLatchPolicy.mark]) — the
      * relay emits both a SessionSuperseded notice and close 4000, so several
-     * paths reach here for one displacement. Main-thread only.
+     * paths reach here for one displacement. Transport-thread only.
      */
     private fun markSuperseded(reason: String?) {
         // The reason goes to the latch, not just the emitter: it has to outlive
@@ -1019,7 +1025,7 @@ class InternetManager(
         // SupersededLatchPolicy.restatementEventJson) rather than existing only
         // as an argument to an emit that may not land.
         if (!supersedeLatch.mark(reason)) return
-        reconnectRunnable?.let { mainHandler.removeCallbacks(it) }
+        reconnectRunnable?.let { transportHandler.removeCallbacks(it) }
         reconnectRunnable = null
         emitDiagnostic("warning", "Relay superseded this session; not auto-reconnecting", mapOf(
             "reason" to (reason ?: "none")
@@ -1060,7 +1066,7 @@ class InternetManager(
             "delayMs" to delay
         ))
         
-        reconnectRunnable?.let { mainHandler.removeCallbacks(it) }
+        reconnectRunnable?.let { transportHandler.removeCallbacks(it) }
         // connect() throws on a malformed server URL (reachable if configure()
         // changed it mid-session); a throw out of a posted runnable would
         // crash the app, so a reconnect that cannot even build its request
@@ -1076,7 +1082,7 @@ class InternetManager(
             }
         }
         reconnectRunnable = runnable
-        mainHandler.postDelayed(runnable, delay)
+        transportHandler.postDelayed(runnable, delay)
     }
     
     // MARK: - WebSocket Listener
@@ -1128,7 +1134,7 @@ class InternetManager(
     /**
      * The single terminal funnel: onClosed, onFailure, and every local
      * teardown ([teardownSocket]) end a socket's life here. Detaching [ws]
-     * BEFORE the closed handler — on main, the only thread that writes
+     * BEFORE the closed handler — on the transport thread, the only one that writes
      * [webSocket] — makes [handleConnectionClosed] unreachable twice for
      * the same socket: whichever signal wins the post detaches it and every
      * later signal fails the identity check. The identity scope also closes
@@ -1136,7 +1142,7 @@ class InternetManager(
      * teardown) can never cancel a newer, healthy socket.
      */
     private fun terminateSocket(ws: WebSocket, code: Int, reason: String?, cancel: Boolean = false) {
-        mainHandler.post {
+        transportHandler.post {
             if (ws !== webSocket) return@post
             webSocket = null
             cancelAuthTimeout()
@@ -1310,10 +1316,10 @@ class InternetManager(
                 // registration for the same identity took the slot. It also
                 // closes with code 4000, but honor the notice too so we never
                 // blind-reconnect even if the close code is lost. Run the mark
-                // + teardown on main like the other lifecycle funnels; the
+                // + teardown on the transport thread like the other lifecycle funnels; the
                 // ws-identity re-check there scopes it to the current socket.
                 val supersedeReason = json.optNullableString("reason")
-                mainHandler.post {
+                transportHandler.post {
                     if (ws !== webSocket) return@post
                     markSuperseded(supersedeReason)
                     // Close the live socket through the shared funnel;
@@ -1634,14 +1640,14 @@ class InternetManager(
                 // worst case is an idempotent re-registration. Drain the
                 // local bucket too: it was clearly too optimistic.
                 //
-                // The whole reaction runs as ONE main post so it serializes
+                // The whole reaction runs as ONE post so it serializes
                 // with poll ticks: resetting the translator here on the
                 // reader thread while the clear is still queued would let an
                 // interleaved tick translate a post-reset register whose
                 // delta frames the clear then wipes (their commits never
                 // run, and the group's relay membership stays stale until
                 // the next register trigger).
-                mainHandler.post {
+                transportHandler.post {
                     controlOpTranslator.reset()
                     rateLimiter.drain(monotonicNowMs())
                     pendingControlFrames.clear()
@@ -1843,11 +1849,11 @@ class InternetManager(
     
     private fun startMessagePolling() {
         stopMessagePolling()
-        mainHandler.post(messagePollingRunnable)
+        transportHandler.post(messagePollingRunnable)
     }
     
     private fun stopMessagePolling() {
-        mainHandler.removeCallbacks(messagePollingRunnable)
+        transportHandler.removeCallbacks(messagePollingRunnable)
     }
     
     private fun pollAndSendMessages() {
@@ -2103,7 +2109,7 @@ class InternetManager(
      * Queues a translation's extra frames for token-gated delivery and
      * drains immediately (the common small case goes out in the same tick).
      * The commit runs only after the translation's last frame is written.
-     * Main-thread only.
+     * Transport-thread only.
      */
     private fun enqueueControlFrames(
         controlOp: String,
@@ -2125,7 +2131,7 @@ class InternetManager(
      * write failure drops everything pending: the frames are per-connection,
      * their commits stay uninvoked (and are generation-dead after the
      * disconnect reset), and the reconnect's re-register re-derives them.
-     * Main-thread only.
+     * Transport-thread only.
      */
     private fun drainPendingControlFrames() {
         if (pendingControlFrames.isEmpty()) return
@@ -2232,11 +2238,11 @@ class InternetManager(
 
     private fun startPresenceWatch() {
         stopPresenceWatch()
-        mainHandler.postDelayed(presenceWatchRunnable, PresenceWatchPolicy.DEFAULT_TICK_INTERVAL_MS)
+        transportHandler.postDelayed(presenceWatchRunnable, PresenceWatchPolicy.DEFAULT_TICK_INTERVAL_MS)
     }
 
     private fun stopPresenceWatch() {
-        mainHandler.removeCallbacks(presenceWatchRunnable)
+        transportHandler.removeCallbacks(presenceWatchRunnable)
     }
 
     private fun presenceWatchTick() {
@@ -2316,7 +2322,7 @@ class InternetManager(
             return
         }
         val deadlineMs = monotonicNowMs() + FORCED_CHECK_DEADLINE_MS
-        mainHandler.post {
+        transportHandler.post {
             attemptForcedCheck(ForcedPresenceCheckQueue.Entry(userId, deadlineMs, callback))
         }
     }
@@ -2339,7 +2345,7 @@ class InternetManager(
     }
 
     /**
-     * Main-confined. Sends the forced check if currently admissible;
+     * Transport-thread confined. Sends the forced check if currently admissible;
      * otherwise the queue policy parks it, expires it, fails it fast on a
      * stopping/stopped transport (no reconnect coming), or rejects it at
      * capacity.
@@ -2356,17 +2362,17 @@ class InternetManager(
     }
 
     /**
-     * Main-confined. One retry tick services the whole queue; the scheduled
+     * Transport-thread confined. One retry tick services the whole queue; the scheduled
      * flag keeps ticks from stacking.
      */
     private fun scheduleForcedCheckRetry() {
         if (forcedChecks.isEmpty || forcedCheckRetryScheduled) return
         forcedCheckRetryScheduled = true
-        mainHandler.postDelayed(forcedCheckRetryRunnable, FORCED_CHECK_RETRY_INTERVAL_MS)
+        transportHandler.postDelayed(forcedCheckRetryRunnable, FORCED_CHECK_RETRY_INTERVAL_MS)
     }
 
     /**
-     * Main-confined. Re-attempts every parked forced check;
+     * Transport-thread confined. Re-attempts every parked forced check;
      * attemptForcedCheck re-parks the still-unsendable ones.
      */
     private fun serviceForcedChecks() {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/InternetManager.kt
@@ -199,9 +199,8 @@ class InternetManager(
     // retry tick and its no-stacking flag — is here. Transport-thread
     // confined (like the rest of the timer state). Never bypasses the rate
     // limiter — the client bucket mirrors the relay's server bucket, and an
-    // over-budget frame is
-    // dropped server-side *after* the local write "succeeded", which is
-    // strictly worse than deferring.
+    // over-budget frame is dropped server-side *after* the local write
+    // "succeeded", which is strictly worse than deferring.
     private val forcedChecks = ForcedPresenceCheckQueue()
     private var forcedCheckRetryScheduled = false
     private val forcedCheckRetryRunnable = Runnable {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
@@ -105,8 +105,16 @@ class NostrManager(
     private val subscriptionIds = mutableMapOf<String, String>()
     private val relayLock = Object()
 
-    // Nostr identity (obtained from Rust core). Same writer and readers as the
-    // configuration above — it is filled in by the same configure() call.
+    // Nostr identity (obtained from Rust core). Unlike the configuration
+    // above this has a second writer, and it is the one that earns the
+    // annotation: configure() seeds it on the RN bridge thread, but
+    // sendSubscription() re-reads it from the core on OkHttp's reader thread
+    // at every relay (re)connect — deliberately, because the signing key
+    // rotates when MLS initialization installs the persisted secret and the
+    // fresh value has to be in place before any event can arrive on the
+    // subscription being opened. Read on the transport thread and, in
+    // processNostrMessage, on the reader thread again for the self-event
+    // filter. Volatile so that reader-thread write is visible to all of them.
     @Volatile private var publicKeyHex: String = ""
 
     // Configuration state
@@ -302,14 +310,21 @@ class NostrManager(
         emitDiagnostic("info", "Nostr transport stopped")
     }
 
+    /**
+     * Synchronous like the other lifecycle entry points — see
+     * [ReticulumManager.pause] for the argument. In short: the module pauses
+     * the transports and then the core, and a posted pause returns before it
+     * has stopped anything, so the poll could re-enter UniFFI after the core
+     * was already paused.
+     */
     override fun pause() {
-        transportHandler.post {
+        runConfinedSync {
             stopMessagePolling()
         }
     }
 
     override fun resume() {
-        transportHandler.post {
+        runConfinedSync {
             if (state == TransportState.RUNNING && isConnected.get()) {
                 startMessagePolling()
             }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
@@ -451,11 +451,28 @@ class NostrManager(
     }
 
     private fun updateConnectionStatus() {
-        val anyConnected = synchronized(relayLock) {
-            relayConnected.values.any { it }
+        // Sampled and published as one step under the lock that owns the map.
+        //
+        // Read and swapped separately — as these were — two relays
+        // transitioning at once can interleave so that the *later* swap
+        // publishes the *earlier* reader's answer. A relay connects and this
+        // reads `anyConnected = true`, then is descheduled; the same relay
+        // drops, and that call reads false, swaps false→false and sees
+        // `wasConnected = false`, so neither edge fires; the first thread
+        // resumes and swaps false→true with `wasConnected = false`, firing the
+        // connected edge against a relay set that is empty. The core is told
+        // the transport is up, polling starts, and every message it drains hits
+        // the no-connected-relays branch of [publishMessage] and comes back as
+        // nostrSendFailed until a relay genuinely reconnects.
+        //
+        // Under one lock the second caller always samples the final map, and
+        // the two edges are enqueued in the order they were swapped.
+        val anyConnected: Boolean
+        val wasConnected: Boolean
+        synchronized(relayLock) {
+            anyConnected = relayConnected.values.any { it }
+            wasConnected = isConnected.getAndSet(anyConnected)
         }
-
-        val wasConnected = isConnected.getAndSet(anyConnected)
 
         if (anyConnected && !wasConnected) {
             // Became connected

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
@@ -11,6 +11,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import uniffi.offline_protocol.OfflineProtocol
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -122,9 +123,14 @@ class NostrManager(
 
     // Connection state
     private val isConnected = AtomicBoolean(false)
-    private val reconnectAttempts = mutableMapOf<String, AtomicInteger>()
-    private val currentReconnectDelay = mutableMapOf<String, AtomicLong>()
-    private val reconnectRunnables = mutableMapOf<String, Runnable>()
+    // Concurrent, not plain: handleRelayConnected reads these on OkHttp's
+    // reader thread while scheduleReconnect's getOrPut structurally modifies
+    // them on the transport thread. A plain HashMap read racing a resize is
+    // the classic corruption/endless-probe case — the atomics inside the
+    // values only cover the counter, not the map that holds it.
+    private val reconnectAttempts = ConcurrentHashMap<String, AtomicInteger>()
+    private val currentReconnectDelay = ConcurrentHashMap<String, AtomicLong>()
+    private val reconnectRunnables = ConcurrentHashMap<String, Runnable>()
 
     // Pending relay confirmations: Nostr event_id → protocol message_id.
     // Populated when a WebSocket send succeeds; removed on relay ["OK", ...].
@@ -291,6 +297,12 @@ class NostrManager(
 
         // Close all WebSocket connections
         disconnectAll()
+
+        // Shut down OkHttp's dispatcher like InternetManager does — start()
+        // builds a fresh client, so a stop that leaves the executor alive
+        // leaks its threads once per stop()/start() cycle.
+        okHttpClient?.dispatcher?.executorService?.shutdown()
+        okHttpClient = null
 
         // The transport thread is process-wide and outlives this stop() — see
         // [TransportConfinement]. Quitting it here is what the per-session

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
@@ -426,6 +426,19 @@ class NostrManager(
             // Became connected
             consecutiveSendFailures.set(0)
             transportHandler.post {
+                // A stop() that landed while this relay's handshake was still
+                // in flight has already told the protocol we are down and
+                // moved to STOPPED. Announcing the connection now would put
+                // the state back to RUNNING and the protocol back to
+                // connected, against a transport nothing will ever tear down
+                // again — and the next start() would throw AlreadyRunning off
+                // it. The relay socket is stray, so close it here, on the
+                // thread that owns disconnectAll().
+                if (state == TransportState.STOPPING || state == TransportState.STOPPED) {
+                    disconnectAll()
+                    return@post
+                }
+
                 updateState(TransportState.RUNNING)
                 try {
                     protocol.nostrStatusChanged(true)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
@@ -63,9 +63,16 @@ class NostrManager(
 
     // MARK: - Properties
 
-    private var relayUrls: List<String> = emptyList()
-    private var autoReconnect = true
-    private var maxReconnectAttempts = 0 // 0 = infinite
+    // Written by configure() on the RN bridge thread, read on the transport
+    // thread (connectToRelay, scheduleReconnect) and on OkHttp's reader
+    // threads. The first start() gets happens-before from runConfinedSync's
+    // post, but a mid-session reconfigure has no such edge — volatile so a
+    // reconnect cannot dial a retired relay set or apply a retired retry
+    // policy. InternetManager annotates serverUrl/authToken for exactly this
+    // reason; these mirrors were missed when it did.
+    @Volatile private var relayUrls: List<String> = emptyList()
+    @Volatile private var autoReconnect = true
+    @Volatile private var maxReconnectAttempts = 0 // 0 = infinite
 
     // The one thread this manager runs on.
     //
@@ -98,8 +105,9 @@ class NostrManager(
     private val subscriptionIds = mutableMapOf<String, String>()
     private val relayLock = Object()
 
-    // Nostr identity (obtained from Rust core)
-    private var publicKeyHex: String = ""
+    // Nostr identity (obtained from Rust core). Same writer and readers as the
+    // configuration above — it is filled in by the same configure() call.
+    @Volatile private var publicKeyHex: String = ""
 
     // Configuration state
     private val isConfigured = AtomicBoolean(false)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
@@ -1,8 +1,5 @@
 package com.offlineprotocol
 
-import android.os.Handler
-import android.os.HandlerThread
-import android.os.Looper
 import android.util.Base64
 import android.util.Log
 import okhttp3.OkHttpClient
@@ -14,7 +11,6 @@ import org.json.JSONArray
 import org.json.JSONObject
 import uniffi.offline_protocol.OfflineProtocol
 import java.util.UUID
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -59,6 +55,10 @@ class NostrManager(
         private const val CONNECTION_TIMEOUT_SECONDS = 30L
         private const val PING_INTERVAL_MS = 30000L  // OkHttp WebSocket ping interval
         private const val MAX_CONSECUTIVE_FAILURES = 2
+        // Name of the private looper this manager confines itself to. Shared
+        // process-wide under this key, so a manager rebuilt after stop()
+        // inherits the same ordered queue.
+        private const val CONFINEMENT_THREAD = "offline-nostr"
     }
 
     // MARK: - Properties
@@ -67,12 +67,16 @@ class NostrManager(
     private var autoReconnect = true
     private var maxReconnectAttempts = 0 // 0 = infinite
 
-    // Handler for main thread operations
-    private val mainHandler = Handler(Looper.getMainLooper())
-
-    // Background handler thread for message polling
-    private var ioThread: HandlerThread? = null
-    private var ioHandler: Handler? = null
+    // The one thread this manager runs on.
+    //
+    // This used to be two: a per-session "NostrIO" HandlerThread for polling,
+    // and the app's main looper for lifecycle and the connect/disconnect
+    // status flips. The poll was already off main, but `nostrStatusChanged`
+    // and the `nostrQueryCompleted` release loop are UniFFI calls and they ran
+    // on main at every relay transition — which, for a flapping relay set, is
+    // the reconnect backoff cadence. See [TransportConfinement].
+    private val confinement = TransportConfinement.shared(CONFINEMENT_THREAD)
+    private val transportHandler = confinement.handler
 
     // Message polling runnable
     private val messagePollingRunnable = object : Runnable {
@@ -80,7 +84,7 @@ class NostrManager(
             pollAndSendMessages()
             pollAndSendQueries()
             if (state == TransportState.RUNNING && isConnected.get()) {
-                ioHandler?.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
+                transportHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
             }
         }
     }
@@ -122,33 +126,19 @@ class NostrManager(
 
     // MARK: - Helper
 
-    private fun <T> runOnMainSync(action: () -> T): T {
-        if (Looper.myLooper() == Looper.getMainLooper()) {
-            return action()
-        }
-
-        val latch = CountDownLatch(1)
-        var outcome: Result<T>? = null
-        mainHandler.post {
-            outcome = try {
-                Result.success(action())
-            } catch (t: Throwable) {
-                Result.failure(t)
-            }
-            latch.countDown()
-        }
-
-        try {
-            if (!latch.await(5, TimeUnit.SECONDS)) {
-                throw RuntimeException("Timed out waiting for main thread execution (5s)")
-            }
-        } catch (ie: InterruptedException) {
-            Thread.currentThread().interrupt()
-            throw RuntimeException("Interrupted while executing on main thread", ie)
-        }
-
-        return outcome!!.getOrThrow()
-    }
+    /**
+     * Runs [action] on the transport thread and waits for it.
+     *
+     * The flat 5s bound this replaces applied to every caller, which was the
+     * wrong shape twice over: it fired on the RN bridge thread — the one
+     * caller that genuinely needs `stop()` to have finished — precisely when
+     * the protocol mutex was most contended, leaving the transport half-down
+     * and rejecting the JS promise; and it did not protect main at all, since
+     * a main-thread caller took the inline fast path straight into the FFI.
+     * [TransportConfinement.runSync] inverts both: main is the only bounded
+     * caller, and it no longer runs the action itself.
+     */
+    private fun <T> runConfinedSync(action: () -> T): T = confinement.runSync(action)
 
     // MARK: - Configuration
 
@@ -191,7 +181,7 @@ class NostrManager(
     }
 
     override fun start() {
-        runOnMainSync {
+        runConfinedSync {
             startUnsafe()
         }
     }
@@ -245,11 +235,6 @@ class NostrManager(
             "publicKey" to publicKeyHex
         ))
 
-        // Start background IO thread
-        val thread = HandlerThread("NostrIO").also { it.start() }
-        ioThread = thread
-        ioHandler = Handler(thread.looper)
-
         // Create OkHttp client
         okHttpClient = OkHttpClient.Builder()
             .connectTimeout(CONNECTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
@@ -267,7 +252,7 @@ class NostrManager(
     }
 
     override fun stop() {
-        runOnMainSync {
+        runConfinedSync {
             stopUnsafe()
         }
     }
@@ -281,7 +266,7 @@ class NostrManager(
 
         // Cancel all reconnect attempts
         for ((_, runnable) in reconnectRunnables) {
-            mainHandler.removeCallbacks(runnable)
+            transportHandler.removeCallbacks(runnable)
         }
         reconnectRunnables.clear()
 
@@ -291,10 +276,12 @@ class NostrManager(
         // Close all WebSocket connections
         disconnectAll()
 
-        // Shut down IO thread
-        ioThread?.quitSafely()
-        ioThread = null
-        ioHandler = null
+        // The transport thread is process-wide and outlives this stop() — see
+        // [TransportConfinement]. Quitting it here is what the per-session
+        // thread used to do, and it is exactly what must not happen now: a
+        // stop() is followed by start() often enough (enableTransport, a
+        // foreground heal) that a dead looper would silently swallow every
+        // post the next session makes.
 
         // Notify protocol
         try {
@@ -308,13 +295,13 @@ class NostrManager(
     }
 
     override fun pause() {
-        ioHandler?.post {
+        transportHandler.post {
             stopMessagePolling()
         }
     }
 
     override fun resume() {
-        ioHandler?.post {
+        transportHandler.post {
             if (state == TransportState.RUNNING && isConnected.get()) {
                 startMessagePolling()
             }
@@ -325,7 +312,7 @@ class NostrManager(
      * Called by the Rust transport callback when new outgoing messages are available.
      */
     fun onMessagesAvailable() {
-        ioHandler?.post { pollAndSendMessages() }
+        transportHandler.post { pollAndSendMessages() }
     }
 
     // MARK: - Relay Connection Management
@@ -424,7 +411,7 @@ class NostrManager(
 
         // Attempt reconnection if enabled
         if (autoReconnect && state != TransportState.STOPPING && state != TransportState.STOPPED) {
-            mainHandler.post { scheduleReconnect(relayUrl) }
+            transportHandler.post { scheduleReconnect(relayUrl) }
         }
     }
 
@@ -438,7 +425,7 @@ class NostrManager(
         if (anyConnected && !wasConnected) {
             // Became connected
             consecutiveSendFailures.set(0)
-            mainHandler.post {
+            transportHandler.post {
                 updateState(TransportState.RUNNING)
                 try {
                     protocol.nostrStatusChanged(true)
@@ -446,11 +433,11 @@ class NostrManager(
                     Log.e(TAG, "Error notifying protocol of connect", e)
                 }
                 startMessagePolling()
-                ioHandler?.post { pollAndSendMessages() }
+                transportHandler.post { pollAndSendMessages() }
             }
         } else if (!anyConnected && wasConnected) {
             // Lost all connections
-            mainHandler.post {
+            transportHandler.post {
                 stopMessagePolling()
                 releaseActiveQueries()
                 try {
@@ -490,10 +477,10 @@ class NostrManager(
             "delayMs" to delay
         ))
 
-        reconnectRunnables[relayUrl]?.let { mainHandler.removeCallbacks(it) }
+        reconnectRunnables[relayUrl]?.let { transportHandler.removeCallbacks(it) }
         val runnable = Runnable { connectToRelay(relayUrl) }
         reconnectRunnables[relayUrl] = runnable
-        mainHandler.postDelayed(runnable, delay)
+        transportHandler.postDelayed(runnable, delay)
     }
 
     // MARK: - Nostr Protocol (NIP-01 / NIP-04)
@@ -673,11 +660,11 @@ class NostrManager(
 
     private fun startMessagePolling() {
         stopMessagePolling()
-        ioHandler?.post(messagePollingRunnable)
+        transportHandler.post(messagePollingRunnable)
     }
 
     private fun stopMessagePolling() {
-        ioHandler?.removeCallbacks(messagePollingRunnable)
+        transportHandler.removeCallbacks(messagePollingRunnable)
     }
 
 

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -1391,6 +1391,24 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
         }
     }
 
+    /**
+     * Pauses the transports and then the core, in that order.
+     *
+     * The order is the contract, not a preference: pausing the transports first
+     * is what bounds the window in which one of them can still re-enter UniFFI
+     * behind a paused core, and it is why [InternetManager.pause] can describe
+     * its final drain as "bounded to sends already in flight".
+     *
+     * Which is exactly why the fan-out runs through [TeardownSequence], like the
+     * two stop paths already do. Each of these is now a synchronous wait on that
+     * transport's own confinement thread, so each is a place a real exception
+     * can surface; written as a plain statement list the first throw skips the
+     * four transports after it *and* the core pause, leaving the core running
+     * against a half-paused transport set — the opposite of what the ordering is
+     * for. Failures are collected, everything still gets paused, and the first
+     * one is rethrown so this method's promise rejects with the same cause it
+     * would have before.
+     */
     @ReactMethod
     fun pause(promise: Promise) {
         try {
@@ -1398,36 +1416,53 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
             stopProcessScheduler()
 
             // Pause all transports consistently
-            bleTransport?.pause()
-            internetManager?.pause()
-            wifiDirectManager?.pause()
-            reticulumManager?.pause()
-            nostrManager?.pause()
+            val teardown = TeardownSequence()
+            teardown.step("BLE manager") { bleTransport?.pause() }
+            teardown.step("Internet manager") { internetManager?.pause() }
+            teardown.step("WiFi Direct manager") { wifiDirectManager?.pause() }
+            teardown.step("Reticulum manager") { reticulumManager?.pause() }
+            teardown.step("Nostr manager") { nostrManager?.pause() }
+            teardown.step("protocol") { protocol?.pause() }
+            teardown.firstFailureOrNull()?.let { throw it }
 
-            protocol?.pause()
             promise.resolve(null)
         } catch (e: Exception) {
             promise.reject("ERROR_PAUSE", "Failed to pause protocol: ${e.message}", e)
         }
     }
 
+    /**
+     * The mirror of [pause], core first — a transport must not hand work to a
+     * still-paused core — and through [TeardownSequence] for the same reason.
+     *
+     * A resume that gives up halfway is the worse half of the pair: [pause] at
+     * least fails safe (things stay stopped), whereas a transport left paused
+     * here is one DORS can still select and nothing will restart until the next
+     * background/foreground cycle. The scheduler restart is the step that most
+     * needs to survive a transport throwing, since without it the core stops
+     * ticking its outbox entirely.
+     */
     @ReactMethod
     fun resume(promise: Promise) {
         try {
-            protocol?.resume()
-            
+            val teardown = TeardownSequence()
+            teardown.step("protocol") { protocol?.resume() }
+
             // Resume all transports consistently
-            bleTransport?.resume()
-            internetManager?.resume()
-            wifiDirectManager?.resume()
-            reticulumManager?.resume()
-            nostrManager?.resume()
+            teardown.step("BLE manager") { bleTransport?.resume() }
+            teardown.step("Internet manager") { internetManager?.resume() }
+            teardown.step("WiFi Direct manager") { wifiDirectManager?.resume() }
+            teardown.step("Reticulum manager") { reticulumManager?.resume() }
+            teardown.step("Nostr manager") { nostrManager?.resume() }
 
             // Restart the process scheduler
-            if (protocol?.getState() == ProtocolState.RUNNING) {
-                startProcessScheduler()
+            teardown.step("process scheduler") {
+                if (protocol?.getState() == ProtocolState.RUNNING) {
+                    startProcessScheduler()
+                }
             }
-            
+            teardown.firstFailureOrNull()?.let { throw it }
+
             promise.resolve(null)
         } catch (e: Exception) {
             promise.reject("ERROR_RESUME", "Failed to resume protocol: ${e.message}", e)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt
@@ -115,7 +115,6 @@ class OfflineProtocolModule(reactContext: ReactApplicationContext) :
     }
 
     private var currentConfig: ProtocolConfig? = null
-    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
 
     companion object {
         const val NAME = "OfflineProtocolModule"

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -50,10 +50,18 @@ class ReticulumManager(
 
     // MARK: - Properties
 
-    private var daemonHost: String = "localhost"
-    private var daemonPort: Int = 4242
-    private var autoReconnect = true
-    private var maxReconnectAttempts = 0 // 0 = infinite
+    // Written by configure() on the RN bridge thread; read on the transport
+    // thread (connect, scheduleReconnect) and on the IO thread (the blocking
+    // connect itself, which reads the host and port it dials). The first
+    // start() gets happens-before from runConfinedSync's post, but a
+    // mid-session reconfigure has no such edge — volatile so a reconnect
+    // cannot dial a stale host or apply a retired retry policy.
+    // InternetManager annotates serverUrl/authToken for exactly this reason;
+    // these mirrors were missed when it did.
+    @Volatile private var daemonHost: String = "localhost"
+    @Volatile private var daemonPort: Int = 4242
+    @Volatile private var autoReconnect = true
+    @Volatile private var maxReconnectAttempts = 0 // 0 = infinite
 
     // The thread this manager's state, lifecycle and FFI run on.
     //
@@ -100,6 +108,10 @@ class ReticulumManager(
     private var socket: Socket? = null
     private var writer: PrintWriter? = null
     private var reader: BufferedReader? = null
+    // Under the same `synchronized(this)` as the socket it reads, because it
+    // crosses the same two threads: [startReceiveLoop] publishes it from the
+    // IO thread, [disconnect] interrupts and clears it from the transport
+    // thread. It was the one field in this group left outside the lock.
     private var receiveThread: Thread? = null
 
     // Configuration state
@@ -111,6 +123,25 @@ class ReticulumManager(
     private var reconnectAttempts = AtomicInteger(0)
     private var currentReconnectDelay = AtomicLong(RECONNECT_INITIAL_DELAY_MS)
     private var reconnectRunnable: Runnable? = null
+
+    // Which connect attempt is the current one.
+    //
+    // [connect] stamps this before handing its blocking work to [ioHandler],
+    // and [disconnect] retires it, so a block that outlives the attempt that
+    // queued it can tell. The flags above cannot answer that question:
+    // `disconnect` clears `isConnecting` while the connect is still inside
+    // `Socket.connect` — up to CONNECTION_TIMEOUT_MS against a host dropping
+    // SYNs — so a stop() followed by a start() passes connect()'s guard and
+    // queues a *second* attempt behind the first on the one shared IO looper.
+    // Both would publish, and the loser's socket and receive thread would leak
+    // with `isConnected` still true, so when that orphaned reader finally
+    // errored it would tear down the session that had replaced it.
+    //
+    // Checked before publishing rather than folded into the connected-edge
+    // gate on the transport thread: that gate catches a connection which
+    // outlived a stop, but not one which outlived a stop *and* a restart,
+    // because by then the state is legitimately STARTING again.
+    private val connectGeneration = AtomicInteger(0)
 
     // Failure tracking for DORS
     private var consecutiveSendFailures = AtomicInteger(0)
@@ -270,6 +301,8 @@ class ReticulumManager(
             "port" to daemonPort
         ))
 
+        val generation = connectGeneration.incrementAndGet()
+
         // Connect on the IO thread to avoid blocking and prevent unmanaged threads
         ioHandler.post {
             try {
@@ -278,6 +311,17 @@ class ReticulumManager(
                     java.net.InetSocketAddress(daemonHost, daemonPort),
                     CONNECTION_TIMEOUT_MS
                 )
+
+                // A teardown, or a restart, happened while this attempt was
+                // still inside connect(). Nothing below is wanted: publishing
+                // now would install this socket over the current session's,
+                // stranding one of the two with a live reader thread. Close
+                // what this opened instead — see [connectGeneration].
+                if (connectGeneration.get() != generation) {
+                    try { sock.close() } catch (_: Exception) {}
+                    return@post
+                }
+
                 sock.soTimeout = 0 // No read timeout — blocking receive
 
                 val w = PrintWriter(sock.getOutputStream(), true)
@@ -299,14 +343,32 @@ class ReticulumManager(
                 handleConnectionOpened()
                 startReceiveLoop(r)
             } catch (e: Exception) {
-                isConnecting.set(false)
                 Log.e(TAG, "Failed to connect to Reticulum daemon", e)
                 emitDiagnostic("error", "Failed to connect to Reticulum daemon", mapOf(
                     "error" to (e.message ?: "unknown"),
                     "host" to daemonHost,
                     "port" to daemonPort
                 ))
-                transportHandler.post { handleConnectionClosed(-1, e.message) }
+
+                // `isConnecting` is deliberately NOT cleared here, and that is
+                // the fix rather than an oversight. [handleConnectionClosed]
+                // decides whether a failure is worth reacting to by reading
+                // exactly these two flags — clearing this one first made that
+                // read false on both counts, so it returned early and never
+                // reached [scheduleReconnect]. The whole 1s→30s ladder was
+                // dead for the case it exists for: a daemon that is not
+                // running. The transport simply sat in STARTING, where
+                // startUnsafe throws AlreadyRunning, until an explicit
+                // stop()/start(). iOS clears the flag inside that handler,
+                // under the same lock that samples it, which is why the ladder
+                // worked there and not here.
+                //
+                // A superseded attempt hands nothing over: the generation that
+                // replaced it owns the flags now, and reporting this failure
+                // would fire the ladder against a session that already moved on.
+                if (connectGeneration.get() == generation) {
+                    transportHandler.post { handleConnectionClosed(-1, e.message) }
+                }
             }
         }
     }
@@ -317,10 +379,15 @@ class ReticulumManager(
         isConnected.set(false)
         isConnecting.set(false)
 
-        receiveThread?.interrupt()
-        receiveThread = null
+        // Any connect still inside Socket.connect on the IO thread belongs to
+        // the session this call is ending, so retire its generation: it closes
+        // what it opened rather than publishing it over whatever comes next.
+        // See [connectGeneration].
+        connectGeneration.incrementAndGet()
 
         synchronized(this) {
+            receiveThread?.interrupt()
+            receiveThread = null
             try { writer?.close() } catch (_: Exception) {}
             try { reader?.close() } catch (_: Exception) {}
             try { socket?.close() } catch (_: Exception) {}
@@ -375,7 +442,7 @@ class ReticulumManager(
     }
 
     private fun startReceiveLoop(reader: BufferedReader) {
-        receiveThread = Thread {
+        val thread = Thread {
             try {
                 while (isConnected.get() && !Thread.currentThread().isInterrupted) {
                     val line = reader.readLine() ?: break
@@ -390,7 +457,15 @@ class ReticulumManager(
             if (isConnected.get()) {
                 transportHandler.post { handleConnectionClosed(-1, "Connection lost") }
             }
-        }.also { it.start() }
+        }
+        // Published under the socket's lock, because this runs on the IO
+        // thread while [disconnect] clears the field from the transport one.
+        // Assigned before start() rather than after, so a teardown landing in
+        // between finds the thread instead of a null: interrupting one that
+        // has not started is a no-op, and the loop it then enters reads the
+        // `isConnected` that teardown already cleared and exits immediately.
+        synchronized(this) { receiveThread = thread }
+        thread.start()
     }
 
     private fun handleConnectionClosed(code: Int, reason: String?) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -1,16 +1,11 @@
 package com.offlineprotocol
 
-import android.os.Handler
-import android.os.HandlerThread
-import android.os.Looper
 import android.util.Log
 import uniffi.offline_protocol.OfflineProtocol
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.io.PrintWriter
 import java.net.Socket
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
@@ -45,6 +40,10 @@ class ReticulumManager(
         private const val RECONNECT_BACKOFF_MULTIPLIER = 2.0
         private const val CONNECTION_TIMEOUT_MS = 60000  // 60s — Reticulum paths can be high-latency
         private const val MAX_CONSECUTIVE_FAILURES = 3
+        // Name of the private looper this manager confines itself to. Shared
+        // process-wide under this key, so a manager rebuilt after stop()
+        // inherits the same ordered queue.
+        private const val CONFINEMENT_THREAD = "offline-reticulum"
     }
 
     // MARK: - Properties
@@ -54,19 +53,28 @@ class ReticulumManager(
     private var autoReconnect = true
     private var maxReconnectAttempts = 0 // 0 = infinite
 
-    // Handler for main thread operations (state updates, listener callbacks)
-    private val mainHandler = Handler(Looper.getMainLooper())
+    // The one thread this manager runs on.
+    //
+    // This used to be two: a per-session "ReticulumIO" HandlerThread for
+    // polling and TCP writes, and the app's main looper for state updates and
+    // the status flips. The split is what left OFF-2123 alive here — the poll
+    // was already off main, but `reticulumStatusChanged` is a UniFFI call and
+    // it ran on main at every connect and disconnect, which for a daemon that
+    // is down means once per rung of the 1s→30s backoff ladder.
+    //
+    // Collapsing both onto one confinement removes the FFI from main and the
+    // per-session thread lifecycle with it: nothing has to decide whether
+    // `ioHandler` is non-null before posting, and no reconnect can race a
+    // quitSafely() that already ran. See [TransportConfinement].
+    private val confinement = TransportConfinement.shared(CONFINEMENT_THREAD)
+    private val transportHandler = confinement.handler
 
-    // Background handler thread for message polling and TCP I/O
-    private var ioThread: HandlerThread? = null
-    private var ioHandler: Handler? = null
-
-    // Message polling runnable — runs on ioHandler (background thread)
+    // Message polling runnable — runs on the transport thread
     private val messagePollingRunnable = object : Runnable {
         override fun run() {
             pollAndSendMessages()
             if (state == TransportState.RUNNING && isConnected.get()) {
-                ioHandler?.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
+                transportHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
             }
         }
     }
@@ -92,33 +100,19 @@ class ReticulumManager(
 
     // MARK: - Helper
 
-    private fun <T> runOnMainSync(action: () -> T): T {
-        if (Looper.myLooper() == Looper.getMainLooper()) {
-            return action()
-        }
-
-        val latch = CountDownLatch(1)
-        var outcome: Result<T>? = null
-        mainHandler.post {
-            outcome = try {
-                Result.success(action())
-            } catch (t: Throwable) {
-                Result.failure(t)
-            }
-            latch.countDown()
-        }
-
-        try {
-            if (!latch.await(5, TimeUnit.SECONDS)) {
-                throw RuntimeException("Timed out waiting for main thread execution (5s)")
-            }
-        } catch (ie: InterruptedException) {
-            Thread.currentThread().interrupt()
-            throw RuntimeException("Interrupted while executing on main thread", ie)
-        }
-
-        return outcome!!.getOrThrow()
-    }
+    /**
+     * Runs [action] on the transport thread and waits for it.
+     *
+     * The flat 5s bound this replaces applied to every caller, which was the
+     * wrong shape twice over: it fired on the RN bridge thread — the one
+     * caller that genuinely needs `stop()` to have finished — precisely when
+     * the protocol mutex was most contended, leaving the transport half-down
+     * and rejecting the JS promise; and it did not protect main at all, since
+     * a main-thread caller took the inline fast path straight into the FFI.
+     * [TransportConfinement.runSync] inverts both: main is the only bounded
+     * caller, and it no longer runs the action itself.
+     */
+    private fun <T> runConfinedSync(action: () -> T): T = confinement.runSync(action)
 
     // MARK: - Configuration
 
@@ -166,7 +160,7 @@ class ReticulumManager(
     }
 
     override fun start() {
-        runOnMainSync {
+        runConfinedSync {
             startUnsafe()
         }
     }
@@ -182,17 +176,12 @@ class ReticulumManager(
             "daemonAddress" to "$daemonHost:$daemonPort"
         ))
 
-        // Start background IO thread for polling and TCP writes
-        val thread = HandlerThread("ReticulumIO").also { it.start() }
-        ioThread = thread
-        ioHandler = Handler(thread.looper)
-
         updateState(TransportState.STARTING)
         connect()
     }
 
     override fun stop() {
-        runOnMainSync {
+        runConfinedSync {
             stopUnsafe()
         }
     }
@@ -205,7 +194,7 @@ class ReticulumManager(
         updateState(TransportState.STOPPING)
 
         // Cancel reconnect attempts
-        reconnectRunnable?.let { mainHandler.removeCallbacks(it) }
+        reconnectRunnable?.let { transportHandler.removeCallbacks(it) }
         reconnectRunnable = null
 
         // Stop timers
@@ -214,10 +203,12 @@ class ReticulumManager(
         // Close TCP connection
         disconnect()
 
-        // Shut down IO thread
-        ioThread?.quitSafely()
-        ioThread = null
-        ioHandler = null
+        // The transport thread is process-wide and outlives this stop() — see
+        // [TransportConfinement]. Quitting it here is what the per-session
+        // thread used to do, and it is exactly what must not happen now: a
+        // stop() is followed by start() often enough (enableTransport, a
+        // foreground heal) that a dead looper would silently swallow every
+        // post the next session makes.
 
         // Notify protocol
         try {
@@ -231,11 +222,11 @@ class ReticulumManager(
     }
 
     override fun pause() {
-        ioHandler?.post { stopMessagePolling() }
+        transportHandler.post { stopMessagePolling() }
     }
 
     override fun resume() {
-        ioHandler?.post {
+        transportHandler.post {
             if (state == TransportState.RUNNING && isConnected.get()) {
                 startMessagePolling()
             }
@@ -247,7 +238,7 @@ class ReticulumManager(
      * This is the primary send path, replacing timer-based polling.
      */
     fun onMessagesAvailable() {
-        ioHandler?.post { pollAndSendMessages() }
+        transportHandler.post { pollAndSendMessages() }
     }
 
     // MARK: - Connection Management
@@ -263,7 +254,7 @@ class ReticulumManager(
         ))
 
         // Connect on the IO thread to avoid blocking and prevent unmanaged threads
-        ioHandler?.post {
+        transportHandler.post {
             try {
                 val sock = Socket()
                 sock.connect(
@@ -298,7 +289,7 @@ class ReticulumManager(
                     "host" to daemonHost,
                     "port" to daemonPort
                 ))
-                mainHandler.post { handleConnectionClosed(-1, e.message) }
+                transportHandler.post { handleConnectionClosed(-1, e.message) }
             }
         }
     }
@@ -333,19 +324,23 @@ class ReticulumManager(
 
         // Update state first, then notify protocol, so state is RUNNING before
         // protocol sees the connection event
-        mainHandler.post {
+        transportHandler.post {
             updateState(TransportState.RUNNING)
 
-            // Notify protocol on main thread (consistent with handleConnectionClosed)
+            // Notify the protocol on the transport thread (consistent with
+            // handleConnectionClosed). This is the heaviest FFI call this
+            // manager makes: the false→true edge flushes the whole outbox
+            // under the global protocol mutex, which is why it must not run
+            // on main.
             try {
                 protocol.reticulumStatusChanged(true)
             } catch (e: Exception) {
                 Log.e(TAG, "Error notifying protocol of connect", e)
             }
 
-            // Start polling + immediately flush queued messages on IO thread
+            // Start polling + immediately flush queued messages
             startMessagePolling()
-            ioHandler?.post { pollAndSendMessages() }
+            transportHandler.post { pollAndSendMessages() }
         }
     }
 
@@ -363,7 +358,7 @@ class ReticulumManager(
             }
             // Connection closed or errored
             if (isConnected.get()) {
-                mainHandler.post { handleConnectionClosed(-1, "Connection lost") }
+                transportHandler.post { handleConnectionClosed(-1, "Connection lost") }
             }
         }.also { it.start() }
     }
@@ -376,7 +371,7 @@ class ReticulumManager(
         if (!wasConnected && !wasConnecting) return
 
         // Stop polling immediately on IO thread
-        ioHandler?.post {
+        transportHandler.post {
             stopMessagePolling()
         }
 
@@ -398,9 +393,9 @@ class ReticulumManager(
 
         // Attempt reconnection if enabled
         if (autoReconnect && state != TransportState.STOPPING && state != TransportState.STOPPED) {
-            mainHandler.post { scheduleReconnect() }
+            transportHandler.post { scheduleReconnect() }
         } else {
-            mainHandler.post { updateState(TransportState.STOPPED) }
+            transportHandler.post { updateState(TransportState.STOPPED) }
         }
     }
 
@@ -428,10 +423,10 @@ class ReticulumManager(
             "delayMs" to delay
         ))
 
-        reconnectRunnable?.let { mainHandler.removeCallbacks(it) }
+        reconnectRunnable?.let { transportHandler.removeCallbacks(it) }
         val runnable = Runnable { connect() }
         reconnectRunnable = runnable
-        mainHandler.postDelayed(runnable, delay)
+        transportHandler.postDelayed(runnable, delay)
     }
 
     // MARK: - Message Handling
@@ -503,11 +498,11 @@ class ReticulumManager(
 
     private fun startMessagePolling() {
         stopMessagePolling()
-        ioHandler?.post(messagePollingRunnable)
+        transportHandler.post(messagePollingRunnable)
     }
 
     private fun stopMessagePolling() {
-        ioHandler?.removeCallbacks(messagePollingRunnable)
+        transportHandler.removeCallbacks(messagePollingRunnable)
     }
 
     private fun pollAndSendMessages() {
@@ -615,7 +610,7 @@ class ReticulumManager(
                 emitDiagnostic("warning", "Too many consecutive send failures, triggering reconnect", mapOf(
                     "failures" to failures
                 ))
-                mainHandler.post { handleConnectionClosed(-1, "Send failures exceeded threshold") }
+                transportHandler.post { handleConnectionClosed(-1, "Send failures exceeded threshold") }
             }
         }
     }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -91,7 +91,12 @@ class ReticulumManager(
     //
     // Ordered, not pooled: this is one TCP stream and its writes must stay in
     // order. `stop()` closes the socket from [confinement], which is what
-    // unblocks an in-flight write here rather than waiting for it.
+    // unblocks an in-flight write here rather than waiting for it — and the
+    // same applies to a connect that has not published one yet, which is what
+    // [pendingConnectSocket] is for. Both matter more now than they did when
+    // this was a per-session thread: that thread was abandoned mid-call and the
+    // restart got a fresh one, whereas here the next session's work queues
+    // behind whatever is still blocked.
     private val ioHandler = TransportConfinement.shared(IO_THREAD).handler
 
     // Message polling runnable — runs on the IO thread
@@ -113,6 +118,20 @@ class ReticulumManager(
     // IO thread, [disconnect] interrupts and clears it from the transport
     // thread. It was the one field in this group left outside the lock.
     private var receiveThread: Thread? = null
+
+    // The socket a connect attempt is blocked inside, before it has anything
+    // to publish. Same lock as the fields above, and for a sharper reason than
+    // visibility: closing it is the only way to end a `Socket.connect` early —
+    // it has no interruption point, ignores `Thread.interrupt`, and runs for
+    // up to CONNECTION_TIMEOUT_MS (60s) against a host dropping SYNs.
+    //
+    // That is a teardown obligation because [ioHandler] is shared and never
+    // quits. A `stop()` does not wait on it, so the stop itself is fine — but
+    // the *restart* posts its connect behind the one still blocked, so without
+    // this a stop/start cycle against an unreachable daemon stalls for the rest
+    // of the timeout. The per-session HandlerThread this replaced never had
+    // that problem: it was left blocked and the new session got a new thread.
+    private var pendingConnectSocket: Socket? = null
 
     // Configuration state
     private val isConfigured = AtomicBoolean(false)
@@ -294,10 +313,20 @@ class ReticulumManager(
      * Costs nothing extra: the module's caller is React Native's
      * native-modules thread, so the wait is the unbounded background one
      * ([TransportConfinement.runSync]) that `stop()` already takes from the
-     * same place. The actual `removeCallbacks` still lands on [ioHandler] a
-     * hop later — see [startMessagePolling] — which is unchanged and correct;
-     * what is now guaranteed is that the cancel has been *issued* before the
-     * core is paused.
+     * same place.
+     *
+     * What this guarantees is issuance, not quiescence, and the difference is
+     * worth stating because it is weaker than [InternetManager.pause]'s. The
+     * `removeCallbacks` lands on [ioHandler] a hop later (see
+     * [startMessagePolling]), and that looper can be inside a connect for up to
+     * CONNECTION_TIMEOUT_MS — so a poll tick already queued behind it can still
+     * re-enter UniFFI after the core has been paused. Internet has no such gap
+     * because its pause and its poll share one thread. Closing it here would
+     * mean waiting on the socket thread, which is exactly what [ioHandler]
+     * exists to stop the lifecycle doing. The residual is bounded and benign:
+     * the core tolerates a poll against a paused protocol (it hands back
+     * nothing), and `stop()` — the path that must actually quiesce — closes the
+     * socket rather than waiting for it.
      */
     override fun pause() {
         runConfinedSync { stopMessagePolling() }
@@ -335,8 +364,13 @@ class ReticulumManager(
 
         // Connect on the IO thread to avoid blocking and prevent unmanaged threads
         ioHandler.post {
+            val sock = Socket()
+            // Published before the blocking call rather than after it, because
+            // this is the only window in which the socket exists and nothing
+            // else can reach it — and a teardown needs to reach it to end the
+            // connect. See [pendingConnectSocket].
+            synchronized(this) { pendingConnectSocket = sock }
             try {
-                val sock = Socket()
                 sock.connect(
                     java.net.InetSocketAddress(daemonHost, daemonPort),
                     CONNECTION_TIMEOUT_MS
@@ -357,10 +391,26 @@ class ReticulumManager(
                 val w = PrintWriter(sock.getOutputStream(), true)
                 val r = BufferedReader(InputStreamReader(sock.getInputStream()))
 
+                // Second checkpoint, folded into the publish rather than
+                // standing beside it: the check and the write have to be one
+                // step under the lock that owns these fields, or a teardown
+                // landing between them installs this socket over a session
+                // that has already been torn down — the field then holds a
+                // socket `disconnect` will never see again. Inside the lock,
+                // the teardown either wins (this closes what it opened) or
+                // loses (it finds the socket published and closes it there).
+                var published = false
                 synchronized(this) {
-                    socket = sock
-                    writer = w
-                    reader = r
+                    if (connectGeneration.get() == generation) {
+                        socket = sock
+                        writer = w
+                        reader = r
+                        published = true
+                    }
+                }
+                if (!published) {
+                    try { sock.close() } catch (_: Exception) {}
+                    return@post
                 }
 
                 // Send identification
@@ -370,22 +420,14 @@ class ReticulumManager(
                 }
                 w.println(identifyMsg.toString())
 
-                // Second checkpoint, for the window the first cannot cover:
-                // publishing the socket, sending Identify and claiming the
-                // flags are not one step, and a stop() — or a stop and a
-                // restart — fits between them. Claiming `isConnected` past
-                // that point leaves it true against a socket `disconnect`
-                // has already closed, and the announcement's own gate cannot
-                // see it: after a restart the state is legitimately STARTING
-                // again, which is the case [connectGeneration] exists for.
-                // Skips [startReceiveLoop] too — a reader for a retired
-                // socket has nothing to read.
-                if (connectGeneration.get() != generation) {
-                    try { sock.close() } catch (_: Exception) {}
-                    return@post
-                }
-
-                handleConnectionOpened(generation)
+                // Third checkpoint, inside [handleConnectionOpened]: sending
+                // Identify sits between the publish and the flag claim, so a
+                // stop() — or a stop and a restart — fits there too. It
+                // refuses rather than claiming, and [startReceiveLoop] is
+                // skipped with it: a reader for a retired socket has nothing
+                // to read, and starting one against the `isConnected` a
+                // teardown just cleared would exit immediately anyway.
+                if (!handleConnectionOpened(generation)) return@post
                 startReceiveLoop(r)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to connect to Reticulum daemon", e)
@@ -414,23 +456,42 @@ class ReticulumManager(
                 if (connectGeneration.get() == generation) {
                     transportHandler.post { handleConnectionClosed(-1, e.message) }
                 }
+            } finally {
+                // By identity, because a teardown may already have closed this
+                // socket and moved the field on. Nothing else runs on this
+                // looper while this block does, so the check can only ever
+                // fail against a null — but the field is the one thing here a
+                // *different* thread writes, and a blanket clear would undo it.
+                synchronized(this) {
+                    if (pendingConnectSocket === sock) pendingConnectSocket = null
+                }
             }
         }
     }
 
     private fun disconnect() {
-        // Clear flags before interrupting the receive thread so it sees
-        // isConnected == false and skips the redundant handleConnectionClosed post.
-        isConnected.set(false)
-        isConnecting.set(false)
-
-        // Any connect still inside Socket.connect on the IO thread belongs to
-        // the session this call is ending, so retire its generation: it closes
-        // what it opened rather than publishing it over whatever comes next.
-        // See [connectGeneration].
-        connectGeneration.incrementAndGet()
-
         synchronized(this) {
+            // Clear flags before interrupting the receive thread so it sees
+            // isConnected == false and skips the redundant handleConnectionClosed post.
+            //
+            // Under the lock, and next to the generation bump, because
+            // [handleConnectionOpened] claims these same flags from the IO
+            // thread. Left outside it they are two unordered writes: a teardown
+            // landing between that thread's generation check and its set(true)
+            // is simply overwritten, so `isConnected` stays true against a
+            // socket this call has already closed. Nothing corrects it until
+            // the orphaned reader errors out — and in the meantime connect()'s
+            // own `isConnected` guard refuses the next start(), so a restart
+            // silently does nothing.
+            isConnected.set(false)
+            isConnecting.set(false)
+
+            // Any connect still inside Socket.connect on the IO thread belongs
+            // to the session this call is ending, so retire its generation: it
+            // closes what it opened rather than publishing it over whatever
+            // comes next. See [connectGeneration].
+            connectGeneration.incrementAndGet()
+
             receiveThread?.interrupt()
             receiveThread = null
             // Socket first. Socket.close() is the one call that makes a
@@ -451,12 +512,39 @@ class ReticulumManager(
             writer = null
             reader = null
             socket = null
+
+            // The attempt that has not published yet, for the same reason and
+            // by the same mechanism: only a close ends a blocked
+            // Socket.connect, and leaving one running holds the shared IO
+            // looper against the next session's connect. See
+            // [pendingConnectSocket].
+            try { pendingConnectSocket?.close() } catch (_: Exception) {}
+            pendingConnectSocket = null
         }
     }
 
-    private fun handleConnectionOpened(generation: Int) {
-        isConnected.set(true)
-        isConnecting.set(false)
+    /**
+     * Promotes this attempt's connection to the current session, or refuses
+     * when the attempt was retired while it was completing.
+     *
+     * The generation check and the flag claim are one step under the lock
+     * [disconnect] clears them in, because those two are the only writers and
+     * nothing else orders them. Checked outside the lock — as the caller used
+     * to do, one statement earlier — the claim is a read-then-write a teardown
+     * can land inside: it clears the flags, and this sets `isConnected` back to
+     * true against a socket that teardown has already closed. The announcement
+     * below still refuses (its own generation check sees the bump), so nothing
+     * is announced; what is left is a flag no path clears, and `connect`'s
+     * guard reads exactly that flag, so the next `start()` returns having done
+     * nothing. It recovers — the orphaned reader errors and the ladder picks it
+     * up — but a restart should not have to wait out a backoff rung.
+     */
+    private fun handleConnectionOpened(generation: Int): Boolean {
+        synchronized(this) {
+            if (connectGeneration.get() != generation) return false
+            isConnected.set(true)
+            isConnecting.set(false)
+        }
         reconnectAttempts.set(0)
         currentReconnectDelay.set(RECONNECT_INITIAL_DELAY_MS)
         consecutiveSendFailures.set(0)
@@ -509,6 +597,8 @@ class ReticulumManager(
             startMessagePolling()
             ioHandler.post { pollAndSendMessages() }
         }
+
+        return true
     }
 
     private fun startReceiveLoop(reader: BufferedReader) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -400,10 +400,12 @@ class ReticulumManager(
         // Prevent duplicate disconnect handling
         if (!wasConnected && !wasConnecting) return
 
-        // Stop polling immediately on IO thread
-        transportHandler.post {
-            stopMessagePolling()
-        }
+        // Stop polling. Called directly rather than posted: every caller of
+        // this reaches it through `transportHandler.post`, so a post here only
+        // re-queues the cancel behind whatever else is waiting on this thread.
+        // The hop that matters is inside [stopMessagePolling], which puts the
+        // removal on the IO thread that owns the runnable.
+        stopMessagePolling()
 
         // Notify protocol
         try {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -269,12 +269,33 @@ class ReticulumManager(
         emitDiagnostic("info", "Reticulum transport stopped")
     }
 
+    /**
+     * Synchronous like every other lifecycle entry point here, and unlike the
+     * fire-and-forget post this replaces.
+     *
+     * `OfflineProtocolModule.pause` pauses the five transports and then the
+     * core, and that order is the point — it is why [InternetManager.pause]
+     * can call its final drain "bounded to sends already in flight". A posted
+     * pause returns before it has done anything, so the core could pause
+     * first and this manager's next poll tick would re-enter UniFFI behind it.
+     * BLE, Internet and Wi-Fi Direct all confine-and-wait here; these two were
+     * the outliers, left over from when the post was the only way onto their
+     * old per-session IO thread.
+     *
+     * Costs nothing extra: the module's caller is React Native's
+     * native-modules thread, so the wait is the unbounded background one
+     * ([TransportConfinement.runSync]) that `stop()` already takes from the
+     * same place. The actual `removeCallbacks` still lands on [ioHandler] a
+     * hop later — see [startMessagePolling] — which is unchanged and correct;
+     * what is now guaranteed is that the cancel has been *issued* before the
+     * core is paused.
+     */
     override fun pause() {
-        transportHandler.post { stopMessagePolling() }
+        runConfinedSync { stopMessagePolling() }
     }
 
     override fun resume() {
-        transportHandler.post {
+        runConfinedSync {
             if (state == TransportState.RUNNING && isConnected.get()) {
                 startMessagePolling()
             }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -159,8 +159,13 @@ class ReticulumManager(
     // Checked at every point a retired attempt can still act, because those
     // are separate boundaries rather than one: before publishing the socket,
     // before claiming the flags, inside the announcement block on the
-    // transport thread, and — on the other branch — before reporting a
-    // failure that belongs to a session already moved on.
+    // transport thread, and — on the other branch — inside
+    // [handleConnectionClosed], which is where every teardown that was
+    // *observed* on another thread (a failed connect, a dead reader, an
+    // exhausted send budget) lands. All three of those hop to the transport
+    // thread to get there, so all three can arrive after the session they
+    // describe is gone; the check belongs on the far side of the hop, where
+    // the flags are actually cleared, not beside each post.
     //
     // The connected-edge state gate cannot stand in for the announcement
     // check. It catches a connection which outlived a stop, but not one which
@@ -428,7 +433,7 @@ class ReticulumManager(
                 // to read, and starting one against the `isConnected` a
                 // teardown just cleared would exit immediately anyway.
                 if (!handleConnectionOpened(generation)) return@post
-                startReceiveLoop(r)
+                startReceiveLoop(r, generation)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to connect to Reticulum daemon", e)
                 emitDiagnostic("error", "Failed to connect to Reticulum daemon", mapOf(
@@ -453,9 +458,11 @@ class ReticulumManager(
                 // A superseded attempt hands nothing over: the generation that
                 // replaced it owns the flags now, and reporting this failure
                 // would fire the ladder against a session that already moved on.
-                if (connectGeneration.get() == generation) {
-                    transportHandler.post { handleConnectionClosed(-1, e.message) }
-                }
+                // Carried into the post rather than checked before it, because
+                // a check here would be on the wrong side of the hop — the same
+                // reasoning the announcement block below spells out. The
+                // handler re-reads it on the transport thread.
+                transportHandler.post { handleConnectionClosed(generation, -1, e.message) }
             } finally {
                 // By identity, because a teardown may already have closed this
                 // socket and moved the field on. Nothing else runs on this
@@ -601,7 +608,7 @@ class ReticulumManager(
         return true
     }
 
-    private fun startReceiveLoop(reader: BufferedReader) {
+    private fun startReceiveLoop(reader: BufferedReader, generation: Int) {
         val thread = Thread {
             try {
                 while (isConnected.get() && !Thread.currentThread().isInterrupted) {
@@ -613,9 +620,14 @@ class ReticulumManager(
                     Log.e(TAG, "Receive loop error", e)
                 }
             }
-            // Connection closed or errored
+            // Connection closed or errored. Stamped with the generation this
+            // reader belongs to, because the `isConnected` check below is not
+            // one: a teardown clears the flag and wakes this thread, and if a
+            // start() lands before it is next scheduled the flag reads true
+            // again — belonging to the session that replaced this one. See
+            // [handleConnectionClosed].
             if (isConnected.get()) {
-                transportHandler.post { handleConnectionClosed(-1, "Connection lost") }
+                transportHandler.post { handleConnectionClosed(generation, -1, "Connection lost") }
             }
         }
         // Published under the socket's lock, because this runs on the IO
@@ -628,7 +640,38 @@ class ReticulumManager(
         thread.start()
     }
 
-    private fun handleConnectionClosed(code: Int, reason: String?) {
+    /**
+     * The teardown half of [connectGeneration], and the sixth point a retired
+     * attempt can still act.
+     *
+     * Every caller reaches this through `transportHandler.post` from another
+     * thread — the IO thread on a failed connect or an exhausted send budget,
+     * the receive thread on a dropped link — so each of them names a session
+     * that may already be over by the time this runs. Both flags below are
+     * *session* state, and clearing them is what makes this destructive: a
+     * stale post lands on whatever session holds them now.
+     *
+     * The `!wasConnected && !wasConnecting` check below cannot stand in for
+     * this one, and that is the whole reason the parameter exists. It is a
+     * duplicate-suppression check, and it answers "is some session live",
+     * never "is it *this* one" — so after a stop() *and* a start() it reads
+     * the successor's flags and passes. The stale post then clears
+     * `isConnected` under a healthy connection, tells the core the transport
+     * is down, and starts a reconnect ladder against it, while the socket that
+     * was actually live is left open with its reader parked in `readLine()`
+     * (soTimeout = 0) and `receiveThread` already reassigned — nothing ever
+     * closes either. The next connect publishes over `socket`/`writer`/
+     * `reader` under the lock without closing what it displaces, so the thread
+     * and the descriptor leak for the life of the process.
+     *
+     * Checked before the flags are touched, for the same reason the publish
+     * and the flag claim fold their checks into the write rather than standing
+     * beside it: the point of a generation is that nothing destructive happens
+     * on behalf of a session that has moved on.
+     */
+    private fun handleConnectionClosed(generation: Int, code: Int, reason: String?) {
+        if (connectGeneration.get() != generation) return
+
         val wasConnected = isConnected.getAndSet(false)
         val wasConnecting = isConnecting.getAndSet(false)
 
@@ -837,9 +880,17 @@ class ReticulumManager(
         data: ByteArray,
         replyToMsg: String? = null
     ) {
+        // The writer and the generation that owns it, sampled together under
+        // the lock `disconnect` clears both in, so the pair is consistent: a
+        // teardown either wins and this sees a null writer, or loses and this
+        // holds a writer with the generation it belonged to. Read separately
+        // they could straddle a stop/start, and the failure teardown below
+        // would name the session that replaced this one.
         val w: PrintWriter?
+        val generation: Int
         synchronized(this) {
             w = writer
+            generation = connectGeneration.get()
         }
 
         if (!isConnected.get() || w == null) {
@@ -899,7 +950,9 @@ class ReticulumManager(
                 emitDiagnostic("warning", "Too many consecutive send failures, triggering reconnect", mapOf(
                     "failures" to failures
                 ))
-                transportHandler.post { handleConnectionClosed(-1, "Send failures exceeded threshold") }
+                transportHandler.post {
+                    handleConnectionClosed(generation, -1, "Send failures exceeded threshold")
+                }
             }
         }
     }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -137,10 +137,19 @@ class ReticulumManager(
     // with `isConnected` still true, so when that orphaned reader finally
     // errored it would tear down the session that had replaced it.
     //
-    // Checked before publishing rather than folded into the connected-edge
-    // gate on the transport thread: that gate catches a connection which
-    // outlived a stop, but not one which outlived a stop *and* a restart,
-    // because by then the state is legitimately STARTING again.
+    // Checked at every point a retired attempt can still act, because those
+    // are separate boundaries rather than one: before publishing the socket,
+    // before claiming the flags, inside the announcement block on the
+    // transport thread, and — on the other branch — before reporting a
+    // failure that belongs to a session already moved on.
+    //
+    // The connected-edge state gate cannot stand in for the announcement
+    // check. It catches a connection which outlived a stop, but not one which
+    // outlived a stop *and* a restart, because by then the state is
+    // legitimately STARTING again and the gate passes — which was the
+    // announcement firing against a closed socket: the core told the transport
+    // was up with `writer` null, and the poll it starts draining the outbox
+    // into reticulumSendFailed until the next attempt resolved the flags.
     private val connectGeneration = AtomicInteger(0)
 
     // Failure tracking for DORS
@@ -361,7 +370,22 @@ class ReticulumManager(
                 }
                 w.println(identifyMsg.toString())
 
-                handleConnectionOpened()
+                // Second checkpoint, for the window the first cannot cover:
+                // publishing the socket, sending Identify and claiming the
+                // flags are not one step, and a stop() — or a stop and a
+                // restart — fits between them. Claiming `isConnected` past
+                // that point leaves it true against a socket `disconnect`
+                // has already closed, and the announcement's own gate cannot
+                // see it: after a restart the state is legitimately STARTING
+                // again, which is the case [connectGeneration] exists for.
+                // Skips [startReceiveLoop] too — a reader for a retired
+                // socket has nothing to read.
+                if (connectGeneration.get() != generation) {
+                    try { sock.close() } catch (_: Exception) {}
+                    return@post
+                }
+
+                handleConnectionOpened(generation)
                 startReceiveLoop(r)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to connect to Reticulum daemon", e)
@@ -430,7 +454,7 @@ class ReticulumManager(
         }
     }
 
-    private fun handleConnectionOpened() {
+    private fun handleConnectionOpened(generation: Int) {
         isConnected.set(true)
         isConnecting.set(false)
         reconnectAttempts.set(0)
@@ -442,6 +466,19 @@ class ReticulumManager(
         // Update state first, then notify protocol, so state is RUNNING before
         // protocol sees the connection event
         transportHandler.post {
+            // Re-checked here, and not merely before this block was posted:
+            // the two are separated by however long this thread was busy, and
+            // a whole stop() plus start() fits in that gap. The state gate
+            // below is blind to exactly that pair — a restarted transport is
+            // legitimately STARTING, so the gate passes and this announces a
+            // socket the stop already closed, with `writer` null. The core is
+            // told the transport is up, and the poll this starts drains the
+            // outbox straight into reticulumSendFailed. Nothing to clean up
+            // here: the generation only moves on when `disconnect` retires it
+            // or a fresh `connect` claims it, and both leave the socket this
+            // attempt opened to the checkpoint in [connect] that owns it.
+            if (connectGeneration.get() != generation) return@post
+
             // A stop() that landed while this connection was still being
             // established has already told the protocol we are down and moved
             // to STOPPED. Announcing the connection now would put the state

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -526,13 +526,35 @@ class ReticulumManager(
         }
     }
 
+    /**
+     * Both halves hop onto the IO thread before touching its queue, rather
+     * than reaching across from the lifecycle thread.
+     *
+     * Every caller of these runs on [confinement]; [messagePollingRunnable]
+     * runs — and reposts itself — on [ioHandler]. A cross-thread
+     * `removeCallbacks` removes nothing while the runnable is mid-flight, so
+     * it loses the race to the repost and polling survives the call. Two of
+     * the three callers happen to be covered anyway: `stopUnsafe` and
+     * `handleConnectionClosed` both clear `isConnected` first, and the
+     * repost gate reads it. [pause] clears nothing, so it was the one that
+     * could leave a paused transport polling — calling the FFI and writing to
+     * the daemon for the whole background stay — and a [resume] landing on the
+     * same race would stack a second runnable and double the rate.
+     *
+     * Posting instead queues the removal *behind* an in-flight runnable's
+     * repost, so it always wins. Ordering across the two loopers is safe for
+     * free: the callers are serialised on the lifecycle thread, so the IO
+     * thread receives these in the order they were issued.
+     */
     private fun startMessagePolling() {
-        stopMessagePolling()
-        ioHandler.post(messagePollingRunnable)
+        ioHandler.post {
+            ioHandler.removeCallbacks(messagePollingRunnable)
+            messagePollingRunnable.run()
+        }
     }
 
     private fun stopMessagePolling() {
-        ioHandler.removeCallbacks(messagePollingRunnable)
+        ioHandler.post { ioHandler.removeCallbacks(messagePollingRunnable) }
     }
 
     private fun pollAndSendMessages() {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -342,6 +342,19 @@ class ReticulumManager(
         // Update state first, then notify protocol, so state is RUNNING before
         // protocol sees the connection event
         transportHandler.post {
+            // A stop() that landed while this connection was still being
+            // established has already told the protocol we are down and moved
+            // to STOPPED. Announcing the connection now would put the state
+            // back to RUNNING and the protocol back to connected, against a
+            // transport nothing will ever tear down again — and the next
+            // start() would throw AlreadyRunning off it. The socket this
+            // opened is stray, so close it here, on the thread that owns
+            // disconnect().
+            if (state == TransportState.STOPPING || state == TransportState.STOPPED) {
+                disconnect()
+                return@post
+            }
+
             updateState(TransportState.RUNNING)
 
             // Notify the protocol on the transport thread (consistent with

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -44,6 +44,8 @@ class ReticulumManager(
         // process-wide under this key, so a manager rebuilt after stop()
         // inherits the same ordered queue.
         private const val CONFINEMENT_THREAD = "offline-reticulum"
+        // Name of the second looper, for blocking socket work only.
+        private const val IO_THREAD = "offline-reticulum-io"
     }
 
     // MARK: - Properties
@@ -53,28 +55,43 @@ class ReticulumManager(
     private var autoReconnect = true
     private var maxReconnectAttempts = 0 // 0 = infinite
 
-    // The one thread this manager runs on.
+    // The thread this manager's state, lifecycle and FFI run on.
     //
-    // This used to be two: a per-session "ReticulumIO" HandlerThread for
-    // polling and TCP writes, and the app's main looper for state updates and
-    // the status flips. The split is what left OFF-2123 alive here — the poll
-    // was already off main, but `reticulumStatusChanged` is a UniFFI call and
-    // it ran on main at every connect and disconnect, which for a daemon that
-    // is down means once per rung of the 1s→30s backoff ladder.
+    // This used to be the app's main looper, which is what left OFF-2123 alive
+    // here — the poll was already off main, but `reticulumStatusChanged` is a
+    // UniFFI call and it ran on main at every connect and disconnect, which
+    // for a daemon that is down means once per rung of the 1s→30s backoff
+    // ladder. See [TransportConfinement].
     //
-    // Collapsing both onto one confinement removes the FFI from main and the
-    // per-session thread lifecycle with it: nothing has to decide whether
-    // `ioHandler` is non-null before posting, and no reconnect can race a
-    // quitSafely() that already ran. See [TransportConfinement].
+    // Lifecycle callers block on this thread ([runConfinedSync]), and a
+    // background caller waits without a bound on purpose, so nothing posted
+    // here may block for longer than the protocol mutex does — which is why
+    // the socket work lives on [ioHandler] and not here.
     private val confinement = TransportConfinement.shared(CONFINEMENT_THREAD)
     private val transportHandler = confinement.handler
 
-    // Message polling runnable — runs on the transport thread
+    // The thread the blocking socket work runs on: connecting (up to
+    // CONNECTION_TIMEOUT_MS), and the TCP writes, which have no timeout at all
+    // — a daemon that stops reading blocks a write until the socket is closed.
+    //
+    // Separate from [confinement] because those durations are bounded by the
+    // network rather than by us, and `stop()` waits on that thread unbounded:
+    // sharing one would let an unreachable host park a stop() (and the RN
+    // bridge thread behind it) for a minute, or a wedged daemon park it
+    // indefinitely. Both are loopers rather than the old per-session
+    // HandlerThread, so neither can be quit out from under a reconnect.
+    //
+    // Ordered, not pooled: this is one TCP stream and its writes must stay in
+    // order. `stop()` closes the socket from [confinement], which is what
+    // unblocks an in-flight write here rather than waiting for it.
+    private val ioHandler = TransportConfinement.shared(IO_THREAD).handler
+
+    // Message polling runnable — runs on the IO thread
     private val messagePollingRunnable = object : Runnable {
         override fun run() {
             pollAndSendMessages()
             if (state == TransportState.RUNNING && isConnected.get()) {
-                transportHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
+                ioHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
             }
         }
     }
@@ -238,7 +255,7 @@ class ReticulumManager(
      * This is the primary send path, replacing timer-based polling.
      */
     fun onMessagesAvailable() {
-        transportHandler.post { pollAndSendMessages() }
+        ioHandler.post { pollAndSendMessages() }
     }
 
     // MARK: - Connection Management
@@ -254,7 +271,7 @@ class ReticulumManager(
         ))
 
         // Connect on the IO thread to avoid blocking and prevent unmanaged threads
-        transportHandler.post {
+        ioHandler.post {
             try {
                 val sock = Socket()
                 sock.connect(
@@ -340,7 +357,7 @@ class ReticulumManager(
 
             // Start polling + immediately flush queued messages
             startMessagePolling()
-            transportHandler.post { pollAndSendMessages() }
+            ioHandler.post { pollAndSendMessages() }
         }
     }
 
@@ -498,11 +515,11 @@ class ReticulumManager(
 
     private fun startMessagePolling() {
         stopMessagePolling()
-        transportHandler.post(messagePollingRunnable)
+        ioHandler.post(messagePollingRunnable)
     }
 
     private fun stopMessagePolling() {
-        transportHandler.removeCallbacks(messagePollingRunnable)
+        ioHandler.removeCallbacks(messagePollingRunnable)
     }
 
     private fun pollAndSendMessages() {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -409,9 +409,21 @@ class ReticulumManager(
         synchronized(this) {
             receiveThread?.interrupt()
             receiveThread = null
+            // Socket first. Socket.close() is the one call that makes a
+            // blocked readLine()/println() throw; interrupt() above does not
+            // unblock a classic socket read. The wrapped streams share a lock
+            // with the I/O they wrap — BufferedReader.close() takes the lock
+            // readLine() holds for its whole blocking duration, and
+            // PrintWriter.close() the one println() holds — so closing them
+            // first waits on the very I/O this teardown exists to interrupt:
+            // with the receive thread parked in readLine() (soTimeout = 0,
+            // the steady state of a connected transport), it would park this
+            // thread — and stop()'s unbounded background wait behind it —
+            // until the daemon happened to send a line. Pinned by the
+            // Reticulum source guard in the UniFFI crate.
+            try { socket?.close() } catch (_: Exception) {}
             try { writer?.close() } catch (_: Exception) {}
             try { reader?.close() } catch (_: Exception) {}
-            try { socket?.close() } catch (_: Exception) {}
             writer = null
             reader = null
             socket = null

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
@@ -88,12 +88,22 @@ internal class TransportConfinement(
 
     /** Runs [action] inline when already confined, otherwise posts it. */
     fun run(action: () -> Unit) {
-        if (isCurrent()) action() else handler.post(action)
+        if (isCurrent()) action() else post(action)
     }
 
-    /** Posts [action] to the back of this thread's queue, always. */
+    /**
+     * Posts [action] to the back of this thread's queue, always.
+     *
+     * Checked for the same reason [runSync] checks: a looper that has quit
+     * accepts nothing and says so only in this return value. The failure is
+     * quieter here — dropped work rather than a permanent park — which is
+     * precisely why it needs saying out loud, since a silently discarded status
+     * flip or teardown step is diagnosed months later if at all. Threads handed
+     * out by [shared] never quit, so this cannot trip in production; it is here
+     * because the constructor takes any [Looper].
+     */
     fun post(action: () -> Unit) {
-        handler.post(action)
+        check(handler.post(action)) { "$name is not accepting work: its looper has quit" }
     }
 
     /**
@@ -247,6 +257,23 @@ internal class TransportConfinement(
         fun shared(name: String): TransportConfinement = instances.getOrPut(name) {
             val thread = HandlerThread(name).apply { start() }
             TransportConfinement(name, thread.looper)
+        }
+
+        /**
+         * Drops the confinement named [name] and quits its thread. Tests only.
+         *
+         * It exists so a test that takes a [shared] thread — the reuse contract
+         * cannot be verified without taking one — does not leave it running for
+         * the rest of the suite. Quitting the looper by hand instead is worse
+         * than leaving it: the entry survives, so the next lookup of that name
+         * returns a confinement that accepts nothing, and Robolectric reuses a
+         * sandbox (and therefore these statics) across test classes with the
+         * same config. Removing the entry and quitting the thread has to be one
+         * step, which is what this is.
+         */
+        @Synchronized
+        fun releaseForTests(name: String) {
+            instances.remove(name)?.looper?.quitSafely()
         }
     }
 }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
@@ -1,0 +1,176 @@
+package com.offlineprotocol
+
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.util.Log
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * The single thread one transport manager runs on, and the primitive it uses
+ * to keep its own state ordered.
+ *
+ * Every transport manager here needs exactly one property from a thread: that
+ * its own posts run one at a time, in order. All four used to take that from
+ * the app's main looper, and that is what OFF-2123 is: every call into UniFFI
+ * serialises on the core protocol's single global mutex, which is held across
+ * MLS work and AndroidKeyStore-backed storage callbacks, so a manager posting
+ * FFI to main charges those multi-second waits to the thread Android watches
+ * for ANRs. None of these managers touches the UI — main was only ever "one
+ * thread, ordered posts", and a private looper is the same primitive without
+ * the app's responsiveness in its blast radius.
+ *
+ * The BLE facade reached this shape first (see `ble.BleTransportFacade`'s
+ * `bleLooper`); this is that remedy extracted so the remaining transports share
+ * one implementation instead of four subtly different ones. They *were* four
+ * different ones: BLE bounded only main-thread callers, Nostr and Reticulum
+ * bounded every caller at a flat 5s — which turns a slow mutex into a failed
+ * `stop()` — and Internet bounded nobody at all, so an RN bridge call could
+ * park forever behind a stalled main looper.
+ *
+ * ## Lifecycle
+ *
+ * Threads obtained through [shared] are process-wide and never quit. That is
+ * deliberate and matches what the main looper they replace did: no teardown
+ * path can strand a pending post on a dead looper, and a manager rebuilt after
+ * `stop()` inherits the same ordered queue instead of racing a fresh one
+ * against the old one's backlog. One idle thread per transport the app has
+ * actually started is the entire cost.
+ */
+internal class TransportConfinement(
+    /** Thread name, for stack traces and ANR/hang reports. */
+    private val name: String,
+    /** The looper every action runs on. */
+    val looper: Looper,
+    /** How long a main-thread caller waits in [runSync] before giving up. */
+    private val mainSyncTimeoutMs: Long = MAIN_THREAD_SYNC_TIMEOUT_MS,
+) {
+
+    val handler = Handler(looper)
+
+    /** True when the calling thread is this confinement's thread. */
+    fun isCurrent(): Boolean = Looper.myLooper() === looper
+
+    /** Runs [action] inline when already confined, otherwise posts it. */
+    fun run(action: () -> Unit) {
+        if (isCurrent()) action() else handler.post(action)
+    }
+
+    /** Posts [action] to the back of this thread's queue, always. */
+    fun post(action: () -> Unit) {
+        handler.post(action)
+    }
+
+    /**
+     * Run [action] on this thread and wait for it.
+     *
+     * The wait is unbounded for every caller except the app's main thread, and
+     * that exception is the whole point rather than a defensive nicety. This
+     * thread can legitimately sit for seconds inside a UniFFI call waiting on
+     * the core protocol mutex; blocking main on it would rebuild the very ANR
+     * the confinement exists to escape, just through the lifecycle door
+     * instead of the message pump.
+     *
+     * The bound is only for main. Background callers — React Native's
+     * native-modules thread, the mesh stop thread — keep an unbounded wait on
+     * purpose: they are the ones that rely on `stop()` having actually
+     * finished before teardown continues, and starving *them* is not an ANR.
+     * A flat timeout for everyone, which two of these managers used to have,
+     * fails a `stop()` precisely when the mutex is most contended and leaves
+     * the transport half-down.
+     *
+     * On expiry the work is not cancelled: it still runs here, we simply stop
+     * waiting, and the caller gets [MainThreadSyncTimeout]. Every action
+     * routed through this is self-contained and idempotent, so completing late
+     * is safe, and the main-reachable lifecycle paths run their transport stops
+     * through [TeardownSequence], which records a throwing step and carries on.
+     * One late-completing action beats an ANR.
+     */
+    fun <T> runSync(action: () -> T): T {
+        if (isCurrent()) {
+            return action()
+        }
+
+        val onMainThread = Looper.myLooper() === Looper.getMainLooper()
+        val latch = CountDownLatch(1)
+        var outcome: Result<T>? = null
+        handler.post {
+            outcome = try {
+                Result.success(action())
+            } catch (t: Throwable) {
+                Result.failure(t)
+            }
+            latch.countDown()
+        }
+
+        try {
+            if (onMainThread) {
+                if (!latch.await(mainSyncTimeoutMs, TimeUnit.MILLISECONDS)) {
+                    Log.w(
+                        TAG,
+                        "$name did not answer a main-thread caller within " +
+                            "${mainSyncTimeoutMs}ms; continuing without it",
+                    )
+                    throw MainThreadSyncTimeout(name, mainSyncTimeoutMs)
+                }
+            } else {
+                latch.await()
+            }
+        } catch (ie: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw RuntimeException("Interrupted while executing on $name", ie)
+        }
+
+        return outcome!!.getOrThrow()
+    }
+
+    /**
+     * Runtime contract check for state documented as confined to this thread.
+     * These invariants used to live only in comments, and comments drift; a
+     * check fails loud instead of corrupting state silently.
+     */
+    fun assertConfined(reason: String) {
+        check(isCurrent()) {
+            "$reason must run on $name (was ${Thread.currentThread().name})"
+        }
+    }
+
+    /** This confinement's thread did not answer a main-thread caller in time. */
+    class MainThreadSyncTimeout(threadName: String, timeoutMs: Long) :
+        RuntimeException("$threadName did not respond within ${timeoutMs}ms")
+
+    companion object {
+        private const val TAG = "TransportConfinement"
+
+        /**
+         * Far below the 5s input-dispatch ANR budget, and far above a healthy
+         * queue turnaround.
+         */
+        const val MAIN_THREAD_SYNC_TIMEOUT_MS = 1_000L
+
+        private val shared = HashMap<String, TransportConfinement>()
+
+        /**
+         * The process-wide confinement named [name], started on first use and
+         * never quit — see the lifecycle note on the class.
+         *
+         * Keyed by name so a manager rebuilt after `stop()` re-attaches to the
+         * queue its predecessor was posting to, rather than racing a fresh
+         * thread against the old one's backlog.
+         *
+         * Deliberately takes nothing from the manager that asks for it. These
+         * instances outlive every manager, so capturing one — a diagnostic
+         * emitter, a listener — would pin it, and with it the React context
+         * and Android [android.content.Context] it holds, for the life of the
+         * process. A timeout therefore reports through the log and the thrown
+         * [MainThreadSyncTimeout], both of which reach the caller's own
+         * reporting without a retained reference.
+         */
+        @Synchronized
+        fun shared(name: String): TransportConfinement = shared.getOrPut(name) {
+            val thread = HandlerThread(name).apply { start() }
+            TransportConfinement(name, thread.looper)
+        }
+    }
+}

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
@@ -210,6 +210,18 @@ internal class TransportConfinement(
         /**
          * Far below the 5s input-dispatch ANR budget, and far above a healthy
          * queue turnaround.
+         *
+         * Per call, which is not the same as per teardown, and the difference
+         * is worth knowing before anyone raises this. Confinements are
+         * per-transport, so the one main-reachable caller that stops several
+         * in a row — `OfflineProtocolModule.invalidate`, five managers
+         * including the BLE facade's own bound of the same size — can spend
+         * this five times over. That is still strictly better than what it
+         * replaced (from main the old helpers took an inline fast path
+         * straight into an unbounded UniFFI call), and `invalidate` runs on a
+         * React Native internal thread rather than main today, which is why
+         * the bound is enforced rather than relied on. But the headroom the
+         * number claims belongs to one call, not to the sequence.
          */
         const val MAIN_THREAD_SYNC_TIMEOUT_MS = 1_000L
 

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
@@ -29,6 +29,27 @@ import java.util.concurrent.TimeUnit
  * `stop()` — and Internet bounded nobody at all, so an RN bridge call could
  * park forever behind a stalled main looper.
  *
+ * ## What may run here
+ *
+ * Anything whose worst case is the protocol mutex, and nothing whose worst
+ * case is the network. That rule is not a preference — it is what makes
+ * [runSync]'s unbounded background wait safe. The mutex is always being
+ * drained by some other thread, so a wait behind it ends; a blocking socket
+ * call is bounded by a peer that may never answer, and a `stop()` queued
+ * behind one waits exactly as long, taking the React Native bridge thread
+ * with it. `ReticulumManager` is the worked example: its `connect` blocks for
+ * up to 60s and its TCP writes have no timeout at all, so they get a second
+ * confinement of their own (`offline-reticulum-io`) and the lifecycle thread
+ * stays answerable.
+ *
+ * The same reasoning bounds long *non*-blocking work when the thread is
+ * shared with something that has its own deadline. A looper handed to
+ * `WifiP2pManager.initialize` or to `registerReceiver` as a scheduler is
+ * delivering framework callbacks, and a broadcast that misses Android's
+ * dispatch budget is an ANR wherever its receiver lives — see
+ * `WifiDirectManager.drainAndSendMessages`, which spends a batch budget and
+ * reposts rather than draining the queue in one pass.
+ *
  * ## Lifecycle
  *
  * Threads obtained through [shared] are process-wide and never quit. That is
@@ -122,7 +143,13 @@ internal class TransportConfinement(
             throw RuntimeException("Interrupted while executing on $name", ie)
         }
 
-        return outcome!!.getOrThrow()
+        // Non-null once the latch has been counted down, and the count-down is
+        // what the await above returned on — so this is a guarantee, not an
+        // assumption. Spelled out rather than `!!` because the guarantee lives
+        // in another block.
+        val completed = outcome
+            ?: error("$name signalled completion without recording an outcome")
+        return completed.getOrThrow()
     }
 
     /**

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportConfinement.kt
@@ -50,6 +50,19 @@ import java.util.concurrent.TimeUnit
  * `WifiDirectManager.drainAndSendMessages`, which spends a batch budget and
  * reposts rather than draining the queue in one pass.
  *
+ * ## What may never wait on this
+ *
+ * Anything the core calls *into*. The transport callbacks
+ * (`onMessagesAvailable`, `onFragmentsAvailable`) are invoked while the core
+ * holds the global protocol mutex, so a callback that waited on a confinement
+ * thread would be waiting on a thread whose next act is to ask for that same
+ * mutex — a permanent deadlock of the core rather than a slow path, and the
+ * only rule here whose violation nothing recovers from. Every such callback
+ * therefore hands its work to a handler and returns, which
+ * `react_native_transport_callbacks_never_wait_on_a_confinement` in the
+ * `offline-protocol-uniffi` crate pins. That rule is also what makes [runSync]
+ * safe to leave unbounded for background callers.
+ *
  * ## Lifecycle
  *
  * Threads obtained through [shared] are process-wide and never quit. That is
@@ -107,6 +120,14 @@ internal class TransportConfinement(
      * is safe, and the main-reachable lifecycle paths run their transport stops
      * through [TeardownSequence], which records a throwing step and carries on.
      * One late-completing action beats an ANR.
+     *
+     * What an expiry must not do is lose a *failure*. Nothing reads the result
+     * once the caller has given up, so an abandoned action that throws would
+     * vanish with no log and no rethrow — a `start()` refused for a real reason
+     * would look like a timeout and nothing else. The follow-up post below
+     * reports it, and it is a post rather than a flag read inside the action
+     * precisely so it cannot race: queued on this same thread, it runs strictly
+     * after the action that recorded the outcome it reads.
      */
     fun <T> runSync(action: () -> T): T {
         if (isCurrent()) {
@@ -116,7 +137,7 @@ internal class TransportConfinement(
         val onMainThread = Looper.myLooper() === Looper.getMainLooper()
         val latch = CountDownLatch(1)
         var outcome: Result<T>? = null
-        handler.post {
+        val accepted = handler.post {
             outcome = try {
                 Result.success(action())
             } catch (t: Throwable) {
@@ -124,6 +145,15 @@ internal class TransportConfinement(
             }
             latch.countDown()
         }
+
+        // A looper that has quit accepts nothing, and the background wait below
+        // has no bound to rescue it from that: the latch would never count down
+        // and the caller — React Native's native-modules thread, on the stop
+        // path — would park for the life of the process. Threads handed out by
+        // [shared] never quit, so this cannot trip in production; it is here
+        // because the constructor takes any [Looper], and a loud failure beats
+        // a silent hang.
+        check(accepted) { "$name is not accepting work: its looper has quit" }
 
         try {
             if (onMainThread) {
@@ -133,6 +163,11 @@ internal class TransportConfinement(
                         "$name did not answer a main-thread caller within " +
                             "${mainSyncTimeoutMs}ms; continuing without it",
                     )
+                    handler.post {
+                        outcome?.exceptionOrNull()?.let { failure ->
+                            Log.w(TAG, "$name failed an abandoned action", failure)
+                        }
+                    }
                     throw MainThreadSyncTimeout(name, mainSyncTimeoutMs)
                 }
             } else {
@@ -152,16 +187,18 @@ internal class TransportConfinement(
         return completed.getOrThrow()
     }
 
-    /**
-     * Runtime contract check for state documented as confined to this thread.
-     * These invariants used to live only in comments, and comments drift; a
-     * check fails loud instead of corrupting state silently.
-     */
-    fun assertConfined(reason: String) {
-        check(isCurrent()) {
-            "$reason must run on $name (was ${Thread.currentThread().name})"
-        }
-    }
+    // There is deliberately no `assertConfined(...)` helper here, and the
+    // omission is the considered answer rather than an oversight. A throwing
+    // contract check is only useful where the throw is caught, and almost every
+    // "transport-thread only" body in these managers is reachable from a posted
+    // block, where an uncaught IllegalStateException takes the process down —
+    // trading a state bug for a crash, which is exactly what the iOS
+    // `dispatchPrecondition` in `drainProcessQueue` had to be walled behind
+    // `#if DEBUG` to avoid. Kotlin has no equivalent compile-time gate here:
+    // narrowing the check to debuggable builds needs `ApplicationInfo`, and
+    // this class holds no Context on purpose (see [shared]). The invariants
+    // stay documented at each site, and the source guards in
+    // `offline-protocol-uniffi` pin the ones whose violation is not recoverable.
 
     /** This confinement's thread did not answer a main-thread caller in time. */
     class MainThreadSyncTimeout(threadName: String, timeoutMs: Long) :
@@ -176,7 +213,7 @@ internal class TransportConfinement(
          */
         const val MAIN_THREAD_SYNC_TIMEOUT_MS = 1_000L
 
-        private val shared = HashMap<String, TransportConfinement>()
+        private val instances = HashMap<String, TransportConfinement>()
 
         /**
          * The process-wide confinement named [name], started on first use and
@@ -195,7 +232,7 @@ internal class TransportConfinement(
          * reporting without a retained reference.
          */
         @Synchronized
-        fun shared(name: String): TransportConfinement = shared.getOrPut(name) {
+        fun shared(name: String): TransportConfinement = instances.getOrPut(name) {
             val thread = HandlerThread(name).apply { start() }
             TransportConfinement(name, thread.looper)
         }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportManager.kt
@@ -93,6 +93,15 @@ interface TransportManager {
      * this body today — but a new transport that does not override is exactly
      * how lifecycle FFI creeps back onto main. Override both, or confine
      * inside [start] and [stop].
+     *
+     * Confining does not mean posting and returning. This must have *taken
+     * effect* by the time it returns: `OfflineProtocolModule.pause` pauses
+     * every transport and then the core, and that order is what bounds the
+     * window in which a paused transport can still re-enter UniFFI. An
+     * implementation that hands the work to its handler and returns has paused
+     * nothing yet, so the core can pause underneath it. Wait on the
+     * confinement — the module's caller is a React Native background thread,
+     * where [TransportConfinement.runSync] does not bound the wait.
      */
     fun pause() {
         // Default implementation: stop the transport

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/TransportManager.kt
@@ -66,24 +66,43 @@ interface TransportManager {
     /**
      * Starts the transport
      * @throws TransportException if start fails
+     *
+     * ## Threading
+     *
+     * An implementation must not run UniFFI calls on the caller's thread.
+     * Every call into the core serialises on one global protocol mutex, held
+     * across MLS work and platform keystore access, so a lifecycle method that
+     * calls the protocol inline hands those waits to whoever called it — and
+     * the callers here include the app's main thread. Confine the work
+     * instead; [TransportConfinement] is what the shipped transports use.
      */
     fun start()
-    
+
     /**
      * Stops the transport
+     *
+     * Same threading obligation as [start].
      */
     fun stop()
-    
+
     /**
      * Pauses the transport (for background mode)
+     *
+     * The default delegates to [stop] and therefore inherits the caller's
+     * thread. Every transport in this module overrides it, so nothing reaches
+     * this body today — but a new transport that does not override is exactly
+     * how lifecycle FFI creeps back onto main. Override both, or confine
+     * inside [start] and [stop].
      */
     fun pause() {
         // Default implementation: stop the transport
         stop()
     }
-    
+
     /**
      * Resumes the transport from paused state
+     *
+     * Same caveat as [pause].
      */
     fun resume() {
         // Default implementation: try to start the transport

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -330,6 +330,15 @@ class WifiDirectManager(
         confinement.runSync {
             if (state == TransportState.RUNNING) {
                 startPeerDiscovery()
+                // Removed before posting, which is the idiom the other three
+                // managers keep in their startMessagePolling helpers. This
+                // runnable reposts itself, and [startUnsafe] already posted one
+                // — so a resume() that does not follow a pause() (two in a row,
+                // or one against a transport that never paused) leaves two
+                // self-reposting chains running and doubles the FFI rate until
+                // the next stop(). Same-thread, so removeCallbacks is exact
+                // here rather than racing an in-flight repost.
+                transportHandler.removeCallbacks(messagePollingRunnable)
                 transportHandler.post(messagePollingRunnable)
             }
         }
@@ -400,11 +409,27 @@ class WifiDirectManager(
         ))
 
         if (!enabled && state == TransportState.RUNNING) {
-            // WiFi P2P was disabled
-            try {
-                protocol.wifiDirectStatusChanged(false)
-            } catch (e: Exception) {
-                Log.e(TAG, "Error notifying protocol", e)
+            // WiFi P2P was disabled.
+            //
+            // Posted rather than called inline, even though this already runs
+            // on the transport thread. This body *is* the broadcast receiver's
+            // onReceive — [startUnsafe] registers with this handler as the
+            // scheduler — and wifiDirectStatusChanged is a UniFFI call that
+            // waits on the core's global protocol mutex, seconds of it under
+            // contention. Holding a receiver's dispatch window open for that is
+            // the hazard [drainAndSendMessages] spends a batch budget to avoid,
+            // reached through the framework's door instead of ours. Posting
+            // lets onReceive return and runs the call as the next item on the
+            // same queue, so the ordering is unchanged.
+            //
+            // Re-read inside, because a stop() fits in the gap the post opens.
+            transportHandler.post {
+                if (state != TransportState.RUNNING) return@post
+                try {
+                    protocol.wifiDirectStatusChanged(false)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error notifying protocol", e)
+                }
             }
         }
     }
@@ -498,7 +523,17 @@ class WifiDirectManager(
                 
                 emitDiagnostic("info", "Server socket started on port $SERVER_PORT")
                 
-                while (serverRunning.get()) {
+                // `serverRunning` alone is the wrong question, because it is
+                // process state and this loop is asking about *its* socket. A
+                // stop() clears the flag and closes the socket; a start()
+                // landing before this thread is next scheduled sets the flag
+                // back — and there is room for one, since stopUnsafe still has
+                // closeAllConnections, unregisterReceiver, channel.close() and
+                // a status FFI under the global mutex to get through. The
+                // accept then throws on the closed socket, the catch reads a
+                // flag that is true again, and this spins at full tilt emitting
+                // a diagnostic per turn, never reaching the finally.
+                while (serverRunning.get() && !server.isClosed) {
                     try {
                         handleClientConnection(server.accept())
                     } catch (e: java.net.SocketTimeoutException) {

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -11,7 +11,6 @@ import android.net.wifi.WifiManager
 import android.net.wifi.p2p.*
 import android.os.Build
 import android.os.Handler
-import android.os.Looper
 import android.util.Log
 import androidx.core.content.ContextCompat
 import uniffi.offline_protocol.OfflineProtocol
@@ -70,7 +69,11 @@ class WifiDirectManager(
     
     override val transportId = "wifi_direct"
     override val transportName = "WiFi Direct (P2P)"
-    override var state: TransportState = TransportState.UNAVAILABLE
+    // Volatile: written on the transport thread (updateState) but read from
+    // RN threads and the socket executor. The other three managers already
+    // declared this; this one did not, and the drain and poll both branch on
+    // it from a different thread than the lifecycle that writes it.
+    @Volatile override var state: TransportState = TransportState.UNAVAILABLE
         private set
     override var listener: TransportManagerListener? = null
 
@@ -82,6 +85,10 @@ class WifiDirectManager(
         private const val MESSAGE_POLL_INTERVAL_MS = 2000L
         private const val CONNECTION_TIMEOUT_MS = 30000L
         private const val SERVER_PORT = 8988
+        // Name of the private looper this manager confines itself to. Shared
+        // process-wide under this key, so a manager rebuilt after stop()
+        // inherits the same ordered queue.
+        private const val CONFINEMENT_THREAD = "offline-wifidirect"
         private const val SOCKET_TIMEOUT_MS = 5000
     }
 
@@ -91,8 +98,19 @@ class WifiDirectManager(
         context.getSystemService(Context.WIFI_P2P_SERVICE) as? WifiP2pManager
     private var channel: WifiP2pManager.Channel? = null
     
-    // Handler for main thread operations
-    private val mainHandler = Handler(Looper.getMainLooper())
+    // The one thread this manager runs on.
+    //
+    // This used to be the app's main looper, which put two UniFFI paths on it:
+    // the 2s fallback poll, and the event-driven drain, whose `while (true)`
+    // takes the global protocol mutex once per queued message with no batch
+    // bound. The Wi-Fi P2P framework callbacks landed there too, since the
+    // channel was initialized with the main looper and the broadcast receiver
+    // registered without a scheduler — so a WIFI_P2P_STATE_CHANGED broadcast
+    // called into the protocol on the main thread as well. All of it moves
+    // here; see [TransportConfinement] for why a private looper is the same
+    // ordering primitive without the ANR exposure.
+    private val confinement = TransportConfinement.shared(CONFINEMENT_THREAD)
+    private val transportHandler = confinement.handler
     
     // Executor for socket operations
     private val socketExecutor = Executors.newCachedThreadPool()
@@ -115,7 +133,7 @@ class WifiDirectManager(
         override fun run() {
             pollAndSendMessages()
             if (state == TransportState.RUNNING) {
-                mainHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
+                transportHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
             }
         }
     }
@@ -161,6 +179,11 @@ class WifiDirectManager(
 
     @SuppressLint("MissingPermission")
     override fun start() {
+        confinement.runSync { startUnsafe() }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun startUnsafe() {
         if (state == TransportState.RUNNING) {
             throw TransportException.AlreadyRunning()
         }
@@ -177,23 +200,38 @@ class WifiDirectManager(
         updateState(TransportState.STARTING)
         transportStartAt = System.currentTimeMillis()
 
-        // Initialize channel
-        channel = wifiP2pManager?.initialize(context, Looper.getMainLooper()) { 
+        // Initialize the channel on the transport looper: `srcLooper` is the
+        // thread every ActionListener / PeerListListener / ConnectionInfoListener
+        // callback is delivered on, and those callbacks share this manager's
+        // state with the drain and the poll. Passing the main looper here was
+        // what put the framework's half of this transport on the UI thread.
+        channel = wifiP2pManager?.initialize(context, confinement.looper) {
             emitDiagnostic("warning", "WiFi P2P channel disconnected")
         }
 
-        // Register broadcast receiver
+        // Register broadcast receiver. The scheduler overload delivers
+        // onReceive on the transport thread instead of main — without it a
+        // WIFI_P2P_STATE_CHANGED broadcast would still call
+        // wifiDirectStatusChanged (a UniFFI call, so the global protocol
+        // mutex) on the UI thread, which is the defect this manager is being
+        // moved off main to fix.
         val intentFilter = IntentFilter().apply {
             addAction(WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION)
             addAction(WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION)
             addAction(WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION)
             addAction(WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION)
         }
-        
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(p2pReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED)
+            context.registerReceiver(
+                p2pReceiver,
+                intentFilter,
+                null,
+                transportHandler,
+                Context.RECEIVER_NOT_EXPORTED,
+            )
         } else {
-            context.registerReceiver(p2pReceiver, intentFilter)
+            context.registerReceiver(p2pReceiver, intentFilter, null, transportHandler)
         }
 
         // Start peer discovery
@@ -212,12 +250,16 @@ class WifiDirectManager(
         }
 
         // Start message polling
-        mainHandler.post(messagePollingRunnable)
+        transportHandler.post(messagePollingRunnable)
 
         emitDiagnostic("info", "WiFi Direct transport started")
     }
 
     override fun stop() {
+        confinement.runSync { stopUnsafe() }
+    }
+
+    private fun stopUnsafe() {
         if (state != TransportState.RUNNING && state != TransportState.STARTING) {
             return
         }
@@ -225,7 +267,7 @@ class WifiDirectManager(
         updateState(TransportState.STOPPING)
 
         // Stop message polling
-        mainHandler.removeCallbacks(messagePollingRunnable)
+        transportHandler.removeCallbacks(messagePollingRunnable)
 
         // Stop peer discovery
         stopPeerDiscovery()
@@ -255,14 +297,18 @@ class WifiDirectManager(
     }
 
     override fun pause() {
-        mainHandler.removeCallbacks(messagePollingRunnable)
-        stopPeerDiscovery()
+        confinement.runSync {
+            transportHandler.removeCallbacks(messagePollingRunnable)
+            stopPeerDiscovery()
+        }
     }
 
     override fun resume() {
-        if (state == TransportState.RUNNING) {
-            startPeerDiscovery()
-            mainHandler.post(messagePollingRunnable)
+        confinement.runSync {
+            if (state == TransportState.RUNNING) {
+                startPeerDiscovery()
+                transportHandler.post(messagePollingRunnable)
+            }
         }
     }
 
@@ -490,7 +536,7 @@ class WifiDirectManager(
                             // `wifiDirectMessageReceived` would attribute the
                             // frame to a socket string, which the core would
                             // then compare against `Message.sender` and reject.
-                            mainHandler.post {
+                            transportHandler.post {
                                 try {
                                     emitDiagnostic("warning", "Wi-Fi Direct frame dropped: sender cannot be identified", mapOf(
                                         "socket" to clientAddress,
@@ -577,12 +623,19 @@ class WifiDirectManager(
      * This is the primary send path, replacing the 100ms polling loop.
      */
     fun onMessagesAvailable() {
-        mainHandler.post { drainAndSendMessages() }
+        transportHandler.post { drainAndSendMessages() }
     }
 
     /**
      * Drains the Rust message queue and sends each message over WiFi Direct.
      * Called from onMessagesAvailable() and from the fallback polling timer.
+     *
+     * The drain is deliberately unbounded: it takes the global protocol mutex
+     * once per queued message, so a backlog is many acquisitions in one
+     * runnable. That was worth bounding while this ran on main; on the
+     * transport thread the only cost of a long drain is delaying this
+     * transport's own next tick, which is exactly what a queue drain should
+     * do. Nothing else shares this looper.
      */
     private fun drainAndSendMessages() {
         if (state != TransportState.RUNNING || connectedPeers.isEmpty()) return

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -89,6 +89,11 @@ class WifiDirectManager(
         // process-wide under this key, so a manager rebuilt after stop()
         // inherits the same ordered queue.
         private const val CONFINEMENT_THREAD = "offline-wifidirect"
+        // Messages one drain pass sends before yielding the transport looper
+        // back to the framework callbacks that share it — see
+        // [drainAndSendMessages]. A fairness budget, not a limit: the pass
+        // reposts itself when it spends the budget with the queue non-empty.
+        private const val MAX_DRAIN_BATCH = 32
         private const val SOCKET_TIMEOUT_MS = 5000
     }
 
@@ -630,21 +635,35 @@ class WifiDirectManager(
      * Drains the Rust message queue and sends each message over WiFi Direct.
      * Called from onMessagesAvailable() and from the fallback polling timer.
      *
-     * The drain is deliberately unbounded: it takes the global protocol mutex
-     * once per queued message, so a backlog is many acquisitions in one
-     * runnable. That was worth bounding while this ran on main; on the
-     * transport thread the only cost of a long drain is delaying this
-     * transport's own next tick, which is exactly what a queue drain should
-     * do. Nothing else shares this looper.
+     * Bounded, and reposting rather than looping past the bound, because this
+     * looper is not this manager's alone. [startUnsafe] hands it to
+     * `WifiP2pManager.initialize` as the callback looper and to
+     * `registerReceiver` as the broadcast scheduler, so every P2P framework
+     * callback queues behind whatever the drain is doing — and a broadcast
+     * that does not reach `onReceive` inside Android's dispatch budget is an
+     * ANR wherever the receiver lives, main or not. `stop()` waits on this
+     * thread without a bound too ([TransportConfinement.runSync]), so an
+     * unbounded drain would put a teardown behind an arbitrary number of
+     * mutex acquisitions.
+     *
+     * Each iteration takes the global protocol mutex once, so the bound is a
+     * fairness budget rather than a correctness one: a queue deeper than
+     * [MAX_DRAIN_BATCH] finishes on the next posted pass, after everything
+     * else sharing this looper has had its turn.
      */
     private fun drainAndSendMessages() {
         if (state != TransportState.RUNNING || connectedPeers.isEmpty()) return
 
         try {
-            while (true) {
-                val message = protocol.wifiDirectGetNextMessage() ?: break
+            var sent = 0
+            while (sent < MAX_DRAIN_BATCH) {
+                val message = protocol.wifiDirectGetNextMessage() ?: return
                 sendMessage(message.recipientId, message.data.map { it.toByte() }.toByteArray())
+                sent++
             }
+            // Budget spent with the queue still non-empty: yield the looper and
+            // come back, rather than starving the callbacks that share it.
+            transportHandler.post { drainAndSendMessages() }
         } catch (e: Exception) {
             emitDiagnostic("error", "Error in drainAndSendMessages", mapOf(
                 "error" to (e.message ?: "unknown")

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -120,8 +120,12 @@ class WifiDirectManager(
     // Executor for socket operations
     private val socketExecutor = Executors.newCachedThreadPool()
     
-    // Server socket for receiving connections
-    private var serverSocket: ServerSocket? = null
+    // Server socket for receiving connections. Volatile because it crosses
+    // two threads with no lock: the socket executor binds and publishes it,
+    // and stopServerSocket() closes and nulls it from the transport thread —
+    // the close is what unblocks a parked accept(), so a stale read there
+    // skips the one call that ends the loop early.
+    @Volatile private var serverSocket: ServerSocket? = null
     private var serverRunning = AtomicBoolean(false)
     
     // Connected peers
@@ -131,7 +135,6 @@ class WifiDirectManager(
     // State tracking
     private var isGroupOwner = false
     private var groupOwnerAddress: String? = null
-    private var transportStartAt: Long = 0L
 
     // True while a budget-spent drain pass has queued its own continuation.
     // Confined to the transport thread — [drainAndSendMessages] and the block
@@ -210,7 +213,6 @@ class WifiDirectManager(
         ))
 
         updateState(TransportState.STARTING)
-        transportStartAt = System.currentTimeMillis()
 
         // Initialize the channel on the transport looper: `srcLooper` is the
         // thread every ActionListener / PeerListListener / ConnectionInfoListener
@@ -296,6 +298,15 @@ class WifiDirectManager(
         } catch (e: Exception) {
             // Ignore - might not be registered
         }
+
+        // Release the framework channel. start() creates a fresh one every
+        // time, so an unclosed channel leaks its binder connection once per
+        // start()/stop() cycle. close() exists since API 27; below that the
+        // framework offers no release and the leak is unavoidable.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            try { channel?.close() } catch (_: Exception) {}
+        }
+        channel = null
 
         // Notify protocol
         try {
@@ -472,18 +483,24 @@ class WifiDirectManager(
         serverRunning.set(true)
         
         socketExecutor.execute {
+            // Held locally as well as published, so the finally closes exactly
+            // the socket this task bound. A stop() can land before the bind
+            // publishes: it clears serverRunning, closes a still-null field
+            // and nulls it — then the bind completes, the loop guard reads
+            // false and exits immediately, and without the finally the
+            // freshly bound socket would leak with port 8988 still held,
+            // failing the next start() with BindException.
+            var server: ServerSocket? = null
             try {
-                serverSocket = ServerSocket(SERVER_PORT)
-                serverSocket?.soTimeout = SOCKET_TIMEOUT_MS
+                server = ServerSocket(SERVER_PORT)
+                server.soTimeout = SOCKET_TIMEOUT_MS
+                serverSocket = server
                 
                 emitDiagnostic("info", "Server socket started on port $SERVER_PORT")
                 
                 while (serverRunning.get()) {
                     try {
-                        val client = serverSocket?.accept()
-                        if (client != null) {
-                            handleClientConnection(client)
-                        }
+                        handleClientConnection(server.accept())
                     } catch (e: java.net.SocketTimeoutException) {
                         // Expected timeout, continue
                     } catch (e: Exception) {
@@ -498,6 +515,8 @@ class WifiDirectManager(
                 emitDiagnostic("error", "Failed to start server socket", mapOf(
                     "error" to (e.message ?: "unknown")
                 ))
+            } finally {
+                try { server?.close() } catch (_: Exception) {}
             }
         }
     }

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -133,6 +133,13 @@ class WifiDirectManager(
     private var groupOwnerAddress: String? = null
     private var transportStartAt: Long = 0L
 
+    // True while a budget-spent drain pass has queued its own continuation.
+    // Confined to the transport thread — [drainAndSendMessages] and the block
+    // in [onMessagesAvailable] are its only reader and writer, and both run
+    // there — so a plain Boolean is enough; @Volatile would advertise a
+    // cross-thread access that must not exist.
+    private var drainContinuationQueued = false
+
     // Message polling
     private val messagePollingRunnable = object : Runnable {
         override fun run() {
@@ -628,7 +635,17 @@ class WifiDirectManager(
      * This is the primary send path, replacing the 100ms polling loop.
      */
     fun onMessagesAvailable() {
-        transportHandler.post { drainAndSendMessages() }
+        transportHandler.post {
+            // A pass that spent its budget has already queued a continuation,
+            // and that continuation drains whatever this callback is
+            // announcing. Without the check, every callback arriving against a
+            // deep queue starts its own self-reposting chain of
+            // [MAX_DRAIN_BATCH] mutex acquisitions apiece — several budgets
+            // running concurrently, which is precisely the looper starvation
+            // the budget exists to prevent.
+            if (drainContinuationQueued) return@post
+            drainAndSendMessages()
+        }
     }
 
     /**
@@ -650,8 +667,21 @@ class WifiDirectManager(
      * fairness budget rather than a correctness one: a queue deeper than
      * [MAX_DRAIN_BATCH] finishes on the next posted pass, after everything
      * else sharing this looper has had its turn.
+     *
+     * There is at most one such chain at a time — [drainContinuationQueued] is
+     * what makes the budget mean anything, since N concurrent chains spend N
+     * budgets between the framework callbacks they were meant to make room for.
      */
     private fun drainAndSendMessages() {
+        // Reached the front of the queue, so whatever continuation was pending
+        // is this one. Cleared here rather than at each exit so that every way
+        // out leaves it false — the stopped-transport return, the drained
+        // return, a throwing send — and only the one path that actually queues
+        // a successor sets it again. A chain that ends because the transport
+        // stopped must not leave the flag suppressing the callbacks that the
+        // next start() delivers.
+        drainContinuationQueued = false
+
         if (state != TransportState.RUNNING || connectedPeers.isEmpty()) return
 
         try {
@@ -663,6 +693,7 @@ class WifiDirectManager(
             }
             // Budget spent with the queue still non-empty: yield the looper and
             // come back, rather than starving the callbacks that share it.
+            drainContinuationQueued = true
             transportHandler.post { drainAndSendMessages() }
         } catch (e: Exception) {
             emitDiagnostic("error", "Error in drainAndSendMessages", mapOf(

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/TransportConfinementTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/TransportConfinementTest.kt
@@ -2,6 +2,7 @@ package com.offlineprotocol
 
 import android.os.HandlerThread
 import android.os.Looper
+import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import org.junit.After
@@ -14,6 +15,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 
 /**
@@ -192,6 +194,88 @@ class TransportConfinementTest {
             fail("expected the off-thread caller to be rejected")
         } catch (e: IllegalStateException) {
             assertTrue(e.message!!.contains("state mutation"))
+        }
+    }
+
+    /**
+     * The hazard `ReticulumManager`'s poll lifecycle posts around, and the
+     * reason it hops onto the IO thread instead of reaching across from the
+     * lifecycle one.
+     *
+     * A self-reposting runnable is not in the queue while it is running, so a
+     * `removeCallbacks` issued from another thread finds nothing to remove and
+     * the repost that follows it survives — a `pause()` that leaves the
+     * transport polling for the whole background stay. Posting the removal
+     * onto the runnable's own thread queues it behind that repost, which is
+     * what actually stops the loop.
+     *
+     * Both halves run against a runnable held mid-flight on purpose, so the
+     * window is the test's rather than the scheduler's. The repost is delayed
+     * because that is what the real one is (a 5s poll interval), and the delay
+     * is load-bearing: a cancel already sitting in the queue is due *now* and
+     * therefore runs first, which is the whole reason posting it works. It
+     * also means the clock has to be driven by hand — Robolectric freezes
+     * `SystemClock`, and under a frozen clock the repost never comes due and
+     * "did not run again" would pass without proving anything.
+     */
+    @Test
+    fun `cancelling a self-reposting runnable requires posting to its own thread`() {
+        val repostDelayMs = 50L
+
+        for (postTheCancel in listOf(false, true)) {
+            val io = confinement(name = "test-io-$postTheCancel")
+            val entered = CountDownLatch(1)
+            val release = CountDownLatch(1)
+            val reposted = CountDownLatch(1)
+            val ranAgain = CountDownLatch(1)
+            var first = true
+
+            val poll = object : Runnable {
+                override fun run() {
+                    if (!first) {
+                        ranAgain.countDown()
+                        return
+                    }
+                    first = false
+                    entered.countDown()
+                    release.await()
+                    // The repost is what a cancel has to beat.
+                    io.handler.postDelayed(this, repostDelayMs)
+                    reposted.countDown()
+                }
+            }
+
+            io.handler.post(poll)
+            assertTrue("poll never started", entered.await(2, TimeUnit.SECONDS))
+
+            if (postTheCancel) {
+                io.post { io.handler.removeCallbacks(poll) }
+            } else {
+                io.handler.removeCallbacks(poll)
+            }
+
+            // Let the runnable finish and re-arm before advancing time, so the
+            // repost is scheduled against the pre-advance clock rather than
+            // racing past it.
+            release.countDown()
+            assertTrue("poll never re-armed", reposted.await(2, TimeUnit.SECONDS))
+            shadowOf(io.looper).idleFor(Duration.ofMillis(repostDelayMs * 4))
+
+            if (postTheCancel) {
+                assertEquals(
+                    "a cancel posted to the runnable's own thread must land behind the " +
+                        "repost and remove it",
+                    1L,
+                    ranAgain.count,
+                )
+            } else {
+                assertEquals(
+                    "a cross-thread cancel cannot stop a runnable that is mid-flight — if " +
+                        "this ever stops holding, the posted form is no longer needed",
+                    0L,
+                    ranAgain.count,
+                )
+            }
         }
     }
 

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/TransportConfinementTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/TransportConfinementTest.kt
@@ -1,0 +1,207 @@
+package com.offlineprotocol
+
+import android.os.HandlerThread
+import android.os.Looper
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the properties the transport managers took from the main looper and now
+ * take from here: ordered one-at-a-time execution, and a wait that cannot turn
+ * a contended protocol mutex into an ANR.
+ *
+ * The timeout asymmetry is the part worth pinning. A flat bound for every
+ * caller — what Nostr and Reticulum used to have — fails a background `stop()`
+ * exactly when the mutex is most contended, leaving a transport half-down; no
+ * bound at all — what Internet used to have — parks the main thread behind that
+ * same mutex, which is OFF-2123 itself. Only main is bounded, and the test
+ * drives both halves against a thread that is deliberately blocked.
+ *
+ * Runs on real (unpaused) loopers: the contract under test is about threads
+ * actually racing, which a paused Robolectric looper cannot express.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class TransportConfinementTest {
+
+    private val threads = mutableListOf<HandlerThread>()
+
+    @After
+    fun tearDown() {
+        threads.forEach { it.quitSafely() }
+        threads.clear()
+    }
+
+    private fun confinement(
+        name: String = "test-confinement",
+        mainSyncTimeoutMs: Long = 120L,
+    ): TransportConfinement {
+        val thread = HandlerThread(name).apply { start() }
+        threads += thread
+        return TransportConfinement(name, thread.looper, mainSyncTimeoutMs)
+    }
+
+    /** Occupies the confinement thread until the returned latch is counted down. */
+    private fun block(confinement: TransportConfinement): CountDownLatch {
+        val release = CountDownLatch(1)
+        val blocking = CountDownLatch(1)
+        confinement.post {
+            blocking.countDown()
+            release.await()
+        }
+        assertTrue("blocker never started", blocking.await(2, TimeUnit.SECONDS))
+        return release
+    }
+
+    @Test
+    fun `posted actions run on the confinement thread in order`() {
+        val confinement = confinement()
+        val seen = mutableListOf<Int>()
+        val threadNames = mutableListOf<String>()
+        val done = CountDownLatch(3)
+
+        repeat(3) { i ->
+            confinement.post {
+                seen += i
+                threadNames += Thread.currentThread().name
+                done.countDown()
+            }
+        }
+
+        assertTrue(done.await(2, TimeUnit.SECONDS))
+        assertEquals(listOf(0, 1, 2), seen)
+        assertTrue(threadNames.all { it == "test-confinement" })
+    }
+
+    @Test
+    fun `runSync on the confinement thread runs inline without re-posting`() {
+        val confinement = confinement()
+
+        // Nesting is the case that would deadlock if the fast path were missing:
+        // the outer runSync owns the thread the inner one would wait for.
+        val result = confinement.runSync {
+            assertTrue(confinement.isCurrent())
+            confinement.runSync { "inner" }
+        }
+
+        assertEquals("inner", result)
+    }
+
+    @Test
+    fun `runSync returns the value and rethrows the failure of its action`() {
+        val confinement = confinement()
+
+        assertEquals(7, confinement.runSync { 7 })
+
+        val boom = IllegalStateException("boom")
+        try {
+            confinement.runSync { throw boom }
+            fail("expected the action's exception to propagate")
+        } catch (e: IllegalStateException) {
+            assertSame(boom, e)
+        }
+    }
+
+    @Test
+    fun `a main-thread caller gives up rather than parking behind a busy transport`() {
+        val confinement = confinement(mainSyncTimeoutMs = 120L)
+        val release = block(confinement)
+
+        try {
+            assertSame(Looper.getMainLooper(), Looper.myLooper())
+            val startedAt = System.nanoTime()
+            try {
+                confinement.runSync { "never observed" }
+                fail("expected MainThreadSyncTimeout")
+            } catch (e: TransportConfinement.MainThreadSyncTimeout) {
+                val waitedMs = (System.nanoTime() - startedAt) / 1_000_000
+                assertTrue("gave up too early: ${waitedMs}ms", waitedMs >= 100)
+                assertTrue("waited far past the bound: ${waitedMs}ms", waitedMs < 2_000)
+            }
+        } finally {
+            release.countDown()
+        }
+    }
+
+    @Test
+    fun `the timed-out action still runs, it is only no longer awaited`() {
+        val confinement = confinement(mainSyncTimeoutMs = 80L)
+        val release = block(confinement)
+        val ran = CountDownLatch(1)
+
+        try {
+            confinement.runSync { ran.countDown() }
+            fail("expected MainThreadSyncTimeout")
+        } catch (e: TransportConfinement.MainThreadSyncTimeout) {
+            // Expected: main stopped waiting.
+        }
+
+        assertEquals("action must not have run while the thread was blocked", 1L, ran.count)
+        release.countDown()
+        assertTrue("abandoned action never completed", ran.await(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun `a background caller waits as long as it takes`() {
+        val confinement = confinement(mainSyncTimeoutMs = 80L)
+        val release = block(confinement)
+        val outcome = arrayOfNulls<Any>(1)
+        val finished = CountDownLatch(1)
+
+        val caller = Thread {
+            outcome[0] = try {
+                confinement.runSync { "delivered" }
+            } catch (t: Throwable) {
+                t
+            }
+            finished.countDown()
+        }
+        caller.start()
+
+        // Well past the main-thread bound: a background caller must not be
+        // subject to it. This is the `stop()` that has to actually finish.
+        assertFalse(
+            "background caller was cut off at the main bound",
+            finished.await(400, TimeUnit.MILLISECONDS),
+        )
+
+        release.countDown()
+        assertTrue(finished.await(2, TimeUnit.SECONDS))
+        assertEquals("delivered", outcome[0])
+    }
+
+    @Test
+    fun `assertConfined accepts the confinement thread and rejects every other`() {
+        val confinement = confinement()
+
+        confinement.runSync { confinement.assertConfined("state mutation") }
+
+        try {
+            confinement.assertConfined("state mutation")
+            fail("expected the off-thread caller to be rejected")
+        } catch (e: IllegalStateException) {
+            assertTrue(e.message!!.contains("state mutation"))
+        }
+    }
+
+    @Test
+    fun `a shared confinement is reused by name so a rebuilt manager keeps one queue`() {
+        val first = TransportConfinement.shared("offline-test-shared")
+        val second = TransportConfinement.shared("offline-test-shared")
+
+        assertSame(first, second)
+        assertNotEquals(Looper.getMainLooper(), first.looper)
+        assertEquals("delivered", second.runSync { "delivered" })
+    }
+}

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/TransportConfinementTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/TransportConfinementTest.kt
@@ -41,21 +41,24 @@ class TransportConfinementTest {
     private val threads = mutableListOf<HandlerThread>()
 
     /**
-     * Loopers taken from [TransportConfinement.shared], which are process-wide
-     * and never quit — that being the contract the reuse test verifies, so the
-     * test cannot avoid starting one. It can avoid leaving it running for the
-     * rest of the suite, which is all this list is for. Safe because the name
-     * used there belongs to this test alone, so nothing looks the stale entry
-     * up afterwards.
+     * Names taken from [TransportConfinement.shared], which hands out
+     * process-wide threads that never quit — that being the contract the reuse
+     * test verifies, so the test cannot avoid taking one. It can avoid leaving
+     * it running for the rest of the suite, which is what
+     * [TransportConfinement.releaseForTests] is for: it drops the registry
+     * entry *and* quits the thread as one step. Quitting the looper alone would
+     * leave the entry behind, and Robolectric reuses a sandbox — and therefore
+     * those statics — across test classes with the same config, so the next
+     * lookup of that name would get a confinement that accepts nothing.
      */
-    private val sharedLoopers = mutableListOf<Looper>()
+    private val sharedNames = mutableListOf<String>()
 
     @After
     fun tearDown() {
         threads.forEach { it.quitSafely() }
         threads.clear()
-        sharedLoopers.forEach { it.quitSafely() }
-        sharedLoopers.clear()
+        sharedNames.forEach { TransportConfinement.releaseForTests(it) }
+        sharedNames.clear()
     }
 
     private fun confinement(
@@ -336,9 +339,9 @@ class TransportConfinementTest {
 
     @Test
     fun `a shared confinement is reused by name so a rebuilt manager keeps one queue`() {
+        sharedNames += "offline-test-shared"
         val first = TransportConfinement.shared("offline-test-shared")
         val second = TransportConfinement.shared("offline-test-shared")
-        sharedLoopers += first.looper
 
         assertSame(first, second)
         assertNotEquals(Looper.getMainLooper(), first.looper)

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/TransportConfinementTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/TransportConfinementTest.kt
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
 
 /**
  * Pins the properties the transport managers took from the main looper and now
@@ -39,10 +40,22 @@ class TransportConfinementTest {
 
     private val threads = mutableListOf<HandlerThread>()
 
+    /**
+     * Loopers taken from [TransportConfinement.shared], which are process-wide
+     * and never quit — that being the contract the reuse test verifies, so the
+     * test cannot avoid starting one. It can avoid leaving it running for the
+     * rest of the suite, which is all this list is for. Safe because the name
+     * used there belongs to this test alone, so nothing looks the stale entry
+     * up afterwards.
+     */
+    private val sharedLoopers = mutableListOf<Looper>()
+
     @After
     fun tearDown() {
         threads.forEach { it.quitSafely() }
         threads.clear()
+        sharedLoopers.forEach { it.quitSafely() }
+        sharedLoopers.clear()
     }
 
     private fun confinement(
@@ -154,6 +167,39 @@ class TransportConfinementTest {
         assertTrue("abandoned action never completed", ran.await(2, TimeUnit.SECONDS))
     }
 
+    /**
+     * An abandoned action still runs, and if it throws there is no longer
+     * anyone positioned to see that: nothing reads the outcome and the caller
+     * already has its [TransportConfinement.MainThreadSyncTimeout]. A `start()`
+     * refused for a real reason would otherwise be indistinguishable from a
+     * slow one, which is the diagnosis this thread exists to make possible.
+     */
+    @Test
+    fun `a failure the main caller stopped waiting for is still reported`() {
+        val confinement = confinement(mainSyncTimeoutMs = 80L)
+        val release = block(confinement)
+        ShadowLog.clear()
+
+        try {
+            confinement.runSync<Unit> { throw IllegalStateException("refused-after-timeout") }
+            fail("expected MainThreadSyncTimeout")
+        } catch (e: TransportConfinement.MainThreadSyncTimeout) {
+            // Expected: main stopped waiting.
+        }
+
+        // The report is posted behind the action on this same thread, so a
+        // marker behind both is enough to know it has run — no polling.
+        val reported = CountDownLatch(1)
+        confinement.post { reported.countDown() }
+        release.countDown()
+        assertTrue("the queue never drained", reported.await(2, TimeUnit.SECONDS))
+
+        assertTrue(
+            "the abandoned action's failure was dropped",
+            ShadowLog.getLogs().any { it.throwable?.message == "refused-after-timeout" },
+        )
+    }
+
     @Test
     fun `a background caller waits as long as it takes`() {
         val confinement = confinement(mainSyncTimeoutMs = 80L)
@@ -183,17 +229,26 @@ class TransportConfinementTest {
         assertEquals("delivered", outcome[0])
     }
 
+    /**
+     * A quit looper accepts nothing, and the background wait has no bound to
+     * rescue it: without the post check the caller — the React Native
+     * native-modules thread, on the stop path — parks for the life of the
+     * process. Threads from [TransportConfinement.shared] never quit, so this
+     * is unreachable through the shipped entry point; it is reachable through
+     * the constructor, which is what this drives.
+     */
     @Test
-    fun `assertConfined accepts the confinement thread and rejects every other`() {
-        val confinement = confinement()
-
-        confinement.runSync { confinement.assertConfined("state mutation") }
+    fun `runSync fails loudly rather than parking forever on a quit looper`() {
+        val thread = HandlerThread("test-quit").apply { start() }
+        val confinement = TransportConfinement("test-quit", thread.looper)
+        thread.quitSafely()
+        thread.join(2_000)
 
         try {
-            confinement.assertConfined("state mutation")
-            fail("expected the off-thread caller to be rejected")
+            confinement.runSync { "never reached" }
+            fail("expected a quit looper to be reported, not waited on")
         } catch (e: IllegalStateException) {
-            assertTrue(e.message!!.contains("state mutation"))
+            assertTrue(e.message!!.contains("test-quit"))
         }
     }
 
@@ -283,6 +338,7 @@ class TransportConfinementTest {
     fun `a shared confinement is reused by name so a rebuilt manager keeps one queue`() {
         val first = TransportConfinement.shared("offline-test-shared")
         val second = TransportConfinement.shared("offline-test-shared")
+        sharedLoopers += first.looper
 
         assertSame(first, second)
         assertNotEquals(Looper.getMainLooper(), first.looper)

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -451,8 +451,21 @@ public class NostrManager: NSObject, TransportManager {
                     return
                 }
 
+                // `isConnected` alongside the state, mirroring
+                // `ReticulumManager` — see the long note there for why a state
+                // check alone is the wrong question. It is defence in depth
+                // here rather than a fix: both of this manager's flips reach
+                // `messageQueue` through a single hop from
+                // [updateConnectionStatus], so they are already ordered by the
+                // relay events that produced them. What it does close is the
+                // check-then-act above it — `wasConnected` is read and
+                // `isConnected` written under two separate [stateLock]
+                // acquisitions, so two relays transitioning at once can enqueue
+                // this block with no relay left connected. Announcing a relay
+                // set that is empty by the time anyone looks is the same lie
+                // the Reticulum window tells, reached from a different side.
                 self.statusFlipLock.lock()
-                if self.state != .stopping && self.state != .stopped {
+                if self.isConnected && self.state != .stopping && self.state != .stopped {
                     try? self.protocolInstance.nostrStatusChanged(isConnected: true)
                 }
                 self.statusFlipLock.unlock()

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -412,6 +412,21 @@ public class NostrManager: NSObject, TransportManager {
         if anyConnected && !wasConnected {
             messageQueue.async { [weak self] in
                 guard let self = self else { return }
+
+                // A stop() that landed while this relay's handshake was still
+                // in flight has already told the core we are down and moved to
+                // .stopped. Announcing the connection now would put the state
+                // back to .running and the core back to connected, against a
+                // transport nothing will ever tear down again — and the next
+                // start() would throw .alreadyRunning off it. The relay socket
+                // is stray, so close it here. The Android manager gates the
+                // same edge the same way; both are pinned in the uniffi source
+                // guards.
+                guard self.state != .stopping, self.state != .stopped else {
+                    self.disconnectAll(fromDeinit: false)
+                    return
+                }
+
                 self.updateState(.running)
                 try? self.protocolInstance.nostrStatusChanged(isConnected: true)
                 self.consecutiveSendFailures = 0

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -57,6 +57,20 @@ public class NostrManager: NSObject, TransportManager {
     // Lock protecting mutable state accessed from multiple queues
     private let stateLock = NSLock()
 
+    /// Orders the two `nostrStatusChanged` call sites that nothing else
+    /// orders: the connected edge, which runs on [messageQueue], and `stop()`,
+    /// which runs inline on whatever thread tore the transport down.
+    ///
+    /// Same reasoning as `ReticulumManager.statusFlipLock`, which carries the
+    /// full argument — these two managers are mirrors of each other and the
+    /// window is the same one. It is narrower here, because this edge's check
+    /// and its flip sit in one [messageQueue] block rather than a hop apart,
+    /// but "narrower" is not "closed": the check and the call are still two
+    /// steps, and `stop()` runs on another thread between them for free.
+    /// `stop()` publishes `.stopping` before contending for this lock, which
+    /// is what makes taking it sufficient.
+    private let statusFlipLock = NSLock()
+
     // Reconnection (guarded by stateLock)
     private var _reconnectAttempts: [String: Int] = [:]
     private var _currentReconnectDelay: [String: TimeInterval] = [:]
@@ -265,8 +279,14 @@ public class NostrManager: NSObject, TransportManager {
         // Close all relay connections
         disconnectAll(fromDeinit: fromDeinit)
 
-        // Notify protocol
+        // Notify protocol. Under [statusFlipLock], and after `.stopping` is
+        // already published above — see `ReticulumManager.stop()` for the
+        // ordering argument. Inline rather than hopped onto messageQueue:
+        // `deinit` reaches here, and a `sync` hop would self-deadlock when the
+        // last reference is released on that queue.
+        statusFlipLock.lock()
         try? protocolInstance.nostrStatusChanged(isConnected: false)
+        statusFlipLock.unlock()
 
         updateState(.stopped)
         emitDiagnostic("info", "Nostr transport stopped")
@@ -422,13 +442,20 @@ public class NostrManager: NSObject, TransportManager {
                 // is stray, so close it here. The Android manager gates the
                 // same edge the same way; both are pinned in the uniffi source
                 // guards.
-                guard self.state != .stopping, self.state != .stopped else {
+                //
+                // The claim covers the state write; the flip below carries its
+                // own check under [statusFlipLock], because `stop()` runs its
+                // own flip on another thread and nothing else orders the two.
+                guard self.markRunningIfLive() else {
                     self.disconnectAll(fromDeinit: false)
                     return
                 }
 
-                self.updateState(.running)
-                try? self.protocolInstance.nostrStatusChanged(isConnected: true)
+                self.statusFlipLock.lock()
+                if self.state != .stopping && self.state != .stopped {
+                    try? self.protocolInstance.nostrStatusChanged(isConnected: true)
+                }
+                self.statusFlipLock.unlock()
                 self.consecutiveSendFailures = 0
                 self.startMessagePolling()
                 self.startPingTimer()
@@ -989,6 +1016,27 @@ public class NostrManager: NSObject, TransportManager {
     private func updateState(_ newState: TransportState) {
         state = newState
         delegate?.transportManager(self, didChangeState: newState)
+    }
+
+    /// Claims `.running` for a relay that has just come up, but only if the
+    /// transport has not begun stopping. Returns false when it has, so the
+    /// caller can close the connection it opened instead of publishing a state
+    /// a concurrent `stop()` has already moved past.
+    ///
+    /// One operation rather than a `guard` followed by an `updateState`, for
+    /// the reason spelled out on `ReticulumManager.markRunningIfLive`: those
+    /// are two separate [stateLock] acquisitions, and a `stop()` landing
+    /// between them leaves a torn-down transport wedged at `.running`.
+    private func markRunningIfLive() -> Bool {
+        stateLock.lock()
+        guard _state != .stopping, _state != .stopped else {
+            stateLock.unlock()
+            return false
+        }
+        _state = .running
+        stateLock.unlock()
+        delegate?.transportManager(self, didChangeState: .running)
+        return true
     }
 
     // MARK: - Diagnostics

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -422,12 +422,29 @@ public class NostrManager: NSObject, TransportManager {
     }
 
     private func updateConnectionStatus() {
-        let anyConnected: Bool = connectionQueue.sync {
-            relayConnected.values.contains(true)
+        // Sampled and published as one step, inside the queue that owns the
+        // map. Read and swapped separately — as these were, across three
+        // separate critical sections — two relays transitioning at once can
+        // interleave so that the *later* swap publishes the *earlier* reader's
+        // answer. A relay connects and this reads `anyConnected = true`, then
+        // is descheduled; the same relay drops, and that call reads false,
+        // swaps false→false and sees `wasConnected = false`, so neither edge
+        // fires; the first resumes and swaps false→true with `wasConnected =
+        // false`, firing the connected edge against a relay set that is empty.
+        //
+        // `stateLock` nests inside `connectionQueue` here and only here. That
+        // is safe because the ordering is one-directional: every `stateLock`
+        // holder in this file releases it across a single field access and
+        // never hops a queue, so nothing ever waits on `connectionQueue` while
+        // holding it.
+        let (anyConnected, wasConnected): (Bool, Bool) = connectionQueue.sync {
+            let any = relayConnected.values.contains(true)
+            stateLock.lock()
+            let was = _isConnected
+            _isConnected = any
+            stateLock.unlock()
+            return (any, was)
         }
-
-        let wasConnected = isConnected
-        isConnected = anyConnected
 
         if anyConnected && !wasConnected {
             messageQueue.async { [weak self] in
@@ -453,17 +470,20 @@ public class NostrManager: NSObject, TransportManager {
 
                 // `isConnected` alongside the state, mirroring
                 // `ReticulumManager` — see the long note there for why a state
-                // check alone is the wrong question. It is defence in depth
-                // here rather than a fix: both of this manager's flips reach
-                // `messageQueue` through a single hop from
-                // [updateConnectionStatus], so they are already ordered by the
-                // relay events that produced them. What it does close is the
-                // check-then-act above it — `wasConnected` is read and
-                // `isConnected` written under two separate [stateLock]
-                // acquisitions, so two relays transitioning at once can enqueue
-                // this block with no relay left connected. Announcing a relay
-                // set that is empty by the time anyone looks is the same lie
-                // the Reticulum window tells, reached from a different side.
+                // check alone is the wrong question.
+                //
+                // It answers a narrower question here than it does there, and
+                // it is worth being exact about which. It does *not* rescue the
+                // check-then-act in [updateConnectionStatus]: this reads the
+                // very value that call published, so a torn swap would be read
+                // back as true and announced anyway. That hole is closed at the
+                // swap itself, which is now one step under `connectionQueue`.
+                // What this term covers is the interval *after* a sound swap —
+                // the last relay dropping between the edge being enqueued and
+                // this block reaching the front of `messageQueue`. Suppressing
+                // the stale true costs nothing: the disconnect that cleared the
+                // flag enqueues its own false behind this, and a reconnect
+                // announces itself.
                 self.statusFlipLock.lock()
                 if self.isConnected && self.state != .stopping && self.state != .stopped {
                     try? self.protocolInstance.nostrStatusChanged(isConnected: true)

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -1166,6 +1166,10 @@ class OfflineProtocolModule: RCTEventEmitter {
         print("[OfflineProtocolModule] Internet Manager stopped")
         emitDiagnostic(level: "info", message: "Internet manager stopped")
 
+        // Stop Wi-Fi Direct manager
+        wifiDirectManager?.stop()
+        emitDiagnostic(level: "info", message: "WiFi Direct manager stopped")
+
         // Stop Reticulum manager
         reticulumManager?.stop()
         print("[OfflineProtocolModule] Reticulum Manager stopped")
@@ -1678,6 +1682,11 @@ class OfflineProtocolModule: RCTEventEmitter {
         bleManager = nil
         internetManager?.stop()
         internetManager = nil
+        // Wi-Fi Direct was missing here and in stop(): only deinit stopped it,
+        // so a destroyed module could leave a live drain path holding the
+        // protocol instance it was told to release.
+        wifiDirectManager?.stop()
+        wifiDirectManager = nil
         reticulumManager?.stop()
         reticulumManager = nil
         nostrManager?.stop()
@@ -4318,7 +4327,17 @@ class OfflineProtocolModule: RCTEventEmitter {
     /// bridge — the tick itself is short, and the timeout is far longer than one
     /// takes. Safe from any other queue: `destroy` runs on the bridge queue,
     /// never on `processQueue`.
+    ///
+    /// That last sentence is the load-bearing one, so it is enforced rather
+    /// than assumed. This blocks the caller for up to two seconds behind a
+    /// queue whose handler is `process()` plus a `receiveMessage()` drain —
+    /// both of which take the core's global protocol mutex. On the bridge
+    /// queue that is a stall; on main it is an App Hang of exactly the kind
+    /// this bridge keeps having to remove. The precondition costs nothing in
+    /// release builds and turns a future `destroy` reached from main into a
+    /// debug crash instead of a shipped hang.
     private func drainProcessQueue() {
+        dispatchPrecondition(condition: .notOnQueue(.main))
         let drained = DispatchSemaphore(value: 0)
         processQueue.async { drained.signal() }
         _ = drained.wait(timeout: .now() + 2.0)

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -4328,16 +4328,24 @@ class OfflineProtocolModule: RCTEventEmitter {
     /// takes. Safe from any other queue: `destroy` runs on the bridge queue,
     /// never on `processQueue`.
     ///
-    /// That last sentence is the load-bearing one, so it is enforced rather
+    /// That last sentence is the load-bearing one, so it is checked rather
     /// than assumed. This blocks the caller for up to two seconds behind a
     /// queue whose handler is `process()` plus a `receiveMessage()` drain —
     /// both of which take the core's global protocol mutex. On the bridge
     /// queue that is a stall; on main it is an App Hang of exactly the kind
-    /// this bridge keeps having to remove. The precondition costs nothing in
-    /// release builds and turns a future `destroy` reached from main into a
-    /// debug crash instead of a shipped hang.
+    /// this bridge keeps having to remove.
+    ///
+    /// Debug-only deliberately. `dispatchPrecondition` is `precondition`,
+    /// which traps under `-O` as well as `-Onone` — only `-Ounchecked` elides
+    /// it, and React Native's Release configuration is `-O`. Left unguarded it
+    /// would turn a `destroy` that ever reached main into a hard crash in a
+    /// shipped app: a two-second stall traded for the teardown abort class
+    /// this bridge has already shipped once. The check belongs where it fails
+    /// the developer who introduces the call, not the user.
     private func drainProcessQueue() {
+        #if DEBUG
         dispatchPrecondition(condition: .notOnQueue(.main))
+        #endif
         let drained = DispatchSemaphore(value: 0)
         processQueue.async { drained.signal() }
         _ = drained.wait(timeout: .now() + 2.0)

--- a/bindings/react-native/ios/ReticulumManager.swift
+++ b/bindings/react-native/ios/ReticulumManager.swift
@@ -292,10 +292,23 @@ public class ReticulumManager: NSObject, TransportManager {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.updateState(.running)
-            try? self.protocolInstance.reticulumStatusChanged(isConnected: true)
             self.startMessagePolling()
-            // Immediately flush queued messages
+            // The status flip is a UniFFI call and does not belong on main:
+            // it takes the global protocol mutex, and on the false→true edge
+            // takes it a second time to flush the entire outbox. That is the
+            // heaviest call this manager makes, at the cadence of a daemon
+            // that keeps reconnecting — the same work InternetManager already
+            // refuses to do on main (see its handleAuthenticated hop), and
+            // the scene-update watchdog does not care that the wait is the
+            // core's fault. messageQueue is where every other FFI call in
+            // this file runs.
+            //
+            // Enqueued from inside the main block on purpose: it puts the
+            // status flip ahead of the flush below on the same serial queue,
+            // preserving the ordering this block already had.
             self.messageQueue.async {
+                try? self.protocolInstance.reticulumStatusChanged(isConnected: true)
+                // Immediately flush queued messages
                 self.pollAndSendMessages()
             }
         }
@@ -355,12 +368,13 @@ public class ReticulumManager: NSObject, TransportManager {
             "wasConnected": wasConnected
         ])
 
-        // Notify protocol and handle reconnection on main thread,
-        // consistent with handleConnectionOpened which also dispatches to main.
-        DispatchQueue.main.async { [weak self] in
+        // Notify the protocol off main, and handle reconnection on main —
+        // consistent with handleConnectionOpened, which splits the same way.
+        // The status flip is a UniFFI call, so it waits on the global protocol
+        // mutex; the reconnect scheduling is timer and state work that the
+        // rest of this manager already drives from main.
+        messageQueue.async { [weak self] in
             guard let self = self else { return }
-
-            // Notify protocol
             do {
                 try self.protocolInstance.reticulumStatusChanged(isConnected: false)
             } catch {
@@ -368,6 +382,10 @@ public class ReticulumManager: NSObject, TransportManager {
                     "error": error.localizedDescription
                 ])
             }
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
 
             // Attempt reconnection if enabled
             if self.autoReconnect && self.state != .stopping && self.state != .stopped {

--- a/bindings/react-native/ios/ReticulumManager.swift
+++ b/bindings/react-native/ios/ReticulumManager.swift
@@ -373,6 +373,12 @@ public class ReticulumManager: NSObject, TransportManager {
         // The status flip is a UniFFI call, so it waits on the global protocol
         // mutex; the reconnect scheduling is timer and state work that the
         // rest of this manager already drives from main.
+        //
+        // The two now run concurrently, where one block ran them in order. The
+        // ordering that mattered survives anyway: `messageQueue` is serial, so
+        // this false always reaches the core ahead of the true a successful
+        // reconnect enqueues, and the reconnect cannot land inside this call
+        // regardless — its shortest delay is a full second.
         messageQueue.async { [weak self] in
             guard let self = self else { return }
             do {

--- a/bindings/react-native/ios/ReticulumManager.swift
+++ b/bindings/react-native/ios/ReticulumManager.swift
@@ -291,6 +291,24 @@ public class ReticulumManager: NSObject, TransportManager {
         // so that any protocol handler querying transport state sees the correct value.
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
+
+            // A stop() that landed while this connection was still being
+            // established has already told the core we are down and moved to
+            // .stopped. Announcing the connection now would put the state back
+            // to .running and the core back to connected, against a transport
+            // nothing will ever tear down again — and the next start() would
+            // throw .alreadyRunning off it. The connection this opened is
+            // stray, so close it here. The Android manager gates the same edge
+            // the same way; both are pinned in the uniffi source guards.
+            //
+            // Deliberately ahead of the messageQueue hop below rather than
+            // inside it: the hop adds a second scheduling boundary, so a gate
+            // that ran after it would widen the window it exists to close.
+            guard self.state != .stopping, self.state != .stopped else {
+                self.disconnect()
+                return
+            }
+
             self.updateState(.running)
             self.startMessagePolling()
             // The status flip is a UniFFI call and does not belong on main:

--- a/bindings/react-native/ios/ReticulumManager.swift
+++ b/bindings/react-native/ios/ReticulumManager.swift
@@ -374,13 +374,32 @@ public class ReticulumManager: NSObject, TransportManager {
             // enough. Unlocked explicitly rather than by `defer`, which would
             // hold it across the flush below.
             //
+            // `isConnected` is the other half of that decision, and it answers
+            // what the state cannot: `stop()` is not the only thing that can
+            // overtake this block. [handleConnectionClosed] reaches
+            // `messageQueue` in ONE hop from `connectionQueue`, while this
+            // `true` takes two — `connectionQueue`, then main, then here — so
+            // a link that opens and dies immediately enqueues its `false`
+            // *ahead* of this `true`. The state says nothing about it: with
+            // `autoReconnect` on, that path leaves `.running` untouched, so
+            // the core would be told "up" about a dead connection and route to
+            // a transport that never drains until the next attempt resolves
+            // the flags. (Before the hop below existed, both flips ran on
+            // main — one queue, so enqueue order was causal. The hop is what
+            // made this reachable, so it is what has to answer for it.)
+            // `isConnected` is cleared before that `false` is enqueued and set
+            // again only by a successful open, so it reads exactly "is there
+            // still a connection to announce". Suppressing a flip can never
+            // lose one: every path that clears it either reconnects, which
+            // announces itself, or stops.
+            //
             // [weak self] like every other closure here: a strong capture
             // would let this flip fire against a manager the module already
             // released through `destroy()`.
             self.messageQueue.async { [weak self] in
                 guard let self = self else { return }
                 self.statusFlipLock.lock()
-                if self.state != .stopping && self.state != .stopped {
+                if self.isConnected && self.state != .stopping && self.state != .stopped {
                     try? self.protocolInstance.reticulumStatusChanged(isConnected: true)
                 }
                 self.statusFlipLock.unlock()

--- a/bindings/react-native/ios/ReticulumManager.swift
+++ b/bindings/react-native/ios/ReticulumManager.swift
@@ -58,6 +58,35 @@ public class ReticulumManager: NSObject, TransportManager {
     // Lock protecting mutable state accessed from multiple queues
     private let stateLock = NSLock()
 
+    /// Orders the two `reticulumStatusChanged` call sites that nothing else
+    /// orders: the connected edge, which runs on [messageQueue], and `stop()`,
+    /// which runs inline on whatever thread tore the transport down.
+    ///
+    /// Without it the connected edge is a check-then-act across two threads.
+    /// It can read a live state, and a `stop()` can then run its whole body —
+    /// including its own `false` — before the `true` it just cleared reaches
+    /// the core. The core is left believing this transport is up moments after
+    /// being told it was down, against a `.stopped` transport with no polling,
+    /// and nothing corrects it: every correcting path is a teardown path that
+    /// already ran. DORS then routes to a transport that will never drain.
+    ///
+    /// What makes the lock sufficient is that `stop()` publishes `.stopping`
+    /// *before* contending for it. Either the announcement takes the lock
+    /// first, and `stop()`'s `false` lands after its `true` — the correct
+    /// final answer — or `stop()` takes it first and the announcement then
+    /// reads a state that refuses it.
+    ///
+    /// Held across a UniFFI call, which nothing else in this file does. That
+    /// is affordable here and only here: the sole contender is the one other
+    /// flip site, so the wait is bounded by a single status call that the
+    /// waiting thread was about to make anyway. It is taken *outside*
+    /// [stateLock] and never the other way round.
+    ///
+    /// Android needs no equivalent. Its gate, its flip and `stopUnsafe` all
+    /// run on the one confinement thread, so they are already atomic against
+    /// each other; this is what that costs on a platform with three queues.
+    private let statusFlipLock = NSLock()
+
     private var reconnectAttempts: Int {
         get { stateLock.lock(); defer { stateLock.unlock() }; return _reconnectAttempts }
         set { stateLock.lock(); defer { stateLock.unlock() }; _reconnectAttempts = newValue }
@@ -179,8 +208,18 @@ public class ReticulumManager: NSObject, TransportManager {
         // Close connection
         disconnect()
 
-        // Notify protocol
+        // Notify protocol. Under [statusFlipLock], and after `.stopping` is
+        // already published above, which is what orders this against a
+        // connected edge racing it from [messageQueue]: that edge either loses
+        // the lock and then reads the state this already moved past, or wins
+        // it and has its `true` overwritten by this `false`. Inline rather
+        // than hopped onto messageQueue — `deinit` calls this, and a `sync`
+        // hop would self-deadlock when the last reference is released on that
+        // queue, while an `async` hop would let `stop()` return before the
+        // core knows.
+        statusFlipLock.lock()
         try? protocolInstance.reticulumStatusChanged(isConnected: false)
+        statusFlipLock.unlock()
 
         updateState(.stopped)
         emitDiagnostic("info", "Reticulum transport stopped")
@@ -301,15 +340,16 @@ public class ReticulumManager: NSObject, TransportManager {
             // stray, so close it here. The Android manager gates the same edge
             // the same way; both are pinned in the uniffi source guards.
             //
-            // Deliberately ahead of the messageQueue hop below rather than
-            // inside it: the hop adds a second scheduling boundary, so a gate
-            // that ran after it would widen the window it exists to close.
-            guard self.state != .stopping, self.state != .stopped else {
+            // This gate covers the state write only. It cannot also cover the
+            // status flip below, which is a queue hop away — that hop is a
+            // second boundary a stop() can land in, and it carries its own
+            // check under [statusFlipLock]. A gate here alone would leave the
+            // wider of the two windows open.
+            guard self.markRunningIfLive() else {
                 self.disconnect()
                 return
             }
 
-            self.updateState(.running)
             self.startMessagePolling()
             // The status flip is a UniFFI call and does not belong on main:
             // it takes the global protocol mutex, and on the false→true edge
@@ -324,8 +364,26 @@ public class ReticulumManager: NSObject, TransportManager {
             // Enqueued from inside the main block on purpose: it puts the
             // status flip ahead of the flush below on the same serial queue,
             // preserving the ordering this block already had.
-            self.messageQueue.async {
-                try? self.protocolInstance.reticulumStatusChanged(isConnected: true)
+            //
+            // The state re-check is not redundant with the gate above. This
+            // block runs a hop later, and `stop()` flips `false` inline on
+            // whichever thread tore the transport down — so between the gate
+            // and here a whole stop can complete, and an unchecked flip would
+            // tell the core "up" after it was told "down". Check and call are
+            // one decision under [statusFlipLock]; see it for why that is
+            // enough. Unlocked explicitly rather than by `defer`, which would
+            // hold it across the flush below.
+            //
+            // [weak self] like every other closure here: a strong capture
+            // would let this flip fire against a manager the module already
+            // released through `destroy()`.
+            self.messageQueue.async { [weak self] in
+                guard let self = self else { return }
+                self.statusFlipLock.lock()
+                if self.state != .stopping && self.state != .stopped {
+                    try? self.protocolInstance.reticulumStatusChanged(isConnected: true)
+                }
+                self.statusFlipLock.unlock()
                 // Immediately flush queued messages
                 self.pollAndSendMessages()
             }
@@ -667,6 +725,32 @@ public class ReticulumManager: NSObject, TransportManager {
     private func updateState(_ newState: TransportState) {
         state = newState
         delegate?.transportManager(self, didChangeState: newState)
+    }
+
+    /// Claims `.running` for a connection that has just come up, but only if
+    /// the transport has not begun stopping. Returns false when it has, so the
+    /// caller can clean up the connection it opened instead of publishing a
+    /// state a concurrent `stop()` has already moved past.
+    ///
+    /// One operation rather than a `guard` followed by an `updateState`,
+    /// because those are two separate [stateLock] acquisitions: a `stop()`
+    /// landing between them writes `.stopped` and this then writes `.running`
+    /// back over it, wedging a torn-down transport at `.running` where the
+    /// next `start()` throws `.alreadyRunning` and nothing else ever tears it
+    /// down. The delegate notification stays outside the lock, matching
+    /// [updateState] — it reaches the bridge module, and calling into that
+    /// while holding this manager's lock would put arbitrary downstream work
+    /// inside the critical section.
+    private func markRunningIfLive() -> Bool {
+        stateLock.lock()
+        guard _state != .stopping, _state != .stopped else {
+            stateLock.unlock()
+            return false
+        }
+        _state = .running
+        stateLock.unlock()
+        delegate?.transportManager(self, didChangeState: .running)
+        return true
     }
 
     // MARK: - Diagnostics

--- a/bindings/react-native/ios/WifiDirectManager.swift
+++ b/bindings/react-native/ios/WifiDirectManager.swift
@@ -261,6 +261,17 @@ public class WifiDirectManager: NSObject, TransportManager {
     }
 
     /// Drains the Rust message queue and sends each message over MultipeerConnectivity.
+    ///
+    /// Unbounded, where the Android manager's mirror of this spends a batch
+    /// budget and reposts. The asymmetry is deliberate: the budget there exists
+    /// because that looper is shared — it also delivers the Wi-Fi P2P framework
+    /// callbacks and the broadcast receiver, and a broadcast that misses its
+    /// dispatch budget is an ANR wherever the receiver runs — and because a
+    /// `stop()` waits on that same thread without a bound. Neither holds here.
+    /// `messageQueue` is this manager's alone, carries no framework callbacks,
+    /// and no lifecycle path waits on it, so a long drain delays nothing but
+    /// the next drain. Add a budget here only if one of those three facts
+    /// changes.
     private func drainAndSendMessages() {
         guard state == .running, hasConnectedPeers else { return }
 

--- a/bindings/react-native/ios/WifiDirectManager.swift
+++ b/bindings/react-native/ios/WifiDirectManager.swift
@@ -65,15 +65,70 @@ public class WifiDirectManager: NSObject, TransportManager {
     private let peerId: MCPeerID
     
     // MultipeerConnectivity components
-    private var session: MCSession?
     private var advertiser: MCNearbyServiceAdvertiser?
     private var browser: MCNearbyServiceBrowser?
-    
+
     // Message sending (event-driven, no polling)
     private let messageQueue = DispatchQueue(label: "com.offlineprotocol.wifidirect.messages")
-    
-    // State tracking
-    private var connectedPeers: [MCPeerID: String] = [:] // MCPeerID -> deviceId
+
+    /// Guards [_session] and [_connectedPeers], which three different threads
+    /// touch: the lifecycle writes them from the bridge queue, the MCSession /
+    /// browser / advertiser delegates from MultipeerConnectivity's own queues,
+    /// and the send path reads them from [messageQueue]. They were plain
+    /// properties, which is the same unsynchronised cross-thread access #338
+    /// removed from BleManager's `peripheralRSSI`.
+    ///
+    /// Held across a dictionary operation and nothing else — never across a
+    /// UniFFI call or an `MCSession.send`. Every accessor below returns a
+    /// snapshot so callers work on values, not on shared storage.
+    private let stateLock = NSLock()
+    private var _session: MCSession?
+    private var _connectedPeers: [MCPeerID: String] = [:] // MCPeerID -> deviceId
+
+    private var session: MCSession? {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _session }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _session = newValue }
+    }
+
+    private var hasConnectedPeers: Bool {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return !_connectedPeers.isEmpty
+    }
+
+    private var connectedPeerCount: Int {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _connectedPeers.count
+    }
+
+    private func deviceId(forPeer peerID: MCPeerID) -> String? {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _connectedPeers[peerID]
+    }
+
+    private func peers(matching recipientId: String) -> [MCPeerID] {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _connectedPeers.filter { $0.value == recipientId }.map { $0.key }
+    }
+
+    private func setPeer(_ peerID: MCPeerID, deviceId: String) {
+        stateLock.lock(); defer { stateLock.unlock() }
+        _connectedPeers[peerID] = deviceId
+    }
+
+    /// Removes [peerID] and returns the device id it was bound to, so the
+    /// caller can branch on "was it there" without a second lock acquisition
+    /// that another thread could interleave.
+    @discardableResult
+    private func removePeer(_ peerID: MCPeerID) -> String? {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _connectedPeers.removeValue(forKey: peerID)
+    }
+
+    private func removeAllPeers() {
+        stateLock.lock(); defer { stateLock.unlock() }
+        _connectedPeers.removeAll()
+    }
+
     private var transportStartAt: Date?
 
     // MARK: - Initialization
@@ -156,7 +211,7 @@ public class WifiDirectManager: NSObject, TransportManager {
         // Disconnect session
         session?.disconnect()
         session = nil
-        connectedPeers.removeAll()
+        removeAllPeers()
         
         // Notify protocol
         try? protocolInstance.wifiDirectStatusChanged(isConnected: false)
@@ -181,16 +236,21 @@ public class WifiDirectManager: NSObject, TransportManager {
     
     /// Called by the Rust transport callback when new outgoing messages are available.
     /// Replaces timer-based `startMessagePolling`.
+    ///
+    /// Goes straight to the drain rather than hopping through main first, as
+    /// the Reticulum and Nostr managers already do. The hop bought nothing:
+    /// the only work it did on main was read `state` and the peer map, both of
+    /// which are now synchronised and readable from anywhere, and it put a
+    /// scheduling dependency on the UI thread into the send path of a
+    /// transport that never touches the UI.
     public func onMessagesAvailable() {
-        DispatchQueue.main.async { [weak self] in
-            self?.drainAndSendMessages()
-        }
+        drainAndSendMessages()
     }
-    
+
     /// Drains the Rust message queue and sends each message over MultipeerConnectivity.
     private func drainAndSendMessages() {
-        guard state == .running, !connectedPeers.isEmpty else { return }
-        
+        guard state == .running, hasConnectedPeers else { return }
+
         messageQueue.async { [weak self] in
             guard let self = self else { return }
             
@@ -207,7 +267,7 @@ public class WifiDirectManager: NSObject, TransportManager {
         }
         
         // Find the peer with matching device ID
-        let targetPeers = connectedPeers.filter { $0.value == recipientId }.map { $0.key }
+        let targetPeers = peers(matching: recipientId)
         
         if targetPeers.isEmpty {
             // Send to all connected peers (broadcast)
@@ -270,7 +330,7 @@ extension WifiDirectManager: MCSessionDelegate {
             switch state {
             case .connected:
                 let peerId = peerID.displayName
-                self.connectedPeers[peerID] = peerId
+                self.setPeer(peerID, deviceId: peerId)
 
                 // NOT announced to the protocol layer — see
                 // `wifiDirectPeerIdIsUnavailable` on the type. `displayName`
@@ -281,9 +341,7 @@ extension WifiDirectManager: MCSessionDelegate {
                 ])
 
             case .notConnected:
-                if let peerId = self.connectedPeers[peerID] {
-                    self.connectedPeers.removeValue(forKey: peerID)
-
+                if let peerId = self.removePeer(peerID) {
                     // No disconnect notification: nothing was announced, so
                     // there is no neighbor for the core to lose.
                     self.emitDiagnostic("info", "Wi-Fi Direct peer disconnected", context: [
@@ -303,7 +361,7 @@ extension WifiDirectManager: MCSessionDelegate {
     }
     
     public func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
-        let senderId = connectedPeers[peerID] ?? peerID.displayName
+        let senderId = deviceId(forPeer: peerID) ?? peerID.displayName
 
         // Dropped, not ingested — see `wifiDirectPeerIdIsUnavailable`.
         // Attributing the frame to an unproven `displayName` would set it as
@@ -341,7 +399,7 @@ extension WifiDirectManager: MCNearbyServiceAdvertiserDelegate {
         ])
         
         // Enforce connection budget: MCSession limit is 8; stay at 7 to avoid daemon overload.
-        let currentCount = session?.connectedPeers.count ?? connectedPeers.count
+        let currentCount = session?.connectedPeers.count ?? connectedPeerCount
         if Self.atConnectionBudgetLimit(connectedCount: currentCount) {
             emitDiagnostic("info", "Rejecting invitation: at connection budget limit", context: [
                 "connectedCount": currentCount,
@@ -377,7 +435,7 @@ extension WifiDirectManager: MCNearbyServiceBrowserDelegate {
         guard session?.connectedPeers.contains(peerID) != true else { return }
         
         // Enforce connection budget: avoid MCSession overflow and connection storms.
-        let currentCount = session?.connectedPeers.count ?? connectedPeers.count
+        let currentCount = session?.connectedPeers.count ?? connectedPeerCount
         guard !Self.atConnectionBudgetLimit(connectedCount: currentCount) else { return }
         
         browser.invitePeer(peerID, to: session!, withContext: nil, timeout: CONNECTION_TIMEOUT)

--- a/bindings/react-native/ios/WifiDirectManager.swift
+++ b/bindings/react-native/ios/WifiDirectManager.swift
@@ -39,7 +39,17 @@ public class WifiDirectManager: NSObject, TransportManager {
     
     public let transportId = "wifi_direct"
     public let transportName = "WiFi Direct (MultipeerConnectivity)"
-    public private(set) var state: TransportState = .unavailable
+    /// Read through [stateLock] like the session and peer map below, because
+    /// it is touched by the same three threads: the lifecycle writes it from
+    /// the bridge queue, and the send path reads it from whichever thread the
+    /// Rust callback arrives on. This is the iOS half of the `@Volatile` the
+    /// Android manager's `state` carries, and it is what makes the claim on
+    /// [onMessagesAvailable] — that the drain's reads are safe from anywhere —
+    /// actually true.
+    public var state: TransportState {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _state
+    }
     public weak var delegate: TransportManagerDelegate?
     
     // MARK: - Constants
@@ -71,19 +81,27 @@ public class WifiDirectManager: NSObject, TransportManager {
     // Message sending (event-driven, no polling)
     private let messageQueue = DispatchQueue(label: "com.offlineprotocol.wifidirect.messages")
 
-    /// Guards [_session] and [_connectedPeers], which three different threads
-    /// touch: the lifecycle writes them from the bridge queue, the MCSession /
-    /// browser / advertiser delegates from MultipeerConnectivity's own queues,
-    /// and the send path reads them from [messageQueue]. They were plain
-    /// properties, which is the same unsynchronised cross-thread access #338
-    /// removed from BleManager's `peripheralRSSI`.
+    /// Guards [_state], [_session] and [_connectedPeers], which three different
+    /// threads touch: the lifecycle writes them from the bridge queue, the
+    /// MCSession / browser / advertiser delegates from MultipeerConnectivity's
+    /// own queues, and the send path reads them from [messageQueue]. They were
+    /// plain properties, which is the same unsynchronised cross-thread access
+    /// #338 removed from BleManager's `peripheralRSSI`.
     ///
-    /// Held across a dictionary operation and nothing else — never across a
-    /// UniFFI call or an `MCSession.send`. Every accessor below returns a
-    /// snapshot so callers work on values, not on shared storage.
+    /// Held across one field read or write and nothing else — never across a
+    /// UniFFI call, an `MCSession.send`, or a delegate callback. Every accessor
+    /// below returns a snapshot so callers work on values, not on shared
+    /// storage. That is also why it can be a plain [NSLock]: no accessor calls
+    /// out, so nothing can re-enter and need recursion.
     private let stateLock = NSLock()
+    private var _state: TransportState = .unavailable
     private var _session: MCSession?
     private var _connectedPeers: [MCPeerID: String] = [:] // MCPeerID -> deviceId
+
+    private func setState(_ newState: TransportState) {
+        stateLock.lock(); defer { stateLock.unlock() }
+        _state = newState
+    }
 
     private var session: MCSession? {
         get { stateLock.lock(); defer { stateLock.unlock() }; return _session }
@@ -93,11 +111,6 @@ public class WifiDirectManager: NSObject, TransportManager {
     private var hasConnectedPeers: Bool {
         stateLock.lock(); defer { stateLock.unlock() }
         return !_connectedPeers.isEmpty
-    }
-
-    private var connectedPeerCount: Int {
-        stateLock.lock(); defer { stateLock.unlock() }
-        return _connectedPeers.count
     }
 
     private func deviceId(forPeer peerID: MCPeerID) -> String? {
@@ -308,7 +321,11 @@ public class WifiDirectManager: NSObject, TransportManager {
     // MARK: - State Management
     
     private func updateState(_ newState: TransportState) {
-        state = newState
+        setState(newState)
+        // Deliberately outside the lock: the delegate is the bridge module,
+        // and calling into it while holding [stateLock] would put arbitrary
+        // downstream work — including UniFFI calls — inside this manager's
+        // critical section.
         delegate?.transportManager(self, didChangeState: newState)
     }
     
@@ -398,8 +415,18 @@ extension WifiDirectManager: MCNearbyServiceAdvertiserDelegate {
             "peerId": peerID.displayName
         ])
         
+        // One snapshot for the whole decision, like `foundPeer` below: reading
+        // `session` again at the accept would let a concurrent stop() hand the
+        // framework a different value than the budget check saw. A stopped
+        // transport has nothing to accept into, so it declines instead of
+        // accepting with a nil session.
+        guard let session = session else {
+            invitationHandler(false, nil)
+            return
+        }
+
         // Enforce connection budget: MCSession limit is 8; stay at 7 to avoid daemon overload.
-        let currentCount = session?.connectedPeers.count ?? connectedPeerCount
+        let currentCount = session.connectedPeers.count
         if Self.atConnectionBudgetLimit(connectedCount: currentCount) {
             emitDiagnostic("info", "Rejecting invitation: at connection budget limit", context: [
                 "connectedCount": currentCount,
@@ -430,15 +457,24 @@ extension WifiDirectManager: MCNearbyServiceBrowserDelegate {
         
         // Don't invite ourselves
         guard peerID != peerId else { return }
-        
+
+        // One snapshot for the whole decision. This read used to happen three
+        // separate times and end in `session!`, so a stop() landing between
+        // the guard and the invite crashed on the force-unwrap — the exact
+        // race the accessors above exist to close, at the one call site that
+        // still reached around them. A nil session means the transport is
+        // down, which is nothing to invite anyone to.
+        guard let session = session else { return }
+
         // Don't invite if already connected
-        guard session?.connectedPeers.contains(peerID) != true else { return }
-        
+        guard !session.connectedPeers.contains(peerID) else { return }
+
         // Enforce connection budget: avoid MCSession overflow and connection storms.
-        let currentCount = session?.connectedPeers.count ?? connectedPeerCount
-        guard !Self.atConnectionBudgetLimit(connectedCount: currentCount) else { return }
-        
-        browser.invitePeer(peerID, to: session!, withContext: nil, timeout: CONNECTION_TIMEOUT)
+        guard !Self.atConnectionBudgetLimit(connectedCount: session.connectedPeers.count) else {
+            return
+        }
+
+        browser.invitePeer(peerID, to: session, withContext: nil, timeout: CONNECTION_TIMEOUT)
     }
     
     public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {

--- a/bindings/react-native/ios/WifiDirectManager.swift
+++ b/bindings/react-native/ios/WifiDirectManager.swift
@@ -272,13 +272,23 @@ public class WifiDirectManager: NSObject, TransportManager {
     /// and no lifecycle path waits on it, so a long drain delays nothing but
     /// the next drain. Add a budget here only if one of those three facts
     /// changes.
+    ///
+    /// Unbounded is not the same as unconditional, though, which is the one
+    /// thing the Android mirror gets for free and this does not. Re-entering
+    /// `drainAndSendMessages` after each batch re-runs its guard; a single
+    /// `while` does not, so the state has to be re-read *inside* the loop. The
+    /// guard below runs before the hop, and a `stop()` landing after it leaves
+    /// every remaining iteration taking the core's global mutex to fetch a
+    /// message that `sendMessage` then drops for want of a session — a warning
+    /// per message, against a transport that is already down.
     private func drainAndSendMessages() {
         guard state == .running, hasConnectedPeers else { return }
 
         messageQueue.async { [weak self] in
             guard let self = self else { return }
-            
-            while let message = self.protocolInstance.wifiDirectGetNextMessage() {
+
+            while self.state == .running,
+                  let message = self.protocolInstance.wifiDirectGetNextMessage() {
                 self.sendMessage(recipientId: message.recipientId, data: Data(message.data))
             }
         }

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10909,6 +10909,47 @@ mod tests {
         }
     }
 
+    /// Nothing that blocks on the network shares the thread `stop()` waits on.
+    ///
+    /// A background caller's `runSync` wait is deliberately unbounded — it is
+    /// the caller that needs the stop to have actually finished. That is safe
+    /// only while every delay on the confinement thread is the protocol mutex,
+    /// which some other thread is always making progress against. Reticulum's
+    /// socket work is not that: `connect` blocks for up to `CONNECTION_TIMEOUT_MS`
+    /// (60s) against an unreachable host, and a TCP write has no timeout at all
+    /// against a daemon that stops reading. Sharing one thread would let either
+    /// park a `stop()` — and the RN bridge thread behind it — so the blocking
+    /// half lives on its own looper.
+    #[test]
+    fn react_native_reticulum_socket_work_is_off_the_lifecycle_thread() {
+        let code =
+            rn_source_code_only("android/src/main/java/com/offlineprotocol/ReticulumManager.kt");
+
+        // Pinned by adjacency, like the iOS status-flip guard below: "an
+        // ioHandler.post appears somewhere" is satisfied by a manager that
+        // still opens its socket on the lifecycle thread and posts something
+        // unrelated elsewhere, which is precisely the regression.
+        for (what, pinned) in [
+            ("the blocking connect", "ioHandler.post { try { val sock = Socket()"),
+            (
+                "the send/poll loop",
+                "private fun startMessagePolling() { stopMessagePolling() \
+                 ioHandler.post(messagePollingRunnable) }",
+            ),
+            (
+                "cancelling the poll",
+                "private fun stopMessagePolling() { ioHandler.removeCallbacks(messagePollingRunnable) }",
+            ),
+        ] {
+            assert!(
+                code.contains(pinned),
+                "{what} must run on ioHandler, not the lifecycle confinement: a stop() waits on \
+                 that thread without a bound, so an unreachable daemon would park it for a \
+                 minute and a wedged one indefinitely. Expected to find:\n  {pinned}"
+            );
+        }
+    }
+
     /// The iOS Reticulum status flips stay off the main thread.
     ///
     /// `reticulum_status_changed` takes the global protocol mutex, and on the

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -11473,6 +11473,28 @@ mod tests {
                  Expected to find:\n  {pinned}"
             );
         }
+
+        // The other half of Wi-Fi Direct's callback: the flag its early return
+        // reads has to be cleared at the *top* of the drain, so that every way
+        // out of a pass — the stopped-transport return, the drained return, a
+        // throwing send — leaves it false, and only the one path that actually
+        // queues a successor sets it again. Moved to the drained return (the
+        // obvious-looking simplification, since that is where the chain
+        // normally ends), a pass that exits because the transport stopped
+        // leaves it stuck true: every subsequent `onMessagesAvailable` returns
+        // early *forever*, and the send path silently degrades to the 2s
+        // fallback poll's one message per tick. Nothing else would fail.
+        let code =
+            rn_source_code_only("android/src/main/java/com/offlineprotocol/WifiDirectManager.kt");
+        let pinned = "private fun drainAndSendMessages() { drainContinuationQueued = false \
+                      if (state != TransportState.RUNNING || connectedPeers.isEmpty()) return";
+        assert!(
+            code.contains(pinned),
+            "WifiDirectManager.kt must clear drainContinuationQueued as the first statement of \
+             drainAndSendMessages, before any early return. Cleared anywhere else, a pass that \
+             exits early leaves the flag set and onMessagesAvailable suppresses every later \
+             callback for the life of the transport. Expected to find:\n  {pinned}"
+        );
     }
 
     /// A transport's `pause()` has actually paused by the time it returns.

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -11011,7 +11011,24 @@ mod tests {
     /// again. Both attempts publish, and the loser's socket and receive thread
     /// leak with `isConnected` still true, so when that orphaned reader
     /// eventually errors it tears down the session that replaced it. Hence a
-    /// generation, stamped before the post and checked before publishing.
+    /// generation, stamped before the post and checked at every point the
+    /// attempt can still act.
+    ///
+    /// **"Checked before publishing" was one boundary of three.** Publishing
+    /// the socket, claiming the flags and announcing the connection are three
+    /// steps with a scheduling gap after each, and the generation was consulted
+    /// only at the first. So a `stop()` landing after the publish still let
+    /// `handleConnectionOpened` set `isConnected` true against a socket the
+    /// teardown had already closed — and if a `start()` followed, the
+    /// announcement's state gate passed (a restarted transport is legitimately
+    /// `STARTING`, the very case the gate cannot see) and called
+    /// `reticulumStatusChanged(true)` with `writer` null. The core routed to a
+    /// transport with no socket, and the poll that announcement starts drained
+    /// the outbox straight into `reticulumSendFailed` — recoverable, since the
+    /// next attempt's result corrects the status and the core retries the
+    /// sends, but a self-inflicted burst of failed sends and a DORS score to
+    /// match. The two added checks are pinned by what *follows* them, because
+    /// the two socket checkpoints are textually identical.
     ///
     /// **A failed connect used to be terminal.** The catch cleared
     /// `isConnecting` before handing off, and `handleConnectionClosed` decides
@@ -11043,7 +11060,18 @@ mod tests {
             (
                 "checking it before publishing the socket",
                 "if (connectGeneration.get() != generation) { try { sock.close() } \
-                 catch (_: Exception) {} return@post }",
+                 catch (_: Exception) {} return@post } sock.soTimeout = 0",
+            ),
+            (
+                "checking it again before claiming the flags",
+                "if (connectGeneration.get() != generation) { try { sock.close() } \
+                 catch (_: Exception) {} return@post } handleConnectionOpened(generation) \
+                 startReceiveLoop(r)",
+            ),
+            (
+                "checking it inside the announcement block",
+                "transportHandler.post { if (connectGeneration.get() != generation) return@post \
+                 if (state == TransportState.STOPPING || state == TransportState.STOPPED) {",
             ),
             (
                 "checking it before reporting a failure",
@@ -11062,6 +11090,25 @@ mod tests {
                  silently ending the reconnect ladder. Expected to find:\n  {pinned}"
             );
         }
+
+        // Two of the pins above are textually identical (both socket
+        // checkpoints close `sock` and return), so `contains` alone cannot
+        // tell four checks from three — each pin is disambiguated by what
+        // follows it, and this counts the whole family. Dropping any one of
+        // them reopens a boundary: the pre-publish check stops a retired
+        // attempt installing its socket over the current session's, the
+        // pre-handoff check stops it claiming `isConnected` against a socket
+        // `disconnect` already closed, and the announcement check is the only
+        // thing standing between a stop-then-restart and a `RUNNING` state
+        // with a null writer.
+        let generation_checks = code.matches("connectGeneration.get()").count();
+        assert_eq!(
+            generation_checks, 4,
+            "ReticulumManager.kt: expected the connect generation to be consulted at all four \
+             points a retired attempt can still act — before publishing the socket, before \
+             claiming the flags, inside the announcement block, and before reporting a failure; \
+             found {generation_checks}."
+        );
 
         // The two legitimate owners: `disconnect`, ending a session, and
         // `handleConnectionOpened`, promoting one. A third is the regression —
@@ -11101,8 +11148,20 @@ mod tests {
     /// [`react_native_ios_status_flips_are_ordered_against_stop`] owns the
     /// status flip at the second.
     ///
-    /// Pinned as the *first* statement of the block: a gate that has drifted
-    /// below the state write is not a gate.
+    /// Pinned as the *first* statement of the block, modulo the liveness
+    /// check that precedes it on Reticulum: a gate that has drifted below the
+    /// state write is not a gate.
+    ///
+    /// **The state gate is necessary and not sufficient, which is why
+    /// Reticulum carries a term in front of it.** "Did a stop happen" and "is
+    /// this still the current connection" are different questions, and only
+    /// the second one survives a restart — after `stop()`; `start()` the state
+    /// is legitimately `STARTING`, so the gate passes for a connection the
+    /// teardown already closed. Reticulum answers it with the connect
+    /// generation that
+    /// [`react_native_reticulum_retires_a_superseded_connect_attempt`] owns;
+    /// the other three managers have no equivalent and remain exposed to that
+    /// narrower window, which is tracked rather than pinned here.
     ///
     /// The two platforms need different amounts of machinery for the same
     /// invariant, and that difference is the point. On Android the gate, the
@@ -11118,15 +11177,19 @@ mod tests {
     /// [`react_native_ios_status_flips_are_ordered_against_stop`].
     #[test]
     fn react_native_transports_do_not_resurrect_a_stopped_connection() {
-        for (manager, cleanup) in [
-            ("ReticulumManager", "disconnect()"),
-            ("NostrManager", "disconnectAll()"),
+        for (manager, liveness, cleanup) in [
+            (
+                "ReticulumManager",
+                "if (connectGeneration.get() != generation) return@post ",
+                "disconnect()",
+            ),
+            ("NostrManager", "", "disconnectAll()"),
         ] {
             let code = rn_source_code_only(&format!(
                 "android/src/main/java/com/offlineprotocol/{manager}.kt"
             ));
             let pinned = format!(
-                "transportHandler.post {{ if (state == TransportState.STOPPING || \
+                "transportHandler.post {{ {liveness}if (state == TransportState.STOPPING || \
                  state == TransportState.STOPPED) {{ {cleanup} return@post }} \
                  updateState(TransportState.RUNNING)"
             );

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10929,6 +10929,17 @@ mod tests {
     /// that by clearing `isConnected` first, but `pause()` clears nothing —
     /// unposted, it leaves a paused transport polling the FFI and writing to
     /// the daemon for the whole background stay.
+    ///
+    /// The split also constrains the teardown, which stays on the lifecycle
+    /// thread and therefore must not *wait* on the socket work it is tearing
+    /// down. `Socket.close()` is the one call that makes a blocked
+    /// `readLine()`/`println()` throw; the wrapped streams share a lock with
+    /// the I/O they wrap (`BufferedReader.close()` takes the lock `readLine()`
+    /// holds for its whole blocking duration, `PrintWriter.close()` likewise
+    /// against `println()`), so closing them *first* parks `disconnect()` —
+    /// and the unbounded background `stop()` wait behind it — until the daemon
+    /// happens to send a line, indefinitely if it has wedged. Hence the fourth
+    /// pin: the socket close must precede the stream closes.
     #[test]
     fn react_native_reticulum_socket_work_is_off_the_lifecycle_thread() {
         let code =
@@ -10962,6 +10973,25 @@ mod tests {
                  minute and a wedged one indefinitely. Expected to find:\n  {pinned}"
             );
         }
+
+        // Pinned as adjacency so the socket close cannot drift back below the
+        // stream closes, which is the shape this replaced: with the receive
+        // thread parked in readLine() (soTimeout = 0), reader?.close() blocks
+        // on the reader's own lock until the daemon sends a line, and the
+        // socket close that would unblock it sat one statement further down,
+        // never reached. interrupt() does not unblock a classic socket read.
+        assert!(
+            code.contains(
+                "try { socket?.close() } catch (_: Exception) {} \
+                 try { writer?.close() } catch (_: Exception) {} \
+                 try { reader?.close() } catch (_: Exception) {}"
+            ),
+            "disconnect() must close the socket before the wrapped streams: reader.close() and \
+             readLine() take the same lock (writer.close()/println() likewise), so closing the \
+             streams first waits on the very I/O the teardown exists to interrupt — parking the \
+             lifecycle thread, and the unbounded stop() wait behind it, until the daemon speaks. \
+             Only Socket.close() makes a blocked stream read/write throw"
+        );
     }
 
     /// A Reticulum connect attempt that outlives its session is retired, and a

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10920,6 +10920,15 @@ mod tests {
     /// against a daemon that stops reading. Sharing one thread would let either
     /// park a `stop()` — and the RN bridge thread behind it — so the blocking
     /// half lives on its own looper.
+    ///
+    /// Splitting the loopers buys a second obligation, which is why the poll
+    /// lifecycle is pinned as *posts* rather than as direct calls. The
+    /// runnable reposts itself on the IO thread, so a `removeCallbacks` issued
+    /// from the lifecycle thread removes nothing while it is mid-flight and
+    /// loses to the repost. `stopUnsafe` and `handleConnectionClosed` survive
+    /// that by clearing `isConnected` first, but `pause()` clears nothing —
+    /// unposted, it leaves a paused transport polling the FFI and writing to
+    /// the daemon for the whole background stay.
     #[test]
     fn react_native_reticulum_socket_work_is_off_the_lifecycle_thread() {
         let code =
@@ -10930,15 +10939,20 @@ mod tests {
         // still opens its socket on the lifecycle thread and posts something
         // unrelated elsewhere, which is precisely the regression.
         for (what, pinned) in [
-            ("the blocking connect", "ioHandler.post { try { val sock = Socket()"),
+            (
+                "the blocking connect",
+                "ioHandler.post { try { val sock = Socket()",
+            ),
             (
                 "the send/poll loop",
-                "private fun startMessagePolling() { stopMessagePolling() \
-                 ioHandler.post(messagePollingRunnable) }",
+                "private fun startMessagePolling() { ioHandler.post { \
+                 ioHandler.removeCallbacks(messagePollingRunnable) \
+                 messagePollingRunnable.run() } }",
             ),
             (
                 "cancelling the poll",
-                "private fun stopMessagePolling() { ioHandler.removeCallbacks(messagePollingRunnable) }",
+                "private fun stopMessagePolling() { ioHandler.post { \
+                 ioHandler.removeCallbacks(messagePollingRunnable) } }",
             ),
         ] {
             assert!(

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10979,16 +10979,30 @@ mod tests {
     /// **Both platforms, deliberately.** The first version of this covered only
     /// the two Kotlin managers, which read as though the invariant held
     /// everywhere it applies — while the identical unguarded block sat in the
-    /// two Swift ones. The iOS Reticulum window is if anything the wider of the
-    /// two: its announcement crosses `DispatchQueue.main` *and* then
-    /// `messageQueue`, so there are two scheduling boundaries for a `stop()` to
-    /// land in rather than one.
+    /// two Swift ones. The iOS Reticulum window is the wider of the two: its
+    /// announcement crosses `DispatchQueue.main` *and* then `messageQueue`, so
+    /// there are two scheduling boundaries for a `stop()` to land in rather
+    /// than one, and a gate at the first boundary does nothing about the
+    /// second. Both are covered now — this test owns the state write at the
+    /// first, and
+    /// [`react_native_ios_status_flips_are_ordered_against_stop`] owns the
+    /// status flip at the second.
     ///
-    /// Pinned as the *first* statement of the block, for the same reason the
-    /// iOS status-flip guard below is: a gate that has drifted below the state
-    /// write is not a gate. On iOS that means ahead of the `messageQueue` hop,
-    /// not inside it — a gate behind the hop is checking state the hop already
-    /// let go stale.
+    /// Pinned as the *first* statement of the block: a gate that has drifted
+    /// below the state write is not a gate.
+    ///
+    /// The two platforms need different amounts of machinery for the same
+    /// invariant, and that difference is the point. On Android the gate, the
+    /// state write, the status flip and `stopUnsafe` all execute on the one
+    /// confinement thread, so a plain `if` is genuinely atomic against a
+    /// `stop()` — nothing more is needed or wanted. On iOS the lifecycle runs
+    /// on the bridge queue, the gate on `main` or `messageQueue`, and the flip
+    /// on `messageQueue`, so an `if` followed by a state write is a
+    /// check-then-act across threads: a `stop()` landing between them writes
+    /// `.stopped` and the write puts `.running` back over it. iOS therefore
+    /// pins a compare-and-set (`markRunningIfLive`) instead, and the flip
+    /// itself is ordered separately by
+    /// [`react_native_ios_status_flips_are_ordered_against_stop`].
     #[test]
     fn react_native_transports_do_not_resurrect_a_stopped_connection() {
         for (manager, cleanup) in [
@@ -11019,17 +11033,121 @@ mod tests {
         ] {
             let code = rn_source_code_only(&format!("ios/{manager}.swift"));
             let pinned = format!(
-                "guard let self = self else {{ return }} guard self.state != .stopping, \
-                 self.state != .stopped else {{ {cleanup} return }} self.updateState(.running)"
+                "guard let self = self else {{ return }} guard self.markRunningIfLive() \
+                 else {{ {cleanup} return }}"
             );
 
             assert!(
                 code.contains(&pinned),
-                "ios/{manager}.swift's connected-edge block must open with the stopped-transport \
-                 gate, ahead of any queue hop, and close the connection it opened. Without it a \
-                 stop() racing the connect leaves the state .running and the core told the \
-                 transport is up, with nothing left that will tear it down and the next start() \
-                 throwing .alreadyRunning. Expected to find:\n  {pinned}"
+                "ios/{manager}.swift's connected-edge block must open by *claiming* .running \
+                 rather than testing the state and then writing it, and must close the \
+                 connection it opened when the claim is refused. A separate test-then-write is \
+                 two lock acquisitions with a stop() free to land between them, which leaves a \
+                 torn-down transport wedged at .running where the next start() throws \
+                 .alreadyRunning. Expected to find:\n  {pinned}"
+            );
+
+            // The claim is only worth pinning if it is actually atomic, so the
+            // compare-and-set itself is pinned too — identical in both files.
+            // Without this, `markRunningIfLive` could be reduced back to the
+            // guard-then-`updateState` pair it replaced and the pin above
+            // would still pass.
+            let cas = "private func markRunningIfLive() -> Bool { stateLock.lock() \
+                       guard _state != .stopping, _state != .stopped else { stateLock.unlock() \
+                       return false } _state = .running stateLock.unlock() \
+                       delegate?.transportManager(self, didChangeState: .running) return true }";
+
+            assert!(
+                code.contains(cas),
+                "ios/{manager}.swift's markRunningIfLive must read and write the state under one \
+                 stateLock acquisition, and notify the delegate outside it. Expected to \
+                 find:\n  {cas}"
+            );
+        }
+    }
+
+    /// The iOS status flips are ordered against `stop()`, not merely near a
+    /// state check.
+    ///
+    /// Each of these managers flips `…StatusChanged` from two places that no
+    /// queue orders against each other: the connected edge, which runs on
+    /// `messageQueue`, and `stop()`, which runs inline on whichever thread
+    /// tore the transport down (the bridge queue, or `deinit`'s). A state
+    /// check on the connected edge is not enough on its own — it can read a
+    /// live state, and a whole `stop()`, including its own `false`, can then
+    /// complete before the `true` it cleared reaches the core. The core is
+    /// left believing the transport is up moments after being told it was
+    /// down, against a `.stopped` transport with no polling, and nothing
+    /// corrects it: every correcting path is a teardown path that already ran.
+    ///
+    /// So both sites take `statusFlipLock`, and `stop()` publishes `.stopping`
+    /// *before* contending for it — which is the whole ordering argument, and
+    /// why the byte-offset check below is not a stylistic preference. Either
+    /// the announcement wins the lock and `stop()`'s `false` lands after its
+    /// `true`, or `stop()` wins and the announcement reads a state that
+    /// refuses it.
+    ///
+    /// Android has no counterpart and must not grow one: its flips are already
+    /// atomic against each other by thread confinement, so a lock there would
+    /// be cargo-culted from a platform whose problem it does not have.
+    #[test]
+    fn react_native_ios_status_flips_are_ordered_against_stop() {
+        for (manager, flip) in [
+            ("ReticulumManager", "reticulumStatusChanged"),
+            ("NostrManager", "nostrStatusChanged"),
+        ] {
+            let code = rn_source_code_only(&format!("ios/{manager}.swift"));
+
+            let connected = format!(
+                "self.statusFlipLock.lock() if self.state != .stopping && \
+                 self.state != .stopped {{ try? self.protocolInstance.{flip}(isConnected: true) \
+                 }} self.statusFlipLock.unlock()"
+            );
+            assert!(
+                code.contains(&connected),
+                "ios/{manager}.swift's connected-edge flip must test the state and call {flip} \
+                 as one decision under statusFlipLock, unlocked explicitly rather than by defer \
+                 (which would hold it across the flush that follows). Expected to \
+                 find:\n  {connected}"
+            );
+
+            let stopping = format!(
+                "statusFlipLock.lock() try? protocolInstance.{flip}(isConnected: false) \
+                 statusFlipLock.unlock()"
+            );
+            assert!(
+                code.contains(&stopping),
+                "ios/{manager}.swift's stop() must take statusFlipLock around its {flip}, or the \
+                 lock on the connected edge orders it against nothing. Expected to \
+                 find:\n  {stopping}"
+            );
+
+            // `.stopping` must be published *before* stop() contends for the
+            // lock: that is what makes losing the race safe for the connected
+            // edge, which re-reads the state under the lock it then wins.
+            //
+            // A byte-offset check is only as good as the uniqueness of what it
+            // locates — a second `.stopping` write added anywhere above stop()
+            // would satisfy the comparison no matter how stop() is ordered. So
+            // the count is asserted first, and a legitimate second writer must
+            // come here and say which one it means.
+            let writes = code.matches("updateState(.stopping)").count();
+            assert_eq!(
+                writes, 1,
+                "ios/{manager}.swift: expected exactly one .stopping write (stop()'s); found \
+                 {writes}, which makes the ordering check below ambiguous"
+            );
+            let published = code.find("updateState(.stopping)").unwrap_or_else(|| {
+                panic!("ios/{manager}.swift: stop() no longer publishes .stopping")
+            });
+            let contends = code
+                .find(&stopping)
+                .unwrap_or_else(|| panic!("ios/{manager}.swift: stop()'s guarded flip not found"));
+            assert!(
+                published < contends,
+                "ios/{manager}.swift must publish .stopping before stop() takes statusFlipLock. \
+                 Reversed, a connected edge that loses the race re-reads a state that still says \
+                 running and flips the core back to connected after this false."
             );
         }
     }
@@ -11090,11 +11208,21 @@ mod tests {
     /// waiting on a thread whose next act is to ask for that same mutex. Neither
     /// side can yield: a hard, permanent deadlock of the core, not a slow path.
     ///
-    /// So the body of each is pinned whole: a post and nothing else. There is no
-    /// weaker form of this worth checking, because "mostly posts" is the same
-    /// deadlock. Wi-Fi Direct's carries one branch — the drain-continuation
-    /// check — which is still inside the posted block, so it is pinned up to and
-    /// including the post that contains it.
+    /// So the body of each is pinned whole, closing braces included: a post and
+    /// nothing else. There is no weaker form of this worth checking, because
+    /// "mostly posts" is the same deadlock — and a prefix pin is exactly that
+    /// weaker form, since it matches a body that posts and *then* blocks:
+    ///
+    /// ```text
+    /// fun onMessagesAvailable() {
+    ///     transportHandler.post { … }   // a prefix pin stops reading here
+    ///     confinement.runSync { … }     // permanent deadlock, guard green
+    /// }
+    /// ```
+    ///
+    /// Wi-Fi Direct's carries one branch — the drain-continuation check — which
+    /// is inside the posted block, so its pin spells that branch out rather
+    /// than stopping short of it.
     #[test]
     fn react_native_transport_callbacks_never_wait_on_a_confinement() {
         for (manager, entry, pinned) in [
@@ -11111,7 +11239,8 @@ mod tests {
             (
                 "WifiDirectManager",
                 "onMessagesAvailable",
-                "fun onMessagesAvailable() { transportHandler.post {",
+                "fun onMessagesAvailable() { transportHandler.post { \
+                 if (drainContinuationQueued) return@post drainAndSendMessages() } }",
             ),
             (
                 "ble/BleTransportFacade",
@@ -11145,6 +11274,16 @@ mod tests {
     /// The connect edge is pinned by *order*: the hop onto `messageQueue` must
     /// appear before the status call, which is what puts the flip ahead of the
     /// flush that follows it on the same serial queue.
+    ///
+    /// An earlier version of this pin required the status call to be the
+    /// literal first statement inside the hop, which is the wrong shape of
+    /// strictness: it rejected the state re-check that
+    /// [`react_native_ios_status_flips_are_ordered_against_stop`] requires
+    /// there, so the guard would have had to be edited to fix a bug it should
+    /// have caught. What it was really protecting against is a hop whose body
+    /// was emptied with the call left behind on main, and that is still caught
+    /// — the pin below spans the hop, the weak capture and the guarded call as
+    /// one string, so the call cannot leave it.
     #[test]
     fn react_native_reticulum_status_flips_run_off_the_main_thread() {
         let code = rn_source_code_only("ios/ReticulumManager.swift");
@@ -11152,12 +11291,15 @@ mod tests {
         // Pinned as *adjacency*, not as "a messageQueue.async appears somewhere
         // earlier". The looser check passes against a hop whose block was
         // emptied out with the status call left behind on main — which is
-        // exactly the regression this guards, so it has to see the call as the
-        // first statement of the block rather than merely after one.
+        // exactly the regression this guards, so the pin has to span the hop
+        // and the call as one string, with nothing between them but the weak
+        // capture and the state gate that orders this against stop().
         for (edge, pinned) in [
             (
                 "connect",
-                "self.messageQueue.async { try? self.protocolInstance\
+                "self.messageQueue.async { [weak self] in guard let self = self else { return } \
+                 self.statusFlipLock.lock() if self.state != .stopping && \
+                 self.state != .stopped { try? self.protocolInstance\
                  .reticulumStatusChanged(isConnected: true)",
             ),
             (

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10951,8 +10951,13 @@ mod tests {
         // unrelated elsewhere, which is precisely the regression.
         for (what, pinned) in [
             (
+                // Spanning through to `sock.connect(` rather than stopping at
+                // the post: this test is about where the *blocking* call runs,
+                // and a post whose body no longer contains it is exactly the
+                // regression.
                 "the blocking connect",
-                "ioHandler.post { try { val sock = Socket()",
+                "ioHandler.post { val sock = Socket() \
+                 synchronized(this) { pendingConnectSocket = sock } try { sock.connect(",
             ),
             (
                 "the send/poll loop",
@@ -11027,8 +11032,23 @@ mod tests {
     /// the outbox straight into `reticulumSendFailed` — recoverable, since the
     /// next attempt's result corrects the status and the core retries the
     /// sends, but a self-inflicted burst of failed sends and a DORS score to
-    /// match. The two added checks are pinned by what *follows* them, because
-    /// the two socket checkpoints are textually identical.
+    /// match.
+    ///
+    /// **A check beside the write it guards is still a check-then-act.** The
+    /// first fix put the two extra checks one statement above the publish and
+    /// the claim, which narrows the window without closing it: the check and
+    /// the write run on the IO thread while `disconnect` runs on the transport
+    /// thread, so a teardown still fits between them and is simply overwritten.
+    /// The claim was the consequential half — the announcement refuses either
+    /// way, so nothing is announced, but `isConnected` is left true against a
+    /// closed socket with no path that clears it, and `connect`'s own guard
+    /// reads exactly that flag. The next `start()` therefore returns having
+    /// done nothing, until the orphaned reader errors and the ladder recovers.
+    /// Both checks now sit *inside* the `synchronized(this)` that owns the
+    /// fields, which is the same lock `disconnect` clears them in, so claim and
+    /// clear are ordered rather than racing. The pins spell out the whole
+    /// locked block for that reason: a check hoisted back out of it would
+    /// satisfy any looser form.
     ///
     /// **A failed connect used to be terminal.** The catch cleared
     /// `isConnecting` before handing off, and `handleConnectionClosed` decides
@@ -11048,14 +11068,14 @@ mod tests {
 
         for (what, pinned) in [
             (
-                "stamping the attempt before posting it",
-                "val generation = connectGeneration.incrementAndGet() ioHandler.post { try { \
-                 val sock = Socket()",
+                "stamping the attempt, and publishing its socket before it blocks",
+                "val generation = connectGeneration.incrementAndGet() ioHandler.post { \
+                 val sock = Socket() synchronized(this) { pendingConnectSocket = sock } try {",
             ),
             (
-                "retiring it on teardown",
-                "isConnected.set(false) isConnecting.set(false) \
-                 connectGeneration.incrementAndGet()",
+                "retiring it on teardown, under the lock the claim takes",
+                "private fun disconnect() { synchronized(this) { isConnected.set(false) \
+                 isConnecting.set(false) connectGeneration.incrementAndGet()",
             ),
             (
                 "checking it before publishing the socket",
@@ -11063,10 +11083,21 @@ mod tests {
                  catch (_: Exception) {} return@post } sock.soTimeout = 0",
             ),
             (
-                "checking it again before claiming the flags",
-                "if (connectGeneration.get() != generation) { try { sock.close() } \
-                 catch (_: Exception) {} return@post } handleConnectionOpened(generation) \
-                 startReceiveLoop(r)",
+                "checking it as part of the publish itself",
+                "var published = false synchronized(this) { \
+                 if (connectGeneration.get() == generation) { socket = sock writer = w \
+                 reader = r published = true } } if (!published) { try { sock.close() } \
+                 catch (_: Exception) {} return@post }",
+            ),
+            (
+                "checking it as part of the flag claim itself",
+                "private fun handleConnectionOpened(generation: Int): Boolean { \
+                 synchronized(this) { if (connectGeneration.get() != generation) return false \
+                 isConnected.set(true) isConnecting.set(false) }",
+            ),
+            (
+                "honouring a refused claim at the call site",
+                "if (!handleConnectionOpened(generation)) return@post startReceiveLoop(r)",
             ),
             (
                 "checking it inside the announcement block",
@@ -11091,24 +11122,60 @@ mod tests {
             );
         }
 
-        // Two of the pins above are textually identical (both socket
-        // checkpoints close `sock` and return), so `contains` alone cannot
-        // tell four checks from three — each pin is disambiguated by what
-        // follows it, and this counts the whole family. Dropping any one of
-        // them reopens a boundary: the pre-publish check stops a retired
-        // attempt installing its socket over the current session's, the
-        // pre-handoff check stops it claiming `isConnected` against a socket
-        // `disconnect` already closed, and the announcement check is the only
-        // thing standing between a stop-then-restart and a `RUNNING` state
-        // with a null writer.
+        // Each pin above is disambiguated by what surrounds it, and this counts
+        // the whole family — the backstop for a check deleted somewhere the
+        // individual pins do not reach. Dropping any one reopens a boundary:
+        // the first stops a retired attempt building streams it will discard,
+        // the publish check stops it installing its socket over the current
+        // session's, the claim check stops it setting `isConnected` true
+        // against a socket `disconnect` already closed, the announcement check
+        // is the only thing standing between a stop-then-restart and a
+        // `RUNNING` state with a null writer, and the last stops a superseded
+        // failure firing the ladder against the session that replaced it.
+        //
+        // Two of them are *inside* the lock rather than beside it, and that is
+        // load-bearing rather than tidy. Checked outside, each is a
+        // read-then-write with a teardown free to land in the middle: the
+        // publish would strand a socket in a field `disconnect` has already
+        // passed, and the claim would put `isConnected` back to true after the
+        // teardown cleared it — leaving a flag nothing clears, which
+        // `connect`'s own guard then reads to refuse the next `start()`.
         let generation_checks = code.matches("connectGeneration.get()").count();
         assert_eq!(
-            generation_checks, 4,
-            "ReticulumManager.kt: expected the connect generation to be consulted at all four \
-             points a retired attempt can still act — before publishing the socket, before \
-             claiming the flags, inside the announcement block, and before reporting a failure; \
-             found {generation_checks}."
+            generation_checks, 5,
+            "ReticulumManager.kt: expected the connect generation to be consulted at all five \
+             points a retired attempt can still act — before building the streams, inside the \
+             publish, inside the flag claim, inside the announcement block, and before reporting \
+             a failure; found {generation_checks}."
         );
+
+        // Only a close ends a blocked `Socket.connect` — it has no
+        // interruption point and ignores `Thread.interrupt` — and this looper
+        // is shared and never quits, so an attempt left running against an
+        // unreachable host holds the *next* session's connect behind it for the
+        // rest of CONNECTION_TIMEOUT_MS. The per-session thread this replaced
+        // had no such coupling: it was abandoned mid-call and the restart got a
+        // fresh one, so the handle is what buys that property back.
+        for (what, pinned) in [
+            (
+                "the teardown closing it",
+                "try { pendingConnectSocket?.close() } catch (_: Exception) {} \
+                 pendingConnectSocket = null",
+            ),
+            (
+                "the attempt releasing it by identity on every exit",
+                "} finally { synchronized(this) { if (pendingConnectSocket === sock) \
+                 pendingConnectSocket = null } }",
+            ),
+        ] {
+            assert!(
+                code.contains(pinned),
+                "ReticulumManager.kt: {what} is what lets a stop() end a connect that has nothing \
+                 published yet. Without it a stop/start against an unreachable daemon leaves the \
+                 restart's connect queued behind the blocked one on the shared IO looper. \
+                 Expected to find:\n  {pinned}"
+            );
+        }
 
         // The two legitimate owners: `disconnect`, ending a session, and
         // `handleConnectionOpened`, promoting one. A third is the regression —

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10950,6 +10950,46 @@ mod tests {
         }
     }
 
+    /// A connection that completes after `stop()` does not resurrect the
+    /// transport.
+    ///
+    /// Both managers announce a new connection from a *posted* block, so a
+    /// `stop()` can land between the socket opening and the announcement. With
+    /// no gate the announcement then runs against a stopped transport: state
+    /// goes back to `RUNNING` and the core is told the transport is up after
+    /// being told it was down — with nothing left that will ever tear it down
+    /// again, and the next `start()` throwing `AlreadyRunning` off the wedged
+    /// state. `InternetManager` has always gated its posted blocks this way;
+    /// these two did not.
+    ///
+    /// Pinned as the *first* statement of the block, for the same reason the
+    /// iOS guard below is: a gate that has drifted below the state write is
+    /// not a gate.
+    #[test]
+    fn react_native_transports_do_not_resurrect_a_stopped_connection() {
+        for (manager, cleanup) in [
+            ("ReticulumManager", "disconnect()"),
+            ("NostrManager", "disconnectAll()"),
+        ] {
+            let code = rn_source_code_only(&format!(
+                "android/src/main/java/com/offlineprotocol/{manager}.kt"
+            ));
+            let pinned = format!(
+                "transportHandler.post {{ if (state == TransportState.STOPPING || \
+                 state == TransportState.STOPPED) {{ {cleanup} return@post }} \
+                 updateState(TransportState.RUNNING)"
+            );
+
+            assert!(
+                code.contains(&pinned),
+                "{manager}.kt's connected-edge post must open with the stopped-transport gate, \
+                 which also closes the socket it opened; otherwise a stop() racing the connect \
+                 leaves the state RUNNING and the core told the transport is up, and no later \
+                 signal corrects either. Expected to find:\n  {pinned}"
+            );
+        }
+    }
+
     /// The iOS Reticulum status flips stay off the main thread.
     ///
     /// `reticulum_status_changed` takes the global protocol mutex, and on the

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -11061,6 +11061,32 @@ mod tests {
     /// that samples it, which is why the ladder worked there and not here.
     /// Pinned as adjacency — nothing between `catch` and the log — plus a count
     /// of the clear's legitimate owners, so re-adding it anywhere fails here.
+    ///
+    /// **The teardown side needed the stamp too, and had none.** The five
+    /// checks above all live on the connect path, and every one of them
+    /// protects a *constructive* step. The destructive step is
+    /// `handleConnectionClosed`, which clears both session flags — and all
+    /// three of its callers reach it by posting from another thread (the IO
+    /// thread on a failed connect or an exhausted send budget, the receive
+    /// thread on a dropped link), so all three can arrive after the session
+    /// they describe is over. Its own `!wasConnected && !wasConnecting` guard
+    /// cannot substitute: it asks whether *a* session is live, never whether it
+    /// is *this* one, so after a stop *and* a start it reads the successor's
+    /// flags and passes. The stale post then clears `isConnected` under a
+    /// healthy connection, reports the transport down, and starts a reconnect
+    /// ladder against it — while the socket that was actually live is left open
+    /// with its reader parked in `readLine()` (soTimeout = 0) and
+    /// `receiveThread` already reassigned. Nothing closes either, and the next
+    /// connect publishes over `socket`/`writer`/`reader` without closing what
+    /// it displaces, so the thread and the descriptor leak for good.
+    ///
+    /// The check therefore sits at the top of the handler rather than beside
+    /// each post, which is the same lesson as the two locked checks below,
+    /// applied to a queue hop instead of a lock: a check on the near side of a
+    /// boundary the session can die inside is not a check. The connect catch's
+    /// pre-post check was exactly that shape and is gone; the receive loop and
+    /// the send-failure threshold carry the generation they belong to instead,
+    /// the latter sampled under the same lock as the writer it used.
     #[test]
     fn react_native_reticulum_retires_a_superseded_connect_attempt() {
         let code =
@@ -11096,8 +11122,10 @@ mod tests {
                  isConnected.set(true) isConnecting.set(false) }",
             ),
             (
-                "honouring a refused claim at the call site",
-                "if (!handleConnectionOpened(generation)) return@post startReceiveLoop(r)",
+                "honouring a refused claim at the call site, and handing the \
+                 reader the generation it belongs to",
+                "if (!handleConnectionOpened(generation)) return@post \
+                 startReceiveLoop(r, generation)",
             ),
             (
                 "checking it inside the announcement block",
@@ -11105,9 +11133,28 @@ mod tests {
                  if (state == TransportState.STOPPING || state == TransportState.STOPPED) {",
             ),
             (
-                "checking it before reporting a failure",
-                "if (connectGeneration.get() == generation) { transportHandler.post { \
-                 handleConnectionClosed(-1, e.message) } }",
+                "checking it inside the teardown handler, where the flags are cleared",
+                "private fun handleConnectionClosed(generation: Int, code: Int, reason: String?) { \
+                 if (connectGeneration.get() != generation) return",
+            ),
+            (
+                "stamping the failure a connect attempt reports",
+                "transportHandler.post { handleConnectionClosed(generation, -1, e.message) }",
+            ),
+            (
+                "stamping the failure a dead receive loop reports",
+                "if (isConnected.get()) { transportHandler.post { \
+                 handleConnectionClosed(generation, -1, \"Connection lost\") } }",
+            ),
+            (
+                "sampling the writer and its generation together",
+                "val w: PrintWriter? val generation: Int synchronized(this) { w = writer \
+                 generation = connectGeneration.get() }",
+            ),
+            (
+                "stamping the failure an exhausted send budget reports",
+                "transportHandler.post { \
+                 handleConnectionClosed(generation, -1, \"Send failures exceeded threshold\") }",
             ),
             (
                 "leaving the in-flight flag for handleConnectionClosed to clear",
@@ -11130,23 +11177,33 @@ mod tests {
         // session's, the claim check stops it setting `isConnected` true
         // against a socket `disconnect` already closed, the announcement check
         // is the only thing standing between a stop-then-restart and a
-        // `RUNNING` state with a null writer, and the last stops a superseded
-        // failure firing the ladder against the session that replaced it.
+        // `RUNNING` state with a null writer, and the teardown check stops any
+        // of the three posted failure reports clearing the flags of a session
+        // that replaced theirs.
         //
-        // Two of them are *inside* the lock rather than beside it, and that is
-        // load-bearing rather than tidy. Checked outside, each is a
-        // read-then-write with a teardown free to land in the middle: the
-        // publish would strand a socket in a field `disconnect` has already
-        // passed, and the claim would put `isConnected` back to true after the
-        // teardown cleared it — leaving a flag nothing clears, which
-        // `connect`'s own guard then reads to refuse the next `start()`.
+        // Three of them are *inside* something rather than beside it — two
+        // inside the lock that owns what they guard, one inside the handler
+        // rather than at each call site — and that is load-bearing rather than
+        // tidy. Checked outside, each becomes a read-then-act with a teardown
+        // free to land in the middle: the publish would strand a socket in a
+        // field `disconnect` has already passed, the claim would put
+        // `isConnected` back to true after the teardown cleared it (leaving a
+        // flag nothing clears, which `connect`'s own guard then reads to refuse
+        // the next `start()`), and the teardown check would pass on the near
+        // side of a queue hop the session can die inside.
+        //
+        // The sixth is `sendMessage`'s, which is a *sample* rather than a
+        // check: it binds the generation to the writer it read under the same
+        // lock, so the failure it may report later names the session that write
+        // actually belonged to.
         let generation_checks = code.matches("connectGeneration.get()").count();
         assert_eq!(
-            generation_checks, 5,
-            "ReticulumManager.kt: expected the connect generation to be consulted at all five \
+            generation_checks, 6,
+            "ReticulumManager.kt: expected the connect generation to be consulted at all six \
              points a retired attempt can still act — before building the streams, inside the \
-             publish, inside the flag claim, inside the announcement block, and before reporting \
-             a failure; found {generation_checks}."
+             publish, inside the flag claim, inside the announcement block, inside the teardown \
+             handler every posted failure funnels through, and alongside the writer sampled by \
+             sendMessage; found {generation_checks}."
         );
 
         // Only a close ends a blocked `Socket.connect` — it has no

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10860,6 +10860,109 @@ mod tests {
         );
     }
 
+    /// No transport manager may take its ordering from the app's main looper.
+    ///
+    /// This is OFF-2123 as an invariant. Every call these managers make into
+    /// this crate serialises on one global protocol mutex, held across MLS
+    /// work and AndroidKeyStore-backed storage callbacks, so a manager that
+    /// posts its work to the main looper charges those waits to the thread
+    /// Android watches for ANRs. All four used to; each now confines itself to
+    /// a private looper through `TransportConfinement`.
+    ///
+    /// Pinned as the absence of `Looper.getMainLooper()` rather than the
+    /// presence of the confinement, because absence is what actually matters
+    /// and it catches the likely regression: not deleting the confinement, but
+    /// adding one more `Handler(Looper.getMainLooper())` next to it for
+    /// "just this one callback". Comments are stripped before the check, so
+    /// the historical notes explaining what moved off main are free to keep
+    /// saying so.
+    #[test]
+    fn react_native_transports_do_not_run_on_the_main_looper() {
+        for manager in [
+            "InternetManager",
+            "WifiDirectManager",
+            "NostrManager",
+            "ReticulumManager",
+        ] {
+            let rel = format!("android/src/main/java/com/offlineprotocol/{manager}.kt");
+            let code = rn_source_code_only(&rel);
+
+            assert!(
+                !code.contains("Looper.getMainLooper()"),
+                "{manager}.kt must not reference the main looper: every UniFFI call it makes \
+                 waits on the core's global protocol mutex, and doing that on the main thread \
+                 is the ANR OFF-2123 tracked. Confine the work with TransportConfinement \
+                 instead — including framework entry points, which take the looper to deliver \
+                 on (WifiP2pManager.initialize) or a scheduler Handler (registerReceiver)"
+            );
+
+            assert!(
+                code.contains("TransportConfinement.shared("),
+                "{manager}.kt must take its thread from TransportConfinement.shared, so a \
+                 manager rebuilt after stop() re-attaches to the same ordered queue instead of \
+                 racing a fresh thread against the old one's backlog"
+            );
+        }
+    }
+
+    /// The iOS Reticulum status flips stay off the main thread.
+    ///
+    /// `reticulum_status_changed` takes the global protocol mutex, and on the
+    /// false→true edge takes it again to run `flush_outbox_all` — the whole
+    /// outbox, under the mutex. Both call sites sat inside
+    /// `DispatchQueue.main.async` blocks, which made this the last iOS
+    /// transport with UniFFI on the main thread, at the cadence of a local
+    /// daemon that keeps reconnecting.
+    ///
+    /// The connect edge is pinned by *order*: the hop onto `messageQueue` must
+    /// appear before the status call, which is what puts the flip ahead of the
+    /// flush that follows it on the same serial queue.
+    #[test]
+    fn react_native_reticulum_status_flips_run_off_the_main_thread() {
+        let code = rn_source_code_only("ios/ReticulumManager.swift");
+
+        // Pinned as *adjacency*, not as "a messageQueue.async appears somewhere
+        // earlier". The looser check passes against a hop whose block was
+        // emptied out with the status call left behind on main — which is
+        // exactly the regression this guards, so it has to see the call as the
+        // first statement of the block rather than merely after one.
+        for (edge, pinned) in [
+            (
+                "connect",
+                "self.messageQueue.async { try? self.protocolInstance\
+                 .reticulumStatusChanged(isConnected: true)",
+            ),
+            (
+                "disconnect",
+                "messageQueue.async { [weak self] in guard let self = self else { return } \
+                 do { try self.protocolInstance.reticulumStatusChanged(isConnected: false)",
+            ),
+        ] {
+            assert!(
+                code.contains(pinned),
+                "the {edge}-edge reticulumStatusChanged must be the first statement inside a \
+                 messageQueue.async block, not run on main: it takes the global protocol mutex, \
+                 and the connected edge flushes the entire outbox under it, which on the main \
+                 thread is the App Hang class OFF-2123 tracked. Expected to find:\n  {pinned}"
+            );
+        }
+
+        // Only the call sites inside closures, which `self.` identifies: the
+        // remaining one is `stop()`'s, which runs on the bridge queue with no
+        // dispatch of its own and is correct there, like every other
+        // manager's lifecycle FFI. A third would escape the adjacency pins
+        // above, so it has to fail here instead.
+        let closure_flips = code
+            .matches("self.protocolInstance.reticulumStatusChanged(")
+            .count();
+        assert_eq!(
+            closure_flips, 2,
+            "expected the connect and disconnect edges to be the only status flips inside \
+             closures; found {closure_flips} — if another was added, confine it the same way \
+             and pin it above"
+        );
+    }
+
     /// Wi-Fi Direct announces nothing, because it can name nobody.
     ///
     /// Both managers used to pass a transport-level string — a TCP endpoint on

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -11475,6 +11475,77 @@ mod tests {
         }
     }
 
+    /// A transport's `pause()` has actually paused by the time it returns.
+    ///
+    /// `OfflineProtocolModule.pause` pauses the five transports and *then* the
+    /// core, and that order is the whole bound on how long a transport can
+    /// still re-enter UniFFI behind a paused core — it is why
+    /// `InternetManager.pause` can call its final drain "bounded to sends
+    /// already in flight". A `pause()` that hands its work to a handler and
+    /// returns has paused nothing yet, so the core pauses underneath it and the
+    /// bound is gone.
+    ///
+    /// This was the shape Nostr and Reticulum shipped with, left over from when
+    /// a post was the only way onto their per-session IO threads — the
+    /// confinement removed the reason and not the post. It is an easy
+    /// regression to re-introduce precisely because it *looks* like the
+    /// callback rule two tests up ("hand it to a handler and return"), which
+    /// applies to calls coming *from* the core and is the opposite obligation.
+    ///
+    /// A prefix pin is enough here, unlike the callback bodies, because the
+    /// hazard is a different first statement rather than something appended
+    /// after a correct one: `runSync` followed by more work is not a defect,
+    /// whereas `post` in its place is the whole defect. `resume` is pinned with
+    /// it because it is the same contract read backwards — the core resumes
+    /// first, and a transport that returns before it has resumed is one DORS
+    /// can select while its poll loop is still stopped.
+    #[test]
+    fn react_native_transport_pause_takes_effect_before_it_returns() {
+        for (manager, pause, resume) in [
+            (
+                "InternetManager",
+                "override fun pause() { runConfinedSync {",
+                "override fun resume() { runConfinedSync {",
+            ),
+            (
+                "NostrManager",
+                "override fun pause() { runConfinedSync {",
+                "override fun resume() { runConfinedSync {",
+            ),
+            (
+                "ReticulumManager",
+                "override fun pause() { runConfinedSync {",
+                "override fun resume() { runConfinedSync {",
+            ),
+            (
+                "WifiDirectManager",
+                "override fun pause() { confinement.runSync {",
+                "override fun resume() { confinement.runSync {",
+            ),
+            (
+                "ble/BleTransportFacade",
+                "override fun pause() { runOnBleThreadSync {",
+                "override fun resume() { runOnBleThreadSync {",
+            ),
+        ] {
+            let code = rn_source_code_only(&format!(
+                "android/src/main/java/com/offlineprotocol/{manager}.kt"
+            ));
+
+            for (entry, pinned) in [("pause", pause), ("resume", resume)] {
+                assert!(
+                    code.contains(pinned),
+                    "{manager}.kt's {entry} must run its body on the confinement and wait for it, \
+                     not post and return. The module pauses every transport and then the core, so \
+                     a transport that has not finished pausing when it returns can re-enter UniFFI \
+                     behind an already-paused core. The wait is safe: the module's caller is a \
+                     React Native background thread, which TransportConfinement.runSync does not \
+                     bound. Expected to find:\n  {pinned}"
+                );
+            }
+        }
+    }
+
     /// The iOS half of the same invariant: nothing calls into the core while
     /// holding `WifiDirectManager`'s `stateLock`.
     ///

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10964,6 +10964,89 @@ mod tests {
         }
     }
 
+    /// A Reticulum connect attempt that outlives its session is retired, and a
+    /// failed one still drives the reconnect ladder.
+    ///
+    /// Two defects at the same seam, both invisible to the connected-edge gate
+    /// that [`react_native_transports_do_not_resurrect_a_stopped_connection`]
+    /// pins, because that gate answers "did a stop happen" and neither of these
+    /// does.
+    ///
+    /// **A superseded attempt used to publish anyway.** `disconnect` clears
+    /// `isConnecting` while the connect is still inside `Socket.connect` — up
+    /// to 60s against a host dropping SYNs — so a `stop()` followed by a
+    /// `start()` passes `connect`'s own guard and queues a *second* attempt
+    /// behind the first on the one shared IO looper. The gate cannot catch the
+    /// survivor: by the time it runs the state is legitimately `STARTING`
+    /// again. Both attempts publish, and the loser's socket and receive thread
+    /// leak with `isConnected` still true, so when that orphaned reader
+    /// eventually errors it tears down the session that replaced it. Hence a
+    /// generation, stamped before the post and checked before publishing.
+    ///
+    /// **A failed connect used to be terminal.** The catch cleared
+    /// `isConnecting` before handing off, and `handleConnectionClosed` decides
+    /// whether a failure is worth reacting to by reading exactly that flag and
+    /// `isConnected` — so it saw both false, returned early, and never reached
+    /// `scheduleReconnect`. The 1s→30s ladder was dead for the case it exists
+    /// for, a daemon that is not running: the transport sat in `STARTING`,
+    /// where `startUnsafe` throws `AlreadyRunning`, until an explicit
+    /// stop/start. iOS clears the flag *inside* that handler, under the lock
+    /// that samples it, which is why the ladder worked there and not here.
+    /// Pinned as adjacency — nothing between `catch` and the log — plus a count
+    /// of the clear's legitimate owners, so re-adding it anywhere fails here.
+    #[test]
+    fn react_native_reticulum_retires_a_superseded_connect_attempt() {
+        let code =
+            rn_source_code_only("android/src/main/java/com/offlineprotocol/ReticulumManager.kt");
+
+        for (what, pinned) in [
+            (
+                "stamping the attempt before posting it",
+                "val generation = connectGeneration.incrementAndGet() ioHandler.post { try { \
+                 val sock = Socket()",
+            ),
+            (
+                "retiring it on teardown",
+                "isConnected.set(false) isConnecting.set(false) \
+                 connectGeneration.incrementAndGet()",
+            ),
+            (
+                "checking it before publishing the socket",
+                "if (connectGeneration.get() != generation) { try { sock.close() } \
+                 catch (_: Exception) {} return@post }",
+            ),
+            (
+                "checking it before reporting a failure",
+                "if (connectGeneration.get() == generation) { transportHandler.post { \
+                 handleConnectionClosed(-1, e.message) } }",
+            ),
+            (
+                "leaving the in-flight flag for handleConnectionClosed to clear",
+                "} catch (e: Exception) { Log.e(TAG, \"Failed to connect to Reticulum daemon\", e)",
+            ),
+        ] {
+            assert!(
+                code.contains(pinned),
+                "ReticulumManager.kt: {what} is what keeps a connect that outlived its session \
+                 from publishing over the one that replaced it, and a failed connect from \
+                 silently ending the reconnect ladder. Expected to find:\n  {pinned}"
+            );
+        }
+
+        // The two legitimate owners: `disconnect`, ending a session, and
+        // `handleConnectionOpened`, promoting one. A third is the regression —
+        // the connect catch clearing it before the handoff, which is what made
+        // `handleConnectionClosed` return early and skip `scheduleReconnect`.
+        let clears = code.matches("isConnecting.set(false)").count();
+        assert_eq!(
+            clears, 2,
+            "ReticulumManager.kt: expected isConnecting to be cleared only by disconnect() and \
+             handleConnectionOpened(); found {clears} sites. A clear on the failure path makes \
+             handleConnectionClosed read both flags false and return before scheduling the \
+             reconnect, which strands the transport in STARTING for good."
+        );
+    }
+
     /// A connection that completes after `stop()` does not resurrect the
     /// transport.
     ///
@@ -11197,7 +11280,16 @@ mod tests {
         }
     }
 
-    /// No transport callback from Rust may wait on a confinement thread.
+    /// No Android transport callback from Rust may wait on a confinement thread.
+    ///
+    /// **Android only, and deliberately so** — the title names the platform
+    /// because the mechanism is Android's. There is no `runSync` on iOS and no
+    /// confinement thread to wait on; the same hazard exists there in a
+    /// different shape (a callback that blocks on a lock whose holder needs the
+    /// core), and it is pinned separately by
+    /// [`react_native_ios_wifi_direct_state_lock_never_calls_the_core`]. A
+    /// guard over managers that are mirrored across `.kt` and `.swift` reads as
+    /// covering both unless it says otherwise, so this one says otherwise.
     ///
     /// This is the invariant that makes [`TransportConfinement.runSync`]'s
     /// unbounded background wait safe, and it is the only one here whose
@@ -11260,6 +11352,102 @@ mod tests {
                  Expected to find:\n  {pinned}"
             );
         }
+    }
+
+    /// The iOS half of the same invariant: nothing calls into the core while
+    /// holding `WifiDirectManager`'s `stateLock`.
+    ///
+    /// iOS has no `runSync`, so a transport callback cannot deadlock by
+    /// *waiting on a thread* the way the Android one can. It can deadlock by
+    /// waiting on a **lock**, and this manager is the one place that became
+    /// possible: `onMessagesAvailable` now runs inline on whichever thread the
+    /// core calls it from — holding the global protocol mutex — and takes
+    /// `stateLock` twice on the way to the drain. That is safe for exactly one
+    /// reason: no holder of `stateLock` ever calls the core back. Add a
+    /// `protocolInstance` call inside any accessor below and the two locks
+    /// acquire in opposite orders on two threads, which is the same permanent
+    /// deadlock the Android guard describes, reached through a lock instead of
+    /// a looper.
+    ///
+    /// Pinned as whole accessor bodies, one per accessor rather than as one
+    /// contiguous run, so reordering them is free and adding a call-out to any
+    /// of them is not. The count assert is the backstop the individual pins
+    /// cannot provide: a *new* accessor that takes the lock and calls the core
+    /// would satisfy every pin above it, so a tenth acquisition has to come
+    /// here and be accounted for.
+    ///
+    /// `updateState` is deliberately not in this list — it takes the lock only
+    /// through `setState` and notifies the delegate *outside* it, which is the
+    /// same reasoning and is documented at the call site.
+    #[test]
+    fn react_native_ios_wifi_direct_state_lock_never_calls_the_core() {
+        let code = rn_source_code_only("ios/WifiDirectManager.swift");
+
+        for (what, pinned) in [
+            (
+                "the state read",
+                "public var state: TransportState { stateLock.lock(); \
+                 defer { stateLock.unlock() } return _state }",
+            ),
+            (
+                "setState",
+                "private func setState(_ newState: TransportState) { stateLock.lock(); \
+                 defer { stateLock.unlock() } _state = newState }",
+            ),
+            (
+                "the session accessor",
+                "private var session: MCSession? { get { stateLock.lock(); \
+                 defer { stateLock.unlock() }; return _session } set { stateLock.lock(); \
+                 defer { stateLock.unlock() }; _session = newValue } }",
+            ),
+            (
+                "hasConnectedPeers",
+                "private var hasConnectedPeers: Bool { stateLock.lock(); \
+                 defer { stateLock.unlock() } return !_connectedPeers.isEmpty }",
+            ),
+            (
+                "deviceId(forPeer:)",
+                "private func deviceId(forPeer peerID: MCPeerID) -> String? { stateLock.lock(); \
+                 defer { stateLock.unlock() } return _connectedPeers[peerID] }",
+            ),
+            (
+                "peers(matching:)",
+                "private func peers(matching recipientId: String) -> [MCPeerID] { \
+                 stateLock.lock(); defer { stateLock.unlock() } \
+                 return _connectedPeers.filter { $0.value == recipientId }.map { $0.key } }",
+            ),
+            (
+                "setPeer",
+                "private func setPeer(_ peerID: MCPeerID, deviceId: String) { stateLock.lock(); \
+                 defer { stateLock.unlock() } _connectedPeers[peerID] = deviceId }",
+            ),
+            (
+                "removePeer",
+                "private func removePeer(_ peerID: MCPeerID) -> String? { stateLock.lock(); \
+                 defer { stateLock.unlock() } return _connectedPeers.removeValue(forKey: peerID) }",
+            ),
+            (
+                "removeAllPeers",
+                "private func removeAllPeers() { stateLock.lock(); \
+                 defer { stateLock.unlock() } _connectedPeers.removeAll() }",
+            ),
+        ] {
+            assert!(
+                code.contains(pinned),
+                "ios/WifiDirectManager.swift: {what} must hold stateLock across one field access \
+                 and nothing else. The core calls onMessagesAvailable holding its global mutex \
+                 and that path takes this lock, so a lock holder that calls back into the core \
+                 deadlocks both. Expected to find:\n  {pinned}"
+            );
+        }
+
+        let acquisitions = code.matches("stateLock.lock()").count();
+        assert_eq!(
+            acquisitions, 10,
+            "ios/WifiDirectManager.swift: expected the 10 pinned stateLock acquisitions; found \
+             {acquisitions}. A new one is not wrong, but it is unreviewed — pin its body above \
+             so it cannot grow a call into the core unnoticed."
+        );
     }
 
     /// The iOS Reticulum status flips stay off the main thread.

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -11170,9 +11170,35 @@ mod tests {
     /// `true`, or `stop()` wins and the announcement reads a state that
     /// refuses it.
     ///
+    /// **The pinned condition tests two things, and `stop()` is only one of
+    /// them** — the name of this test is the dominant half, not the whole
+    /// claim. `stop()` is not the only writer that can overtake the connected
+    /// edge: on Reticulum, `handleConnectionClosed` reaches `messageQueue` in
+    /// one hop from `connectionQueue` while the connected edge takes two
+    /// (`connectionQueue` → main → `messageQueue`), so a link that opens and
+    /// dies immediately enqueues its `false` *ahead* of the `true` announcing
+    /// it. No state check can see that: with `autoReconnect` on — the default
+    /// — that path leaves `.running` untouched, so the core is told "up" about
+    /// a dead connection and routes to a transport that never drains until the
+    /// next attempt resolves the flags. `isConnected` is the term that answers
+    /// it, and it is pinned in the same string as the state check because they
+    /// are one decision. Nostr carries it for symmetry and for its own
+    /// narrower reason (the check-then-act in `updateConnectionStatus`); its
+    /// two flips already share a single hop, so it was never exposed to the
+    /// Reticulum window.
+    ///
+    /// A text pin cannot express cross-queue ordering, which is why this class
+    /// of bug reached review rather than CI. What it *can* do is make the
+    /// condition that answers it un-droppable, which is what the string below
+    /// is for.
+    ///
     /// Android has no counterpart and must not grow one: its flips are already
     /// atomic against each other by thread confinement, so a lock there would
-    /// be cargo-culted from a platform whose problem it does not have.
+    /// be cargo-culted from a platform whose problem it does not have. Nor
+    /// does it need the liveness term — both its flips post to the one
+    /// transport handler, and `startReceiveLoop` runs only after
+    /// `handleConnectionOpened` has already enqueued its block, so enqueue
+    /// order there is causal.
     #[test]
     fn react_native_ios_status_flips_are_ordered_against_stop() {
         for (manager, flip) in [
@@ -11182,16 +11208,18 @@ mod tests {
             let code = rn_source_code_only(&format!("ios/{manager}.swift"));
 
             let connected = format!(
-                "self.statusFlipLock.lock() if self.state != .stopping && \
+                "self.statusFlipLock.lock() if self.isConnected && self.state != .stopping && \
                  self.state != .stopped {{ try? self.protocolInstance.{flip}(isConnected: true) \
                  }} self.statusFlipLock.unlock()"
             );
             assert!(
                 code.contains(&connected),
-                "ios/{manager}.swift's connected-edge flip must test the state and call {flip} \
-                 as one decision under statusFlipLock, unlocked explicitly rather than by defer \
-                 (which would hold it across the flush that follows). Expected to \
-                 find:\n  {connected}"
+                "ios/{manager}.swift's connected-edge flip must test that the connection is still \
+                 live AND that the transport is not stopping, and call {flip}, as one decision \
+                 under statusFlipLock, unlocked explicitly rather than by defer (which would hold \
+                 it across the flush that follows). Dropping the isConnected term leaves the \
+                 disconnect race open — a link that dies during the hop enqueues its false ahead \
+                 of this true, and no state check can tell. Expected to find:\n  {connected}"
             );
 
             let stopping = format!(
@@ -11472,6 +11500,15 @@ mod tests {
     /// was emptied with the call left behind on main, and that is still caught
     /// — the pin below spans the hop, the weak capture and the guarded call as
     /// one string, so the call cannot leave it.
+    ///
+    /// That shape earned itself again: the guarded call has since grown an
+    /// `isConnected` term, because the same hop this test exists to require is
+    /// what let a `false` from `handleConnectionClosed` — one hop from
+    /// `connectionQueue`, against this edge's two — overtake the `true` it
+    /// answers. Spanning the condition rather than fixing the call's position
+    /// meant the pin absorbed that without being pointed anywhere new. See
+    /// [`react_native_ios_status_flips_are_ordered_against_stop`], which owns
+    /// the condition itself.
     #[test]
     fn react_native_reticulum_status_flips_run_off_the_main_thread() {
         let code = rn_source_code_only("ios/ReticulumManager.swift");
@@ -11486,7 +11523,7 @@ mod tests {
             (
                 "connect",
                 "self.messageQueue.async { [weak self] in guard let self = self else { return } \
-                 self.statusFlipLock.lock() if self.state != .stopping && \
+                 self.statusFlipLock.lock() if self.isConnected && self.state != .stopping && \
                  self.state != .stopped { try? self.protocolInstance\
                  .reticulumStatusChanged(isConnected: true)",
             ),

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10967,18 +10967,28 @@ mod tests {
     /// A connection that completes after `stop()` does not resurrect the
     /// transport.
     ///
-    /// Both managers announce a new connection from a *posted* block, so a
+    /// All four managers announce a new connection from a *posted* block, so a
     /// `stop()` can land between the socket opening and the announcement. With
     /// no gate the announcement then runs against a stopped transport: state
     /// goes back to `RUNNING` and the core is told the transport is up after
     /// being told it was down — with nothing left that will ever tear it down
     /// again, and the next `start()` throwing `AlreadyRunning` off the wedged
-    /// state. `InternetManager` has always gated its posted blocks this way;
-    /// these two did not.
+    /// state. `InternetManager` has always gated its posted blocks this way, on
+    /// both platforms; the Reticulum and Nostr managers did not, on either.
+    ///
+    /// **Both platforms, deliberately.** The first version of this covered only
+    /// the two Kotlin managers, which read as though the invariant held
+    /// everywhere it applies — while the identical unguarded block sat in the
+    /// two Swift ones. The iOS Reticulum window is if anything the wider of the
+    /// two: its announcement crosses `DispatchQueue.main` *and* then
+    /// `messageQueue`, so there are two scheduling boundaries for a `stop()` to
+    /// land in rather than one.
     ///
     /// Pinned as the *first* statement of the block, for the same reason the
-    /// iOS guard below is: a gate that has drifted below the state write is
-    /// not a gate.
+    /// iOS status-flip guard below is: a gate that has drifted below the state
+    /// write is not a gate. On iOS that means ahead of the `messageQueue` hop,
+    /// not inside it — a gate behind the hop is checking state the hop already
+    /// let go stale.
     #[test]
     fn react_native_transports_do_not_resurrect_a_stopped_connection() {
         for (manager, cleanup) in [
@@ -11000,6 +11010,125 @@ mod tests {
                  which also closes the socket it opened; otherwise a stop() racing the connect \
                  leaves the state RUNNING and the core told the transport is up, and no later \
                  signal corrects either. Expected to find:\n  {pinned}"
+            );
+        }
+
+        for (manager, cleanup) in [
+            ("ReticulumManager", "self.disconnect()"),
+            ("NostrManager", "self.disconnectAll(fromDeinit: false)"),
+        ] {
+            let code = rn_source_code_only(&format!("ios/{manager}.swift"));
+            let pinned = format!(
+                "guard let self = self else {{ return }} guard self.state != .stopping, \
+                 self.state != .stopped else {{ {cleanup} return }} self.updateState(.running)"
+            );
+
+            assert!(
+                code.contains(&pinned),
+                "ios/{manager}.swift's connected-edge block must open with the stopped-transport \
+                 gate, ahead of any queue hop, and close the connection it opened. Without it a \
+                 stop() racing the connect leaves the state .running and the core told the \
+                 transport is up, with nothing left that will tear it down and the next start() \
+                 throwing .alreadyRunning. Expected to find:\n  {pinned}"
+            );
+        }
+    }
+
+    /// The Wi-Fi Direct framework's own callbacks stay off the main thread too.
+    ///
+    /// This transport is the one where moving *our* posts off main is only half
+    /// the job. `WifiP2pManager.initialize` takes the looper every
+    /// `ActionListener` / `PeerListListener` / `ConnectionInfoListener` callback
+    /// is delivered on, and `registerReceiver` takes the scheduler `onReceive`
+    /// runs on. Left at their defaults both land on main — and `onReceive`
+    /// reaches `wifiDirectStatusChanged`, a UniFFI call, so the global protocol
+    /// mutex would still be waited on by the UI thread with every other trace of
+    /// the defect gone.
+    ///
+    /// Neither is caught by the `Looper.getMainLooper()` guard above: the
+    /// regression is a *default*, spelled `registerReceiver(p2pReceiver,
+    /// intentFilter)` with no scheduler and no mention of a looper anywhere.
+    /// Pinned as the full argument lists so dropping an argument fails here.
+    #[test]
+    fn react_native_wifi_direct_framework_callbacks_are_confined() {
+        let code =
+            rn_source_code_only("android/src/main/java/com/offlineprotocol/WifiDirectManager.kt");
+
+        for (what, pinned) in [
+            (
+                "the P2P channel's callback looper",
+                "channel = wifiP2pManager?.initialize(context, confinement.looper) {",
+            ),
+            (
+                "the broadcast receiver's scheduler on API 33+",
+                "context.registerReceiver( p2pReceiver, intentFilter, null, transportHandler, \
+                 Context.RECEIVER_NOT_EXPORTED, )",
+            ),
+            (
+                "the broadcast receiver's scheduler below API 33",
+                "context.registerReceiver(p2pReceiver, intentFilter, null, transportHandler)",
+            ),
+        ] {
+            assert!(
+                code.contains(pinned),
+                "{what} must be the transport confinement, not the default: a Wi-Fi P2P callback \
+                 or broadcast delivered on main calls wifiDirectStatusChanged, which waits on the \
+                 core's global protocol mutex — the ANR OFF-2123 tracked, reintroduced through the \
+                 framework's door rather than ours. Expected to find:\n  {pinned}"
+            );
+        }
+    }
+
+    /// No transport callback from Rust may wait on a confinement thread.
+    ///
+    /// This is the invariant that makes [`TransportConfinement.runSync`]'s
+    /// unbounded background wait safe, and it is the only one here whose
+    /// violation is unrecoverable at runtime. These callbacks are invoked by the
+    /// core *while it holds the global protocol mutex*. A callback that waited
+    /// on a confinement thread — directly, or through any lifecycle method,
+    /// since `start`/`stop`/`pause`/`resume` are all `runSync` — would be
+    /// waiting on a thread whose next act is to ask for that same mutex. Neither
+    /// side can yield: a hard, permanent deadlock of the core, not a slow path.
+    ///
+    /// So the body of each is pinned whole: a post and nothing else. There is no
+    /// weaker form of this worth checking, because "mostly posts" is the same
+    /// deadlock. Wi-Fi Direct's carries one branch — the drain-continuation
+    /// check — which is still inside the posted block, so it is pinned up to and
+    /// including the post that contains it.
+    #[test]
+    fn react_native_transport_callbacks_never_wait_on_a_confinement() {
+        for (manager, entry, pinned) in [
+            (
+                "ReticulumManager",
+                "onMessagesAvailable",
+                "fun onMessagesAvailable() { ioHandler.post { pollAndSendMessages() } }",
+            ),
+            (
+                "NostrManager",
+                "onMessagesAvailable",
+                "fun onMessagesAvailable() { transportHandler.post { pollAndSendMessages() } }",
+            ),
+            (
+                "WifiDirectManager",
+                "onMessagesAvailable",
+                "fun onMessagesAvailable() { transportHandler.post {",
+            ),
+            (
+                "ble/BleTransportFacade",
+                "onFragmentsAvailable",
+                "fun onFragmentsAvailable() { bleHandler.post { drainAndSendFragments() } }",
+            ),
+        ] {
+            let code = rn_source_code_only(&format!(
+                "android/src/main/java/com/offlineprotocol/{manager}.kt"
+            ));
+
+            assert!(
+                code.contains(pinned),
+                "{manager}.kt's {entry} must hand its work to a handler and return. The core calls \
+                 it holding the global protocol mutex, so anything that waits on a confinement \
+                 thread here deadlocks against the very mutex that thread is about to ask for. \
+                 Expected to find:\n  {pinned}"
             );
         }
     }

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10878,6 +10878,10 @@ mod tests {
     /// saying so.
     #[test]
     fn react_native_transports_do_not_run_on_the_main_looper() {
+        // Named rather than globbed, because the directory holds plenty of
+        // files that are not transport managers. The cost of that is this
+        // list: a new transport manager is outside the invariant until it is
+        // added here, so add it with the manager.
         for manager in [
             "InternetManager",
             "WifiDirectManager",


### PR DESCRIPTION
Completes OFF-2123. #338 and #341 moved the BLE path off the main thread on
iOS and Android; this does the same for the other four transports, which had
the same defect for the same reason.

Reviewing it turned up a family of teardown races living at the same seam, and
those fixes are the larger half of the diff now — see **What else is in here**.

## Why they were broken

Every call these managers make into the core serialises on one global protocol
mutex, held across MLS work and AndroidKeyStore-backed storage callbacks. A
manager that posts its work to the main looper charges those multi-second waits
to the thread Android watches for ANRs and iOS for App Hangs. None of these
managers touches the UI — main was only ever "one thread, ordered posts".

**Android — all four:**

| Manager | What ran on main |
|---|---|
| Internet | 100ms message poll, 20s presence tick, `getIdentityPublicKey` + `signData` on every authenticate, and a lifecycle wait with **no** timeout that could park the RN bridge thread indefinitely |
| Wi-Fi Direct | 2s poll, an unbounded `while (true)` drain, and the framework's half — the P2P channel was initialized with the main looper and the receiver registered with no scheduler, so `WIFI_P2P_STATE_CHANGED` called the protocol on main |
| Nostr | lifecycle, both connect/disconnect status flips, and the `nostrQueryCompleted` release loop |
| Reticulum | lifecycle and both status flips |

Nostr and Reticulum already polled off main, which is why they looked done.

**iOS — Reticulum only.** Both `reticulumStatusChanged` calls sat inside
`DispatchQueue.main.async`. The connected edge is the expensive one: it runs
`flush_outbox_all` under the mutex — the whole outbox, on the UI thread — at
the cadence of a daemon that keeps reconnecting. The other three iOS managers
were already clean, and `InternetManager.swift` is the shape the rest now match.

## What changed

A shared `TransportConfinement` gives each Android manager a private,
process-wide, never-quit looper. This is the BLE remedy extracted, so four
subtly different threading models become one — and Nostr and Reticulum *lose*
machinery, since their per-session threads collapse into it along with the
null-checks before every post and the reconnect-races-quitSafely() hazard.

The sync helpers were three different contracts (BLE: main-only bound; Nostr
and Reticulum: flat 5s for everyone; Internet: unbounded). They now share
BLE's, which also fixes a latent bug: a flat bound fires on the RN bridge
thread — the caller that actually needs `stop()` to have finished — exactly
when the mutex is most contended, leaving a transport half-down.

Reticulum gets a **second** looper (`offline-reticulum-io`) for blocking socket
work only. The rule the confinement doc states is that nothing whose worst case
is the *network* may share the thread a `stop()` waits on: `Socket.connect` is
60s against a host dropping SYNs and a TCP write has no bound at all, so
collapsing that onto the lifecycle thread would have made `stop()` — and the RN
bridge thread behind it — parkable for a minute or forever.

Three behaviour changes worth review attention:

- `internetForceReconnect` no longer waits. It is reached from `onHostResume`
  on main, the one caller a bounded wait would throw into, and there is no
  `TeardownSequence` around a lifecycle callback to absorb that. Nothing read
  its result — the RN entry point resolves "accepted", never "reconnected".
- `pause()`/`resume()` went the other way on Nostr and Reticulum: they used to
  post and return, which paused nothing, so the core could pause underneath a
  transport still calling into it. Both wait now, and the module's fan-out runs
  through `TeardownSequence` so one throwing transport cannot skip the other
  four and the core pause behind them.
- Wi-Fi Direct's framework callbacks move via `WifiP2pManager.initialize`'s
  `srcLooper` and `registerReceiver`'s scheduler overload (which predates this
  module's minSdk and composes with the API 33+ flag argument).

## What else is in here

Bugs found reviewing the above, at the seam it touches. Several are
pre-existing; the ones marked *(introduced)* were created by the move itself.

**Announcing a connection that a stop already ended (both platforms).** All
four managers announce from a posted block, so a `stop()` fits between the
socket opening and the announcement: state went back to `RUNNING` and the core
was told the transport was up moments after being told it was down, with
nothing left to tear it down and the next `start()` throwing `AlreadyRunning`.
The relay manager had always gated its posted blocks; these had not, on either
platform. Android gets a plain check (gate, state write, flip and `stopUnsafe`
all run on the one confinement thread); iOS needs a compare-and-set plus a
`statusFlipLock`, because there the same four steps are spread over three
queues.

**A status flip overtaking its own opposite** *(introduced)*. Hopping iOS
Reticulum's connected-edge `true` onto `messageQueue` was right — but the
disconnect `false` reaches that queue in one hop from `connectionQueue` while
the `true` now takes two. A link that opens and immediately dies enqueues its
`false` *ahead* of the `true`. Pre-PR both ran on main, one queue, causal
order. No state check can see it (with `autoReconnect` on, that path never
touches `.running`), so the flip requires `isConnected` as well.

**Reticulum, Android — a failed connect never retried.** The catch cleared
`isConnecting` before handing off, and `handleConnectionClosed` decides whether
to react by reading exactly that flag plus `isConnected` — both false, early
return, no `scheduleReconnect`. The 1s→30s ladder was dead for the case it
exists for, a daemon that is not running: the transport sat in `STARTING`,
where `start()` throws, until an explicit stop/start. iOS clears it inside the
handler, under the lock that samples it, which is why it worked there.

**Reticulum, Android — a stop/restart mid-connect left two live connections.**
`disconnect` clears `isConnecting` while the connect is still blocked, so the
restart passed `connect`'s guard and queued a second attempt. Whichever lost
left a live reader believing it was connected, and tore down its successor when
it failed. Attempts are versioned now, and the version is checked at every
point a retired one can still act — with two of those checks *inside* the lock
that owns what they guard, since a check beside a cross-thread write is still a
check-then-act.

**Reticulum, Android — a stop could not end a blocked connect** *(introduced)*.
Only a close ends `Socket.connect`; it ignores interruption. With a per-session
thread that did not matter (abandon it, the restart gets a fresh one), but the
shared looper never quits, so an attempt against an unreachable daemon held the
next session's connect for the rest of the 60s timeout. The socket handle is
published before the block so teardown can reach it.

**Reticulum — teardown closed the streams before the socket.**
`BufferedReader.close()` takes the lock `readLine()` holds for its whole
blocking duration, so with the receive thread parked (`soTimeout = 0`, the
steady state) closing the streams first parked the lifecycle thread — and the
unbounded `stop()` wait behind it — until the daemon happened to speak. Only
`Socket.close()` makes a blocked read/write throw.

**Wi-Fi Direct, Android — a stop/bind race stranded port 8988**, and every
`start()` leaked a `WifiP2pManager` channel. The accept task now closes the
socket it bound on every exit; `stop()` closes the channel on API 27+.

**Nostr, Android — three plain maps crossed by two threads.** OkHttp's reader
thread reset a relay's counters while the transport thread structurally
modified the same maps; a `HashMap` read racing a resize is the classic
corruption case. Also: `stop()` never shut down the OkHttp dispatcher, so its
threads outlived every stop/start cycle.

**iOS Wi-Fi Direct** — `stop()` and `destroy()` never stopped it (only `deinit`
did), so a destroyed module could leave a live drain path holding the protocol
instance it was told to release; `session` and `connectedPeers` were touched
from three threads unsynchronised; and the drain re-reads transport state each
iteration rather than only before it starts.

**`drainProcessQueue`'s doc leaned on "never called from main"** as the reason a
2s semaphore wait is safe. That is a `dispatchPrecondition` now — behind
`#if DEBUG`, because `dispatchPrecondition` is `precondition` and traps under
`-O` too, which would have turned a stall into a shipped crash.

Plus: Android Wi-Fi Direct's `state` was the only transport state field not
`@Volatile`; a dead main-looper `Handler` field in the Android module.

No FFI, UDL, wire-format, or JS API change — no bindings regeneration needed.

## Testing

Neither platform can instantiate these managers in a test: Android has no
`OfflineProtocol` fake and no mocking library, and the iOS managers are on
`Package.swift`'s exclude list so `swift test` never compiles them. So:

- New `TransportConfinementTest` (Robolectric, 8 tests) covers ordering, the
  inline fast path, and both halves of the timeout asymmetry against a
  deliberately blocked thread.
- **Eleven** source guards in the uniffi crate pin the invariants: no
  `Looper.getMainLooper()` in the four managers, the framework-callback looper
  and receiver scheduler (invisible to the first, since that regression is a
  *dropped argument*), the connected-edge gate on both platforms, the iOS
  status-flip lock and its publish-before-lock ordering, the Reticulum socket
  split and close order, the connect generation at all five checkpoints, "no
  transport callback may wait on a confinement", "no `stateLock` holder calls
  the core", where the Wi-Fi Direct drain clears its continuation flag, and
  `pause`/`resume` waiting rather than posting.

**Every guard was verified by mutation, not assumed.** Two earned it. The first
iOS pin passed while the code was deliberately broken — "a hop appears
somewhere earlier" is satisfied by a hop whose body was emptied with the FFI
left on main, which is precisely the regression. And a prefix pin on the
Wi-Fi Direct callback matched a body that posts and *then* blocks, i.e. the
permanent core deadlock the test claims to forbid.

**Known ceiling: these pin *shape*, never *interleaving*.** All twenty guards
were green through the status-flip ordering bug above. No text pin could have
caught it; what a pin can do is make the condition that fixes it un-droppable,
which is where the `isConnected` term now lives.

Green: `cargo clippy --workspace -- -D warnings`, `cargo fmt --all --check`,
`cargo test --workspace --lib`, the Android harness suite (417), `swift test`
(233), the ci.yml `swiftc -typecheck`, and the manual symlink-farm typecheck for
`OfflineProtocolModule.swift` (which CI never compiles) — the latter
negative-controlled with an injected error.

## Not covered

The Android relay path this rewires is the layer with no automated coverage on
either platform. It wants the live-relay device pass before release.

The `TransportConfinement` rule that keeps `runSync`'s unbounded background wait
safe — nothing whose worst case is the network runs on a confinement — is
documented with one worked example and enforced by nothing. It will be violated
eventually.
