### PR TITLE
fix(bindings,uniffi): make pause() stop the send path, not just the timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   Wi-Fi Direct explicitly, since its fallback would otherwise trickle a backlog
   out at one message every two seconds.
 
+  On iOS the arming itself is what refuses: `startMessagePolling` and
+  `startPingTimer` check the flag and install the timer in one locked step,
+  because there — unlike Android, where `pause()` and the reconnect edge share
+  a thread — the two run on unrelated queues, and a check at the call site
+  could be overtaken by a whole `pause()` and arm a fresh timer against a
+  paused transport for the rest of the background stay. The poll and ping
+  handlers re-read the flag as well, since cancelling a timer cannot reach a
+  tick already dispatched.
+
 - **The iOS bridge now pauses and resumes the Wi-Fi Direct manager.** It held
   one and drove its full lifecycle everywhere else, but omitted it from the
   pause/resume fan-out that covers the other four transports — so a
@@ -282,9 +291,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
   Two of the three transports are live today. `WifiDirectTransport` is not
   registered by the bindings layer, so its managers cannot resolve a transport
-  to drain and the send-path half of the fix there is forward-looking; the send
-  behaviour this changes in a shipped app is Nostr's and Reticulum's. The iOS
-  browsing leak above is live now.
+  to drain and the send-path half of the fix there is forward-looking; the
+  send behaviour this changes in a shipped app is Nostr's and Reticulum's. The
+  iOS browsing leak above is live now.
 
 - **The remaining transports no longer run protocol calls on the app's main
   thread.** Completing what the BLE fixes started: on Android all four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,10 +273,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   Wi-Fi Direct explicitly, since its fallback would otherwise trickle a backlog
   out at one message every two seconds.
 
-  Two of the three are live today. `WifiDirectTransport` is not registered by
-  the bindings layer, so its managers cannot resolve a transport to drain and
-  the fix there is forward-looking; the behaviour this changes in a shipped app
-  is Nostr's and Reticulum's.
+- **The iOS bridge now pauses and resumes the Wi-Fi Direct manager.** It held
+  one and drove its full lifecycle everywhere else, but omitted it from the
+  pause/resume fan-out that covers the other four transports — so a
+  backgrounded app went on browsing for peers over MultipeerConnectivity, and
+  the manager's pause handling could never engage. The Android bridge already
+  paused all five.
+
+  Two of the three transports are live today. `WifiDirectTransport` is not
+  registered by the bindings layer, so its managers cannot resolve a transport
+  to drain and the send-path half of the fix there is forward-looking; the send
+  behaviour this changes in a shipped app is Nostr's and Reticulum's. The iOS
+  browsing leak above is live now.
 
 - **The remaining transports no longer run protocol calls on the app's main
   thread.** Completing what the BLE fixes started: on Android all four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **`pause()` now stops a transport sending, not just its fallback timer.**
+  Every transport drives sends from two places: a timer, which `pause()`
+  cancelled, and the callback the core makes whenever it has something to send
+  — which is the *primary* path. Nostr, Reticulum and Wi-Fi Direct cancelled
+  only the timer, on both platforms, so a backgrounded app went on draining a
+  full batch per callback: a global-mutex acquisition per message, plus a TCP
+  write on Reticulum.
+
+  The reconnect edge was the worse half, because it was durable rather than
+  transient. A relay or daemon that dropped and reconnected during a background
+  stay ran the connected branch, which restarted the timers unconditionally —
+  so the 100ms Nostr poll (and its 30s ping) came back for the rest of the
+  stay, against a transport the app had paused. The internet transport has
+  always guarded that branch; the other three now do too, along with the
+  callback, and both clear on `resume()` and on an explicit `start()`. Nothing
+  is stranded: messages stay queued in the core, and `resume()` drains them —
+  Wi-Fi Direct explicitly, since its fallback would otherwise trickle a backlog
+  out at one message every two seconds.
+
 - **The remaining transports no longer run protocol calls on the app's main
   thread.** Completing what the BLE fixes started: on Android all four
   non-BLE transport managers took their ordering from the app's main looper,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   Wi-Fi Direct explicitly, since its fallback would otherwise trickle a backlog
   out at one message every two seconds.
 
+  Two of the three are live today. `WifiDirectTransport` is not registered by
+  the bindings layer, so its managers cannot resolve a transport to drain and
+  the fix there is forward-looking; the behaviour this changes in a shipped app
+  is Nostr's and Reticulum's.
+
 - **The remaining transports no longer run protocol calls on the app's main
   thread.** Completing what the BLE fixes started: on Android all four
   non-BLE transport managers took their ordering from the app's main looper,

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/NostrManager.kt
@@ -89,6 +89,12 @@ class NostrManager(
     // Message polling runnable
     private val messagePollingRunnable = object : Runnable {
         override fun run() {
+            // Returning here also stops the repost, so a paused transport's
+            // poll chain terminates itself. Belt to `removeCallbacks`' braces:
+            // pause and this runnable share the transport thread, so the
+            // removal is already exact — but the reconnect edge can start a
+            // fresh chain, and this is what stops that one too.
+            if (isPaused) return
             pollAndSendMessages()
             pollAndSendQueries()
             if (state == TransportState.RUNNING && isConnected.get()) {
@@ -123,6 +129,22 @@ class NostrManager(
 
     // Connection state
     private val isConnected = AtomicBoolean(false)
+
+    // True between pause() and resume(). Mirrors InternetManager's flag of the
+    // same name, and exists for the same reason: stopping the poll timer is not
+    // the same as pausing the transport.
+    //
+    // Two paths re-arm the send loop behind a pause without it. The reconnect
+    // edge is the durable one — a relay that drops and reconnects while the app
+    // is backgrounded runs [updateConnectionStatus]'s connected branch, which
+    // restarted a 100ms poll for the whole background stay. The other is
+    // [onMessagesAvailable], the *primary* send path: the timer this manager's
+    // pause stops is only the fallback, so a core callback still drained a
+    // batch of ten straight through a paused transport.
+    //
+    // Volatile because [onMessagesAvailable] arrives on whichever thread the
+    // core calls it from, while pause/resume write on the transport thread.
+    @Volatile private var isPaused = false
     // Concurrent, not plain: handleRelayConnected reads these on OkHttp's
     // reader thread while scheduleReconnect's getOrPut structurally modifies
     // them on the transport thread. A plain HashMap read racing a resize is
@@ -250,6 +272,11 @@ class NostrManager(
             )
         }
 
+        // An explicit start() means "run": a pause() from a previous session
+        // must not leave this fresh transport connected-but-mute. Mirrors
+        // InternetManager.startUnsafe.
+        isPaused = false
+
         Log.i(TAG, "Starting Nostr transport for address: $address")
         emitDiagnostic("info", "Starting Nostr transport", mapOf(
             "address" to address,
@@ -331,13 +358,24 @@ class NostrManager(
      */
     override fun pause() {
         runConfinedSync {
+            // Set before the timer is stopped, and read by both paths that
+            // would otherwise re-arm the send loop behind this call — see
+            // [isPaused]. Stopping the timer alone paused the fallback and
+            // left the primary path running.
+            isPaused = true
             stopMessagePolling()
         }
     }
 
     override fun resume() {
         runConfinedSync {
+            isPaused = false
             if (state == TransportState.RUNNING && isConnected.get()) {
+                // Also drains whatever queued during the pause:
+                // [startMessagePolling] runs the runnable immediately rather
+                // than waiting out a first interval, and the core does not
+                // re-issue [onMessagesAvailable] for messages it already
+                // announced.
                 startMessagePolling()
             }
         }
@@ -345,9 +383,23 @@ class NostrManager(
 
     /**
      * Called by the Rust transport callback when new outgoing messages are available.
+     *
+     * This is the *primary* send path — the timer [pause] stops is the 100ms
+     * fallback — so it carries the pause check itself. Without it a paused
+     * transport still drained a batch of ten per callback, each one taking the
+     * core's global protocol mutex, for as long as the core kept announcing.
+     * The messages are not lost: they stay queued in the core and [resume]
+     * drains them.
      */
     fun onMessagesAvailable() {
-        transportHandler.post { pollAndSendMessages() }
+        if (isPaused) return
+        transportHandler.post {
+            // Re-read on the transport thread: pause() writes there, so a
+            // callback that passed the check above can still be overtaken by
+            // the pause it raced.
+            if (isPaused) return@post
+            pollAndSendMessages()
+        }
     }
 
     // MARK: - Relay Connection Management
@@ -497,8 +549,17 @@ class NostrManager(
                 } catch (e: Exception) {
                     Log.e(TAG, "Error notifying protocol of connect", e)
                 }
-                startMessagePolling()
-                transportHandler.post { pollAndSendMessages() }
+                // The status flip stands even while paused — the transport
+                // really is up, and DORS needs to know — but the timers do
+                // not. This is the durable half of what [isPaused] closes: a
+                // relay that drops and reconnects during a background stay
+                // reaches here, and restarting the 100ms poll from it re-armed
+                // the loop the app paused, for the rest of the stay. Mirrors
+                // InternetManager.handleAuthenticated's `if (!isPaused)`.
+                if (!isPaused) {
+                    startMessagePolling()
+                    transportHandler.post { pollAndSendMessages() }
+                }
             }
         } else if (!anyConnected && wasConnected) {
             // Lost all connections

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -174,8 +174,9 @@ class ReticulumManager(
     // batch of ten — each one a UniFFI call plus a TCP write — straight
     // through a paused transport.
     //
-    // Volatile because it is read on the IO thread ([pollAndSendMessages]) and
-    // on whichever thread the core calls [onMessagesAvailable] from, while
+    // Volatile because it is read on the IO thread — [messagePollingRunnable]'s
+    // tick and the block [onMessagesAvailable] posts — and on whichever thread
+    // the core calls [onMessagesAvailable] from (its pre-post check), while
     // pause/resume write on the transport thread.
     @Volatile private var isPaused = false
     private var reconnectAttempts = AtomicInteger(0)

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ReticulumManager.kt
@@ -97,11 +97,32 @@ class ReticulumManager(
     // this was a per-session thread: that thread was abandoned mid-call and the
     // restart got a fresh one, whereas here the next session's work queues
     // behind whatever is still blocked.
+    //
+    // "Next session" includes the next *manager*, and that is the one coupling
+    // the per-session thread did not have. [TransportConfinement.shared] is
+    // keyed by name and process-wide, so two ReticulumManager instances share
+    // this looper — reachable on a React Native reload, where the new
+    // ReactContext's module can be built before the old one's `invalidate()`
+    // runs. Only the *owning* manager's `disconnect` can close its own
+    // `pendingConnectSocket`, so a stale instance that is never stopped holds a
+    // fresh instance's connect for the rest of CONNECTION_TIMEOUT_MS. Bounded
+    // at 60s and self-healing, and `invalidate()`'s stop is what normally
+    // prevents it — but it is a real window, and the rule on
+    // [TransportConfinement] ("nothing whose worst case is the network may
+    // share the thread a stop() waits on") does not cover it: nothing waits
+    // here, the cost is queueing behind a stranger.
     private val ioHandler = TransportConfinement.shared(IO_THREAD).handler
 
     // Message polling runnable — runs on the IO thread
     private val messagePollingRunnable = object : Runnable {
         override fun run() {
+            // Returning here also stops the repost, so a paused transport's
+            // poll chain terminates itself rather than depending on the
+            // cross-looper `removeCallbacks` winning its race. That ordering
+            // still holds (see [startMessagePolling]) — this is the belt to
+            // its braces, and the only thing that covers a tick already past
+            // the removal.
+            if (isPaused) return
             pollAndSendMessages()
             if (state == TransportState.RUNNING && isConnected.get()) {
                 ioHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
@@ -139,6 +160,24 @@ class ReticulumManager(
     // Connection state
     private val isConnected = AtomicBoolean(false)
     private val isConnecting = AtomicBoolean(false)
+
+    // True between pause() and resume(). Mirrors InternetManager's flag of the
+    // same name, and exists for the same reason: stopping the poll timer is not
+    // the same as pausing the transport.
+    //
+    // Two paths re-arm the send loop behind a pause without it. The reconnect
+    // edge is the durable one — a daemon that drops and reconnects while the
+    // app is backgrounded reaches [handleConnectionOpened], which restarted the
+    // 5s poll for the whole background stay. The other is
+    // [onMessagesAvailable], the *primary* send path: the timer this manager's
+    // pause stops is only the fallback, so a core callback still drained a
+    // batch of ten — each one a UniFFI call plus a TCP write — straight
+    // through a paused transport.
+    //
+    // Volatile because it is read on the IO thread ([pollAndSendMessages]) and
+    // on whichever thread the core calls [onMessagesAvailable] from, while
+    // pause/resume write on the transport thread.
+    @Volatile private var isPaused = false
     private var reconnectAttempts = AtomicInteger(0)
     private var currentReconnectDelay = AtomicLong(RECONNECT_INITIAL_DELAY_MS)
     private var reconnectRunnable: Runnable? = null
@@ -251,6 +290,11 @@ class ReticulumManager(
             throw TransportException.AlreadyRunning()
         }
 
+        // An explicit start() means "run": a pause() from a previous session
+        // must not leave this fresh transport connected-but-mute. Mirrors
+        // InternetManager.startUnsafe.
+        isPaused = false
+
         Log.i(TAG, "Starting Reticulum transport for device: $deviceId")
         emitDiagnostic("info", "Starting Reticulum transport", mapOf(
             "deviceId" to deviceId,
@@ -320,26 +364,36 @@ class ReticulumManager(
      * ([TransportConfinement.runSync]) that `stop()` already takes from the
      * same place.
      *
-     * What this guarantees is issuance, not quiescence, and the difference is
-     * worth stating because it is weaker than [InternetManager.pause]'s. The
-     * `removeCallbacks` lands on [ioHandler] a hop later (see
-     * [startMessagePolling]), and that looper can be inside a connect for up to
-     * CONNECTION_TIMEOUT_MS — so a poll tick already queued behind it can still
-     * re-enter UniFFI after the core has been paused. Internet has no such gap
-     * because its pause and its poll share one thread. Closing it here would
-     * mean waiting on the socket thread, which is exactly what [ioHandler]
-     * exists to stop the lifecycle doing. The residual is bounded and benign:
-     * the core tolerates a poll against a paused protocol (it hands back
-     * nothing), and `stop()` — the path that must actually quiesce — closes the
-     * socket rather than waiting for it.
+     * The `removeCallbacks` alone guarantees issuance rather than quiescence,
+     * which is why [isPaused] carries the rest. The removal lands on
+     * [ioHandler] a hop later (see [startMessagePolling]), and that looper can
+     * be inside a connect for up to CONNECTION_TIMEOUT_MS — so a poll tick
+     * already queued behind it outlives this call however long it waits.
+     * Closing *that* by waiting is not available: it would mean the lifecycle
+     * thread blocking on the socket thread, exactly what [ioHandler] exists to
+     * prevent. So the tick is allowed to run and made a no-op instead, which is
+     * what the flag is for. Same for the two paths a `removeCallbacks` was
+     * never going to reach at all — [onMessagesAvailable] and the reconnect
+     * edge in [handleConnectionOpened].
      */
     override fun pause() {
-        runConfinedSync { stopMessagePolling() }
+        runConfinedSync {
+            // Set before the removal is issued, so the tick that outruns the
+            // removal still reads it. See the note above.
+            isPaused = true
+            stopMessagePolling()
+        }
     }
 
     override fun resume() {
         runConfinedSync {
+            isPaused = false
             if (state == TransportState.RUNNING && isConnected.get()) {
+                // Also drains whatever queued during the pause:
+                // [startMessagePolling] runs the runnable immediately rather
+                // than waiting out a first interval, and the core does not
+                // re-issue [onMessagesAvailable] for messages it already
+                // announced.
                 startMessagePolling()
             }
         }
@@ -348,9 +402,24 @@ class ReticulumManager(
     /**
      * Called by the Rust transport callback when new outgoing messages are available.
      * This is the primary send path, replacing timer-based polling.
+     *
+     * Which is why it carries its own pause check: the timer [pause] stops is
+     * the 5s *fallback*, so without this a paused transport still drained a
+     * batch of ten per callback — a UniFFI call and a TCP write apiece — for as
+     * long as the core kept announcing. The messages are not lost; they stay
+     * queued in the core and [resume] drains them.
      */
     fun onMessagesAvailable() {
-        ioHandler.post { pollAndSendMessages() }
+        if (isPaused) return
+        ioHandler.post {
+            // Re-read on the IO thread. The check above can be overtaken by a
+            // pause() on the transport thread, and this post can additionally
+            // sit behind a connect for up to CONNECTION_TIMEOUT_MS — the same
+            // window the poll tick has, and the reason the flag rather than a
+            // removal is what answers it.
+            if (isPaused) return@post
+            pollAndSendMessages()
+        }
     }
 
     // MARK: - Connection Management
@@ -600,9 +669,18 @@ class ReticulumManager(
                 Log.e(TAG, "Error notifying protocol of connect", e)
             }
 
-            // Start polling + immediately flush queued messages
-            startMessagePolling()
-            ioHandler.post { pollAndSendMessages() }
+            // Start polling + immediately flush queued messages — unless the
+            // app paused the transport. The status flip above stands either
+            // way (the daemon really is connected, and DORS needs to know),
+            // but the timers do not: this is the durable half of what
+            // [isPaused] closes, since a daemon that drops and reconnects
+            // during a background stay reaches here and re-armed the 5s poll
+            // for the rest of it. Mirrors
+            // InternetManager.handleAuthenticated's `if (!isPaused)`.
+            if (!isPaused) {
+                startMessagePolling()
+                ioHandler.post { pollAndSendMessages() }
+            }
         }
 
         return true

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -381,7 +381,21 @@ class WifiDirectManager(
                 // moment later. Ordering is preserved: this post is enqueued
                 // ahead of the polling runnable below, so the backlog still
                 // goes out before the first fallback tick.
-                transportHandler.post { drainAndSendMessages() }
+                //
+                // Carries [onMessagesAvailable]'s continuation check for the
+                // same reason it does, and skipping it here would not have
+                // been harmless: a continuation posted before the pause is
+                // still queued when this runs (it returns early once, on the
+                // pause, and clears the flag doing so), so continuation ->
+                // this lambda gives two self-reposting chains spending a
+                // [MAX_DRAIN_BATCH] budget each — the state
+                // [drainContinuationQueued] exists to make impossible. The
+                // continuation drains this backlog anyway, so returning here
+                // loses nothing.
+                transportHandler.post {
+                    if (drainContinuationQueued) return@post
+                    drainAndSendMessages()
+                }
                 // Removed before posting, which is the idiom the other three
                 // managers keep in their startMessagePolling helpers. This
                 // runnable reposts itself, and [startUnsafe] already posted one

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -148,8 +148,12 @@ class WifiDirectManager(
     // lambda, which `removeCallbacks` cannot target: nothing but this flag can
     // stop a continuation already in flight.
     //
-    // Volatile because [onMessagesAvailable] arrives on whichever thread the
-    // core calls it from, while pause/resume write on the transport thread.
+    // Volatile although every current access is confined to the transport
+    // thread: writes come from `runSync` blocks and reads from posted blocks
+    // — this manager's [onMessagesAvailable] posts unconditionally and never
+    // reads the flag itself. Kept volatile because this is exactly the kind
+    // of flag a future callback will read from the core's thread, as Nostr's
+    // and Reticulum's already do.
     @Volatile private var isPaused = false
 
     // True while a budget-spent drain pass has queued its own continuation.

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -365,10 +365,19 @@ class WifiDirectManager(
                 // tick sends one message every 2s, and the core does not
                 // re-issue [onMessagesAvailable] for messages it already
                 // announced, so a backlog would trickle out at that rate.
-                // Safe inline — this already runs on the transport thread,
-                // which is where the drain belongs. Mirrors
-                // WifiDirectManager.swift's resume().
-                drainAndSendMessages()
+                //
+                // Posted, not inline. This block already runs on the
+                // transport thread, so an inline call would be correct — but
+                // the `runSync` wrapping it holds the caller until the whole
+                // block finishes, and the caller is the RN native-modules
+                // thread ([OfflineProtocolModule.resume]). Inline, that
+                // thread waits through up to [MAX_DRAIN_BATCH] global-mutex
+                // acquisitions; posted, it is released after the cheap
+                // lifecycle work and the drain runs on this same thread a
+                // moment later. Ordering is preserved: this post is enqueued
+                // ahead of the polling runnable below, so the backlog still
+                // goes out before the first fallback tick.
+                transportHandler.post { drainAndSendMessages() }
                 // Removed before posting, which is the idiom the other three
                 // managers keep in their startMessagePolling helpers. This
                 // runnable reposts itself, and [startUnsafe] already posted one

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -384,12 +384,15 @@ class WifiDirectManager(
                 //
                 // Carries [onMessagesAvailable]'s continuation check for the
                 // same reason it does, and skipping it here would not have
-                // been harmless: a continuation posted before the pause is
-                // still queued when this runs (it returns early once, on the
-                // pause, and clears the flag doing so), so continuation ->
-                // this lambda gives two self-reposting chains spending a
-                // [MAX_DRAIN_BATCH] budget each — the state
-                // [drainContinuationQueued] exists to make impossible. The
+                // been harmless. The reachable ordering is this one: a
+                // continuation queued before the pause is still ahead of us
+                // on the looper when `resume()` posts this lambda — it does
+                // *not* self-cancel, because by the time it runs the flag is
+                // already false again — so it drains, spends its budget, and
+                // reposts. Without the check this lambda then starts a second
+                // self-reposting chain alongside it, two [MAX_DRAIN_BATCH]
+                // budgets deep, which is exactly the state
+                // [drainContinuationQueued] exists to make impossible. That
                 // continuation drains this backlog anyway, so returning here
                 // loses nothing.
                 transportHandler.post {
@@ -753,8 +756,19 @@ class WifiDirectManager(
     /**
      * Called by the Rust transport callback when new outgoing messages are available.
      * This is the primary send path, replacing the 100ms polling loop.
+     *
+     * The pre-post check mirrors [NostrManager.onMessagesAvailable] and
+     * [ReticulumManager.onMessagesAvailable], and earns its keep for a reason
+     * specific to this manager: [drainAndSendMessages] already refuses while
+     * paused, so without this every core callback during a background stay
+     * still posts a runnable onto [transportHandler] just to return. That
+     * looper is not this manager's alone — [startUnsafe] hands it to
+     * `WifiP2pManager.initialize` and to `registerReceiver`, and a broadcast
+     * that misses Android's dispatch budget is an ANR wherever the receiver
+     * lives. Not posting at all is strictly better than posting a no-op.
      */
     fun onMessagesAvailable() {
+        if (isPaused) return
         transportHandler.post {
             // A pass that spent its budget has already queued a continuation,
             // and that continuation drains whatever this callback is

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/WifiDirectManager.kt
@@ -136,6 +136,22 @@ class WifiDirectManager(
     private var isGroupOwner = false
     private var groupOwnerAddress: String? = null
 
+    // True between pause() and resume(). Mirrors InternetManager's flag of the
+    // same name, and exists for the same reason: stopping the poll timer is not
+    // the same as pausing the transport.
+    //
+    // The timer [pause] removes is the 2s *fallback*. The primary send path is
+    // [onMessagesAvailable] → [drainAndSendMessages], which gated only on
+    // `state` — and pause does not change `state` — so a paused transport went
+    // on draining batches of [MAX_DRAIN_BATCH], each message a global-mutex
+    // acquisition. Worse, a budget-spent pass reposts itself as an anonymous
+    // lambda, which `removeCallbacks` cannot target: nothing but this flag can
+    // stop a continuation already in flight.
+    //
+    // Volatile because [onMessagesAvailable] arrives on whichever thread the
+    // core calls it from, while pause/resume write on the transport thread.
+    @Volatile private var isPaused = false
+
     // True while a budget-spent drain pass has queued its own continuation.
     // Confined to the transport thread — [drainAndSendMessages] and the block
     // in [onMessagesAvailable] are its only reader and writer, and both run
@@ -146,6 +162,10 @@ class WifiDirectManager(
     // Message polling
     private val messagePollingRunnable = object : Runnable {
         override fun run() {
+            // Returning here also stops the repost, so a paused transport's
+            // poll chain terminates itself rather than relying on the
+            // `removeCallbacks` in [pause] having landed first.
+            if (isPaused) return
             pollAndSendMessages()
             if (state == TransportState.RUNNING) {
                 transportHandler.postDelayed(this, MESSAGE_POLL_INTERVAL_MS)
@@ -213,6 +233,11 @@ class WifiDirectManager(
         ))
 
         updateState(TransportState.STARTING)
+
+        // An explicit start() means "run": a pause() from a previous session
+        // must not leave this fresh transport connected-but-mute. Mirrors
+        // InternetManager.startUnsafe.
+        isPaused = false
 
         // Initialize the channel on the transport looper: `srcLooper` is the
         // thread every ActionListener / PeerListListener / ConnectionInfoListener
@@ -321,6 +346,10 @@ class WifiDirectManager(
 
     override fun pause() {
         confinement.runSync {
+            // Set before the removal, and the only thing that stops a drain
+            // continuation already queued — those are posted as anonymous
+            // lambdas, which removeCallbacks cannot target. See [isPaused].
+            isPaused = true
             transportHandler.removeCallbacks(messagePollingRunnable)
             stopPeerDiscovery()
         }
@@ -328,8 +357,18 @@ class WifiDirectManager(
 
     override fun resume() {
         confinement.runSync {
+            isPaused = false
             if (state == TransportState.RUNNING) {
                 startPeerDiscovery()
+                // Drain what queued during the pause. Unlike the other three
+                // managers, restarting the timer is not enough here: a poll
+                // tick sends one message every 2s, and the core does not
+                // re-issue [onMessagesAvailable] for messages it already
+                // announced, so a backlog would trickle out at that rate.
+                // Safe inline — this already runs on the transport thread,
+                // which is where the drain belongs. Mirrors
+                // WifiDirectManager.swift's resume().
+                drainAndSendMessages()
                 // Removed before posting, which is the idiom the other three
                 // managers keep in their startMessagePolling helpers. This
                 // runnable reposts itself, and [startUnsafe] already posted one
@@ -736,7 +775,14 @@ class WifiDirectManager(
         // next start() delivers.
         drainContinuationQueued = false
 
-        if (state != TransportState.RUNNING || connectedPeers.isEmpty()) return
+        // `isPaused` alongside the state, because pause() does not change the
+        // state and this is the *primary* send path — the timer it removes is
+        // the 2s fallback. Checked here rather than in [onMessagesAvailable]
+        // alone so it also catches the self-posted continuation, which no
+        // removeCallbacks can reach. Clearing the flag above first is what
+        // keeps a pause from wedging the callback path: the pass exits with
+        // drainContinuationQueued false, so resume()'s drain is not suppressed.
+        if (isPaused || state != TransportState.RUNNING || connectedPeers.isEmpty()) return
 
         try {
             var sent = 0

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -543,6 +543,13 @@ public class NostrManager: NSObject, TransportManager {
                 // per 30s is noise next to the 100ms poll the guard below
                 // stops.
                 //
+                // Not a one-platform exception, though it reads like one:
+                // Android reaches the same end state by a different route —
+                // its ping is OkHttp's `.pingInterval(...)`, inside the client
+                // rather than a manager timer, so `pause()` never touched it
+                // there either. Gating this one to "restore symmetry" would
+                // be what creates the divergence.
+                //
                 // The poll is the durable half of what `isPaused` closes: a
                 // relay that drops and reconnects during a background stay
                 // reaches here, and restarting the poll from it re-armed the

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -123,6 +123,24 @@ public class NostrManager: NSObject, TransportManager {
         set { stateLock.lock(); defer { stateLock.unlock() }; _isConnected = newValue }
     }
 
+    /// True between `pause()` and `resume()`. Mirrors `InternetManager`'s flag
+    /// of the same name, and exists for the same reason: stopping the poll and
+    /// ping timers is not the same as pausing the transport.
+    ///
+    /// Two paths re-arm the send loop behind a pause without it. The reconnect
+    /// edge is the durable one — a relay that drops and reconnects while the
+    /// app is backgrounded runs `updateConnectionStatus`'s connected branch,
+    /// which restarted a 100ms poll *and* the 30s ping for the whole background
+    /// stay. The other is `onMessagesAvailable`, the *primary* send path: the
+    /// timer this manager's pause stops is only the fallback, so a core
+    /// callback still drained a batch of ten straight through a paused
+    /// transport. The Android manager carries the identical pair.
+    private var _isPaused = false
+    private var isPaused: Bool {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _isPaused }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _isPaused = newValue }
+    }
+
     // Failure tracking for DORS
     private var _consecutiveSendFailures: Int = 0
     private var consecutiveSendFailures: Int {
@@ -238,6 +256,11 @@ public class NostrManager: NSObject, TransportManager {
             "publicKey": publicKeyHex
         ])
 
+        // An explicit start() means "run": a pause() from a previous session
+        // must not leave this fresh transport connected-but-mute. Mirrors
+        // `InternetManager.start()`.
+        isPaused = false
+
         updateState(.starting)
 
         // Create URL session for WebSocket connections
@@ -293,12 +316,20 @@ public class NostrManager: NSObject, TransportManager {
     }
 
     public func pause() {
+        // Set before the timers are cancelled, and read by both paths a
+        // cancellation was never going to reach — `onMessagesAvailable` and
+        // the reconnect edge in `updateConnectionStatus`. See `isPaused`.
+        isPaused = true
         stopMessagePolling()
         stopPingTimer()
     }
 
     public func resume() {
+        isPaused = false
         if state == .running && isConnected {
+            // Also drains whatever queued during the pause: the poll timer is
+            // scheduled at `.now()`, and the core does not re-issue
+            // `onMessagesAvailable` for messages it already announced.
             startMessagePolling()
             startPingTimer()
         }
@@ -307,9 +338,20 @@ public class NostrManager: NSObject, TransportManager {
     // MARK: - Event-Driven Sending
 
     /// Called by the Rust transport callback when new outgoing messages are available.
+    /// Called by the Rust transport callback when new outgoing messages are
+    /// available.
+    ///
+    /// This is the *primary* send path — the timer `pause()` cancels is the
+    /// 100ms fallback — so it carries the pause check itself. Without it a
+    /// paused transport still drained a batch of ten per callback, each one
+    /// taking the core's global protocol mutex, for as long as the core kept
+    /// announcing. The messages are not lost: they stay queued in the core and
+    /// `resume()` drains them.
     public func onMessagesAvailable() {
+        guard !isPaused else { return }
         messageQueue.async { [weak self] in
-            self?.pollAndSendMessages()
+            guard let self = self, !self.isPaused else { return }
+            self.pollAndSendMessages()
         }
     }
 
@@ -490,6 +532,14 @@ public class NostrManager: NSObject, TransportManager {
                 }
                 self.statusFlipLock.unlock()
                 self.consecutiveSendFailures = 0
+                // The status flip above stands even while paused — the relay
+                // really is up, and DORS needs to know — but the timers do
+                // not. This is the durable half of what `isPaused` closes: a
+                // relay that drops and reconnects during a background stay
+                // reaches here, and restarting the 100ms poll and 30s ping
+                // from it re-armed both for the rest of the stay. Mirrors
+                // `InternetManager.handleAuthenticated`'s `if !isPaused`.
+                guard !self.isPaused else { return }
                 self.startMessagePolling()
                 self.startPingTimer()
                 self.pollAndSendMessages()

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -1003,6 +1003,16 @@ public class NostrManager: NSObject, TransportManager {
     /// and the `resume()` below is still required — releasing a suspended
     /// `DispatchSource` is a hard crash, so the paused branch must return
     /// *before* a source exists rather than cancel one it never resumed.
+    ///
+    /// The same crash is why the gap is safe against a *second* arming, which
+    /// is less obvious. Two callers can overlap so that the second one reads
+    /// the first's source as its `previous` and cancels it while the first has
+    /// not resumed it yet. Cancelling a suspended source is fine; *releasing*
+    /// one is not, and the release cannot happen there — the first caller
+    /// still holds its own strong reference and drops it only after
+    /// `timer.resume()` returns. Anything that moves the `resume()` off this
+    /// straight-line path, or hands the source somewhere it can outlive this
+    /// frame while suspended, reintroduces the crash.
     private func startMessagePolling() {
         stateLock.lock()
         guard !_isPaused else {

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -533,15 +533,25 @@ public class NostrManager: NSObject, TransportManager {
                 self.statusFlipLock.unlock()
                 self.consecutiveSendFailures = 0
                 // The status flip above stands even while paused — the relay
-                // really is up, and DORS needs to know — but the timers do
-                // not. This is the durable half of what `isPaused` closes: a
+                // really is up, and DORS needs to know — and so does the
+                // ping: it is the socket's liveness keepalive, not the send
+                // path. A socket that reconnects while paused and is left
+                // unpinged is a zombie nothing here can detect —
+                // `InternetManager` gates its ping the same way but carries
+                // `WriteStallWatchdog` + `forceReconnect` as the recovery;
+                // this manager's only detector is `consecutiveSendFailures`,
+                // which needs the very sends the pause suppresses. One frame
+                // per 30s is noise next to the 100ms poll the guard below
+                // stops.
+                //
+                // The poll is the durable half of what `isPaused` closes: a
                 // relay that drops and reconnects during a background stay
-                // reaches here, and restarting the 100ms poll and 30s ping
-                // from it re-armed both for the rest of the stay. Mirrors
+                // reaches here, and restarting the poll from it re-armed the
+                // 100ms timer for the rest of the stay. Mirrors
                 // `InternetManager.handleAuthenticated`'s `if !isPaused`.
+                self.startPingTimer()
                 guard !self.isPaused else { return }
                 self.startMessagePolling()
-                self.startPingTimer()
                 self.pollAndSendMessages()
             }
         } else if !anyConnected && wasConnected {

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -48,9 +48,11 @@ public class NostrManager: NSObject, TransportManager {
     // Nostr public key (obtained from Rust core)
     private var publicKeyHex: String = ""
 
-    // Message polling
-    private var messageTimer: DispatchSourceTimer?
-    private var pingTimer: DispatchSourceTimer?
+    // Message polling. Both timers are guarded by [stateLock] — see
+    // [startMessagePolling] for why they have to share the flag's lock rather
+    // than sit beside it.
+    private var _messageTimer: DispatchSourceTimer?
+    private var _pingTimer: DispatchSourceTimer?
     private let messageQueue = DispatchQueue(label: "com.offlineprotocol.nostr.messages")
     private let connectionQueue = DispatchQueue(label: "com.offlineprotocol.nostr.connection")
 
@@ -319,6 +321,12 @@ public class NostrManager: NSObject, TransportManager {
         // Set before the timers are cancelled, and read by both paths a
         // cancellation was never going to reach — `onMessagesAvailable` and
         // the reconnect edge in `updateConnectionStatus`. See `isPaused`.
+        //
+        // The ordering is what makes this a pause rather than a cancel: any
+        // arming that has not yet taken [stateLock] sees the flag and refuses
+        // (`startMessagePolling`), and any that already holds it installs a
+        // timer the `stop` below then cancels. Neither order leaves a live
+        // timer behind.
         isPaused = true
         stopMessagePolling()
         stopPingTimer()
@@ -532,32 +540,25 @@ public class NostrManager: NSObject, TransportManager {
                 self.statusFlipLock.unlock()
                 self.consecutiveSendFailures = 0
                 // The status flip above stands even while paused — the relay
-                // really is up, and DORS needs to know — and so does the
-                // ping: it is the socket's liveness keepalive, not the send
-                // path. A socket that reconnects while paused and is left
-                // unpinged is a zombie nothing here can detect —
-                // `InternetManager` gates its ping the same way but carries
-                // `WriteStallWatchdog` + `forceReconnect` as the recovery;
-                // this manager's only detector is `consecutiveSendFailures`,
-                // which needs the very sends the pause suppresses. One frame
-                // per 30s is noise next to the 100ms poll the guard below
-                // stops.
-                //
-                // Not a one-platform exception, though it reads like one:
-                // Android reaches the same end state by a different route —
-                // its ping is OkHttp's `.pingInterval(...)`, inside the client
-                // rather than a manager timer, so `pause()` never touched it
-                // there either. Gating this one to "restore symmetry" would
-                // be what creates the divergence.
-                //
-                // The poll is the durable half of what `isPaused` closes: a
+                // really is up, and DORS needs to know — but the timers do
+                // not. This is the durable half of what `isPaused` closes: a
                 // relay that drops and reconnects during a background stay
                 // reaches here, and restarting the poll from it re-armed the
                 // 100ms timer for the rest of the stay. Mirrors
-                // `InternetManager.handleAuthenticated`'s `if !isPaused`.
-                self.startPingTimer()
+                // `InternetManager.handleAuthenticated`'s `if !isPaused`,
+                // ping included — the earlier ping exception here is gone,
+                // see `startPingTimer`.
+                //
+                // Belt to the braces `startMessagePolling`/`startPingTimer`
+                // now carry internally: those two refuse to arm while paused
+                // whatever this reads, which is what makes the refusal proof
+                // against a `pause()` landing between this guard and the
+                // calls below. What the guard still earns on its own is
+                // `pollAndSendMessages`, which is not a timer and has no
+                // internal gate to fall back on.
                 guard !self.isPaused else { return }
                 self.startMessagePolling()
+                self.startPingTimer()
                 self.pollAndSendMessages()
             }
         } else if !anyConnected && wasConnected {
@@ -973,39 +974,105 @@ public class NostrManager: NSObject, TransportManager {
 
     // MARK: - Message Polling
 
+    /// Arms the fallback poll timer, unless the transport is paused.
+    ///
+    /// The pause gate lives *here*, not at the four call sites that arm this,
+    /// and it shares one [stateLock] critical section with installing the
+    /// timer. Both halves of that are load-bearing.
+    ///
+    /// **Why here.** A gate at the call site is an invariant every future
+    /// caller has to remember; a gate at the one function that can violate it
+    /// is an invariant a new caller cannot get wrong. This is the same move
+    /// `react_native_transports_do_not_run_on_the_main_looper` makes by
+    /// deriving its manager set instead of listing it.
+    ///
+    /// **Why under the lock.** `pause()` runs on the React Native method
+    /// queue, while the reconnect edge that arms this runs on `messageQueue`
+    /// (Reticulum's, on main). They are not ordered against each other, so a
+    /// caller that read `isPaused` and *then* called in could be overtaken by
+    /// the whole of `pause()` in between — flag set, timer cancelled — and
+    /// arm a fresh 100ms timer against a transport the app just paused, which
+    /// then polls for the rest of the background stay. That is precisely the
+    /// durable symptom `isPaused` exists to remove, so the check and the
+    /// install have to be one decision. The Android managers get this for
+    /// free: their `pause()` and their reconnect edge are the same thread.
+    ///
+    /// The source is created inside the critical section and resumed outside
+    /// it, which is safe in both directions: a `pause()` that lands in the gap
+    /// cancels the timer through [stopMessagePolling] before it ever fires,
+    /// and the `resume()` below is still required — releasing a suspended
+    /// `DispatchSource` is a hard crash, so the paused branch must return
+    /// *before* a source exists rather than cancel one it never resumed.
     private func startMessagePolling() {
-        stopMessagePolling()
-
+        stateLock.lock()
+        guard !_isPaused else {
+            stateLock.unlock()
+            return
+        }
+        let previous = _messageTimer
         let timer = DispatchSource.makeTimerSource(queue: messageQueue)
+        _messageTimer = timer
+        stateLock.unlock()
+
+        previous?.cancel()
         timer.schedule(deadline: .now(), repeating: MESSAGE_POLL_INTERVAL)
         timer.setEventHandler { [weak self] in
-            self?.pollAndSendMessages()
-            self?.pollAndSendQueries()
+            // Re-read per tick: `cancel()` cannot reach a handler already
+            // dispatched onto `messageQueue`, so without this one full poll
+            // batch — messages *and* queries — leaks past every `pause()`.
+            // The Android polling runnables carry the identical check.
+            guard let self = self, !self.isPaused else { return }
+            self.pollAndSendMessages()
+            self.pollAndSendQueries()
         }
         timer.resume()
-        messageTimer = timer
     }
 
     private func stopMessagePolling() {
-        messageTimer?.cancel()
-        messageTimer = nil
+        stateLock.lock()
+        let timer = _messageTimer
+        _messageTimer = nil
+        stateLock.unlock()
+        timer?.cancel()
     }
 
+    /// The keepalive ping, armed under the same rule as the poll above.
+    ///
+    /// Gating it here is what lets the reconnect edge call this
+    /// unconditionally and still honour a pause — and it is why `pause()`
+    /// stopping the ping is now the whole story rather than half of it. An
+    /// earlier revision left the reconnect edge restarting the ping on the
+    /// grounds that an unpinged paused socket is an undetectable zombie; that
+    /// argument applies at least as strongly to a socket already connected
+    /// when the pause landed, whose ping `pause()` stops and never restarts,
+    /// so it bought nothing and only diverged from `InternetManager`, which
+    /// gates both timers together.
     private func startPingTimer() {
-        stopPingTimer()
-
+        stateLock.lock()
+        guard !_isPaused else {
+            stateLock.unlock()
+            return
+        }
+        let previous = _pingTimer
         let timer = DispatchSource.makeTimerSource(queue: connectionQueue)
+        _pingTimer = timer
+        stateLock.unlock()
+
+        previous?.cancel()
         timer.schedule(deadline: .now() + PING_INTERVAL, repeating: PING_INTERVAL)
         timer.setEventHandler { [weak self] in
-            self?.sendPings()
+            guard let self = self, !self.isPaused else { return }
+            self.sendPings()
         }
         timer.resume()
-        pingTimer = timer
     }
 
     private func stopPingTimer() {
-        pingTimer?.cancel()
-        pingTimer = nil
+        stateLock.lock()
+        let timer = _pingTimer
+        _pingTimer = nil
+        stateLock.unlock()
+        timer?.cancel()
     }
 
     /// Must be called on `connectionQueue` (the ping timer fires there).

--- a/bindings/react-native/ios/NostrManager.swift
+++ b/bindings/react-native/ios/NostrManager.swift
@@ -337,7 +337,6 @@ public class NostrManager: NSObject, TransportManager {
 
     // MARK: - Event-Driven Sending
 
-    /// Called by the Rust transport callback when new outgoing messages are available.
     /// Called by the Rust transport callback when new outgoing messages are
     /// available.
     ///

--- a/bindings/react-native/ios/OfflineProtocolModule.swift
+++ b/bindings/react-native/ios/OfflineProtocolModule.swift
@@ -1195,11 +1195,20 @@ class OfflineProtocolModule: RCTEventEmitter {
     @objc func pause(_ resolver: @escaping RCTPromiseResolveBlock,
                     rejecter: @escaping RCTPromiseRejectBlock) {
         do {
-            // Pause transports for background mode
+            // Pause transports for background mode.
+            //
+            // Every manager the module can hold, and the Android mirror
+            // ([OfflineProtocolModule.pause]) names the same five — a manager
+            // missing from this list is not "paused but dormant", it is a
+            // transport whose `isPaused` can never become true, so every gate
+            // written against that flag is dead code and every source pin over
+            // its `pause()` body is vacuous. Wi-Fi Direct was exactly that
+            // until this call was added. Pinned in the uniffi source guards.
             bleManager?.pause()
             reticulumManager?.pause()
             nostrManager?.pause()
             internetManager?.pause()
+            wifiDirectManager?.pause()
 
             try protocolInstance?.pause()
             resolver(nil)
@@ -1213,11 +1222,13 @@ class OfflineProtocolModule: RCTEventEmitter {
         do {
             try protocolInstance?.resume()
 
-            // Resume transports
+            // Resume transports — the same five [pause] stops, core first so a
+            // transport never hands work to a still-paused core.
             bleManager?.resume()
             reticulumManager?.resume()
             nostrManager?.resume()
             internetManager?.resume()
+            wifiDirectManager?.resume()
 
             resolver(nil)
         } catch {

--- a/bindings/react-native/ios/ReticulumManager.swift
+++ b/bindings/react-native/ios/ReticulumManager.swift
@@ -700,6 +700,16 @@ public class ReticulumManager: NSObject, TransportManager {
     /// and the `resume()` below is still required — releasing a suspended
     /// `DispatchSource` is a hard crash, so the paused branch must return
     /// *before* a source exists rather than cancel one it never resumed.
+    ///
+    /// The same crash is why the gap is safe against a *second* arming, which
+    /// is less obvious. Two callers can overlap so that the second one reads
+    /// the first's source as its `previous` and cancels it while the first has
+    /// not resumed it yet. Cancelling a suspended source is fine; *releasing*
+    /// one is not, and the release cannot happen there — the first caller
+    /// still holds its own strong reference and drops it only after
+    /// `timer.resume()` returns. Anything that moves the `resume()` off this
+    /// straight-line path, or hands the source somewhere it can outlive this
+    /// frame while suspended, reintroduces the crash.
     private func startMessagePolling() {
         stateLock.lock()
         guard !_isPaused else {

--- a/bindings/react-native/ios/ReticulumManager.swift
+++ b/bindings/react-native/ios/ReticulumManager.swift
@@ -104,6 +104,24 @@ public class ReticulumManager: NSObject, TransportManager {
     }
 
     // State tracking (guarded by stateLock)
+    /// True between `pause()` and `resume()`. Mirrors `InternetManager`'s flag
+    /// of the same name, and exists for the same reason: stopping the poll
+    /// timer is not the same as pausing the transport.
+    ///
+    /// Two paths re-arm the send loop behind a pause without it. The reconnect
+    /// edge is the durable one — a daemon that drops and reconnects while the
+    /// app is backgrounded reaches `handleConnectionOpened`, which restarted
+    /// the poll for the whole background stay. The other is
+    /// `onMessagesAvailable`, the *primary* send path: the timer this manager's
+    /// pause stops is only the fallback, so a core callback still drained a
+    /// batch straight through a paused transport. The Android manager carries
+    /// the identical pair.
+    private var _isPaused = false
+    private var isPaused: Bool {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _isPaused }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _isPaused = newValue }
+    }
+
     private var _isConnected = false
     private var isConnected: Bool {
         get { stateLock.lock(); defer { stateLock.unlock() }; return _isConnected }
@@ -187,6 +205,11 @@ public class ReticulumManager: NSObject, TransportManager {
             "daemonAddress": "\(daemonHost):\(daemonPort)"
         ])
 
+        // An explicit start() means "run": a pause() from a previous session
+        // must not leave this fresh transport connected-but-mute. Mirrors
+        // `InternetManager.start()`.
+        isPaused = false
+
         updateState(.starting)
         connect()
     }
@@ -226,11 +249,19 @@ public class ReticulumManager: NSObject, TransportManager {
     }
 
     public func pause() {
+        // Set before the timer is cancelled, and read by both paths a
+        // cancellation was never going to reach — `onMessagesAvailable` and
+        // the reconnect edge in `handleConnectionOpened`. See `isPaused`.
+        isPaused = true
         stopMessagePolling()
     }
 
     public func resume() {
+        isPaused = false
         if state == .running && isConnected {
+            // Also drains whatever queued during the pause: the poll timer is
+            // scheduled at `.now()`, and the core does not re-issue
+            // `onMessagesAvailable` for messages it already announced.
             startMessagePolling()
         }
     }
@@ -350,7 +381,16 @@ public class ReticulumManager: NSObject, TransportManager {
                 return
             }
 
-            self.startMessagePolling()
+            // Skipped while paused. The status flip below stands either way
+            // (the daemon really is connected, and DORS needs to know), but
+            // the timer does not: this is the durable half of what `isPaused`
+            // closes, since a daemon that drops and reconnects during a
+            // background stay reaches here and re-armed the poll for the rest
+            // of it. Mirrors `InternetManager.handleAuthenticated`'s
+            // `if !isPaused`.
+            if !self.isPaused {
+                self.startMessagePolling()
+            }
             // The status flip is a UniFFI call and does not belong on main:
             // it takes the global protocol mutex, and on the false→true edge
             // takes it a second time to flush the entire outbox. That is the
@@ -403,7 +443,9 @@ public class ReticulumManager: NSObject, TransportManager {
                     try? self.protocolInstance.reticulumStatusChanged(isConnected: true)
                 }
                 self.statusFlipLock.unlock()
-                // Immediately flush queued messages
+                // Immediately flush queued messages — unless paused, for the
+                // same reason the poll restart above is skipped.
+                guard !self.isPaused else { return }
                 self.pollAndSendMessages()
             }
         }
@@ -533,9 +575,20 @@ public class ReticulumManager: NSObject, TransportManager {
 
     /// Called by the Rust transport callback when new outgoing messages are available.
     /// This is the primary send path, replacing timer-based polling.
+    /// Called by the Rust transport callback when new outgoing messages are
+    /// available.
+    ///
+    /// This is the *primary* send path — the timer `pause()` cancels is the
+    /// fallback — so it carries the pause check itself. Without it a paused
+    /// transport still drained a batch per callback, each message taking the
+    /// core's global protocol mutex, for as long as the core kept announcing.
+    /// The messages are not lost: they stay queued in the core and `resume()`
+    /// drains them.
     public func onMessagesAvailable() {
+        guard !isPaused else { return }
         messageQueue.async { [weak self] in
-            self?.pollAndSendMessages()
+            guard let self = self, !self.isPaused else { return }
+            self.pollAndSendMessages()
         }
     }
 

--- a/bindings/react-native/ios/ReticulumManager.swift
+++ b/bindings/react-native/ios/ReticulumManager.swift
@@ -44,7 +44,9 @@ public class ReticulumManager: NSObject, TransportManager {
     private let connectionQueue = DispatchQueue(label: "com.offlineprotocol.reticulum.connection")
 
     // Message polling
-    private var messageTimer: DispatchSourceTimer?
+    // Guarded by [stateLock] — see [startMessagePolling] for why it has to
+    // share the flag's lock rather than sit beside it.
+    private var _messageTimer: DispatchSourceTimer?
     private let messageQueue = DispatchQueue(label: "com.offlineprotocol.reticulum.messages")
 
     // Reconnection (guarded by stateLock)
@@ -252,6 +254,12 @@ public class ReticulumManager: NSObject, TransportManager {
         // Set before the timer is cancelled, and read by both paths a
         // cancellation was never going to reach — `onMessagesAvailable` and
         // the reconnect edge in `handleConnectionOpened`. See `isPaused`.
+        //
+        // The ordering is what makes this a pause rather than a cancel: any
+        // arming that has not yet taken [stateLock] sees the flag and refuses
+        // ([startMessagePolling]), and any that already holds it installs a
+        // timer the `stop` below then cancels. Neither order leaves a live
+        // timer behind.
         isPaused = true
         stopMessagePolling()
     }
@@ -388,6 +396,13 @@ public class ReticulumManager: NSObject, TransportManager {
             // background stay reaches here and re-armed the poll for the rest
             // of it. Mirrors `InternetManager.handleAuthenticated`'s
             // `if !isPaused`.
+            //
+            // Belt to the braces [startMessagePolling] now carries internally.
+            // It refuses to arm while paused whatever this reads, which is
+            // what makes the refusal proof against a `pause()` landing between
+            // this check and the call — this block runs on main while
+            // `pause()` runs on the React Native method queue, so nothing
+            // orders them.
             if !self.isPaused {
                 self.startMessagePolling()
             }
@@ -657,21 +672,64 @@ public class ReticulumManager: NSObject, TransportManager {
         }
     }
 
+    /// Arms the fallback poll timer, unless the transport is paused.
+    ///
+    /// The pause gate lives *here*, not at the call sites that arm this, and
+    /// it shares one [stateLock] critical section with installing the timer.
+    /// Both halves of that are load-bearing.
+    ///
+    /// **Why here.** A gate at the call site is an invariant every future
+    /// caller has to remember; a gate at the one function that can violate it
+    /// is an invariant a new caller cannot get wrong.
+    ///
+    /// **Why under the lock.** `pause()` runs on the React Native method
+    /// queue while [handleConnectionOpened] arms this from *main*, so the two
+    /// are fully concurrent — wider than the Nostr manager's window, which at
+    /// least shares `messageQueue` with its own poll. A caller that read
+    /// `isPaused` and then called in could be overtaken by the whole of
+    /// `pause()` in between — flag set, timer cancelled — and arm a fresh 5s
+    /// timer against a transport the app just paused, which then polls for the
+    /// rest of the background stay. That is the durable symptom `isPaused`
+    /// exists to remove, so the check and the install are one decision. The
+    /// Android manager gets this for free: its `pause()` and its reconnect
+    /// edge are the same thread.
+    ///
+    /// The source is created inside the critical section and resumed outside
+    /// it, which is safe in both directions: a `pause()` that lands in the gap
+    /// cancels the timer through [stopMessagePolling] before it ever fires,
+    /// and the `resume()` below is still required — releasing a suspended
+    /// `DispatchSource` is a hard crash, so the paused branch must return
+    /// *before* a source exists rather than cancel one it never resumed.
     private func startMessagePolling() {
-        stopMessagePolling()
-
+        stateLock.lock()
+        guard !_isPaused else {
+            stateLock.unlock()
+            return
+        }
+        let previous = _messageTimer
         let timer = DispatchSource.makeTimerSource(queue: messageQueue)
+        _messageTimer = timer
+        stateLock.unlock()
+
+        previous?.cancel()
         timer.schedule(deadline: .now(), repeating: MESSAGE_POLL_INTERVAL)
         timer.setEventHandler { [weak self] in
-            self?.pollAndSendMessages()
+            // Re-read per tick: `cancel()` cannot reach a handler already
+            // dispatched onto `messageQueue`, so without this one full poll
+            // batch leaks past every `pause()`. The Android polling runnable
+            // carries the identical check.
+            guard let self = self, !self.isPaused else { return }
+            self.pollAndSendMessages()
         }
         timer.resume()
-        messageTimer = timer
     }
 
     private func stopMessagePolling() {
-        messageTimer?.cancel()
-        messageTimer = nil
+        stateLock.lock()
+        let timer = _messageTimer
+        _messageTimer = nil
+        stateLock.unlock()
+        timer?.cancel()
     }
 
     private func pollAndSendMessages() {

--- a/bindings/react-native/ios/ReticulumManager.swift
+++ b/bindings/react-native/ios/ReticulumManager.swift
@@ -573,8 +573,6 @@ public class ReticulumManager: NSObject, TransportManager {
 
     // MARK: - Event-Driven Sending
 
-    /// Called by the Rust transport callback when new outgoing messages are available.
-    /// This is the primary send path, replacing timer-based polling.
     /// Called by the Rust transport callback when new outgoing messages are
     /// available.
     ///

--- a/bindings/react-native/ios/WifiDirectManager.swift
+++ b/bindings/react-native/ios/WifiDirectManager.swift
@@ -95,12 +95,29 @@ public class WifiDirectManager: NSObject, TransportManager {
     /// out, so nothing can re-enter and need recursion.
     private let stateLock = NSLock()
     private var _state: TransportState = .unavailable
+
+    /// True between `pause()` and `resume()`. Mirrors `InternetManager`'s flag
+    /// of the same name.
+    ///
+    /// This manager's `pause()` stopped browsing and nothing else, so the send
+    /// path ignored it entirely: `onMessagesAvailable` runs
+    /// `drainAndSendMessages`, which gated on `state` — and pause does not
+    /// change `state` — so a paused transport drained the whole queue, each
+    /// message taking the core's global protocol mutex. Guarded here rather
+    /// than only at the callback because `drainAndSendMessages` is also reached
+    /// from `resume()`, and because the drain loop re-reads it every iteration.
+    private var _isPaused = false
     private var _session: MCSession?
     private var _connectedPeers: [MCPeerID: String] = [:] // MCPeerID -> deviceId
 
     private func setState(_ newState: TransportState) {
         stateLock.lock(); defer { stateLock.unlock() }
         _state = newState
+    }
+
+    private var isPaused: Bool {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _isPaused }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _isPaused = newValue }
     }
 
     private var session: MCSession? {
@@ -172,7 +189,12 @@ public class WifiDirectManager: NSObject, TransportManager {
         emitDiagnostic("info", "Starting WiFi Direct transport", context: [
             "deviceId": deviceId
         ])
-        
+
+        // An explicit start() means "run": a pause() from a previous session
+        // must not leave this fresh transport connected-but-mute. Mirrors
+        // `InternetManager.start()`.
+        isPaused = false
+
         updateState(.starting)
         transportStartAt = Date()
         
@@ -234,13 +256,21 @@ public class WifiDirectManager: NSObject, TransportManager {
     }
     
     public func pause() {
+        // Set before browsing stops. This is what actually pauses the send
+        // path — see `isPaused`; stopping the browser only stops finding new
+        // peers, and this manager has no timer to cancel.
+        isPaused = true
         browser?.stopBrowsingForPeers()
     }
 
     public func resume() {
+        isPaused = false
         if state == .running {
             browser?.startBrowsingForPeers()
-            // Drain any messages that accumulated while paused
+            // Drain any messages that accumulated while paused. Required
+            // rather than tidy: the core does not re-issue
+            // `onMessagesAvailable` for messages it already announced, and
+            // this manager has no fallback timer to pick them up.
             drainAndSendMessages()
         }
     }
@@ -282,12 +312,17 @@ public class WifiDirectManager: NSObject, TransportManager {
     /// message that `sendMessage` then drops for want of a session — a warning
     /// per message, against a transport that is already down.
     private func drainAndSendMessages() {
-        guard state == .running, hasConnectedPeers else { return }
+        guard !isPaused, state == .running, hasConnectedPeers else { return }
 
         messageQueue.async { [weak self] in
             guard let self = self else { return }
 
-            while self.state == .running,
+            // `isPaused` re-read every iteration alongside the state, and for
+            // the same reason the state is: this loop can run for as long as
+            // the queue is deep, and a `pause()` landing inside it would
+            // otherwise keep taking the core's global protocol mutex once per
+            // remaining message against a transport the app has backgrounded.
+            while !self.isPaused, self.state == .running,
                   let message = self.protocolInstance.wifiDirectGetNextMessage() {
                 self.sendMessage(recipientId: message.recipientId, data: Data(message.data))
             }

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10932,9 +10932,22 @@ mod tests {
         // it cannot see — no constructor parameters, a second supertype, a
         // base class — would vanish from the invariant silently, which is
         // the exact regression deriving the set was meant to kill. Close it
-        // with the wide form: every file that mentions the supertype at all
-        // is either a manager the narrow scan found, or is listed here with
-        // a reason.
+        // with the wide form: every file that names the supertype in *any*
+        // supertype-list position is either a manager the narrow scan found,
+        // or is listed here with a reason.
+        //
+        // Both separators are needed, and the comma one is not decoration.
+        // A colon-only match sees `: TransportManager` and
+        // `: TransportManager, Other`, but not `: Base(), TransportManager`
+        // — the base-class form named above — so a manager whose `listener`
+        // property is inherited rather than declared in-file matched neither
+        // scan and passed this test green. (A colon-only match did catch the
+        // in-file spellings of that form, but only by accident: it also
+        // matches `: TransportManagerListener`, which every in-file
+        // implementation carries via `override var listener`. That prefix
+        // breadth is now load-bearing on purpose — narrowing either term to
+        // an exact `": TransportManager {"` or a word boundary reopens the
+        // hole for all three forms at once.)
         //
         // TransportManager.kt is the interface itself (its listener methods
         // take `manager: TransportManager` parameters); OfflineProtocolModule.kt
@@ -10944,7 +10957,8 @@ mod tests {
         let expected_from_wide_scan: Vec<String> = rn_android_kotlin_sources()
             .into_iter()
             .filter(|(rel, code)| {
-                code.contains(": TransportManager") && !NOT_A_MANAGER.contains(&rel.as_str())
+                (code.contains(": TransportManager") || code.contains(", TransportManager"))
+                    && !NOT_A_MANAGER.contains(&rel.as_str())
             })
             .map(|(rel, _)| rel)
             .collect();
@@ -11998,10 +12012,19 @@ mod tests {
             // caller waiting through up to MAX_DRAIN_BATCH global-mutex
             // acquisitions. The post keeps the ordering (drain ahead of the
             // polling runnable posted after it).
+            //
+            // The continuation check rides inside the pin because dropping it
+            // is invisible at runtime: a continuation posted before the pause
+            // is still queued when resume() runs, so without it this lambda
+            // starts a second self-reposting chain alongside that one and each
+            // spends its own MAX_DRAIN_BATCH — the state `drainContinuationQueued`
+            // exists to make impossible, reintroduced by the one path that does
+            // not go through `onMessagesAvailable`.
             (
                 "android/src/main/java/com/offlineprotocol/WifiDirectManager.kt",
                 "the resume drain",
-                "startPeerDiscovery() transportHandler.post { drainAndSendMessages() }",
+                "startPeerDiscovery() transportHandler.post { \
+                 if (drainContinuationQueued) return@post drainAndSendMessages() }",
             ),
             (
                 "ios/WifiDirectManager.swift",

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -11942,10 +11942,15 @@ mod tests {
             // the backlog up. This one's fallback sends a single message every
             // two seconds, and the core does not re-announce what it already
             // announced, so without this the queue trickles out at that rate.
+            // Posted rather than inline on Android: resume() runs under
+            // `runSync`, so an inline drain keeps the RN native-modules
+            // caller waiting through up to MAX_DRAIN_BATCH global-mutex
+            // acquisitions. The post keeps the ordering (drain ahead of the
+            // polling runnable posted after it).
             (
                 "android/src/main/java/com/offlineprotocol/WifiDirectManager.kt",
                 "the resume drain",
-                "startPeerDiscovery() drainAndSendMessages()",
+                "startPeerDiscovery() transportHandler.post { drainAndSendMessages() }",
             ),
             (
                 "ios/WifiDirectManager.swift",

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10876,24 +10876,75 @@ mod tests {
     /// "just this one callback". Comments are stripped before the check, so
     /// the historical notes explaining what moved off main are free to keep
     /// saying so.
+    ///
+    /// The set of managers is **derived, not listed**, and that is the point of
+    /// this guard rather than a tidiness detail. A hand-maintained list — what
+    /// this used to carry — is blind to exactly the regression the invariant
+    /// exists to stop: a *new* transport manager, written against
+    /// `Handler(Looper.getMainLooper())` because that is what the other four
+    /// looked like before OFF-2123. It would simply not be in the list, and the
+    /// guard would stay green while the defect shipped. Deriving flips the
+    /// default: a new manager is inside the invariant the moment it declares
+    /// itself one, and getting out takes a deliberate entry in
+    /// [MAIN_LOOPER_EXEMPT] with a reason.
     #[test]
     fn react_native_transports_do_not_run_on_the_main_looper() {
-        // Named rather than globbed, because the directory holds plenty of
-        // files that are not transport managers. The cost of that is this
-        // list: a new transport manager is outside the invariant until it is
-        // added here, so add it with the manager.
-        for manager in [
-            "InternetManager",
-            "WifiDirectManager",
-            "NostrManager",
-            "ReticulumManager",
+        /// Managers held to a *different* form of the same invariant.
+        ///
+        /// The BLE facade predates `TransportConfinement` and owns the private
+        /// looper the confinement was extracted from (`bleThread`/`bleLooper`),
+        /// so it cannot satisfy the `TransportConfinement.shared(` pin. It also
+        /// reads `Looper.getMainLooper()` legitimately, to tell a main-thread
+        /// caller from a background one and bound only the former — which is
+        /// precisely the job `TransportConfinement.runSync` does on behalf of
+        /// the other four. Exempt from the two pins below, held to the two
+        /// beneath them instead. This is the one manager for which "references
+        /// the main looper" is not the same question as "runs on it".
+        const MAIN_LOOPER_EXEMPT: &[&str] = &["ble/BleTransportFacade.kt"];
+
+        let managers = rn_android_transport_managers();
+        let found: Vec<&str> = managers.iter().map(|(rel, _)| rel.as_str()).collect();
+
+        // The harness has to prove it found something before its per-file
+        // assertions mean anything: a moved directory or a changed class
+        // declaration would otherwise leave this iterating an empty set and
+        // reporting success. Named here purely as a non-vacuity floor — the
+        // *checking* is derived, so a fifth manager needs no edit here.
+        for expected in [
+            "InternetManager.kt",
+            "WifiDirectManager.kt",
+            "NostrManager.kt",
+            "ReticulumManager.kt",
+            "ble/BleTransportFacade.kt",
         ] {
-            let rel = format!("android/src/main/java/com/offlineprotocol/{manager}.kt");
-            let code = rn_source_code_only(&rel);
+            assert!(
+                found.contains(&expected),
+                "the transport-manager scan found {found:?}, which is missing {expected} — \
+                 the scan itself is broken (moved directory, or a changed class declaration \
+                 form), so every assertion below it is vacuous"
+            );
+        }
+
+        for (rel, code) in &managers {
+            if MAIN_LOOPER_EXEMPT.contains(&rel.as_str()) {
+                assert!(
+                    !code.contains("Handler(Looper.getMainLooper())"),
+                    "{rel} must not build a main-looper Handler: it is exempt from the blanket \
+                     ban only because it reads the main looper to *identify* a main-thread \
+                     caller, never to run its own work there"
+                );
+                assert!(
+                    code.contains("bleThread") && code.contains("bleLooper"),
+                    "{rel} is exempt from the TransportConfinement pin only because it owns the \
+                     private looper that confinement was extracted from. If bleThread/bleLooper \
+                     are gone it must adopt TransportConfinement and leave MAIN_LOOPER_EXEMPT"
+                );
+                continue;
+            }
 
             assert!(
                 !code.contains("Looper.getMainLooper()"),
-                "{manager}.kt must not reference the main looper: every UniFFI call it makes \
+                "{rel} must not reference the main looper: every UniFFI call it makes \
                  waits on the core's global protocol mutex, and doing that on the main thread \
                  is the ANR OFF-2123 tracked. Confine the work with TransportConfinement \
                  instead — including framework entry points, which take the looper to deliver \
@@ -10902,11 +10953,56 @@ mod tests {
 
             assert!(
                 code.contains("TransportConfinement.shared("),
-                "{manager}.kt must take its thread from TransportConfinement.shared, so a \
+                "{rel} must take its thread from TransportConfinement.shared, so a \
                  manager rebuilt after stop() re-attaches to the same ordered queue instead of \
                  racing a fresh thread against the old one's backlog"
             );
         }
+    }
+
+    /// Every Android `TransportManager` implementation, as
+    /// (path relative to the managers package, comment-stripped source).
+    ///
+    /// Walks the package directory rather than taking a list, so a manager
+    /// added in a subdirectory (as the BLE facade is) is found too. The
+    /// discriminator is the Kotlin class-declaration form `) : TransportManager
+    /// {` — every implementation here takes constructor parameters, so the
+    /// supertype lands on the line that closes them. It is deliberately
+    /// narrower than a bare `: TransportManager`, which also matches the
+    /// interface's own method signatures and the module's listener object.
+    fn rn_android_transport_managers() -> Vec<(String, String)> {
+        let package = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../bindings/react-native/android/src/main/java/com/offlineprotocol");
+
+        fn walk(dir: &std::path::Path, prefix: &str, out: &mut Vec<(String, String)>) {
+            let entries = std::fs::read_dir(dir)
+                .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()));
+            for entry in entries {
+                let entry = entry.expect("directory entry");
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let rel = if prefix.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{prefix}/{name}")
+                };
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, &rel, out);
+                } else if name.ends_with(".kt") {
+                    let code = rn_source_code_only(&format!(
+                        "android/src/main/java/com/offlineprotocol/{rel}"
+                    ));
+                    if code.contains(") : TransportManager {") {
+                        out.push((rel, code));
+                    }
+                }
+            }
+        }
+
+        let mut found = Vec::new();
+        walk(&package, "", &mut found);
+        found.sort_by(|a, b| a.0.cmp(&b.0));
+        found
     }
 
     /// Nothing that blocks on the network shares the thread `stop()` waits on.
@@ -11557,21 +11653,28 @@ mod tests {
     /// }
     /// ```
     ///
-    /// Wi-Fi Direct's carries one branch — the drain-continuation check — which
-    /// is inside the posted block, so its pin spells that branch out rather
-    /// than stopping short of it.
+    /// Bodies that carry a branch spell it out rather than stopping short of
+    /// it: Wi-Fi Direct's drain-continuation check, and — on Nostr and
+    /// Reticulum — the `isPaused` pair that
+    /// `react_native_transport_pause_silences_the_event_driven_send_path` owns
+    /// the *reasoning* for. Both guards therefore have to be edited together
+    /// when either changes, which is the price of pinning whole bodies and is
+    /// paid deliberately: a pin that stopped before the branch would admit the
+    /// blocking tail this test exists to forbid.
     #[test]
     fn react_native_transport_callbacks_never_wait_on_a_confinement() {
         for (manager, entry, pinned) in [
             (
                 "ReticulumManager",
                 "onMessagesAvailable",
-                "fun onMessagesAvailable() { ioHandler.post { pollAndSendMessages() } }",
+                "fun onMessagesAvailable() { if (isPaused) return ioHandler.post { \
+                 if (isPaused) return@post pollAndSendMessages() } }",
             ),
             (
                 "NostrManager",
                 "onMessagesAvailable",
-                "fun onMessagesAvailable() { transportHandler.post { pollAndSendMessages() } }",
+                "fun onMessagesAvailable() { if (isPaused) return transportHandler.post { \
+                 if (isPaused) return@post pollAndSendMessages() } }",
             ),
             (
                 "WifiDirectManager",
@@ -11608,16 +11711,26 @@ mod tests {
         // leaves it stuck true: every subsequent `onMessagesAvailable` returns
         // early *forever*, and the send path silently degrades to the 2s
         // fallback poll's one message per tick. Nothing else would fail.
+        //
+        // The `isPaused` term rides inside the same pin because it makes that
+        // ordering load-bearing a second time over: a pause arrives while a
+        // continuation is queued, the continuation runs, and it must leave the
+        // flag false or `resume()`'s drain is suppressed by a chain that no
+        // longer exists. Clear-then-return is what guarantees that; the two
+        // cannot be reordered independently.
         let code =
             rn_source_code_only("android/src/main/java/com/offlineprotocol/WifiDirectManager.kt");
         let pinned = "private fun drainAndSendMessages() { drainContinuationQueued = false \
-                      if (state != TransportState.RUNNING || connectedPeers.isEmpty()) return";
+                      if (isPaused || state != TransportState.RUNNING || \
+                      connectedPeers.isEmpty()) return";
         assert!(
             code.contains(pinned),
             "WifiDirectManager.kt must clear drainContinuationQueued as the first statement of \
-             drainAndSendMessages, before any early return. Cleared anywhere else, a pass that \
-             exits early leaves the flag set and onMessagesAvailable suppresses every later \
-             callback for the life of the transport. Expected to find:\n  {pinned}"
+             drainAndSendMessages, before an early return that also tests isPaused. Cleared \
+             anywhere else, a pass that exits early leaves the flag set and onMessagesAvailable \
+             suppresses every later callback for the life of the transport. Without the isPaused \
+             term the primary send path ignores pause() entirely — the timer pause() removes is \
+             only the 2s fallback. Expected to find:\n  {pinned}"
         );
     }
 
@@ -11689,6 +11802,195 @@ mod tests {
                      bound. Expected to find:\n  {pinned}"
                 );
             }
+        }
+    }
+
+    /// `pause()` silences the *primary* send path, not just the fallback timer.
+    ///
+    /// The guard above pins the mechanism — pause runs on the confinement and
+    /// waits — and for a while that was mistaken for pinning the contract. It
+    /// is not. Every one of these managers drives sends from two places: a
+    /// timer, which `pause()` cancels, and `onMessagesAvailable`, the callback
+    /// the core makes whenever it has something to send. The callback is the
+    /// primary path; the timer is a 2s–5s fallback (100ms on Nostr). Cancelling
+    /// only the timer left a paused transport draining a full batch per
+    /// callback — a global-mutex acquisition per message, plus a TCP write on
+    /// Reticulum — for as long as the core kept announcing.
+    ///
+    /// The reconnect edge is the worse half, because it is durable rather than
+    /// transient. A relay or daemon that drops and reconnects during a
+    /// background stay runs the connected branch, which restarted the timers
+    /// unconditionally — so the poll the app paused came back for the rest of
+    /// the stay. `InternetManager` has always guarded that branch with
+    /// `if (!isPaused)`; the other three did not, on either platform.
+    ///
+    /// Pinned **site by site**, and deliberately not as a count of `isPaused`
+    /// mentions. A count was tried first and is worth recording as a failure:
+    /// these managers mention the flag ten or more times, so a floor loose
+    /// enough not to be brittle was loose enough to pass with the reconnect-edge
+    /// gate deleted — the single most valuable of the four checks, and the one a
+    /// well-meaning simplification is likeliest to reach for, since it *looks*
+    /// redundant beside the callback gate. It is not: they cover different
+    /// paths. Each obligation therefore gets its own pinned text.
+    ///
+    /// The callback gate itself is pinned elsewhere and on purpose — Android's
+    /// inside `react_native_transport_callbacks_never_wait_on_a_confinement`,
+    /// whose whole-body pins already have to spell it out, and Wi-Fi Direct's
+    /// inside the drain pin in that same test. Only what those do not reach is
+    /// pinned here.
+    #[test]
+    fn react_native_transport_pause_silences_the_event_driven_send_path() {
+        for (rel, what, pinned) in [
+            // --- the reconnect edge: restart the timers only if not paused ---
+            (
+                "android/src/main/java/com/offlineprotocol/NostrManager.kt",
+                "the reconnect edge",
+                "if (!isPaused) { startMessagePolling() \
+                 transportHandler.post { pollAndSendMessages() } }",
+            ),
+            (
+                "android/src/main/java/com/offlineprotocol/ReticulumManager.kt",
+                "the reconnect edge",
+                "if (!isPaused) { startMessagePolling() ioHandler.post { pollAndSendMessages() } }",
+            ),
+            (
+                "ios/NostrManager.swift",
+                "the reconnect edge",
+                "guard !self.isPaused else { return } self.startMessagePolling() \
+                 self.startPingTimer() self.pollAndSendMessages()",
+            ),
+            (
+                "ios/ReticulumManager.swift",
+                "the reconnect edge",
+                "if !self.isPaused { self.startMessagePolling() }",
+            ),
+            (
+                "android/src/main/java/com/offlineprotocol/InternetManager.kt",
+                "the reconnect edge",
+                "if (!isPaused) { startMessagePolling() startPresenceWatch()",
+            ),
+            (
+                "ios/InternetManager.swift",
+                "the reconnect edge",
+                "if !isPaused { startMessagePolling()",
+            ),
+            // --- pause sets the flag, and sets it first --------------------
+            (
+                "android/src/main/java/com/offlineprotocol/NostrManager.kt",
+                "pause",
+                "override fun pause() { runConfinedSync { isPaused = true",
+            ),
+            (
+                "android/src/main/java/com/offlineprotocol/ReticulumManager.kt",
+                "pause",
+                "override fun pause() { runConfinedSync { isPaused = true",
+            ),
+            (
+                "android/src/main/java/com/offlineprotocol/WifiDirectManager.kt",
+                "pause",
+                "override fun pause() { confinement.runSync { isPaused = true",
+            ),
+            (
+                "ios/NostrManager.swift",
+                "pause",
+                "public func pause() { isPaused = true",
+            ),
+            (
+                "ios/ReticulumManager.swift",
+                "pause",
+                "public func pause() { isPaused = true",
+            ),
+            (
+                "ios/WifiDirectManager.swift",
+                "pause",
+                "public func pause() { isPaused = true",
+            ),
+            // --- resume clears it, and clears it first ---------------------
+            (
+                "android/src/main/java/com/offlineprotocol/NostrManager.kt",
+                "resume",
+                "override fun resume() { runConfinedSync { isPaused = false",
+            ),
+            (
+                "android/src/main/java/com/offlineprotocol/ReticulumManager.kt",
+                "resume",
+                "override fun resume() { runConfinedSync { isPaused = false",
+            ),
+            (
+                "android/src/main/java/com/offlineprotocol/WifiDirectManager.kt",
+                "resume",
+                "override fun resume() { confinement.runSync { isPaused = false",
+            ),
+            (
+                "ios/NostrManager.swift",
+                "resume",
+                "public func resume() { isPaused = false",
+            ),
+            (
+                "ios/ReticulumManager.swift",
+                "resume",
+                "public func resume() { isPaused = false",
+            ),
+            (
+                "ios/WifiDirectManager.swift",
+                "resume",
+                "public func resume() { isPaused = false",
+            ),
+            // --- Wi-Fi Direct resume drains, since it has no fallback timer -
+            //
+            // The other three restart a timer that fires immediately and picks
+            // the backlog up. This one's fallback sends a single message every
+            // two seconds, and the core does not re-announce what it already
+            // announced, so without this the queue trickles out at that rate.
+            (
+                "android/src/main/java/com/offlineprotocol/WifiDirectManager.kt",
+                "the resume drain",
+                "startPeerDiscovery() drainAndSendMessages()",
+            ),
+            (
+                "ios/WifiDirectManager.swift",
+                "the resume drain",
+                "browser?.startBrowsingForPeers() drainAndSendMessages()",
+            ),
+            // --- an explicit start() means "run" ---------------------------
+            (
+                "android/src/main/java/com/offlineprotocol/NostrManager.kt",
+                "start",
+                "isPaused = false Log.i(TAG, \"Starting Nostr transport",
+            ),
+            (
+                "android/src/main/java/com/offlineprotocol/ReticulumManager.kt",
+                "start",
+                "isPaused = false Log.i(TAG, \"Starting Reticulum transport",
+            ),
+            (
+                "android/src/main/java/com/offlineprotocol/WifiDirectManager.kt",
+                "start",
+                "updateState(TransportState.STARTING) isPaused = false",
+            ),
+            (
+                "ios/NostrManager.swift",
+                "start",
+                "isPaused = false updateState(.starting)",
+            ),
+            (
+                "ios/ReticulumManager.swift",
+                "start",
+                "isPaused = false updateState(.starting)",
+            ),
+            (
+                "ios/WifiDirectManager.swift",
+                "start",
+                "isPaused = false updateState(.starting)",
+            ),
+        ] {
+            let code = rn_source_code_only(rel);
+            assert!(
+                code.contains(pinned),
+                "{rel}: {what} must honour isPaused — see this test's docstring for which path \
+                 each site covers and why none of them is redundant with the others. \
+                 Expected to find:\n  {pinned}"
+            );
         }
     }
 
@@ -11769,6 +12071,12 @@ mod tests {
                 "private func removeAllPeers() { stateLock.lock(); \
                  defer { stateLock.unlock() } _connectedPeers.removeAll() }",
             ),
+            (
+                "the isPaused accessor",
+                "private var isPaused: Bool { get { stateLock.lock(); \
+                 defer { stateLock.unlock() }; return _isPaused } set { stateLock.lock(); \
+                 defer { stateLock.unlock() }; _isPaused = newValue } }",
+            ),
         ] {
             assert!(
                 code.contains(pinned),
@@ -11781,8 +12089,8 @@ mod tests {
 
         let acquisitions = code.matches("stateLock.lock()").count();
         assert_eq!(
-            acquisitions, 10,
-            "ios/WifiDirectManager.swift: expected the 10 pinned stateLock acquisitions; found \
+            acquisitions, 12,
+            "ios/WifiDirectManager.swift: expected the 12 pinned stateLock acquisitions; found \
              {acquisitions}. A new one is not wrong, but it is unreviewed — pin its body above \
              so it cannot grow a call into the core unnoticed."
         );

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -11853,11 +11853,15 @@ mod tests {
                 "the reconnect edge",
                 "if (!isPaused) { startMessagePolling() ioHandler.post { pollAndSendMessages() } }",
             ),
+            // The ping sits *above* the guard on purpose: it is the socket's
+            // liveness keepalive, not the send path, and this manager has no
+            // watchdog to notice a reconnected-while-paused socket going
+            // zombie — see the comment at the call site.
             (
                 "ios/NostrManager.swift",
                 "the reconnect edge",
-                "guard !self.isPaused else { return } self.startMessagePolling() \
-                 self.startPingTimer() self.pollAndSendMessages()",
+                "self.startPingTimer() guard !self.isPaused else { return } \
+                 self.startMessagePolling() self.pollAndSendMessages()",
             ),
             (
                 "ios/ReticulumManager.swift",

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -11740,7 +11740,7 @@ mod tests {
             (
                 "WifiDirectManager",
                 "onMessagesAvailable",
-                "fun onMessagesAvailable() { transportHandler.post { \
+                "fun onMessagesAvailable() { if (isPaused) return transportHandler.post { \
                  if (drainContinuationQueued) return@post drainAndSendMessages() } }",
             ),
             (
@@ -11914,15 +11914,11 @@ mod tests {
                 "the reconnect edge",
                 "if (!isPaused) { startMessagePolling() ioHandler.post { pollAndSendMessages() } }",
             ),
-            // The ping sits *above* the guard on purpose: it is the socket's
-            // liveness keepalive, not the send path, and this manager has no
-            // watchdog to notice a reconnected-while-paused socket going
-            // zombie — see the comment at the call site.
             (
                 "ios/NostrManager.swift",
                 "the reconnect edge",
-                "self.startPingTimer() guard !self.isPaused else { return } \
-                 self.startMessagePolling() self.pollAndSendMessages()",
+                "guard !self.isPaused else { return } self.startMessagePolling() \
+                 self.startPingTimer() self.pollAndSendMessages()",
             ),
             (
                 "ios/ReticulumManager.swift",
@@ -12061,6 +12057,103 @@ mod tests {
                 "ios/WifiDirectManager.swift",
                 "start",
                 "isPaused = false updateState(.starting)",
+            ),
+            // --- iOS only: the arming functions gate themselves, atomically -
+            //
+            // The one obligation on this list that is not a mirror of an
+            // Android site, because the hazard it answers does not exist on
+            // Android. There `pause()` and the reconnect edge are the same
+            // thread, so a call-site check cannot be overtaken. On iOS
+            // `pause()` runs on the React Native method queue while the edge
+            // arms from `messageQueue` (Reticulum's, from *main*), so a caller
+            // that reads the flag and then arms can have the whole of
+            // `pause()` land in between — flag set, timer cancelled — and
+            // install a fresh timer against a paused transport that then polls
+            // for the rest of the background stay. That is the durable symptom
+            // the flag exists to remove, reached through the fix for it.
+            //
+            // Pinned as the `_isPaused` read *and* the `_messageTimer` write
+            // inside one `stateLock` section, because splitting them is what
+            // reopens the window and the split reads as a harmless tidy-up.
+            // `_`-prefixed on purpose: the accessor form (`isPaused`) takes and
+            // releases the lock on its own, so using it here would compile,
+            // pass a laxer pin, and race exactly as before.
+            (
+                "ios/NostrManager.swift",
+                "the self-gating poll arm",
+                "private func startMessagePolling() { stateLock.lock() \
+                 guard !_isPaused else { stateLock.unlock() return } \
+                 let previous = _messageTimer \
+                 let timer = DispatchSource.makeTimerSource(queue: messageQueue) \
+                 _messageTimer = timer stateLock.unlock()",
+            ),
+            (
+                "ios/ReticulumManager.swift",
+                "the self-gating poll arm",
+                "private func startMessagePolling() { stateLock.lock() \
+                 guard !_isPaused else { stateLock.unlock() return } \
+                 let previous = _messageTimer \
+                 let timer = DispatchSource.makeTimerSource(queue: messageQueue) \
+                 _messageTimer = timer stateLock.unlock()",
+            ),
+            (
+                "ios/NostrManager.swift",
+                "the self-gating ping arm",
+                "private func startPingTimer() { stateLock.lock() \
+                 guard !_isPaused else { stateLock.unlock() return } \
+                 let previous = _pingTimer \
+                 let timer = DispatchSource.makeTimerSource(queue: connectionQueue) \
+                 _pingTimer = timer stateLock.unlock()",
+            ),
+            // The suspended-source rule that makes the arm above safe to write
+            // this way: the paused branch returns *before* a `DispatchSource`
+            // exists. Cancelling one that was never resumed and dropping it is
+            // a hard crash ("release of a suspended object"), so a refactor
+            // that hoists the `makeTimerSource` above the guard to "simplify"
+            // turns a pause into a SIGABRT. The `resume()` is what discharges
+            // it on the armed path.
+            (
+                "ios/NostrManager.swift",
+                "the resumed-before-release rule",
+                "_messageTimer = timer stateLock.unlock() previous?.cancel()",
+            ),
+            (
+                "ios/ReticulumManager.swift",
+                "the resumed-before-release rule",
+                "_messageTimer = timer stateLock.unlock() previous?.cancel()",
+            ),
+            // --- iOS only: the timer handler re-reads the flag -------------
+            //
+            // `DispatchSourceTimer.cancel()` cannot reach a handler already
+            // dispatched onto its queue, which is the same window Android's
+            // polling runnables close with their own `if (isPaused) return`.
+            // Without it one full poll batch leaks past every `pause()`.
+            //
+            // Anchored on the `timer.resume()` that closes the arming
+            // function, and that suffix is not decoration. `onMessagesAvailable`
+            // opens its own posted block with the identical guard-then-poll
+            // pair, so the handler body alone is a substring of a *different*
+            // function on both managers: the Reticulum pin without this anchor
+            // was satisfied by `onMessagesAvailable` and stayed green with the
+            // timer handler's guard deleted. Caught by mutation-testing this
+            // guard, which is the only reason it is not still vacuous.
+            (
+                "ios/NostrManager.swift",
+                "the poll handler's re-read",
+                "guard let self = self, !self.isPaused else { return } \
+                 self.pollAndSendMessages() self.pollAndSendQueries() } timer.resume()",
+            ),
+            (
+                "ios/ReticulumManager.swift",
+                "the poll handler's re-read",
+                "guard let self = self, !self.isPaused else { return } \
+                 self.pollAndSendMessages() } timer.resume()",
+            ),
+            (
+                "ios/NostrManager.swift",
+                "the ping handler's re-read",
+                "guard let self = self, !self.isPaused else { return } self.sendPings() } \
+                 timer.resume()",
             ),
         ] {
             let code = rn_source_code_only(rel);

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -12073,6 +12073,199 @@ mod tests {
         }
     }
 
+    /// Every transport manager the bridge holds is on the pause/resume fan-out.
+    ///
+    /// The obligation the pause guards above structurally cannot state. They
+    /// pin the *bodies* of `pause()` and `resume()`; a body pin is green
+    /// whether or not anything calls the function. iOS held a
+    /// `WifiDirectManager`, gave it an `isPaused` flag, a drain gate, a
+    /// per-iteration re-read and a resume drain — and never called either
+    /// method, so the flag could not become true, every gate written against
+    /// it was dead, and all three of that manager's pins were vacuous. Android
+    /// had the same five managers and paused all five.
+    ///
+    /// So the set is derived from what each module *holds* rather than listed:
+    /// a field of a manager type is a manager the module can pause, and the
+    /// invariant is that both lifecycle methods name every one of them. Adding
+    /// a sixth transport puts it inside this the moment the field is declared,
+    /// which is the same reason
+    /// [react_native_transports_do_not_run_on_the_main_looper] derives its set.
+    ///
+    /// Scoped to the two lifecycle methods by slicing the module source between
+    /// the `pause` entry point and the end of `resume`, so an unrelated
+    /// `nostrManager?.stop()` elsewhere in a 4000-line file cannot satisfy it.
+    #[test]
+    fn react_native_bridges_pause_and_resume_every_transport_manager() {
+        for (rel, manager_types, start_marker) in [
+            (
+                "ios/OfflineProtocolModule.swift",
+                rn_ios_transport_manager_types(),
+                "@objc func pause(",
+            ),
+            (
+                "android/src/main/java/com/offlineprotocol/OfflineProtocolModule.kt",
+                rn_android_transport_manager_types(),
+                "fun pause(promise: Promise)",
+            ),
+        ] {
+            let code = rn_source_code_only(rel);
+
+            // Both modules end `resume` by rejecting with this code, so it is
+            // the first thing past the pair on either platform.
+            let start = code.find(start_marker).unwrap_or_else(|| {
+                panic!("{rel}: cannot find the pause entry point {start_marker}")
+            });
+            let end = code[start..]
+                .find("ERROR_RESUME")
+                .map(|offset| start + offset)
+                .unwrap_or_else(|| panic!("{rel}: cannot find the end of resume (ERROR_RESUME)"));
+            let lifecycle = &code[start..end];
+
+            // The slice has to hold both methods before its contents mean
+            // anything — markers that stopped bracketing the pair would leave
+            // every assertion below passing against the wrong text.
+            assert!(
+                lifecycle.contains("resume"),
+                "{rel}: the pause..resume slice found no resume — the markers no longer bracket \
+                 the two lifecycle methods, so this guard is vacuous"
+            );
+
+            let mut held = 0;
+            for ty in &manager_types {
+                // A manager type the module does not hold is a manager it
+                // cannot pause, and that is legitimate — the iOS module has no
+                // field for a manager it never builds. The obligation attaches
+                // to the field, not to the type.
+                let Some(field) = rn_module_field_of_type(&code, ty) else {
+                    continue;
+                };
+                held += 1;
+
+                for method in ["pause", "resume"] {
+                    let expected = format!("{field}?.{method}()");
+                    assert!(
+                        lifecycle.contains(&expected),
+                        "{rel}: the module holds `{field}: {ty}?` but its lifecycle fan-out never \
+                         calls {expected}. A manager missing here is not paused-but-dormant — its \
+                         isPaused can never become true, so every gate written against that flag \
+                         is dead code and every source pin over its pause() body is vacuous. Add \
+                         it to both pause() and resume(), or drop the field"
+                    );
+                }
+            }
+
+            // Non-vacuity floor. The derivation above is two greps deep — the
+            // manager-type scan and the field scan — and either coming back
+            // empty would silently assert nothing. Five is what both modules
+            // hold today; a sixth transport raises it deliberately.
+            assert_eq!(
+                held, 5,
+                "{rel}: derived {held} held transport managers from {manager_types:?}, expected 5 \
+                 — either the manager class declarations or the `private var name: Type?` field \
+                 form changed, and the derivation is now blind"
+            );
+        }
+    }
+
+    /// The Android transport-manager *type* names, derived from the same scan
+    /// [react_native_transports_do_not_run_on_the_main_looper] uses, so the two
+    /// invariants can never disagree about what a manager is.
+    fn rn_android_transport_manager_types() -> Vec<String> {
+        rn_android_transport_managers()
+            .into_iter()
+            .map(|(rel, _)| {
+                rel.rsplit('/')
+                    .next()
+                    .and_then(|file| file.strip_suffix(".kt"))
+                    .expect("a .kt manager path")
+                    .to_string()
+            })
+            .collect()
+    }
+
+    /// The iOS transport-manager type names, derived the same way its Android
+    /// counterpart is: every file that declares itself a `TransportManager`.
+    ///
+    /// The class name is taken from the file stem and then *checked* against
+    /// the declaration rather than assumed, so a file whose class stops
+    /// matching its name fails here instead of quietly dropping out of the
+    /// derived set.
+    fn rn_ios_transport_manager_types() -> Vec<String> {
+        rn_ios_swift_sources()
+            .into_iter()
+            .filter_map(|(rel, code)| {
+                let stem = rel.rsplit('/').next()?.strip_suffix(".swift")?;
+                let decl = format!("class {stem}: NSObject, TransportManager {{");
+                code.contains(&decl).then(|| stem.to_string())
+            })
+            .collect()
+    }
+
+    /// The field a module holds a `ty` in, if it holds one.
+    ///
+    /// Matched as a whole `private var <name>: <ty>?` declaration rather than
+    /// on the type alone, because both modules also carry `weak var` captures
+    /// of the same types inside their transport-callback shims — taking the
+    /// first mention of the type would find one of those instead.
+    fn rn_module_field_of_type(module_code: &str, ty: &str) -> Option<String> {
+        let needle = format!(": {ty}?");
+        module_code.match_indices(&needle).find_map(|(at, _)| {
+            let before = &module_code[..at];
+            let field: String = before
+                .chars()
+                .rev()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+            (!field.is_empty() && before.ends_with(&format!("private var {field}")))
+                .then_some(field)
+        })
+    }
+
+    /// Every hand-written `.swift` file under the React Native iOS directory,
+    /// as (path relative to `ios/`, comment-stripped source), sorted by path.
+    ///
+    /// `Generated`, `libs` and `tests` are skipped: the first two are UniFFI
+    /// output and vendored code rather than anything hand-written here, and
+    /// both are large enough that reading them on every call would be the
+    /// dominant cost of the suite. Which files are hand-written is governed
+    /// separately by [react_native_podspec_ships_every_hand_written_ios_source].
+    fn rn_ios_swift_sources() -> Vec<(String, String)> {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../bindings/react-native/ios");
+
+        fn walk(dir: &std::path::Path, prefix: &str, out: &mut Vec<(String, String)>) {
+            let entries = std::fs::read_dir(dir)
+                .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()));
+            for entry in entries {
+                let entry = entry.expect("directory entry");
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if matches!(name.as_str(), "Generated" | "libs" | "tests") {
+                    continue;
+                }
+                let rel = if prefix.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{prefix}/{name}")
+                };
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, &rel, out);
+                } else if name.ends_with(".swift") {
+                    let code = rn_source_code_only(&format!("ios/{rel}"));
+                    out.push((rel, code));
+                }
+            }
+        }
+
+        let mut found = Vec::new();
+        walk(&dir, "", &mut found);
+        found.sort_by(|a, b| a.0.cmp(&b.0));
+        found
+    }
+
     /// The iOS half of the same invariant: nothing calls into the core while
     /// holding `WifiDirectManager`'s `stateLock`.
     ///

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -10925,6 +10925,39 @@ mod tests {
             );
         }
 
+        // The floor above proves the five *known* files were found; it
+        // structurally cannot notice a sixth being missed. The scan's
+        // discriminator is deliberately narrow (see
+        // [rn_android_transport_managers]), so a manager declared in a form
+        // it cannot see — no constructor parameters, a second supertype, a
+        // base class — would vanish from the invariant silently, which is
+        // the exact regression deriving the set was meant to kill. Close it
+        // with the wide form: every file that mentions the supertype at all
+        // is either a manager the narrow scan found, or is listed here with
+        // a reason.
+        //
+        // TransportManager.kt is the interface itself (its listener methods
+        // take `manager: TransportManager` parameters); OfflineProtocolModule.kt
+        // hosts the listener objects, whose overrides carry the same
+        // parameter.
+        const NOT_A_MANAGER: &[&str] = &["TransportManager.kt", "OfflineProtocolModule.kt"];
+        let expected_from_wide_scan: Vec<String> = rn_android_kotlin_sources()
+            .into_iter()
+            .filter(|(rel, code)| {
+                code.contains(": TransportManager") && !NOT_A_MANAGER.contains(&rel.as_str())
+            })
+            .map(|(rel, _)| rel)
+            .collect();
+        assert_eq!(
+            found, expected_from_wide_scan,
+            "a file names TransportManager but the narrow `) : TransportManager {{` scan \
+             disagrees with the wide one. If a new manager is declared in a form the narrow \
+             scan cannot see (no constructor parameters, a second supertype, a base class), \
+             it is outside the main-looper invariant without anyone having decided that — \
+             widen the discriminator. If the file is genuinely not a manager, add it to \
+             NOT_A_MANAGER with a reason"
+        );
+
         for (rel, code) in &managers {
             if MAIN_LOOPER_EXEMPT.contains(&rel.as_str()) {
                 assert!(
@@ -10969,8 +11002,24 @@ mod tests {
     /// {` — every implementation here takes constructor parameters, so the
     /// supertype lands on the line that closes them. It is deliberately
     /// narrower than a bare `: TransportManager`, which also matches the
-    /// interface's own method signatures and the module's listener object.
+    /// interface's own method signatures and the module's listener objects —
+    /// and that narrowness is a silent escape hatch on its own: a manager
+    /// declared in any other form (`class Foo : TransportManager {` with no
+    /// constructor parameters, a second supertype, a base class before the
+    /// interface) matches nothing and falls outside the invariant without
+    /// anyone deciding that. The caller closes it by cross-checking against
+    /// the wide form; keep the two in sync.
     fn rn_android_transport_managers() -> Vec<(String, String)> {
+        rn_android_kotlin_sources()
+            .into_iter()
+            .filter(|(_, code)| code.contains(") : TransportManager {"))
+            .collect()
+    }
+
+    /// Every `.kt` file under the React Native Android package, as
+    /// (path relative to the package, comment-stripped source), sorted by
+    /// path.
+    fn rn_android_kotlin_sources() -> Vec<(String, String)> {
         let package = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../bindings/react-native/android/src/main/java/com/offlineprotocol");
 
@@ -10992,9 +11041,7 @@ mod tests {
                     let code = rn_source_code_only(&format!(
                         "android/src/main/java/com/offlineprotocol/{rel}"
                     ));
-                    if code.contains(") : TransportManager {") {
-                        out.push((rel, code));
-                    }
+                    out.push((rel, code));
                 }
             }
         }


### PR DESCRIPTION
Follow-up to #342, from reviewing it after merge. Three findings, plus the
verification #342 owed.

## `pause()` did not pause the send path

#342 wrote a contract into `TransportManager.pause()` — *"this must have
**taken effect** by the time it returns"* — and added a guard that reads as
verifying it. The guard pins the **mechanism**: pause runs on the confinement
and waits. That is not the contract.

Every transport drives sends from two places: a timer, which `pause()`
cancels, and `onMessagesAvailable`, the callback the core makes whenever it has
something to send. **The callback is the primary path**; the timer is a 2s–5s
fallback (100ms on Nostr). Nostr, Reticulum and Wi-Fi Direct cancelled only the
timer, on both platforms — so a backgrounded app went on draining a full batch
per callback: a global-mutex acquisition per message, plus a TCP write apiece on
Reticulum.

**The reconnect edge is the worse half**, because it is durable rather than
transient. A relay or daemon that drops and reconnects during a background stay
runs the connected branch, which restarted the timers unconditionally — so the
100ms Nostr poll (and its 30s ping) came back for the rest of the stay, against
a transport the app had paused. `InternetManager` has always guarded that branch
with `if (!isPaused)`; that guard is the entire reason its flag exists. The other
three did not have it.

The other three now carry the same flag — set in `pause`, cleared in `resume` and
in `start` (an explicit start means "run"), read on the callback and on the
reconnect edge. Nothing is stranded: messages stay queued in the core and
`resume()` drains them. Wi-Fi Direct drains **explicitly**, since its fallback
would otherwise trickle a backlog out at one message every two seconds.

## The main-looper guard could not see a new transport

`react_native_transports_do_not_run_on_the_main_looper` iterated a hardcoded list
of four managers. That is blind to exactly the regression the invariant exists to
stop: a **new** manager written against `Handler(Looper.getMainLooper())`, because
that is what the other four looked like before OFF-2123. It would simply not be in
the list, and the guard would stay green while the defect shipped.

The scan now walks the package for the class-declaration form, so a new manager is
inside the invariant the moment it declares itself one, and getting out takes a
deliberate `MAIN_LOOPER_EXEMPT` entry with a reason. `ble/BleTransportFacade` is
that exemption — it reads the main looper to *identify* a main-thread caller,
which is the job `TransportConfinement.runSync` does for the other four — so it is
held to a narrower pin instead. A non-vacuity floor asserts the scan found the
five known managers, so a moved directory cannot silently empty it.

## Documented what the shared Reticulum IO looper couples

`TransportConfinement.shared` is process-wide and keyed by name, so two
`ReticulumManager` instances share `offline-reticulum-io` — reachable on an RN
reload, where the new ReactContext's module can be built before the old one's
`invalidate()` runs. Only the *owning* manager can close its own
`pendingConnectSocket`, so a stale instance holds a fresh one's connect for the
rest of the 60s timeout. Bounded and self-healing, but the rule on
`TransportConfinement` does not cover it: nothing waits there, the cost is
queueing behind a stranger. Comment only.

## A count-based pin is not a pin

Recorded in the guard's docstring because it nearly shipped. The pause sites were
first pinned as a **floor on `isPaused` mentions**. These managers mention the flag
ten or more times, so a floor loose enough not to be brittle was loose enough to
pass **with the reconnect-edge gate deleted** — the most valuable of the four
checks, and the one a simplification is likeliest to reach for since beside the
callback gate it *looks* redundant. It is not; they cover different paths. Every
site is pinned by its own text now.

## Verification

CI covers none of the changed manager behaviour, so this was run by hand.

- `cargo test --workspace --lib` — 2054 pass; `cargo clippy --workspace -D warnings`, `cargo fmt --check` clean
- Android harness (clean-dir recipe) — **417 tests, 0 failures**, module compiles
- iOS ci.yml `swiftc -typecheck` list — exit 0, 0 errors
- **iOS symlink-farm typecheck incl. `OfflineProtocolModule.swift`** — exit 0. This is the check #342 owed: that file is on `Package.swift`'s `exclude:` *and* absent from the ci.yml list, so no CI job compiles it, and #342 edited it three times. Negative-controlled (a deliberate bad call at the exact line #342 added is reported), so the pass is not vacuous. **It typechecks — #342 is clean on this.**
- Mutation-tested every new/changed guard: new manager on the main looper → caught; broken scan → caught by the non-vacuity floor; reconnect-edge gate dropped (Android Nostr, iOS Reticulum) → caught; `pause` not setting the flag → caught; drain gate ungated → caught. All working-tree restores verified byte-identical.