### PR TITLE
chore(bindings): generate every binding from one script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,7 @@ Closes #
 - [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <subject>`)
 - [ ] Docs / `CHANGELOG.md` updated where relevant
 - [ ] No new `unsafe` in core crates (only the `offline-protocol-uniffi` FFI boundary may use it, with SAFETY comments)
-- [ ] If the UniFFI UDL changed, bindings were regenerated (`npm run generate:bindings` and/or the Python build) and committed
+- [ ] If the UniFFI UDL changed, bindings were regenerated (`./scripts/generate-bindings.sh`) and **all three** — Swift, Kotlin, Python — committed together; a partial set fails at runtime, not build time
 
 ## Breaking changes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,14 +207,16 @@ jobs:
       - name: Install uniffi-bindgen
         run: cargo install uniffi --version 0.30.0 --features cli --locked
 
-      # Builds the desktop cdylib pytest needs, and — via
-      # scripts/generate-bindings.sh — regenerates Swift, Kotlin and Python
-      # together. One regeneration, one gate: the three files are one artifact
-      # set off one UDL, so checking them separately would let a half-updated
-      # commit pass the half of the gate it happened to satisfy.
+      # Regenerate before building anything. Bindgen reads the UDL and nothing
+      # else, so putting this ahead of the cdylib compile means drift surfaces
+      # in seconds rather than after a full debug build — and a broken desktop
+      # build stops costing us Swift/Kotlin drift coverage it never needed.
       - name: Regenerate all UniFFI bindings
-        run: bash bindings/python/scripts/build-desktop.sh
+        run: bash scripts/generate-bindings.sh
 
+      # One regeneration, one gate: the three files are one artifact set off one
+      # UDL, so checking them separately would let a half-updated commit pass
+      # the half of the gate it happened to satisfy.
       - name: Fail on stale bindings
         run: |
           if ! git diff --exit-code -- \
@@ -225,6 +227,12 @@ jobs:
             echo "Run: bash scripts/generate-bindings.sh and commit all three."
             exit 1
           fi
+
+      # Builds the desktop cdylib pytest loads. It re-runs the generator on the
+      # way out, which is idempotent and is what keeps the one-entry-point rule
+      # true for the script developers actually invoke.
+      - name: Build the desktop library
+        run: bash bindings/python/scripts/build-desktop.sh
 
       - name: Install Python binding
         run: pip install -e 'bindings/python[dev]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,27 @@ jobs:
           cache: "pip"
           cache-dependency-path: bindings/python/pyproject.toml
 
+      # Keep in sync with the `uniffi` pin in crates/offline-protocol-uniffi/Cargo.toml;
+      # scripts/generate-bindings.sh fails the build if the two disagree.
       - name: Install uniffi-bindgen
         run: cargo install uniffi --version 0.30.0 --features cli --locked
+
+      # Delete the generated files first, so the drift gate below proves they
+      # were *written* and not merely unchanged. `git diff --exit-code` on a
+      # path nothing wrote to reports no diff, which makes "up to date" and
+      # "never regenerated" indistinguishable — so a mistyped output path in
+      # the generator would sail through this job green while every UDL change
+      # afterwards shipped stale bindings. Deleting turns that into a diff.
+      #
+      # Only the generated members: `java/` also holds hand-written
+      # com/offlineprotocol/**, and the Python package dir is mostly
+      # hand-written too. `git diff` restores nothing, so if a later step fails
+      # the checkout is discarded with the runner.
+      - name: Remove generated bindings so regeneration must replace them
+        run: |
+          rm -rf bindings/react-native/ios/Generated \
+                 bindings/react-native/android/src/main/java/uniffi
+          rm -f bindings/python/offline_protocol_sdk/offline_protocol.py
 
       # Regenerate before building anything. Bindgen reads the UDL and nothing
       # else, so putting this ahead of the cdylib compile means drift surfaces

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Static — no bindgen, no toolchain — so a regression in the
+      # single-entry-point rule fails in seconds rather than after the install
+      # and build below. The drift gate at the end of this job only catches a
+      # partial regeneration that someone actually committed; this catches the
+      # script that would produce one.
+      - name: Guard the shared binding generator
+        run: |
+          shellcheck --severity=warning \
+            scripts/generate-bindings.sh \
+            scripts/tests/test-generate-bindings.sh
+          bash scripts/tests/test-generate-bindings.sh
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
@@ -195,27 +207,22 @@ jobs:
       - name: Install uniffi-bindgen
         run: cargo install uniffi --version 0.30.0 --features cli --locked
 
-      - name: Regenerate Python bindings
+      # Builds the desktop cdylib pytest needs, and — via
+      # scripts/generate-bindings.sh — regenerates Swift, Kotlin and Python
+      # together. One regeneration, one gate: the three files are one artifact
+      # set off one UDL, so checking them separately would let a half-updated
+      # commit pass the half of the gate it happened to satisfy.
+      - name: Regenerate all UniFFI bindings
         run: bash bindings/python/scripts/build-desktop.sh
 
-      - name: Fail on stale offline_protocol.py
-        run: |
-          if ! git diff --exit-code -- bindings/python/offline_protocol_sdk/offline_protocol.py; then
-            echo "::error::bindings/python/offline_protocol_sdk/offline_protocol.py is out of date."
-            echo "Run: bash bindings/python/scripts/build-desktop.sh and commit the regenerated file."
-            exit 1
-          fi
-
-      - name: Regenerate Swift and Kotlin bindings
-        run: bash bindings/react-native/scripts/generate-bindings.sh
-
-      - name: Fail on stale Swift or Kotlin bindings
+      - name: Fail on stale bindings
         run: |
           if ! git diff --exit-code -- \
+            bindings/python/offline_protocol_sdk/offline_protocol.py \
             bindings/react-native/ios/Generated/ \
             bindings/react-native/android/src/main/java/uniffi/; then
-            echo "::error::Committed Swift/Kotlin UniFFI bindings are out of date."
-            echo "Run: bash bindings/react-native/scripts/generate-bindings.sh"
+            echo "::error::Committed UniFFI bindings are out of date."
+            echo "Run: bash scripts/generate-bindings.sh and commit all three."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Keep in sync with the `uniffi` pin in crates/offline-protocol-uniffi/Cargo.toml.
+  # scripts/generate-bindings.sh compares the two and fails the build on a
+  # minor-version disagreement, so drift here is loud rather than silent — but
+  # it is still four edits (this, ci.yml, README, CLAUDE.md) on a uniffi bump.
   UNIFFI_VERSION: "0.30.0"
 
 jobs:
@@ -169,9 +173,9 @@ jobs:
       # gate verified: same bindgen, same --no-format, generated alongside the
       # Swift and Python it shares FFI checksums with. Generating it directly
       # here would also skip the script's check that the installed bindgen
-      # matches the crate's uniffi pin, which is the one thing standing between
-      # UNIFFI_VERSION drifting from Cargo.toml and a released package whose
-      # Kotlin checksums fail at the app's first FFI call.
+      # agrees with the crate's uniffi pin to the minor version, which is what
+      # stands between UNIFFI_VERSION drifting from Cargo.toml and a released
+      # package whose Kotlin checksums fail at the app's first FFI call.
       #
       # Staged into android-bindings/ so the uploaded artifact keeps the
       # uniffi/... root the publish job's download path expects.
@@ -360,8 +364,11 @@ jobs:
       # Generates all three languages; only the Python file is uploaded here.
       # Going through the shared script keeps the released wheel's bindings
       # produced exactly the way CI's drift gate verified them, and picks up its
-      # check that uniffi-bindgen matches the crate's uniffi pin — a mismatch
-      # would ship bindings whose checksums fail at the app's first call.
+      # check that uniffi-bindgen agrees with the crate's uniffi pin to the
+      # minor version — enough to catch UNIFFI_VERSION drifting from Cargo.toml,
+      # which would otherwise ship bindings whose checksums fail at the app's
+      # first call. Patch drift is deliberately tolerated: uniffi's FFI contract
+      # version is not patch-scoped.
       - name: Generate Python bindings
         run: bash scripts/generate-bindings.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,9 @@ env:
   # Keep in sync with the `uniffi` pin in crates/offline-protocol-uniffi/Cargo.toml.
   # scripts/generate-bindings.sh compares the two and fails the build on a
   # minor-version disagreement, so drift here is loud rather than silent — but
-  # it is still four edits (this, ci.yml, README, CLAUDE.md) on a uniffi bump.
+  # a uniffi bump still means editing several files that name the version
+  # prescriptively (this, ci.yml, README, CLAUDE.md, CONTRIBUTING.md and the
+  # install hints the scripts print).
   UNIFFI_VERSION: "0.30.0"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,10 +163,23 @@ jobs:
         if: steps.cache-uniffi.outputs.cache-hit != 'true'
         run: cargo install uniffi --version ${{ env.UNIFFI_VERSION }} --features cli --locked
 
+      # The Kotlin this job uploads is downloaded *over* the committed Android
+      # bindings in the publish job, so it — not the committed file — is what
+      # ships to npm. It therefore has to be produced the same way CI's drift
+      # gate verified: same bindgen, same --no-format, generated alongside the
+      # Swift and Python it shares FFI checksums with. Generating it directly
+      # here would also skip the script's check that the installed bindgen
+      # matches the crate's uniffi pin, which is the one thing standing between
+      # UNIFFI_VERSION drifting from Cargo.toml and a released package whose
+      # Kotlin checksums fail at the app's first FFI call.
+      #
+      # Staged into android-bindings/ so the uploaded artifact keeps the
+      # uniffi/... root the publish job's download path expects.
       - name: Generate Kotlin bindings
         run: |
-          cd crates/offline-protocol-uniffi
-          uniffi-bindgen generate src/offline_protocol.udl --language kotlin --out-dir ../../android-bindings
+          bash scripts/generate-bindings.sh
+          mkdir -p android-bindings
+          cp -R bindings/react-native/android/src/main/java/uniffi android-bindings/
 
       - name: Upload Android Bindings
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,10 +344,13 @@ jobs:
         if: steps.cache-uniffi.outputs.cache-hit != 'true'
         run: cargo install uniffi --version ${{ env.UNIFFI_VERSION }} --features cli --locked
 
+      # Generates all three languages; only the Python file is uploaded here.
+      # Going through the shared script keeps the released wheel's bindings
+      # produced exactly the way CI's drift gate verified them, and picks up its
+      # check that uniffi-bindgen matches the crate's uniffi pin — a mismatch
+      # would ship bindings whose checksums fail at the app's first call.
       - name: Generate Python bindings
-        run: |
-          cd crates/offline-protocol-uniffi
-          uniffi-bindgen generate src/offline_protocol.udl --language python --out-dir ../../bindings/python/offline_protocol_sdk/
+        run: bash scripts/generate-bindings.sh
 
       - uses: actions/upload-artifact@v7
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,11 +38,17 @@ cargo bench --package offline-protocol-bench
 ### UniFFI / Mobile Builds
 
 ```bash
+# Regenerate every binding after a UDL change — Swift, Kotlin and Python
+# together. The three are one artifact set off one UDL, so there is one
+# script; npm run generate:bindings and the python/RN build scripts all
+# delegate to it. A partial regeneration fails at runtime, not build time.
+./scripts/generate-bindings.sh
+
 cd bindings/react-native
 npm run build:uniffi:all          # all platforms
 npm run build:uniffi:ios          # iOS only
 npm run build:uniffi:android      # Android only
-npm run generate:bindings         # regenerate after UDL changes
+npm run generate:bindings         # wrapper for ../../scripts/generate-bindings.sh
 ```
 
 Prerequisites: `cargo install uniffi --version 0.30.0 --features cli --locked` (must match the workspace `uniffi = "0.30"` pin), Android NDK (`ANDROID_NDK_HOME`), Xcode.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,14 @@ test(dors): add tests for transport switching
 1. **Core Logic**: Implement in appropriate Rust crate (100% safe)
 2. **Tests**: Add comprehensive unit tests
 3. **UniFFI**: Expose via UDL if needed for mobile platforms
-4. **Bindings**: Update platform bindings (React Native, etc.)
-5. **Docs**: Update README and relevant docs
-6. **Commit**: Use conventional commits format
+4. **Regenerate**: After any UDL change run `./scripts/generate-bindings.sh` and commit
+   **all three** generated files (Swift, Kotlin, Python). They are one artifact set off one
+   UDL and carry the FFI checksums of the library they were generated against — committing a
+   subset leaves the rest describing a different ABI, which no build catches; the app fails
+   at its first FFI call instead.
+5. **Bindings**: Update platform bindings (React Native, etc.)
+6. **Docs**: Update README and relevant docs
+7. **Commit**: Use conventional commits format
 
 ### File Structure
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,20 @@ npm run build:uniffi:all
 # Or build individually
 npm run build:uniffi:ios      # iOS only
 npm run build:uniffi:android  # Android only
-
-# Regenerate bindings after UDL changes
-npm run generate:bindings
 ```
+
+### Regenerate Bindings After a UDL Change
+
+```bash
+./scripts/generate-bindings.sh
+```
+
+One script generates all three languages — Swift, Kotlin and Python — because
+they are one artifact set produced from one UDL and carry the FFI checksums of
+the library they were generated against. Regenerating a subset leaves the rest
+describing a different ABI, which no build catches; the app fails at the first
+call instead. `npm run generate:bindings` and the platform build scripts
+delegate here, so every path produces the whole set. Commit all three together.
 
 ### Build Python Desktop Bindings
 
@@ -152,7 +162,8 @@ bash scripts/build-desktop.sh
 ```
 
 The desktop build produces the native `.dylib`, `.so`, or `.dll` for the host
-platform and regenerates the Python UniFFI module.
+platform and regenerates the bindings (all three languages, via the shared
+script above).
 
 
 ## Architecture

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -22,7 +22,7 @@ regenerates Swift and Kotlin alongside Python by delegating to the repo-root
 `scripts/generate-bindings.sh` — the three are one artifact set off one UDL, so
 they are never refreshed apart.
 
-**Prerequisites:** Rust toolchain, `uniffi-bindgen` (`cargo install uniffi --version 0.30.0 --features cli`).
+**Prerequisites:** Rust toolchain, `uniffi-bindgen` (`cargo install uniffi --version 0.30.0 --features cli --locked`).
 
 ### 2. Install the package
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -17,7 +17,10 @@ cd bindings/python
 bash scripts/build-desktop.sh
 ```
 
-This compiles the Rust core for your platform and generates the Python FFI bindings.
+This compiles the Rust core for your platform and generates the FFI bindings. It
+regenerates Swift and Kotlin alongside Python by delegating to the repo-root
+`scripts/generate-bindings.sh` — the three are one artifact set off one UDL, so
+they are never refreshed apart.
 
 **Prerequisites:** Rust toolchain, `uniffi-bindgen` (`cargo install uniffi --version 0.30.0 --features cli`).
 

--- a/bindings/python/scripts/build-desktop.sh
+++ b/bindings/python/scripts/build-desktop.sh
@@ -75,6 +75,19 @@ if [[ -z "$TARGET" ]]; then
     echo "Auto-detected platform: $TARGET"
 fi
 
+# Pre-flight. The authoritative check (bindgen present *and* matching the crate
+# pin) lives in scripts/generate-bindings.sh, which this script calls at the
+# end — but that is after a full cdylib build, so without this a contributor on
+# the wrong bindgen waits out a release compile to be told. Presence only; the
+# version comparison stays in the one place that owns it.
+if ! command -v uniffi-bindgen &>/dev/null; then
+    echo "Error: uniffi-bindgen not found — the build would compile the library" >&2
+    echo "and then fail at binding generation. Install it first:" >&2
+    echo "" >&2
+    echo "  cargo install uniffi --version 0.30.0 --features cli --locked" >&2
+    exit 1
+fi
+
 # Determine library filename by platform
 case "$TARGET" in
     *-apple-darwin)

--- a/bindings/python/scripts/build-desktop.sh
+++ b/bindings/python/scripts/build-desktop.sh
@@ -14,7 +14,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-UNIFFI_DIR="$PROJECT_ROOT/crates/offline-protocol-uniffi"
 PKG_DIR="$SCRIPT_DIR/../offline_protocol_sdk"
 
 # Defaults
@@ -158,27 +157,11 @@ case "$TARGET" in
         ;;
 esac
 
-# Generate Python bindings
+# Generate the bindings. This regenerates Swift and Kotlin alongside Python:
+# the three are one artifact set off one UDL, and the whole point of the shared
+# script is that no entry point can refresh a subset. See its header.
 echo ""
-echo "Generating Python bindings..."
-
-if command -v uniffi-bindgen &>/dev/null; then
-    cd "$UNIFFI_DIR"
-    uniffi-bindgen generate \
-        src/offline_protocol.udl \
-        --language python \
-        --out-dir "$PKG_DIR"
-
-    echo "Python bindings generated in $PKG_DIR/"
-else
-    echo "uniffi-bindgen not found!"
-    echo "Install it with: cargo install uniffi --version 0.30.0 --features cli"
-    echo ""
-    echo "Native library is built. Generate bindings manually when uniffi-bindgen is available:"
-    echo "  cd $UNIFFI_DIR"
-    echo "  uniffi-bindgen generate src/offline_protocol.udl --language python --out-dir $PKG_DIR"
-    exit 1
-fi
+bash "$PROJECT_ROOT/scripts/generate-bindings.sh"
 
 echo ""
 echo "Build complete!"

--- a/bindings/react-native/WIRING_GUIDE.md
+++ b/bindings/react-native/WIRING_GUIDE.md
@@ -162,7 +162,7 @@ Use this checklist every time you add or modify a bridged method:
 ```
 [ ] Rust implementation in uniffi crate (lib.rs)
 [ ] UDL declaration (offline_protocol.udl)
-[ ] Regenerated bindings (npm run generate:bindings)
+[ ] Regenerated bindings (./scripts/generate-bindings.sh) and committed all three
 [ ] iOS: @objc func in OfflineProtocolModule.swift
 [ ] iOS: RCT_EXTERN_METHOD in OfflineProtocolModule.m  ← EASY TO FORGET
 [ ] iOS: Parameter types in .m match the Swift signature exactly

--- a/bindings/react-native/WIRING_GUIDE.md
+++ b/bindings/react-native/WIRING_GUIDE.md
@@ -56,9 +56,11 @@ interface OfflineProtocol {
 ### 3. Regenerate Bindings
 
 ```bash
-cd bindings/react-native
-npm run generate:bindings
+./scripts/generate-bindings.sh          # or: npm run generate:bindings
 ```
+
+This regenerates Swift, Kotlin **and** Python in one pass — they are one
+artifact set off one UDL, so they are never refreshed apart. Commit all three.
 
 This auto-generates:
 - `ios/Generated/offline_protocol.swift` — Swift wrapper classes

--- a/bindings/react-native/scripts/build-all.sh
+++ b/bindings/react-native/scripts/build-all.sh
@@ -1,40 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Build all platforms
-# This script orchestrates building for iOS and Android
+# `npm run build:all` — kept as the documented entry point (six example READMEs
+# route new contributors through it), but the work lives in build-uniffi-all.sh.
+#
+# This used to orchestrate build-ios.sh and build-android.sh, the two copies
+# that built native libraries without regenerating bindings. See those files
+# for why that was the single most travelled way to produce a mismatched
+# artifact set.
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "========================================="
-echo "Building Rust libraries for all platforms"
-echo "========================================="
-echo ""
-
-# Build iOS
-echo "📱 Building iOS..."
-bash "$SCRIPT_DIR/build-ios.sh"
-
-echo ""
-echo "========================================="
-echo ""
-
-# Build Android
-echo "🤖 Building Android..."
-bash "$SCRIPT_DIR/build-android.sh"
-
-echo ""
-echo "========================================="
-echo ""
-echo "✅ All platforms built successfully!"
-echo ""
-echo "Pre-built libraries are ready for npm distribution:"
-echo "  - iOS: bindings/react-native/ios/libs/offline_protocol_uniffi.xcframework (device + simulator slices)"
-echo "  - Android: bindings/react-native/android/src/main/jniLibs/**/*.so"
-echo ""
-echo "You can now:"
-echo "  1. Commit these binaries (or use git-lfs)"
-echo "  2. Run 'npm publish' to distribute the package"
-echo ""
-
+exec bash "$SCRIPT_DIR/build-uniffi-all.sh" "$@"

--- a/bindings/react-native/scripts/build-android.sh
+++ b/bindings/react-native/scripts/build-android.sh
@@ -1,129 +1,22 @@
 #!/usr/bin/env bash
 
-# Build Android libraries for all ABIs
-# This script builds the Rust library for all Android architectures
-# Compatible with bash 3.2+ (macOS default)
+# `npm run build:android` — kept as the documented entry point, but the work
+# lives in build-uniffi-android.sh.
+#
+# This used to be a near-copy of that script minus the binding generation, and
+# that made it the largest remaining hole in the single-entry-point rule: it
+# produced fresh .so files beside whatever Kotlin happened to be committed,
+# which is the ABI mismatch scripts/generate-bindings.sh exists to prevent —
+# not on a missing-bindgen edge case, but on every run.
+#
+# The copy had also drifted behind on two things that matter more than the
+# duplication: it never ran check-elf-alignment.py, so it produced libraries
+# Google Play rejects for 16 KB page alignment (release.yml enforces this on
+# every ABI), and its NDK toolchain resolution predates the modern prebuilt
+# layouts build-uniffi-android.sh handles. Delegating fixes all three at once.
 
-set -e
+set -euo pipefail
 
-echo "Building Android libraries..."
-
-# Navigate to the Rust project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-OUTPUT_DIR="$SCRIPT_DIR/../android/src/main/jniLibs"
 
-cd "$PROJECT_ROOT"
-
-# Android ABIs and their Rust targets (bash 3.2 compatible)
-ABIS=("arm64-v8a" "armeabi-v7a" "x86_64" "x86")
-TARGETS=("aarch64-linux-android" "armv7-linux-androideabi" "x86_64-linux-android" "i686-linux-android")
-
-# Check if NDK is available
-if [ -z "$ANDROID_NDK_HOME" ] && [ -z "$NDK_HOME" ]; then
-  echo "Warning: ANDROID_NDK_HOME or NDK_HOME not set."
-  echo "Please set one of these environment variables to your Android NDK path."
-  echo "Example: export ANDROID_NDK_HOME=/Users/\$USER/Library/Android/sdk/ndk/25.1.8937393"
-  echo ""
-  echo "Attempting to find NDK in common locations..."
-  
-  # Try to find NDK in common locations
-  POSSIBLE_NDKS=(
-    "$HOME/Library/Android/sdk/ndk"
-    "$HOME/Android/Sdk/ndk"
-    "/opt/android-ndk"
-  )
-  
-  for ndk_path in "${POSSIBLE_NDKS[@]}"; do
-    if [ -d "$ndk_path" ]; then
-      # Use the first (usually latest) version found
-      NDK_VERSION=$(ls -1 "$ndk_path" | sort -V | tail -1)
-      if [ -n "$NDK_VERSION" ]; then
-        export ANDROID_NDK_HOME="$ndk_path/$NDK_VERSION"
-        echo "Found NDK at: $ANDROID_NDK_HOME"
-        break
-      fi
-    fi
-  done
-  
-  if [ -z "$ANDROID_NDK_HOME" ]; then
-    echo "Error: Could not find Android NDK. Please install it or set ANDROID_NDK_HOME."
-    exit 1
-  fi
-fi
-
-# Add NDK toolchain to PATH (detect OS)
-OS_NAME="$(uname -s)"
-case "$OS_NAME" in
-  Darwin)
-    ARCH_NAME="$(uname -m)"
-    if [ "$ARCH_NAME" = "arm64" ]; then
-      NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-aarch64/bin"
-    else
-      NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin"
-    fi
-    ;;
-  Linux)
-    NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
-    ;;
-  *)
-    echo "Warning: Unsupported OS: $OS_NAME"
-    NDK_TOOLCHAIN=""
-    ;;
-esac
-
-if [ -n "$NDK_TOOLCHAIN" ] && [ -d "$NDK_TOOLCHAIN" ]; then
-  export PATH="$NDK_TOOLCHAIN:$PATH"
-  echo "Added NDK toolchain to PATH: $NDK_TOOLCHAIN"
-else
-  echo "Warning: Could not find NDK toolchain directory"
-fi
-
-# Ensure targets are installed
-echo "Installing Android targets..."
-for target in "${TARGETS[@]}"; do
-  rustup target add "$target"
-done
-
-# Build for each ABI
-echo "Building for Android ABIs..."
-for i in "${!ABIS[@]}"; do
-  abi="${ABIS[$i]}"
-  target="${TARGETS[$i]}"
-  echo "Building for $abi ($target)..."
-  
-  cargo build --release --target "$target" --package offline-protocol-uniffi
-  
-  # Create output directory for this ABI
-  mkdir -p "$OUTPUT_DIR/$abi"
-  
-  # Cargo may put the cdylib in release/ or release/deps/
-  so_root="$PROJECT_ROOT/target/$target/release"
-  if [ -f "$so_root/liboffline_protocol_uniffi.so" ]; then
-    so_path="$so_root/liboffline_protocol_uniffi.so"
-  else
-    so_path="$so_root/deps/liboffline_protocol_uniffi.so"
-  fi
-  
-  # UniFFI loads "uniffi_offline_protocol", which maps to this filename on Android.
-  cp "$so_path" "$OUTPUT_DIR/$abi/libuniffi_offline_protocol.so"
-  
-  echo "✅ Built and copied library for $abi"
-done
-
-echo ""
-echo "Android libraries built and copied to $OUTPUT_DIR"
-echo ""
-
-# Print library info
-echo "Library sizes:"
-for abi in "${ABIS[@]}"; do
-  lib_path="$OUTPUT_DIR/$abi/libuniffi_offline_protocol.so"
-  if [ -f "$lib_path" ]; then
-    size=$(du -h "$lib_path" | cut -f1)
-    echo "  $abi: $size"
-  fi
-done
-
-echo ""
-echo "✅ Android build complete!"
+exec bash "$SCRIPT_DIR/build-uniffi-android.sh" "$@"

--- a/bindings/react-native/scripts/build-ios.sh
+++ b/bindings/react-native/scripts/build-ios.sh
@@ -1,57 +1,23 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Build iOS universal library
-# This script builds the Rust library for all iOS architectures and combines them into a universal library
+# `npm run build:ios` — kept as the documented entry point, but the work lives
+# in build-uniffi-ios.sh.
+#
+# This used to be a near-copy of that script minus the binding generation, and
+# that made it the largest remaining hole in the single-entry-point rule: it
+# produced a fresh xcframework beside whatever Swift happened to be committed,
+# which is the ABI mismatch scripts/generate-bindings.sh exists to prevent —
+# not on a missing-bindgen edge case, but on every run. Six example READMEs
+# route new contributors through `npm run build:all`, so this was also the most
+# travelled path in the repo.
+#
+# The copy had drifted in the SDK's favour too: build-uniffi-ios.sh handles
+# cargo placing the staticlib in release/deps/ as well as release/, which this
+# script did not. So it is a strict superset, and delegating both closes the
+# hole and deletes a second copy of the packaging logic.
 
-set -e
+set -euo pipefail
 
-echo "Building iOS universal library..."
-
-# Navigate to the Rust project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-# shellcheck source=shared/xcframework.sh
-source "$SCRIPT_DIR/shared/xcframework.sh"
-OUTPUT_DIR="$SCRIPT_DIR/../ios/libs"
-XCFRAMEWORK="$OUTPUT_DIR/offline_protocol_uniffi.xcframework"
 
-cd "$PROJECT_ROOT"
-
-# iOS architectures
-IOS_ARCHS=(
-  "aarch64-apple-ios"           # iOS devices (ARM64)
-  "aarch64-apple-ios-sim"       # iOS simulator on Apple Silicon
-  "x86_64-apple-ios"           # iOS simulator on Intel
-)
-
-# Ensure targets are installed
-echo "Installing iOS targets..."
-for arch in "${IOS_ARCHS[@]}"; do
-  rustup target add "$arch"
-done
-
-# Build for each architecture
-echo "Building for iOS architectures..."
-for arch in "${IOS_ARCHS[@]}"; do
-  echo "Building for $arch..."
-  cargo build --release --target "$arch" --package offline-protocol-uniffi
-done
-
-# Create output directory
-mkdir -p "$OUTPUT_DIR"
-
-echo "Packaging the XCFramework..."
-
-# Why an XCFramework, and why both slices share one archive basename: see
-# scripts/shared/xcframework.sh.
-package_xcframework \
-  "$OUTPUT_DIR" \
-  "$PROJECT_ROOT/target/aarch64-apple-ios/release/liboffline_protocol_uniffi.a" \
-  "$PROJECT_ROOT/target/aarch64-apple-ios-sim/release/liboffline_protocol_uniffi.a" \
-  "$PROJECT_ROOT/target/x86_64-apple-ios/release/liboffline_protocol_uniffi.a"
-
-print_xcframework_slices "$XCFRAMEWORK"
-
-echo ""
-echo "✅ iOS build complete!"
-
+exec bash "$SCRIPT_DIR/build-uniffi-ios.sh" "$@"

--- a/bindings/react-native/scripts/build-uniffi-all.sh
+++ b/bindings/react-native/scripts/build-uniffi-all.sh
@@ -12,20 +12,24 @@ echo "Building UniFFI libraries for all platforms"
 echo "========================================="
 echo ""
 
-# Check if uniffi-bindgen is installed
+# Check if uniffi-bindgen is installed.
+#
+# This used to warn and offer to continue, on the premise that the native
+# libraries were still worth building on their own. They are not: the iOS and
+# Android scripts below now fail rather than pair a fresh native library with
+# the previously committed bindings, so continuing here only buys a longer wait
+# before the same error. Fail immediately instead.
 if ! command -v uniffi-bindgen &> /dev/null; then
-  echo "⚠️  WARNING: uniffi-bindgen not found!"
-  echo ""
-  echo "Native libraries will be built, but bindings won't be generated."
-  echo "To install uniffi-bindgen, run:"
-  echo "  cargo install uniffi --version 0.30.0 --features cli"
-  echo ""
-  echo "Press Enter to continue or Ctrl+C to cancel..."
-  read -r
+  echo "❌ Error: uniffi-bindgen not found — the platform builds below would" >&2
+  echo "   compile the native libraries and then fail at binding generation." >&2
+  echo "" >&2
+  echo "   cargo install uniffi --version 0.30.0 --features cli --locked" >&2
+  echo "" >&2
+  exit 1
 fi
 
 # Build iOS
-echo "📱 Building iOS + generating Swift bindings..."
+echo "📱 Building iOS + generating bindings..."
 bash "$SCRIPT_DIR/build-uniffi-ios.sh"
 
 echo ""
@@ -33,7 +37,7 @@ echo "========================================="
 echo ""
 
 # Build Android
-echo "🤖 Building Android + generating Kotlin bindings..."
+echo "🤖 Building Android + generating bindings..."
 bash "$SCRIPT_DIR/build-uniffi-android.sh"
 
 echo ""
@@ -46,27 +50,21 @@ echo "  iOS:            bindings/react-native/ios/libs/offline_protocol_uniffi.x
 echo "  Android:        bindings/react-native/android/src/main/jniLibs/**/*.so"
 echo ""
 
-if command -v uniffi-bindgen &> /dev/null; then
-  # The iOS and Android scripts above each delegate to the shared generator, so
-  # the full set is written twice. That is deliberate: both are also run on
-  # their own, and idempotent regeneration is cheaper than either script being
-  # allowed to emit only its own language.
-  echo "Generated bindings (all three — one artifact set off one UDL):"
-  echo "  Swift:   bindings/react-native/ios/Generated/"
-  echo "  Kotlin:  bindings/react-native/android/src/main/java/uniffi/"
-  echo "  Python:  bindings/python/offline_protocol_sdk/"
-  echo ""
-  echo "Next steps:"
-  echo "  1. Commit all three together — a partial commit is drift"
-  echo "  2. Test on iOS and Android"
-  echo "  3. Run 'npm publish' to distribute the package"
-else
-  echo "⚠️  Bindings were NOT generated (uniffi-bindgen not installed)"
-  echo ""
-  echo "To generate bindings, install uniffi-bindgen and run:"
-  echo "  cargo install uniffi --version 0.30.0 --features cli --locked"
-  echo "  ./scripts/generate-bindings.sh"
-fi
+# Unconditional: the bindgen check at the top exits rather than continuing, and
+# both platform scripts fail if generation does not happen, so reaching here
+# means all three were written. The iOS and Android scripts each delegate to the
+# shared generator, so the full set is written twice — deliberate, since both
+# are also run on their own and idempotent regeneration is cheaper than letting
+# either emit only its own language.
+echo "Generated bindings (all three — one artifact set off one UDL):"
+echo "  Swift:   bindings/react-native/ios/Generated/"
+echo "  Kotlin:  bindings/react-native/android/src/main/java/uniffi/"
+echo "  Python:  bindings/python/offline_protocol_sdk/"
+echo ""
+echo "Next steps:"
+echo "  1. Commit all three together — a partial commit is drift"
+echo "  2. Test on iOS and Android"
+echo "  3. Run 'npm publish' to distribute the package"
 
 echo ""
 

--- a/bindings/react-native/scripts/build-uniffi-all.sh
+++ b/bindings/react-native/scripts/build-uniffi-all.sh
@@ -47,21 +47,25 @@ echo "  Android:        bindings/react-native/android/src/main/jniLibs/**/*.so"
 echo ""
 
 if command -v uniffi-bindgen &> /dev/null; then
-  echo "Generated bindings:"
+  # The iOS and Android scripts above each delegate to the shared generator, so
+  # the full set is written twice. That is deliberate: both are also run on
+  # their own, and idempotent regeneration is cheaper than either script being
+  # allowed to emit only its own language.
+  echo "Generated bindings (all three — one artifact set off one UDL):"
   echo "  Swift:   bindings/react-native/ios/Generated/"
-  echo "  Kotlin:  bindings/react-native/android/src/main/java/"
+  echo "  Kotlin:  bindings/react-native/android/src/main/java/uniffi/"
+  echo "  Python:  bindings/python/offline_protocol_sdk/"
   echo ""
   echo "Next steps:"
-  echo "  1. Update OfflineProtocolModule.swift to use generated Swift bindings"
-  echo "  2. Update OfflineProtocolModule.kt to use generated Kotlin bindings"
-  echo "  3. Test on iOS and Android"
-  echo "  4. Run 'npm publish' to distribute the package"
+  echo "  1. Commit all three together — a partial commit is drift"
+  echo "  2. Test on iOS and Android"
+  echo "  3. Run 'npm publish' to distribute the package"
 else
   echo "⚠️  Bindings were NOT generated (uniffi-bindgen not installed)"
   echo ""
   echo "To generate bindings, install uniffi-bindgen and run:"
-  echo "  cargo install uniffi --version 0.30.0 --features cli"
-  echo "  npm run generate:bindings"
+  echo "  cargo install uniffi --version 0.30.0 --features cli --locked"
+  echo "  ./scripts/generate-bindings.sh"
 fi
 
 echo ""

--- a/bindings/react-native/scripts/build-uniffi-android.sh
+++ b/bindings/react-native/scripts/build-uniffi-android.sh
@@ -180,22 +180,19 @@ for abi in "${ABIS[@]}"; do
 done
 
 # Generate bindings — all languages, not just Kotlin: they are one artifact set
-# off one UDL (see scripts/generate-bindings.sh). Still tolerant of a missing
-# uniffi-bindgen, because the native libraries above are the point of this
-# script and they are already built by here.
+# off one UDL (see scripts/generate-bindings.sh).
+#
+# This used to warn and exit 0 when uniffi-bindgen was missing, on the grounds
+# that the native libraries above are the point of the script. That is the one
+# tolerance this script cannot afford: freshly built .so files beside the
+# previously committed Kotlin *are* the ABI mismatch the whole single-entry-
+# point rule exists to prevent, and it fails at the app's first FFI call rather
+# than here. Shipping that silently is worse than not building. The generator's
+# own error message names the install command, so let it fail.
 echo ""
 echo "Generating bindings..."
 
-if command -v uniffi-bindgen &> /dev/null; then
-  bash "$PROJECT_ROOT/scripts/generate-bindings.sh"
-else
-  echo "⚠️  uniffi-bindgen not found!"
-  echo "Install it with: cargo install uniffi --version 0.30.0 --features cli"
-  echo ""
-  echo "For now, the native libraries are built, but you'll need to"
-  echo "generate bindings manually when uniffi-bindgen is available:"
-  echo "  bash $PROJECT_ROOT/scripts/generate-bindings.sh"
-fi
+bash "$PROJECT_ROOT/scripts/generate-bindings.sh"
 
 echo ""
 echo "✅ Android UniFFI build complete!"

--- a/bindings/react-native/scripts/build-uniffi-android.sh
+++ b/bindings/react-native/scripts/build-uniffi-android.sh
@@ -15,9 +15,7 @@ echo "Building UniFFI Android libraries and generating Kotlin bindings..."
 # Navigate to the Rust project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-UNIFFI_DIR="$PROJECT_ROOT/crates/offline-protocol-uniffi"
 OUTPUT_DIR="$SCRIPT_DIR/../android/src/main/jniLibs"
-GENERATED_DIR="$SCRIPT_DIR/../android/src/main/java"
 
 cd "$PROJECT_ROOT"
 
@@ -181,30 +179,22 @@ for abi in "${ABIS[@]}"; do
   fi
 done
 
-# Generate Kotlin bindings
+# Generate bindings — all languages, not just Kotlin: they are one artifact set
+# off one UDL (see scripts/generate-bindings.sh). Still tolerant of a missing
+# uniffi-bindgen, because the native libraries above are the point of this
+# script and they are already built by here.
 echo ""
-echo "Generating Kotlin bindings..."
+echo "Generating bindings..."
 
 if command -v uniffi-bindgen &> /dev/null; then
-  mkdir -p "$GENERATED_DIR"
-  cd "$UNIFFI_DIR"
-  
-  uniffi-bindgen generate \
-    src/offline_protocol.udl \
-    --language kotlin \
-    --out-dir "$GENERATED_DIR"
-  
-  echo "✅ Kotlin bindings generated in $GENERATED_DIR"
+  bash "$PROJECT_ROOT/scripts/generate-bindings.sh"
 else
   echo "⚠️  uniffi-bindgen not found!"
   echo "Install it with: cargo install uniffi --version 0.30.0 --features cli"
   echo ""
   echo "For now, the native libraries are built, but you'll need to"
-  echo "generate Kotlin bindings manually when uniffi-bindgen is available."
-  echo ""
-  echo "To generate bindings later, run:"
-  echo "  cd $UNIFFI_DIR"
-  echo "  uniffi-bindgen generate src/offline_protocol.udl --language kotlin --out-dir $GENERATED_DIR"
+  echo "generate bindings manually when uniffi-bindgen is available:"
+  echo "  bash $PROJECT_ROOT/scripts/generate-bindings.sh"
 fi
 
 echo ""

--- a/bindings/react-native/scripts/build-uniffi-ios.sh
+++ b/bindings/react-native/scripts/build-uniffi-ios.sh
@@ -12,7 +12,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # shellcheck source=shared/xcframework.sh
 source "$SCRIPT_DIR/shared/xcframework.sh"
-UNIFFI_DIR="$PROJECT_ROOT/crates/offline-protocol-uniffi"
 OUTPUT_DIR="$SCRIPT_DIR/../ios/libs"
 GENERATED_DIR="$SCRIPT_DIR/../ios/Generated"
 XCFRAMEWORK="$OUTPUT_DIR/offline_protocol_uniffi.xcframework"
@@ -64,29 +63,22 @@ package_xcframework \
   "$(static_lib_for aarch64-apple-ios-sim)" \
   "$(static_lib_for x86_64-apple-ios)"
 
-# Generate Swift bindings
+# Generate bindings — all languages, not just Swift: they are one artifact set
+# off one UDL (see scripts/generate-bindings.sh). Still tolerant of a missing
+# uniffi-bindgen, because the native libraries above are the point of this
+# script and they are already built by here.
 echo ""
-echo "Generating Swift bindings..."
+echo "Generating bindings..."
 
 if command -v uniffi-bindgen &> /dev/null; then
-  cd "$UNIFFI_DIR"
-  
-  uniffi-bindgen generate \
-    src/offline_protocol.udl \
-    --language swift \
-    --out-dir "$GENERATED_DIR"
-  
-  echo "✅ Swift bindings generated in $GENERATED_DIR"
+  bash "$PROJECT_ROOT/scripts/generate-bindings.sh"
 else
   echo "⚠️  uniffi-bindgen not found!"
   echo "Install it with: cargo install uniffi --version 0.30.0 --features cli"
   echo ""
   echo "For now, the native libraries are built, but you'll need to"
-  echo "generate Swift bindings manually when uniffi-bindgen is available."
-  echo ""
-  echo "To generate bindings later, run:"
-  echo "  cd $UNIFFI_DIR"
-  echo "  uniffi-bindgen generate src/offline_protocol.udl --language swift --out-dir $GENERATED_DIR"
+  echo "generate bindings manually when uniffi-bindgen is available:"
+  echo "  bash $PROJECT_ROOT/scripts/generate-bindings.sh"
 fi
 
 print_xcframework_slices "$XCFRAMEWORK"

--- a/bindings/react-native/scripts/build-uniffi-ios.sh
+++ b/bindings/react-native/scripts/build-uniffi-ios.sh
@@ -64,22 +64,19 @@ package_xcframework \
   "$(static_lib_for x86_64-apple-ios)"
 
 # Generate bindings — all languages, not just Swift: they are one artifact set
-# off one UDL (see scripts/generate-bindings.sh). Still tolerant of a missing
-# uniffi-bindgen, because the native libraries above are the point of this
-# script and they are already built by here.
+# off one UDL (see scripts/generate-bindings.sh).
+#
+# This used to warn and exit 0 when uniffi-bindgen was missing, on the grounds
+# that the native libraries above are the point of the script. That is the one
+# tolerance this script cannot afford: a freshly built xcframework beside the
+# previously committed Swift *is* the ABI mismatch the whole single-entry-point
+# rule exists to prevent, and it fails at the app's first FFI call rather than
+# here. Shipping that silently is worse than not building. The generator's own
+# error message names the install command, so let it fail.
 echo ""
 echo "Generating bindings..."
 
-if command -v uniffi-bindgen &> /dev/null; then
-  bash "$PROJECT_ROOT/scripts/generate-bindings.sh"
-else
-  echo "⚠️  uniffi-bindgen not found!"
-  echo "Install it with: cargo install uniffi --version 0.30.0 --features cli"
-  echo ""
-  echo "For now, the native libraries are built, but you'll need to"
-  echo "generate bindings manually when uniffi-bindgen is available:"
-  echo "  bash $PROJECT_ROOT/scripts/generate-bindings.sh"
-fi
+bash "$PROJECT_ROOT/scripts/generate-bindings.sh"
 
 print_xcframework_slices "$XCFRAMEWORK"
 

--- a/bindings/react-native/scripts/generate-bindings.sh
+++ b/bindings/react-native/scripts/generate-bindings.sh
@@ -1,64 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Generate UniFFI bindings only (without building native libraries)
-# Useful when you just need to regenerate bindings from UDL changes
+# Regenerate the UniFFI bindings after a UDL change (`npm run generate:bindings`).
+#
+# Kept as a wrapper because the npm script and CI both call this path, but the
+# work — and every language, not just Swift and Kotlin — lives in the repo-root
+# scripts/generate-bindings.sh. Swift and Kotlin are deliberately not
+# regenerable on their own: see the header there for why a partial set fails at
+# runtime rather than at build time.
 
-set -e
-
-echo "Generating UniFFI bindings for Swift and Kotlin..."
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-UNIFFI_DIR="$PROJECT_ROOT/crates/offline-protocol-uniffi"
-SWIFT_OUT="$SCRIPT_DIR/../ios/Generated"
-KOTLIN_OUT="$SCRIPT_DIR/../android/src/main/java"
 
-# Check if uniffi-bindgen is installed
-if ! command -v uniffi-bindgen &> /dev/null; then
-  echo "❌ Error: uniffi-bindgen not found!"
-  echo ""
-  echo "Install it with:"
-  echo "  cargo install uniffi --version 0.30.0 --features cli"
-  echo ""
-  exit 1
-fi
-
-cd "$UNIFFI_DIR"
-
-# Create output directories
-mkdir -p "$SWIFT_OUT"
-mkdir -p "$KOTLIN_OUT"
-
-# Generate Swift bindings
-echo "Generating Swift bindings..."
-uniffi-bindgen generate \
-  src/offline_protocol.udl \
-  --language swift \
-  --out-dir "$SWIFT_OUT"
-
-echo "✅ Swift bindings generated in $SWIFT_OUT"
-
-# Generate Kotlin bindings
-echo "Generating Kotlin bindings..."
-uniffi-bindgen generate \
-  src/offline_protocol.udl \
-  --language kotlin \
-  --out-dir "$KOTLIN_OUT"
-
-echo "✅ Kotlin bindings generated in $KOTLIN_OUT"
-
-echo ""
-echo "========================================="
-echo "✅ All bindings generated successfully!"
-echo "========================================="
-echo ""
-echo "Generated files:"
-echo "  Swift:   $SWIFT_OUT"
-echo "  Kotlin:  $KOTLIN_OUT"
-echo ""
-echo "Next steps:"
-echo "  1. Review the generated bindings"
-echo "  2. Update your Swift/Kotlin modules to use them"
-echo "  3. Build and test your app"
-echo ""
-
+exec bash "$PROJECT_ROOT/scripts/generate-bindings.sh" "$@"

--- a/bindings/react-native/scripts/shared/xcframework.sh
+++ b/bindings/react-native/scripts/shared/xcframework.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #
-# Shared iOS XCFramework packaging. Sourced by build-ios.sh and
-# build-uniffi-ios.sh, which differ only in how they locate the per-arch Rust
-# staticlibs; everything downstream of that is identical and lives here so the
-# two paths cannot drift. build-uniffi-ios.sh is the one the release workflow
-# runs, so a change here reaches production — keep it dependency-free and
-# exercise both callers.
+# Shared iOS XCFramework packaging. Sourced by build-uniffi-ios.sh, now the
+# only caller: build-ios.sh used to source this too and duplicate the rest of
+# the build, and is a thin wrapper over build-uniffi-ios.sh since that copy
+# turned out to pair fresh native artifacts with stale committed bindings.
+# build-uniffi-ios.sh is what the release workflow runs, so a change here
+# reaches production — keep it dependency-free.
 #
 # WHY AN XCFRAMEWORK AND NOT LOOSE ARCHIVES
 #

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1083,9 +1083,10 @@ wire-format change, Android untouched.
 `pending_message_max_lifetime_ms` on `RetryConfig`.
 
 ```bash
+./scripts/generate-bindings.sh   # after UDL changes — Swift, Kotlin, Python
+
 cd bindings/react-native
-npm run generate:bindings      # after UDL changes
-npm run build:uniffi:all       # or :ios / :android
+npm run build:uniffi:all         # or :ios / :android
 ```
 
 Requires `uniffi` CLI `0.30.0` matching the workspace pin.

--- a/docs/android-integration.md
+++ b/docs/android-integration.md
@@ -42,7 +42,9 @@ android/app/src/main/jniLibs/
 ```
 
 The `bindings/react-native/scripts/build-uniffi-android.sh` helper builds every ABI and
-renames automatically (and regenerates the Kotlin bindings).
+renames automatically. It also regenerates the UniFFI bindings — all three languages, not
+just Kotlin: they are one artifact set off one UDL, so the Swift and Python bindings are
+rewritten too and all three must be committed together (see `scripts/generate-bindings.sh`).
 
 ### 4. Use in Kotlin
 

--- a/docs/ios-integration.md
+++ b/docs/ios-integration.md
@@ -35,7 +35,9 @@ Each build produces `liboffline_protocol_uniffi.a` under `target/<triple>/releas
 ### 3. Package the Library and Generate Bindings
 
 The recommended path is the helper script, which builds the device/simulator slices **and**
-regenerates the UniFFI Swift bindings:
+regenerates the UniFFI bindings — all three languages, not just Swift. They are one artifact
+set off one UDL, so the script also rewrites the Kotlin and Python bindings; commit all three
+together (see `scripts/generate-bindings.sh`):
 
 ```bash
 # From bindings/react-native

--- a/docs/ios-integration.md
+++ b/docs/ios-integration.md
@@ -57,8 +57,11 @@ this is an XCFramework rather than a single fat `.a`.
 To do it by hand instead: `lipo`-combine the two simulator per-arch
 `liboffline_protocol_uniffi.a` outputs, leave the device one alone, give both
 files the *same* basename in separate staging directories, and pass each with
-`-library` to `xcodebuild -create-xcframework`. Then run
-`uniffi-bindgen generate --language swift` for the Swift bindings.
+`-library` to `xcodebuild -create-xcframework`. For the Swift bindings run
+`./scripts/generate-bindings.sh` — never `uniffi-bindgen` directly. It emits
+Swift, Kotlin and Python together because they are one artifact set off one
+UDL, and a subset leaves the rest describing a different ABI, which fails at
+the app's first FFI call rather than at build time.
 
 ### 4. Use in Swift
 

--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -22,6 +22,12 @@ copy into a real app.
 ## Setup
 
 ```bash
+# 0. One-time prerequisite. The build regenerates the UniFFI bindings alongside
+#    the native libraries, so it needs uniffi-bindgen at the crate's pinned
+#    version (it refuses to run on a mismatch rather than emit bindings whose
+#    checksums fail at the app's first call).
+cargo install uniffi --version 0.30.0 --features cli --locked
+
 # 1. Build the SDK's native libraries first (required before the first run —
 #    the app cannot load the native module otherwise).
 cd bindings/react-native

--- a/examples/mesh-wiki/README.md
+++ b/examples/mesh-wiki/README.md
@@ -24,6 +24,12 @@ file.
 ## Setup
 
 ```bash
+# 0. One-time prerequisite. The build regenerates the UniFFI bindings alongside
+#    the native libraries, so it needs uniffi-bindgen at the crate's pinned
+#    version (it refuses to run on a mismatch rather than emit bindings whose
+#    checksums fail at the app's first call).
+cargo install uniffi --version 0.30.0 --features cli --locked
+
 # 1. Build the SDK's native libraries first (required before the first run —
 #    the app cannot load the native module otherwise).
 cd bindings/react-native

--- a/examples/nostr-example/README.md
+++ b/examples/nostr-example/README.md
@@ -20,6 +20,12 @@ Minimal React Native app demonstrating the Nostr relay transport for the Offline
 ## Setup
 
 ```bash
+# 0. One-time prerequisite. The build regenerates the UniFFI bindings alongside
+#    the native libraries, so it needs uniffi-bindgen at the crate's pinned
+#    version (it refuses to run on a mismatch rather than emit bindings whose
+#    checksums fail at the app's first call).
+cargo install uniffi --version 0.30.0 --features cli --locked
+
 # 1. Build the SDK's native libraries first (required before the first run —
 #    the app cannot load the native module otherwise).
 cd bindings/react-native

--- a/examples/react-native-app/README.md
+++ b/examples/react-native-app/README.md
@@ -69,6 +69,10 @@ A modern, user-friendly messaging application built with the Offline Protocol SD
 > full first-time setup.
 
 1. **Build Native Libraries** (required before first run)
+
+   Needs `uniffi-bindgen` at the crate's pinned version — the build regenerates
+   the UniFFI bindings alongside the native libraries and refuses to run on a
+   mismatch: `cargo install uniffi --version 0.30.0 --features cli --locked`.
    ```bash
    cd ../../bindings/react-native
    npm run build:all

--- a/examples/react-native-app/SETUP.md
+++ b/examples/react-native-app/SETUP.md
@@ -13,9 +13,14 @@
 
 ### 1. Build Native Libraries
 
-Navigate to the React Native bindings directory and build native libraries for all platforms:
+Navigate to the React Native bindings directory and build native libraries for all platforms.
+This also regenerates the UniFFI bindings (Swift, Kotlin and Python are one artifact set off one
+UDL), so it needs `uniffi-bindgen` at the crate's pinned version first — it refuses to run on a
+mismatch rather than emit bindings whose checksums fail at the app's first call:
 
 ```bash
+cargo install uniffi --version 0.30.0 --features cli --locked
+
 cd ../../bindings/react-native
 npm run build:all
 cd ../../examples/react-native-app

--- a/examples/service-discovery-app/README.md
+++ b/examples/service-discovery-app/README.md
@@ -57,7 +57,8 @@ The quickest way to try it end-to-end on real hardware:
 
 Alternatively, scaffold native projects for this directory yourself
 (`npx react-native init` or an Expo prebuild), build the SDK's native libraries
-(`cd ../../bindings/react-native && npm run build:all`), then:
+(`cargo install uniffi --version 0.30.0 --features cli --locked`, then
+`cd ../../bindings/react-native && npm run build:all`), then:
 
 ```bash
 npm install

--- a/scripts/generate-bindings.sh
+++ b/scripts/generate-bindings.sh
@@ -37,7 +37,10 @@ set -euo pipefail
 # that flag does not exist instead of watching all three regenerate anyway and
 # concluding the flag worked.
 if [[ $# -gt 0 ]]; then
-  echo "Error: $(basename "$0") takes no arguments (got: $*)." >&2
+  # Repo-relative rather than the basename: two tracked files are named
+  # generate-bindings.sh, and the RN one execs this, so a basename cannot say
+  # which of them rejected the flag.
+  echo "Error: scripts/generate-bindings.sh takes no arguments (got: $*)." >&2
   echo "It generates Swift, Kotlin and Python together on purpose — they are one" >&2
   echo "artifact set off one UDL, and a partial set fails at runtime, not build time." >&2
   exit 2

--- a/scripts/generate-bindings.sh
+++ b/scripts/generate-bindings.sh
@@ -7,13 +7,21 @@
 # produced by one bindgen from one UDL and carry the FFI checksums of the
 # cdylib they were generated against. Regenerating a subset leaves the others
 # describing a different ABI — which does not fail any build, only the app at
-# the first call. Every other script that used to run `uniffi-bindgen` itself
-# now delegates here, so no path can produce a partial set:
+# the first call. Every caller that used to run `uniffi-bindgen` itself now
+# delegates here, so no path can produce a partial set:
 #
 #   bindings/react-native/scripts/generate-bindings.sh   (npm run generate:bindings)
 #   bindings/react-native/scripts/build-uniffi-ios.sh
 #   bindings/react-native/scripts/build-uniffi-android.sh
 #   bindings/python/scripts/build-desktop.sh
+#   .github/workflows/ci.yml                             (via build-desktop.sh)
+#   .github/workflows/release.yml                        (android-bindings, python-bindings)
+#
+# The release workflow matters most and is the least obvious: the Kotlin it
+# generates is downloaded *over* the committed Android bindings in the publish
+# job, so it — not the committed file — is what ships to npm. Anything that
+# generates there must come through this script, or the released Kotlin and the
+# released Swift can be built by different bindgens.
 #
 # Usage:
 #   ./scripts/generate-bindings.sh
@@ -22,6 +30,18 @@
 # reads that pin rather than repeating it.
 
 set -euo pipefail
+
+# Takes no arguments, and says so rather than ignoring them. The wrapper at
+# bindings/react-native/scripts/generate-bindings.sh forwards "$@", so someone
+# reaching for `npm run generate:bindings -- --language swift` gets told why
+# that flag does not exist instead of watching all three regenerate anyway and
+# concluding the flag worked.
+if [[ $# -gt 0 ]]; then
+  echo "Error: $(basename "$0") takes no arguments (got: $*)." >&2
+  echo "It generates Swift, Kotlin and Python together on purpose — they are one" >&2
+  echo "artifact set off one UDL, and a partial set fails at runtime, not build time." >&2
+  exit 2
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -51,9 +71,15 @@ if ! command -v uniffi-bindgen &>/dev/null; then
   exit 1
 fi
 
+# Compare at major.minor on *both* sides. The crate pin and the installed
+# version are written to different precisions by convention — `uniffi = "0.30"`
+# against a bindgen that reports `0.30.0` — so normalizing only the installed
+# side makes a patch-level pin (`uniffi = "0.30.1"`) permanently unsatisfiable,
+# killing all codegen with a message naming a version that cannot fix it.
 INSTALLED_VERSION="$(uniffi-bindgen --version | awk '{print $NF}')"
 INSTALLED_MAJOR_MINOR="$(printf '%s' "$INSTALLED_VERSION" | cut -d. -f1,2)"
-if [[ "$INSTALLED_MAJOR_MINOR" != "$REQUIRED_VERSION" ]]; then
+REQUIRED_MAJOR_MINOR="$(printf '%s' "$REQUIRED_VERSION" | cut -d. -f1,2)"
+if [[ "$INSTALLED_MAJOR_MINOR" != "$REQUIRED_MAJOR_MINOR" ]]; then
   echo "Error: uniffi-bindgen $INSTALLED_VERSION does not match the crate's uniffi $REQUIRED_VERSION pin." >&2
   echo "Generating with it would produce bindings whose checksums fail at runtime, not at build time." >&2
   echo "" >&2
@@ -62,10 +88,17 @@ if [[ "$INSTALLED_MAJOR_MINOR" != "$REQUIRED_VERSION" ]]; then
   exit 1
 fi
 
+# --no-format is load-bearing, not tidiness: uniffi-bindgen shells out to
+# ktlint for Kotlin and swiftformat for Swift *when they happen to be on PATH*,
+# so without it the bytes written depend on what the developer has installed.
+# The committed bindings are the unformatted form (CI runners carry neither
+# tool), which means an Android or iOS contributor with those formatters —
+# exactly the people editing this repo — would regenerate correctly and still
+# trip the drift gate. Pin the output to the one form instead.
 generate() {
   local language="$1" out_dir="$2"
   mkdir -p "$out_dir"
-  uniffi-bindgen generate "$UDL" --language "$language" --out-dir "$out_dir"
+  uniffi-bindgen generate --no-format "$UDL" --language "$language" --out-dir "$out_dir"
   printf '  %-7s -> %s\n' "$language" "${out_dir#"$PROJECT_ROOT"/}"
 }
 

--- a/scripts/generate-bindings.sh
+++ b/scripts/generate-bindings.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Generate every UniFFI binding from the one UDL: Swift, Kotlin and Python.
+#
+# This is the single entry point, and the reason it exists is that the three
+# generated files are one artifact set, not three independent ones: they are
+# produced by one bindgen from one UDL and carry the FFI checksums of the
+# cdylib they were generated against. Regenerating a subset leaves the others
+# describing a different ABI — which does not fail any build, only the app at
+# the first call. Every other script that used to run `uniffi-bindgen` itself
+# now delegates here, so no path can produce a partial set:
+#
+#   bindings/react-native/scripts/generate-bindings.sh   (npm run generate:bindings)
+#   bindings/react-native/scripts/build-uniffi-ios.sh
+#   bindings/react-native/scripts/build-uniffi-android.sh
+#   bindings/python/scripts/build-desktop.sh
+#
+# Usage:
+#   ./scripts/generate-bindings.sh
+#
+# Requires uniffi-bindgen matching the crate's `uniffi` pin; the check below
+# reads that pin rather than repeating it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+UNIFFI_DIR="$PROJECT_ROOT/crates/offline-protocol-uniffi"
+UDL="src/offline_protocol.udl"
+
+SWIFT_OUT="$PROJECT_ROOT/bindings/react-native/ios/Generated"
+KOTLIN_OUT="$PROJECT_ROOT/bindings/react-native/android/src/main/java"
+PYTHON_OUT="$PROJECT_ROOT/bindings/python/offline_protocol_sdk"
+
+# The bindgen version is baked into the generated code as FFI checksums, so
+# generating with a bindgen that disagrees with the crate's `uniffi` compiles
+# fine and fails at runtime instead. Read the required version from the crate
+# so there is exactly one version of record.
+REQUIRED_VERSION="$(sed -n 's/^uniffi = "\([0-9.]*\)"$/\1/p' "$UNIFFI_DIR/Cargo.toml" | head -1)"
+if [[ -z "$REQUIRED_VERSION" ]]; then
+  echo "Error: could not read the uniffi version from $UNIFFI_DIR/Cargo.toml." >&2
+  echo "The pin moved or changed shape — fix this check rather than skipping it." >&2
+  exit 1
+fi
+
+if ! command -v uniffi-bindgen &>/dev/null; then
+  echo "Error: uniffi-bindgen not found." >&2
+  echo "" >&2
+  echo "  cargo install uniffi --version $REQUIRED_VERSION --features cli --locked" >&2
+  echo "" >&2
+  exit 1
+fi
+
+INSTALLED_VERSION="$(uniffi-bindgen --version | awk '{print $NF}')"
+INSTALLED_MAJOR_MINOR="$(printf '%s' "$INSTALLED_VERSION" | cut -d. -f1,2)"
+if [[ "$INSTALLED_MAJOR_MINOR" != "$REQUIRED_VERSION" ]]; then
+  echo "Error: uniffi-bindgen $INSTALLED_VERSION does not match the crate's uniffi $REQUIRED_VERSION pin." >&2
+  echo "Generating with it would produce bindings whose checksums fail at runtime, not at build time." >&2
+  echo "" >&2
+  echo "  cargo install uniffi --version $REQUIRED_VERSION --features cli --locked --force" >&2
+  echo "" >&2
+  exit 1
+fi
+
+generate() {
+  local language="$1" out_dir="$2"
+  mkdir -p "$out_dir"
+  uniffi-bindgen generate "$UDL" --language "$language" --out-dir "$out_dir"
+  printf '  %-7s -> %s\n' "$language" "${out_dir#"$PROJECT_ROOT"/}"
+}
+
+cd "$UNIFFI_DIR"
+
+echo "Generating UniFFI bindings from $UDL (uniffi-bindgen $INSTALLED_VERSION)"
+generate swift "$SWIFT_OUT"
+generate kotlin "$KOTLIN_OUT"
+generate python "$PYTHON_OUT"
+
+echo "All bindings generated. Commit all three together — a partial commit is drift."

--- a/scripts/tests/test-generate-bindings.sh
+++ b/scripts/tests/test-generate-bindings.sh
@@ -9,15 +9,34 @@
 # uniffi-bindgen behind its back, and nothing about a new build script makes
 # violating it obvious. So: assert it, statically, with no bindgen required.
 #
-# Out of scope by design: .github/workflows/release.yml's Kotlin step, which
-# generates into an ephemeral release build directory rather than the committed
-# paths this rule is about.
+# Scope covers tracked shell scripts *and* the GitHub workflows. The workflows
+# are not an afterthought: release.yml's Kotlin step generates into a scratch
+# directory that the publish job then downloads over the committed Android
+# bindings, so a direct invocation there ships to npm without ever touching a
+# .sh file. A guard that read only *.sh would call that rule enforced while
+# leaving the one path users actually receive exempt.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GENERATOR="scripts/generate-bindings.sh"
+
+cd "$REPO_ROOT"
+
+SELF="${BASH_SOURCE[0]}"
+case "$SELF" in
+  /*) SELF="${SELF#"$REPO_ROOT"/}" ;;
+esac
+
+# A direct invocation, in either of the two shapes it is written in: the command
+# and subcommand on one line, or `uniffi-bindgen \` continued onto the next.
+# Matching the flat string "uniffi-bindgen generate" alone would miss the
+# continuation form — which is precisely how every script this rule replaced
+# used to be written, so it is the likeliest way the violation comes back.
+# Deliberately does not match `command -v uniffi-bindgen` or the install
+# instructions that callers legitimately still print.
+INVOCATION='(^|[^[:alnum:]_-])uniffi-bindgen([[:space:]]+generate|[[:space:]]*\\[[:space:]]*$)'
 
 FAILURES=0
 
@@ -27,8 +46,6 @@ fail() {
   echo "  FAIL — $*" >&2
   FAILURES=$((FAILURES + 1))
 }
-
-cd "$REPO_ROOT"
 
 echo "Guarding the shared binding generator..."
 
@@ -47,20 +64,21 @@ for language in swift kotlin python; do
   fi
 done
 
-# 2. No other tracked shell script invokes uniffi-bindgen directly. Callers must
-#    delegate, or they can refresh one language and leave the other two stale.
+# 2. Nothing else invokes uniffi-bindgen directly — not a shell script, not a
+#    workflow. Callers must delegate, or they can refresh one language and
+#    leave the other two describing a different ABI.
 offenders=""
-while IFS= read -r script; do
-  [[ "$script" == "$GENERATOR" ]] && continue
-  if grep -q 'uniffi-bindgen generate' "$script"; then
-    offenders+="      $script"$'\n'
+while IFS= read -r file; do
+  [[ "$file" == "$GENERATOR" || "$file" == "$SELF" ]] && continue
+  if grep -Eq "$INVOCATION" "$file"; then
+    offenders+="      $file"$'\n'
   fi
-done < <(git ls-files '*.sh')
+done < <(git ls-files '*.sh' '.github/workflows/*.yml')
 
 if [[ -z "$offenders" ]]; then
-  pass "no other shell script calls uniffi-bindgen generate directly"
+  pass "no other script or workflow calls uniffi-bindgen directly"
 else
-  fail "these scripts call uniffi-bindgen generate instead of delegating to $GENERATOR:"
+  fail "these files call uniffi-bindgen directly instead of delegating to $GENERATOR:"
   printf '%s' "$offenders" >&2
 fi
 
@@ -71,6 +89,44 @@ if grep -q 'crates/offline-protocol-uniffi' "$GENERATOR" \
   pass "the bindgen version check is derived from the crate's uniffi pin"
 else
   fail "$GENERATOR no longer derives the required bindgen version from the crate pin"
+fi
+
+# 4. Codegen is pinned to one output form. uniffi-bindgen post-processes with
+#    ktlint (Kotlin) and swiftformat (Swift) when they are on PATH, so without
+#    --no-format the committed bytes depend on the developer's machine and a
+#    correct regeneration can still fail the drift gate.
+if grep -q 'uniffi-bindgen generate --no-format' "$GENERATOR"; then
+  pass "$GENERATOR generates with --no-format, so output does not vary by machine"
+else
+  fail "$GENERATOR dropped --no-format — output now depends on whether ktlint/swiftformat are installed"
+fi
+
+# 5. Negative control. Every assertion above says "the good state is present",
+#    and a detector that cannot fail is indistinguishable from one that passes
+#    vacuously. Prove the scan in step 2 actually fires — on both invocation
+#    shapes — against fixtures that are never part of the real scan.
+control_dir="$(mktemp -d)"
+trap 'rm -rf "$control_dir"' EXIT
+
+printf '#!/usr/bin/env bash\nuniffi-bindgen generate src/x.udl --language swift\n' \
+  >"$control_dir/inline.sh"
+printf '#!/usr/bin/env bash\nuniffi-bindgen \\\n  generate src/x.udl --language kotlin\n' \
+  >"$control_dir/continued.sh"
+printf '#!/usr/bin/env bash\nif command -v uniffi-bindgen; then bash scripts/generate-bindings.sh; fi\n' \
+  >"$control_dir/delegating.sh"
+
+for shape in inline continued; do
+  if grep -Eq "$INVOCATION" "$control_dir/$shape.sh"; then
+    pass "the scan detects a $shape uniffi-bindgen invocation"
+  else
+    fail "the scan MISSES a $shape uniffi-bindgen invocation — it would pass vacuously"
+  fi
+done
+
+if grep -Eq "$INVOCATION" "$control_dir/delegating.sh"; then
+  fail "the scan flags a delegating caller that only probes for uniffi-bindgen"
+else
+  pass "the scan ignores a delegating caller that only probes for uniffi-bindgen"
 fi
 
 echo ""

--- a/scripts/tests/test-generate-bindings.sh
+++ b/scripts/tests/test-generate-bindings.sh
@@ -115,6 +115,25 @@ bindings/react-native/scripts/build-android.sh:build-uniffi-android.sh
 bindings/react-native/scripts/build-all.sh:build-uniffi-all.sh
 "
 
+# The negative-control fixtures, by name. Listed here with the other driver
+# lists so they are size-pinned too: they are what proves the scan can fire.
+HIT_FIXTURES="
+inline
+continued
+global-option
+cargo-run
+gradle-kotlin
+gradle-groovy
+argv-list
+nested-list
+"
+
+MISS_FIXTURES="
+delegating
+prose
+prose-adjacent
+"
+
 # The three committed paths, repo-relative. CI deletes exactly these before
 # regenerating and diffs exactly these afterwards; if the generator ever writes
 # somewhere else, `git diff` on a path nothing wrote to reports no diff and the
@@ -126,27 +145,69 @@ kotlin:bindings/react-native/android/src/main/java
 python:bindings/python/offline_protocol_sdk
 "
 
-FAILURES=0
+# Total number of assertions a healthy run makes. This is the backstop for the
+# whole "silently deleted assertion" class, which five review rounds hit five
+# different ways: a trimmed driver list, a fixture whose creation was removed,
+# a loop whose glob stopped matching. Each was fixed where it was found, and
+# each time the next one appeared somewhere the previous fix did not reach.
+# Counting is the check that does not need to anticipate the mechanism — a run
+# that asserts fewer things than it used to is wrong however it got that way.
+#
+# It does mean this number moves when assertions are added or removed on
+# purpose. That is the intended cost: the failure is loud, names the expected
+# and actual counts, and updating it is a deliberate one-line acknowledgement
+# that the guard's coverage changed.
+EXPECTED_ASSERTIONS=50
 
-pass() { echo "  ok — $*"; }
+FAILURES=0
+ASSERTIONS=0
+
+pass() {
+  ASSERTIONS=$((ASSERTIONS + 1))
+  echo "  ok — $*"
+}
 
 fail() {
+  ASSERTIONS=$((ASSERTIONS + 1))
   echo "  FAIL — $*" >&2
   FAILURES=$((FAILURES + 1))
 }
 
-# Every list below drives a loop, and an emptied list silently deletes its
-# assertions while the run still reports success — emptying EXPECTED_OUTPUTS
-# alone removed fifteen checks and still printed "All binding-generator guards
-# passed." Pin each size, so deleting an entry is a failure rather than a
-# quieter test run.
+# Size pins for the lists that drive loops. Necessary but not sufficient on
+# their own — a list can keep its length while losing coverage (swapping the
+# python entry for a second swift entry left the count at 3 and the run at
+# "all passed" with Python entirely untested), so the loops below also pin the
+# *identity* of what they processed.
 assert_list_size() {
   local name="$1" expected="$2" actual
-  actual="$(printf '%s\n' "$3" | grep -c .)"
+  # `|| true` because `grep -c` exits 1 on a zero count, which under
+  # `set -euo pipefail` would abort the script at this assignment — killing the
+  # run before it could print the message written to explain exactly this case.
+  actual="$(printf '%s\n' "$3" | grep -c . || true)"
   if [[ "$actual" -eq "$expected" ]]; then
     pass "$name still has $expected entries"
   else
     fail "$name has $actual entries, expected $expected — an emptied or trimmed list silently deletes the assertions it drives"
+  fi
+}
+
+# Identity pin: the set a loop actually processed must be the set it was meant
+# to. Catches duplicates and substitutions that leave the count intact.
+# Sorted, not deduplicated: a duplicate must read as different from the set it
+# displaced, which is the whole point (swapping python for a second swift kept
+# every count correct).
+normalize_set() {
+  printf '%s\n' "$1" | tr '[:space:]' '\n' | grep . | sort | tr '\n' ' '
+}
+
+assert_set_equals() {
+  local name="$1" expected actual
+  expected="$(normalize_set "$2")"
+  actual="$(normalize_set "$3")"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$name covered exactly [${expected% }]"
+  else
+    fail "$name covered [${actual% }] but should have covered [${expected% }] — a duplicated or substituted entry drops coverage while keeping the count"
   fi
 }
 
@@ -290,10 +351,12 @@ else
   fail "it invoked bindgen $call_count time(s), expected 3 (Swift, Kotlin, Python)"
 fi
 
+languages_seen=""
 while IFS= read -r spec; do
   [[ -z "$spec" ]] && continue
   language="${spec%%:*}"
   expected_dir="${spec#*:}"
+  languages_seen="$languages_seen $language"
 
   call=""
   for candidate in "$call_dir"/*; do
@@ -352,6 +415,8 @@ while IFS= read -r spec; do
 done <<EOF
 $EXPECTED_OUTPUTS
 EOF
+
+assert_set_equals "the per-language checks" "swift kotlin python" "$languages_seen"
 
 # ---------------------------------------------------------------------------
 # 3. Behavioral: the version gate actually rejects a mismatched bindgen.
@@ -469,37 +534,52 @@ printf 'if command -v uniffi-bindgen; then bash %s; fi\n' "$GENERATOR" >"$fixtur
 printf 'Run uniffi-bindgen to generate the Swift bindings.\n'        >"$fixtures/miss-prose"
 printf 'the uniffi-bindgen generator produces code\n'                >"$fixtures/miss-prose-adjacent"
 
-for fixture in "$fixtures"/hit-*; do
-  if [[ ! -f "$fixture" ]]; then
-    fail "expected hit fixtures are missing — these negative controls are vacuous"
-    break
-  fi
-  if grep -Eq "$INVOCATION" "$fixture"; then
-    pass "the scan detects $(basename "$fixture" | sed 's/^hit-//') invocations"
-  else
-    fail "the scan MISSES $(basename "$fixture" | sed 's/^hit-//') invocations — it would pass vacuously"
-  fi
-done
+# Driven by an explicit list rather than a glob. A glob makes the fixture set
+# its own silent driver list: deleting three of the eight hit- fixtures left
+# the run green at 44 assertions, because the loop simply had less to do and
+# the `-f` guard only fires when *nothing* matches. These negative controls are
+# the only evidence INVOCATION can fire at all, so quietly shrinking them is
+# the purest form of the vacuous pass.
+assert_list_size HIT_FIXTURES 8 "$HIT_FIXTURES"
+assert_list_size MISS_FIXTURES 3 "$MISS_FIXTURES"
 
-for fixture in "$fixtures"/miss-*; do
-  # The -f test is load-bearing here in a way it is not in the loop above: an
-  # unmatched glob leaves the literal pattern, grep fails on the nonexistent
-  # file, and "does not match" reads as "the scan correctly ignores it". The
-  # hit- loop fails safe in that situation; this one would not.
+while IFS= read -r name; do
+  [[ -z "$name" ]] && continue
+  fixture="$fixtures/hit-$name"
   if [[ ! -f "$fixture" ]]; then
-    fail "expected miss fixtures are missing — these negative controls are vacuous"
-    break
-  fi
-  if grep -Eq "$INVOCATION" "$fixture"; then
-    fail "the scan falsely flags $(basename "$fixture" | sed 's/^miss-//')"
+    fail "the hit fixture '$name' was never created — its negative control is vacuous"
+  elif grep -Eq "$INVOCATION" "$fixture"; then
+    pass "the scan detects $name invocations"
   else
-    pass "the scan ignores $(basename "$fixture" | sed 's/^miss-//')"
+    fail "the scan MISSES $name invocations — it would pass vacuously"
   fi
-done
+done <<EOF
+$HIT_FIXTURES
+EOF
+
+while IFS= read -r name; do
+  [[ -z "$name" ]] && continue
+  fixture="$fixtures/miss-$name"
+  if [[ ! -f "$fixture" ]]; then
+    fail "the miss fixture '$name' was never created — its negative control is vacuous"
+  elif grep -Eq "$INVOCATION" "$fixture"; then
+    fail "the scan falsely flags $name"
+  else
+    pass "the scan ignores $name"
+  fi
+done <<EOF
+$MISS_FIXTURES
+EOF
+
+# Deliberately not routed through fail(), which would itself increment.
+if [[ "$ASSERTIONS" -ne "$EXPECTED_ASSERTIONS" ]]; then
+  echo "  FAIL — ran $ASSERTIONS assertions, expected $EXPECTED_ASSERTIONS — checks were added or silently deleted; if the change was intentional, update EXPECTED_ASSERTIONS" >&2
+  FAILURES=$((FAILURES + 1))
+fi
 
 echo ""
 if [[ "$FAILURES" -eq 0 ]]; then
-  echo "All binding-generator guards passed."
+  echo "All $ASSERTIONS binding-generator guards passed."
 else
   echo "$FAILURES guard(s) failed." >&2
   exit 1

--- a/scripts/tests/test-generate-bindings.sh
+++ b/scripts/tests/test-generate-bindings.sh
@@ -70,7 +70,15 @@ INVOCATION="$INVOCATION|uniffi-bindgen[\"${SQ}]?[],[:space:]\"${SQ}[]*generate"
 # deletes the real call. The path-separator requirement keeps this from also
 # matching `bash scripts/tests/test-generate-bindings.sh`, which would let a
 # workflow that runs only the guard read as delegating to the generator.
-DELEGATION='^[[:space:]]*(run:[[:space:]]+)?(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?([^|;&]*[/"])?generate-bindings\.sh([[:space:]]|"|$)'
+#
+# The path prefix must contain no whitespace and no quotes, and that is the
+# part doing the work above. A permissive `[^|;&]*` prefix swallows a whole
+# comment or echo body, so `# TODO restore: bash .../generate-bindings.sh`
+# satisfied the check — commenting out the call, which is the most natural way
+# this regression actually happens, read as still delegating. Requiring a
+# single unbroken path token is what makes the sentence above true rather than
+# aspirational.
+DELEGATION='^[[:space:]]*(run:[[:space:]]+)?(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?"?([^[:space:]"]*/)?generate-bindings\.sh([[:space:]]|"|$)'
 
 # Every caller the generator's header claims delegates to it. Listed here so
 # that deleting a delegation is a test failure rather than a silent return to
@@ -373,7 +381,7 @@ while IFS= read -r spec; do
   counterpart="${spec#*:}"
   if [[ ! -f "$alias_script" ]]; then
     fail "$alias_script is missing — package.json still exposes it as an npm build script"
-  elif grep -Eq "^[[:space:]]*(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?[^|;&]*/$counterpart" "$alias_script"; then
+  elif grep -Eq "^[[:space:]]*(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?\"?[^[:space:]\"]*/$counterpart" "$alias_script"; then
     pass "$(basename "$alias_script") routes through $counterpart"
   else
     fail "$alias_script no longer routes through $counterpart — it would build native artifacts without regenerating bindings"

--- a/scripts/tests/test-generate-bindings.sh
+++ b/scripts/tests/test-generate-bindings.sh
@@ -78,7 +78,18 @@ INVOCATION="$INVOCATION|uniffi-bindgen[\"${SQ}]?[],[:space:]\"${SQ}[]*generate"
 # this regression actually happens, read as still delegating. Requiring a
 # single unbroken path token is what makes the sentence above true rather than
 # aspirational.
-DELEGATION='^[[:space:]]*(run:[[:space:]]+)?(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?"?([^[:space:]"]*/)?generate-bindings\.sh([[:space:]]|"|$)'
+#
+# A bare relative path is *not* enough on its own: it must either carry an
+# interpreter (`bash x`, `sh x`) or be explicitly rooted (`./x`, `/x`, `"$VAR/x`).
+# Without that, ci.yml's own shellcheck argument list —
+#
+#     $ shellcheck --severity=warning \
+#         scripts/generate-bindings.sh \
+#
+# — satisfied the assertion for ci.yml, which made it unconditionally true: the
+# guard must lint the generator, so that line is permanent, and deleting the
+# actual regeneration step still reported "ok". Linting a file is not running it.
+DELEGATION='^[[:space:]]*(-[[:space:]]+)?(run:[[:space:]]+)?((exec[[:space:]]+)?(bash|sh)[[:space:]]+"?([^[:space:]"]*/)?|(exec[[:space:]]+)?"?[.$/][^[:space:]"]*/)generate-bindings\.sh([[:space:]]|"|$)'
 
 # Every caller the generator's header claims delegates to it. Listed here so
 # that deleting a delegation is a test failure rather than a silent return to
@@ -124,6 +135,21 @@ fail() {
   FAILURES=$((FAILURES + 1))
 }
 
+# Every list below drives a loop, and an emptied list silently deletes its
+# assertions while the run still reports success — emptying EXPECTED_OUTPUTS
+# alone removed fifteen checks and still printed "All binding-generator guards
+# passed." Pin each size, so deleting an entry is a failure rather than a
+# quieter test run.
+assert_list_size() {
+  local name="$1" expected="$2" actual
+  actual="$(printf '%s\n' "$3" | grep -c .)"
+  if [[ "$actual" -eq "$expected" ]]; then
+    pass "$name still has $expected entries"
+  else
+    fail "$name has $actual entries, expected $expected — an emptied or trimmed list silently deletes the assertions it drives"
+  fi
+}
+
 # Body of a named step in ci.yml, used to check that the workflow's own path
 # lists have not drifted from EXPECTED_OUTPUTS. Steps in that file are indented
 # six spaces.
@@ -136,6 +162,10 @@ ci_step_body() {
 }
 
 echo "Guarding the shared binding generator..."
+
+assert_list_size EXPECTED_OUTPUTS 3 "$EXPECTED_OUTPUTS"
+assert_list_size DELEGATING_CALLERS 6 "$DELEGATING_CALLERS"
+assert_list_size NATIVE_BUILD_ALIASES 3 "$NATIVE_BUILD_ALIASES"
 
 # ---------------------------------------------------------------------------
 # 1. The generator exists and is executable.
@@ -222,6 +252,21 @@ if [[ -n "$DRIFT_STEP" ]]; then
   pass "$CI_WORKFLOW has the drift gate step"
 else
   fail "$CI_WORKFLOW has no 'Fail on stale bindings' step — nothing checks the committed bindings, and the per-path checks below are vacuous"
+fi
+
+# Every path those two steps name must be tracked. `rm -f` and `git diff --
+# <pathspec>` both succeed silently on a path that does not exist, so a typo in
+# a leaf filename disables the delete and the diff for that file while both
+# steps still go green — the same "empty haystack reads as clean" shape, one
+# level below the directory the per-language checks pin.
+untracked_ci_paths=""
+for ci_path in $(printf '%s\n%s\n' "$RM_STEP" "$DRIFT_STEP" | grep -oE 'bindings/[^ \\]+' | sed 's/[;\\]*$//' | sort -u); do
+  git ls-files --error-unmatch "$ci_path" >/dev/null 2>&1 || untracked_ci_paths="$untracked_ci_paths $ci_path"
+done
+if [[ -z "$untracked_ci_paths" ]]; then
+  pass "every path $CI_WORKFLOW deletes and diffs is tracked"
+else
+  fail "$CI_WORKFLOW names untracked path(s) —$untracked_ci_paths — rm and git diff both succeed silently on those, so they are neither deleted nor checked"
 fi
 
 ok_bin="$STUB_ROOT/ok"
@@ -321,10 +366,23 @@ if [[ ! -x "$bad_bin/uniffi-bindgen" ]]; then
   # the generator exits 1 with "not found", which reads exactly like "mismatch
   # rejected" and reports ok.
   fail "the mismatched-bindgen stub was not created — this check would pass vacuously"
-elif PATH="$bad_bin:$PATH" STUB_LOG_DIR="$STUB_ROOT/bad-calls" bash "$GENERATOR" >/dev/null 2>&1; then
+elif mkdir -p "$STUB_ROOT/bad-calls" \
+  && PATH="$bad_bin:$PATH" STUB_LOG_DIR="$STUB_ROOT/bad-calls" bash "$GENERATOR" >/dev/null 2>&1; then
   fail "$GENERATOR generated with a bindgen whose minor version disagrees with the crate pin — those bindings' checksums fail at runtime, not at build time"
 else
-  pass "a bindgen disagreeing with the crate pin is rejected before anything is written"
+  # A non-zero exit alone does not mean nothing was generated, and this check
+  # is about *when* the refusal happens. Move the comparison below the three
+  # generate calls and the generator still exits non-zero — having already
+  # written all three binding sets with the wrong bindgen, which is precisely
+  # the outcome the pin exists to prevent. The stub logs every call it is
+  # asked to make, so assert it was asked for none. (Zero is right: the
+  # --version branch returns before logging.)
+  bad_calls="$(find "$STUB_ROOT/bad-calls" -type f | wc -l | tr -d ' ')"
+  if [[ "$bad_calls" -eq 0 ]]; then
+    pass "a bindgen disagreeing with the crate pin is rejected before anything is written"
+  else
+    fail "$GENERATOR refused the mismatched bindgen only after invoking it $bad_calls time(s) — the bindings were already written with the wrong bindgen"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -381,7 +439,7 @@ while IFS= read -r spec; do
   counterpart="${spec#*:}"
   if [[ ! -f "$alias_script" ]]; then
     fail "$alias_script is missing — package.json still exposes it as an npm build script"
-  elif grep -Eq "^[[:space:]]*(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?\"?[^[:space:]\"]*/$counterpart" "$alias_script"; then
+  elif grep -Eq "^[[:space:]]*(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?\"?[^[:space:]\"]*/$counterpart([[:space:]]|\"|\$)" "$alias_script"; then
     pass "$(basename "$alias_script") routes through $counterpart"
   else
     fail "$alias_script no longer routes through $counterpart — it would build native artifacts without regenerating bindings"
@@ -412,6 +470,10 @@ printf 'Run uniffi-bindgen to generate the Swift bindings.\n'        >"$fixtures
 printf 'the uniffi-bindgen generator produces code\n'                >"$fixtures/miss-prose-adjacent"
 
 for fixture in "$fixtures"/hit-*; do
+  if [[ ! -f "$fixture" ]]; then
+    fail "expected hit fixtures are missing — these negative controls are vacuous"
+    break
+  fi
   if grep -Eq "$INVOCATION" "$fixture"; then
     pass "the scan detects $(basename "$fixture" | sed 's/^hit-//') invocations"
   else
@@ -420,6 +482,14 @@ for fixture in "$fixtures"/hit-*; do
 done
 
 for fixture in "$fixtures"/miss-*; do
+  # The -f test is load-bearing here in a way it is not in the loop above: an
+  # unmatched glob leaves the literal pattern, grep fails on the nonexistent
+  # file, and "does not match" reads as "the scan correctly ignores it". The
+  # hit- loop fails safe in that situation; this one would not.
+  if [[ ! -f "$fixture" ]]; then
+    fail "expected miss fixtures are missing — these negative controls are vacuous"
+    break
+  fi
   if grep -Eq "$INVOCATION" "$fixture"; then
     fail "the scan falsely flags $(basename "$fixture" | sed 's/^miss-//')"
   else

--- a/scripts/tests/test-generate-bindings.sh
+++ b/scripts/tests/test-generate-bindings.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Guards the single-entry-point rule for UniFFI codegen.
+#
+# scripts/generate-bindings.sh exists so that Swift, Kotlin and Python are
+# always regenerated together — they are one artifact set off one UDL, and a
+# partial set does not fail any build, only the app at its first FFI call. That
+# property is only as good as the rule that nothing else shells out to
+# uniffi-bindgen behind its back, and nothing about a new build script makes
+# violating it obvious. So: assert it, statically, with no bindgen required.
+#
+# Out of scope by design: .github/workflows/release.yml's Kotlin step, which
+# generates into an ephemeral release build directory rather than the committed
+# paths this rule is about.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GENERATOR="scripts/generate-bindings.sh"
+
+FAILURES=0
+
+pass() { echo "  ok — $*"; }
+
+fail() {
+  echo "  FAIL — $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+cd "$REPO_ROOT"
+
+echo "Guarding the shared binding generator..."
+
+# 1. The generator exists, is executable, and covers all three languages.
+if [[ -x "$GENERATOR" ]]; then
+  pass "$GENERATOR is executable"
+else
+  fail "$GENERATOR is missing or not executable"
+fi
+
+for language in swift kotlin python; do
+  if grep -q "^generate $language " "$GENERATOR"; then
+    pass "$GENERATOR generates $language"
+  else
+    fail "$GENERATOR no longer generates $language — a caller would silently ship a partial set"
+  fi
+done
+
+# 2. No other tracked shell script invokes uniffi-bindgen directly. Callers must
+#    delegate, or they can refresh one language and leave the other two stale.
+offenders=""
+while IFS= read -r script; do
+  [[ "$script" == "$GENERATOR" ]] && continue
+  if grep -q 'uniffi-bindgen generate' "$script"; then
+    offenders+="      $script"$'\n'
+  fi
+done < <(git ls-files '*.sh')
+
+if [[ -z "$offenders" ]]; then
+  pass "no other shell script calls uniffi-bindgen generate directly"
+else
+  fail "these scripts call uniffi-bindgen generate instead of delegating to $GENERATOR:"
+  printf '%s' "$offenders" >&2
+fi
+
+# 3. The version check reads the crate pin rather than repeating it, so the
+#    pin has exactly one place of record.
+if grep -q 'crates/offline-protocol-uniffi' "$GENERATOR" \
+  && grep -q 'REQUIRED_VERSION' "$GENERATOR"; then
+  pass "the bindgen version check is derived from the crate's uniffi pin"
+else
+  fail "$GENERATOR no longer derives the required bindgen version from the crate pin"
+fi
+
+echo ""
+if [[ "$FAILURES" -eq 0 ]]; then
+  echo "All binding-generator guards passed."
+else
+  echo "$FAILURES guard(s) failed." >&2
+  exit 1
+fi

--- a/scripts/tests/test-generate-bindings.sh
+++ b/scripts/tests/test-generate-bindings.sh
@@ -5,38 +5,76 @@
 # scripts/generate-bindings.sh exists so that Swift, Kotlin and Python are
 # always regenerated together — they are one artifact set off one UDL, and a
 # partial set does not fail any build, only the app at its first FFI call. That
-# property is only as good as the rule that nothing else shells out to
-# uniffi-bindgen behind its back, and nothing about a new build script makes
-# violating it obvious. So: assert it, statically, with no bindgen required.
+# property is only as good as two things nothing else checks: that the
+# generator still writes all three languages to the three committed paths, and
+# that nothing else in the repo shells out to uniffi-bindgen behind its back.
 #
-# Scope covers tracked shell scripts *and* the GitHub workflows. The workflows
-# are not an afterthought: release.yml's Kotlin step generates into a scratch
-# directory that the publish job then downloads over the committed Android
-# bindings, so a direct invocation there ships to npm without ever touching a
-# .sh file. A guard that read only *.sh would call that rule enforced while
-# leaving the one path users actually receive exempt.
+# Both are asserted here, and deliberately by *behavior* rather than by
+# grepping the generator's source. A guard that greps for `generate swift`
+# fails a correct refactor into a loop and passes a one-character typo in an
+# output path — the second being the exact bug class this whole rule exists to
+# prevent. So the generator is instead run for real against a stub
+# uniffi-bindgen, and what it asked the bindgen to do is checked. Still no real
+# bindgen, no Rust toolchain, no network, well under a second: cheap enough to
+# be the first step of the CI job, which is where it earns its keep.
+#
+# Scope of the scan is every tracked file, matched by content. Not `*.sh`:
+# release.yml's Kotlin step generates into a scratch directory that the publish
+# job downloads over the committed Android bindings, so a direct invocation in
+# a workflow ships to npm without touching a shell script — and the same goes
+# for a composite action, a package.json script, a Gradle exec task, or a doc
+# that simply tells a human to run bindgen. Extension-scoped scanning would
+# call this rule enforced while leaving those exempt.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GENERATOR="scripts/generate-bindings.sh"
+SELF="scripts/tests/test-generate-bindings.sh"
 
 cd "$REPO_ROOT"
 
-SELF="${BASH_SOURCE[0]}"
-case "$SELF" in
-  /*) SELF="${SELF#"$REPO_ROOT"/}" ;;
-esac
+# A direct invocation, in every shape it gets written in: subcommand adjacent
+# (`uniffi-bindgen generate`), behind global options (`uniffi-bindgen --config
+# x.toml generate`), continued onto the next line (`uniffi-bindgen \`), or via
+# cargo (`cargo run --bin uniffi-bindgen -- generate`). Only flag-shaped tokens
+# and their values may sit between the binary and the subcommand, which is what
+# keeps prose like "run uniffi-bindgen to generate the bindings" from matching
+# while the command forms all do.
+INVOCATION='(^|[^[:alnum:]_-])uniffi-bindgen([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+generate|(^|[^[:alnum:]_-])uniffi-bindgen[[:space:]]*\\[[:space:]]*$|--bin[[:space:]]+uniffi-bindgen'
 
-# A direct invocation, in either of the two shapes it is written in: the command
-# and subcommand on one line, or `uniffi-bindgen \` continued onto the next.
-# Matching the flat string "uniffi-bindgen generate" alone would miss the
-# continuation form — which is precisely how every script this rule replaced
-# used to be written, so it is the likeliest way the violation comes back.
-# Deliberately does not match `command -v uniffi-bindgen` or the install
-# instructions that callers legitimately still print.
-INVOCATION='(^|[^[:alnum:]_-])uniffi-bindgen([[:space:]]+generate|[[:space:]]*\\[[:space:]]*$)'
+# A line that actually *runs* the generator, as opposed to merely naming it.
+# Anchored at the start of the line (allowing a YAML `run:` prefix) so that a
+# comment pointing at the script, or an echo printing it in an error message,
+# does not count as delegating — those are exactly what is left behind when
+# someone deletes the real call.
+# The trailing path-separator requirement matters: without it this also matches
+# `bash scripts/tests/test-generate-bindings.sh`, so a workflow that runs only
+# the guard would read as delegating to the generator it is supposed to guard.
+DELEGATION='^[[:space:]]*(run:[[:space:]]+)?(exec[[:space:]]+)?bash[[:space:]]+([^|;&]*[/"])?generate-bindings\.sh'
+
+# Every caller the generator's header claims delegates to it. Listed here so
+# that deleting a delegation is a test failure rather than a silent return to
+# per-language generation from the other side.
+DELEGATING_CALLERS="
+bindings/react-native/scripts/generate-bindings.sh
+bindings/react-native/scripts/build-uniffi-ios.sh
+bindings/react-native/scripts/build-uniffi-android.sh
+bindings/python/scripts/build-desktop.sh
+.github/workflows/ci.yml
+.github/workflows/release.yml
+"
+
+# The three committed paths, repo-relative. The drift gate in ci.yml checks
+# exactly these; if the generator ever writes somewhere else, `git diff` on a
+# path nothing wrote to reports no diff and the gate goes green on stale
+# bindings. This list is what makes that detectable.
+EXPECTED_OUTPUTS="
+swift:bindings/react-native/ios/Generated
+kotlin:bindings/react-native/android/src/main/java
+python:bindings/python/offline_protocol_sdk
+"
 
 FAILURES=0
 
@@ -49,85 +87,196 @@ fail() {
 
 echo "Guarding the shared binding generator..."
 
-# 1. The generator exists, is executable, and covers all three languages.
+# ---------------------------------------------------------------------------
+# 1. The generator exists and is executable.
+# ---------------------------------------------------------------------------
+
 if [[ -x "$GENERATOR" ]]; then
   pass "$GENERATOR is executable"
 else
   fail "$GENERATOR is missing or not executable"
 fi
 
-for language in swift kotlin python; do
-  if grep -q "^generate $language " "$GENERATOR"; then
-    pass "$GENERATOR generates $language"
+# ---------------------------------------------------------------------------
+# 2. Behavioral: run the real generator against a stub bindgen and check what
+#    it actually asked for — languages, output paths, and --no-format.
+# ---------------------------------------------------------------------------
+
+STUB_ROOT="$(mktemp -d)"
+trap 'rm -rf "$STUB_ROOT"' EXIT
+
+# Reports a patch version deliberately different from the crate pin, so the
+# run also proves the version gate tolerates patch drift (uniffi's FFI contract
+# is not patch-scoped) rather than only that it exists.
+make_stub() {
+  local bin_dir="$1" reported="$2"
+  mkdir -p "$bin_dir"
+  cat >"$bin_dir/uniffi-bindgen" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--version" ]]; then
+  echo "uniffi-bindgen $reported"
+  exit 0
+fi
+printf '%s\n' "\$*" >>"\$STUB_LOG"
+exit 0
+STUB
+  chmod +x "$bin_dir/uniffi-bindgen"
+}
+
+CRATE_PIN="$(sed -n 's/^uniffi = "\([0-9.]*\)"$/\1/p' crates/offline-protocol-uniffi/Cargo.toml | head -1)"
+if [[ -z "$CRATE_PIN" ]]; then
+  fail "could not read the uniffi pin from crates/offline-protocol-uniffi/Cargo.toml"
+  CRATE_PIN="0.0"
+fi
+
+ok_bin="$STUB_ROOT/ok"
+call_log="$STUB_ROOT/calls.log"
+: >"$call_log"
+make_stub "$ok_bin" "$CRATE_PIN.99"
+
+if PATH="$ok_bin:$PATH" STUB_LOG="$call_log" bash "$GENERATOR" >"$STUB_ROOT/out" 2>&1; then
+  pass "$GENERATOR runs to completion (patch-level version drift tolerated)"
+else
+  fail "$GENERATOR failed against a stub bindgen: $(tail -3 "$STUB_ROOT/out" | tr '\n' ' ')"
+fi
+
+call_count="$(grep -c . "$call_log" || true)"
+if [[ "$call_count" -eq 3 ]]; then
+  pass "it invoked bindgen exactly 3 times — one per language"
+else
+  fail "it invoked bindgen $call_count time(s), expected 3 (Swift, Kotlin, Python)"
+fi
+
+while IFS= read -r spec; do
+  [[ -z "$spec" ]] && continue
+  language="${spec%%:*}"
+  expected_dir="${spec#*:}"
+  line="$(grep -- "--language $language " "$call_log" || true)"
+  if [[ -z "$line" ]]; then
+    fail "$GENERATOR never generated $language — a caller would ship a partial set"
+    continue
+  fi
+  actual_dir="${line##*--out-dir }"
+  actual_dir="${actual_dir%% *}"
+  actual_dir="${actual_dir#"$REPO_ROOT"/}"
+  if [[ "$actual_dir" == "$expected_dir" ]]; then
+    pass "$language -> $expected_dir"
   else
-    fail "$GENERATOR no longer generates $language — a caller would silently ship a partial set"
+    fail "$language written to '$actual_dir', but the drift gate checks '$expected_dir' — a mismatch here is invisible to CI (git diff on a path nothing wrote to reports no diff)"
+    # mkdir -p in the generator may have created the wrong path; take it back
+    # if it is empty so a failing run does not litter the tree.
+    rmdir "$actual_dir" 2>/dev/null || true
+  fi
+done <<EOF
+$EXPECTED_OUTPUTS
+EOF
+
+# --no-format is load-bearing: uniffi-bindgen post-processes with ktlint and
+# swiftformat when they are on PATH, so without it the committed bytes depend
+# on what the developer happens to have installed and a correct regeneration
+# can still fail the drift gate.
+unformatted="$(grep -c -- '--no-format' "$call_log" || true)"
+if [[ "$unformatted" -eq "$call_count" && "$call_count" -gt 0 ]]; then
+  pass "every invocation passes --no-format, so output does not vary by machine"
+else
+  fail "only $unformatted of $call_count invocations pass --no-format — output would depend on whether ktlint/swiftformat are installed"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Behavioral: the version gate actually rejects a mismatched bindgen.
+# ---------------------------------------------------------------------------
+
+bad_bin="$STUB_ROOT/bad"
+bad_major="${CRATE_PIN%%.*}"
+bad_minor="${CRATE_PIN#*.}"
+make_stub "$bad_bin" "$bad_major.$((bad_minor + 1)).0"
+
+if PATH="$bad_bin:$PATH" STUB_LOG="$STUB_ROOT/bad.log" bash "$GENERATOR" >/dev/null 2>&1; then
+  fail "$GENERATOR generated with a bindgen whose minor version disagrees with the crate pin — those bindings' checksums fail at runtime, not at build time"
+else
+  pass "a bindgen disagreeing with the crate pin is rejected before anything is written"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Nothing else invokes uniffi-bindgen — any tracked file, matched by
+#    content. Excluded by pathspec rather than by comparing "$0" against the
+#    index, so the result cannot depend on how this script was invoked.
+# ---------------------------------------------------------------------------
+
+set +e
+offenders="$(git grep -lIE "$INVOCATION" -- . ":!$GENERATOR" ":!$SELF")"
+scan_rc=$?
+set -e
+
+case "$scan_rc" in
+  0)
+    fail "these files invoke uniffi-bindgen directly instead of delegating to $GENERATOR:"
+    printf '%s\n' "$offenders" | sed 's/^/      /' >&2
+    ;;
+  1) pass "no other tracked file invokes uniffi-bindgen directly" ;;
+  *) fail "the scan could not run (git grep exit $scan_rc) — it would otherwise report success having examined nothing" ;;
+esac
+
+# Positive control on the *real* corpus. Every other assertion here is "the bad
+# thing is absent", which is exactly what a scan that silently examines zero
+# files also reports. Re-run without the generator exclusion: it must find the
+# generator, or enumeration is broken and the check above proved nothing.
+if git grep -lIE "$INVOCATION" -- . ":!$SELF" | grep -qx "$GENERATOR"; then
+  pass "the scan reaches the repository (it finds $GENERATOR when not excluded)"
+else
+  fail "the scan did not find $GENERATOR — enumeration is broken, so the offender check above is vacuous"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. The enumerated callers still delegate. Without this, deleting the
+#    delegation from a build script leaves the guard green while that script
+#    builds a fresh native library against stale committed bindings.
+# ---------------------------------------------------------------------------
+
+while IFS= read -r caller; do
+  [[ -z "$caller" ]] && continue
+  if [[ ! -f "$caller" ]]; then
+    fail "$caller is missing — the generator's header still lists it as delegating"
+  elif grep -Eq "$DELEGATION" "$caller"; then
+    pass "$caller invokes $GENERATOR"
+  else
+    fail "$caller no longer invokes $GENERATOR — it can now build artifacts against stale bindings"
+  fi
+done <<EOF
+$DELEGATING_CALLERS
+EOF
+
+# ---------------------------------------------------------------------------
+# 6. Negative controls for the scan regex. A detector that cannot fire is
+#    indistinguishable from one that passes vacuously, so prove it catches
+#    every invocation shape and ignores the benign ones.
+# ---------------------------------------------------------------------------
+
+fixtures="$STUB_ROOT/fixtures"
+mkdir -p "$fixtures"
+
+printf 'uniffi-bindgen generate x.udl --language swift\n'          >"$fixtures/hit-inline"
+printf 'uniffi-bindgen \\\n  generate x.udl --language kotlin\n'   >"$fixtures/hit-continued"
+printf 'uniffi-bindgen --config u.toml generate x.udl\n'           >"$fixtures/hit-global-option"
+printf 'cargo run --bin uniffi-bindgen -- generate x.udl\n'        >"$fixtures/hit-cargo-run"
+printf 'if command -v uniffi-bindgen; then bash %s; fi\n' "$GENERATOR" >"$fixtures/miss-delegating"
+printf 'Run uniffi-bindgen to generate the Swift bindings.\n'      >"$fixtures/miss-prose"
+
+for fixture in "$fixtures"/hit-*; do
+  if grep -Eq "$INVOCATION" "$fixture"; then
+    pass "the scan detects $(basename "$fixture" | sed 's/^hit-//') invocations"
+  else
+    fail "the scan MISSES $(basename "$fixture" | sed 's/^hit-//') invocations — it would pass vacuously"
   fi
 done
 
-# 2. Nothing else invokes uniffi-bindgen directly — not a shell script, not a
-#    workflow. Callers must delegate, or they can refresh one language and
-#    leave the other two describing a different ABI.
-offenders=""
-while IFS= read -r file; do
-  [[ "$file" == "$GENERATOR" || "$file" == "$SELF" ]] && continue
-  if grep -Eq "$INVOCATION" "$file"; then
-    offenders+="      $file"$'\n'
-  fi
-done < <(git ls-files '*.sh' '.github/workflows/*.yml')
-
-if [[ -z "$offenders" ]]; then
-  pass "no other script or workflow calls uniffi-bindgen directly"
-else
-  fail "these files call uniffi-bindgen directly instead of delegating to $GENERATOR:"
-  printf '%s' "$offenders" >&2
-fi
-
-# 3. The version check reads the crate pin rather than repeating it, so the
-#    pin has exactly one place of record.
-if grep -q 'crates/offline-protocol-uniffi' "$GENERATOR" \
-  && grep -q 'REQUIRED_VERSION' "$GENERATOR"; then
-  pass "the bindgen version check is derived from the crate's uniffi pin"
-else
-  fail "$GENERATOR no longer derives the required bindgen version from the crate pin"
-fi
-
-# 4. Codegen is pinned to one output form. uniffi-bindgen post-processes with
-#    ktlint (Kotlin) and swiftformat (Swift) when they are on PATH, so without
-#    --no-format the committed bytes depend on the developer's machine and a
-#    correct regeneration can still fail the drift gate.
-if grep -q 'uniffi-bindgen generate --no-format' "$GENERATOR"; then
-  pass "$GENERATOR generates with --no-format, so output does not vary by machine"
-else
-  fail "$GENERATOR dropped --no-format — output now depends on whether ktlint/swiftformat are installed"
-fi
-
-# 5. Negative control. Every assertion above says "the good state is present",
-#    and a detector that cannot fail is indistinguishable from one that passes
-#    vacuously. Prove the scan in step 2 actually fires — on both invocation
-#    shapes — against fixtures that are never part of the real scan.
-control_dir="$(mktemp -d)"
-trap 'rm -rf "$control_dir"' EXIT
-
-printf '#!/usr/bin/env bash\nuniffi-bindgen generate src/x.udl --language swift\n' \
-  >"$control_dir/inline.sh"
-printf '#!/usr/bin/env bash\nuniffi-bindgen \\\n  generate src/x.udl --language kotlin\n' \
-  >"$control_dir/continued.sh"
-printf '#!/usr/bin/env bash\nif command -v uniffi-bindgen; then bash scripts/generate-bindings.sh; fi\n' \
-  >"$control_dir/delegating.sh"
-
-for shape in inline continued; do
-  if grep -Eq "$INVOCATION" "$control_dir/$shape.sh"; then
-    pass "the scan detects a $shape uniffi-bindgen invocation"
+for fixture in "$fixtures"/miss-*; do
+  if grep -Eq "$INVOCATION" "$fixture"; then
+    fail "the scan falsely flags $(basename "$fixture" | sed 's/^miss-//')"
   else
-    fail "the scan MISSES a $shape uniffi-bindgen invocation — it would pass vacuously"
+    pass "the scan ignores $(basename "$fixture" | sed 's/^miss-//')"
   fi
 done
-
-if grep -Eq "$INVOCATION" "$control_dir/delegating.sh"; then
-  fail "the scan flags a delegating caller that only probes for uniffi-bindgen"
-else
-  pass "the scan ignores a delegating caller that only probes for uniffi-bindgen"
-fi
 
 echo ""
 if [[ "$FAILURES" -eq 0 ]]; then

--- a/scripts/tests/test-generate-bindings.sh
+++ b/scripts/tests/test-generate-bindings.sh
@@ -157,7 +157,7 @@ python:bindings/python/offline_protocol_sdk
 # purpose. That is the intended cost: the failure is loud, names the expected
 # and actual counts, and updating it is a deliberate one-line acknowledgement
 # that the guard's coverage changed.
-EXPECTED_ASSERTIONS=50
+EXPECTED_ASSERTIONS=54
 
 FAILURES=0
 ASSERTIONS=0
@@ -197,7 +197,32 @@ assert_list_size() {
 # displaced, which is the whole point (swapping python for a second swift kept
 # every count correct).
 normalize_set() {
-  printf '%s\n' "$1" | tr '[:space:]' '\n' | grep . | sort | tr '\n' ' '
+  # sed rather than `grep .`: grep exits 1 on no matches, which under
+  # `set -euo pipefail` kills the run at the caller's assignment — no FAIL
+  # line, no summary, and the assertion-count backstop never reached. Same
+  # defect as the one `|| true` fixes above, one function over.
+  printf '%s\n' "$1" | tr '[:space:]' '\n' | sed '/^$/d' | sort | tr '\n' ' '
+}
+
+# A duplicated entry keeps `assert_list_size` correct AND keeps the assertion
+# total correct, so both backstops report ok while the displaced entry's
+# coverage is simply gone — duplicating the release.yml entry and deleting both
+# of its real invocations left the run green at 50. That is the caller whose
+# Kotlin is downloaded over the committed Android bindings at publish time, and
+# §4's scan cannot backstop it: a caller that stops regenerating invokes no
+# bindgen and so produces no offender.
+#
+# This rather than a second assert_set_equals: comparing a list against itself
+# is the R1 self-comparison shape and catches nothing. EXPECTED_OUTPUTS can use
+# assert_set_equals only because its expected side is a hardcoded literal.
+assert_no_duplicates() {
+  local name="$1" dupes
+  dupes="$(printf '%s\n' "$2" | sed '/^$/d' | sort | uniq -d | tr '\n' ' ')"
+  if [[ -z "$dupes" ]]; then
+    pass "$name has no duplicated entries"
+  else
+    fail "$name repeats [${dupes% }] — a duplicated entry keeps the count while deleting the coverage of the entry it displaced"
+  fi
 }
 
 assert_set_equals() {
@@ -227,6 +252,10 @@ echo "Guarding the shared binding generator..."
 assert_list_size EXPECTED_OUTPUTS 3 "$EXPECTED_OUTPUTS"
 assert_list_size DELEGATING_CALLERS 6 "$DELEGATING_CALLERS"
 assert_list_size NATIVE_BUILD_ALIASES 3 "$NATIVE_BUILD_ALIASES"
+# EXPECTED_OUTPUTS is covered by assert_set_equals against a hardcoded literal;
+# these four have no such literal to compare against.
+assert_no_duplicates DELEGATING_CALLERS "$DELEGATING_CALLERS"
+assert_no_duplicates NATIVE_BUILD_ALIASES "$NATIVE_BUILD_ALIASES"
 
 # ---------------------------------------------------------------------------
 # 1. The generator exists and is executable.
@@ -504,7 +533,12 @@ while IFS= read -r spec; do
   counterpart="${spec#*:}"
   if [[ ! -f "$alias_script" ]]; then
     fail "$alias_script is missing — package.json still exposes it as an npm build script"
-  elif grep -Eq "^[[:space:]]*(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?\"?[^[:space:]\"]*/$counterpart([[:space:]]|\"|\$)" "$alias_script"; then
+  # Mirrors DELEGATION's alternation: an interpreter, or an explicitly rooted
+  # path. Without it any line-initial token containing the counterpart's path
+  # counted as routing — `COUNTERPART=scripts/build-uniffi-ios.sh` in a script
+  # that then builds natively and generates nothing passed green. That is the
+  # R4 shellcheck-argument bug verbatim, left standing one regex over.
+  elif grep -Eq "^[[:space:]]*((exec[[:space:]]+)?(bash|sh)[[:space:]]+\"?([^[:space:]\"]*/)?|(exec[[:space:]]+)?\"?[.\$/][^[:space:]\"]*/)$counterpart([[:space:]]|\"|\$)" "$alias_script"; then
     pass "$(basename "$alias_script") routes through $counterpart"
   else
     fail "$alias_script no longer routes through $counterpart — it would build native artifacts without regenerating bindings"
@@ -542,6 +576,8 @@ printf 'the uniffi-bindgen generator produces code\n'                >"$fixtures
 # the purest form of the vacuous pass.
 assert_list_size HIT_FIXTURES 8 "$HIT_FIXTURES"
 assert_list_size MISS_FIXTURES 3 "$MISS_FIXTURES"
+assert_no_duplicates HIT_FIXTURES "$HIT_FIXTURES"
+assert_no_duplicates MISS_FIXTURES "$MISS_FIXTURES"
 
 while IFS= read -r name; do
   [[ -z "$name" ]] && continue

--- a/scripts/tests/test-generate-bindings.sh
+++ b/scripts/tests/test-generate-bindings.sh
@@ -25,6 +25,10 @@
 # for a composite action, a package.json script, a Gradle exec task, or a doc
 # that simply tells a human to run bindgen. Extension-scoped scanning would
 # call this rule enforced while leaving those exempt.
+#
+# Standing rule for anything added below: an assertion whose *setup* can fail
+# silently is worse than no assertion, because it reports success. Every check
+# that depends on a fixture proves the fixture exists first.
 
 set -euo pipefail
 
@@ -32,27 +36,41 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GENERATOR="scripts/generate-bindings.sh"
 SELF="scripts/tests/test-generate-bindings.sh"
+CI_WORKFLOW=".github/workflows/ci.yml"
 
 cd "$REPO_ROOT"
 
 # A direct invocation, in every shape it gets written in: subcommand adjacent
 # (`uniffi-bindgen generate`), behind global options (`uniffi-bindgen --config
-# x.toml generate`), continued onto the next line (`uniffi-bindgen \`), or via
-# cargo (`cargo run --bin uniffi-bindgen -- generate`). Only flag-shaped tokens
-# and their values may sit between the binary and the subcommand, which is what
-# keeps prose like "run uniffi-bindgen to generate the bindings" from matching
-# while the command forms all do.
-INVOCATION='(^|[^[:alnum:]_-])uniffi-bindgen([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+generate|(^|[^[:alnum:]_-])uniffi-bindgen[[:space:]]*\\[[:space:]]*$|--bin[[:space:]]+uniffi-bindgen'
+# x.toml generate`), continued onto the next line (`uniffi-bindgen \`), via
+# cargo (`cargo run --bin uniffi-bindgen -- generate`), or as an argument list
+# rather than a command line — `commandLine("uniffi-bindgen", "generate", …)`
+# in a Gradle task, `subprocess.run([...])`, `spawnSync('uniffi-bindgen',
+# ['generate', …])`. The list forms matter because this is a Gradle-built
+# Android repo, so a codegen task is a realistic place for the rule to be
+# broken, and a command-line-only regex would call it covered.
+#
+# In the command-line form only flag-shaped tokens and their values may sit
+# between the binary and the subcommand, which is what keeps prose like "run
+# uniffi-bindgen to generate the bindings" from matching while every command
+# form does.
+SQ=\'
+INVOCATION='(^|[^[:alnum:]_-])uniffi-bindgen([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+generate'
+INVOCATION="$INVOCATION"'|(^|[^[:alnum:]_-])uniffi-bindgen[[:space:]]*\\[[:space:]]*$'
+INVOCATION="$INVOCATION"'|--bin[[:space:]]+uniffi-bindgen'
+INVOCATION="$INVOCATION|uniffi-bindgen[\"${SQ}]?[],[:space:]\"${SQ}[]*generate"
 
 # A line that actually *runs* the generator, as opposed to merely naming it.
-# Anchored at the start of the line (allowing a YAML `run:` prefix) so that a
-# comment pointing at the script, or an echo printing it in an error message,
-# does not count as delegating — those are exactly what is left behind when
-# someone deletes the real call.
-# The trailing path-separator requirement matters: without it this also matches
-# `bash scripts/tests/test-generate-bindings.sh`, so a workflow that runs only
-# the guard would read as delegating to the generator it is supposed to guard.
-DELEGATION='^[[:space:]]*(run:[[:space:]]+)?(exec[[:space:]]+)?bash[[:space:]]+([^|;&]*[/"])?generate-bindings\.sh'
+# The interpreter is optional because the script is executable and this PR's
+# own docs teach `./scripts/generate-bindings.sh`; requiring a literal `bash `
+# would report a caller refactored to the direct-exec form as no longer
+# delegating. Anchored at the start of the line (allowing a YAML `run:` prefix)
+# so a comment pointing at the script, or an echo printing it in an error
+# message, does not count — those are exactly what is left behind when someone
+# deletes the real call. The path-separator requirement keeps this from also
+# matching `bash scripts/tests/test-generate-bindings.sh`, which would let a
+# workflow that runs only the guard read as delegating to the generator.
+DELEGATION='^[[:space:]]*(run:[[:space:]]+)?(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?([^|;&]*[/"])?generate-bindings\.sh([[:space:]]|"|$)'
 
 # Every caller the generator's header claims delegates to it. Listed here so
 # that deleting a delegation is a test failure rather than a silent return to
@@ -66,10 +84,23 @@ bindings/python/scripts/build-desktop.sh
 .github/workflows/release.yml
 "
 
-# The three committed paths, repo-relative. The drift gate in ci.yml checks
-# exactly these; if the generator ever writes somewhere else, `git diff` on a
-# path nothing wrote to reports no diff and the gate goes green on stale
-# bindings. This list is what makes that detectable.
+# The npm-exposed build scripts, which must reach the generator through their
+# build-uniffi-* counterpart. They used to be near-copies that built native
+# libraries and regenerated nothing — the most travelled way to produce a
+# mismatched artifact set, since six example READMEs start with
+# `npm run build:all`. A script that generates nothing satisfies both checks
+# above trivially, so it needs its own.
+NATIVE_BUILD_ALIASES="
+bindings/react-native/scripts/build-ios.sh:build-uniffi-ios.sh
+bindings/react-native/scripts/build-android.sh:build-uniffi-android.sh
+bindings/react-native/scripts/build-all.sh:build-uniffi-all.sh
+"
+
+# The three committed paths, repo-relative. CI deletes exactly these before
+# regenerating and diffs exactly these afterwards; if the generator ever writes
+# somewhere else, `git diff` on a path nothing wrote to reports no diff and the
+# gate goes green on stale bindings. This list is the single record of what
+# those three places must agree on, and it is checked against both.
 EXPECTED_OUTPUTS="
 swift:bindings/react-native/ios/Generated
 kotlin:bindings/react-native/android/src/main/java
@@ -83,6 +114,17 @@ pass() { echo "  ok — $*"; }
 fail() {
   echo "  FAIL — $*" >&2
   FAILURES=$((FAILURES + 1))
+}
+
+# Body of a named step in ci.yml, used to check that the workflow's own path
+# lists have not drifted from EXPECTED_OUTPUTS. Steps in that file are indented
+# six spaces.
+ci_step_body() {
+  awk -v want="      - name: $1" '
+    index($0, want) == 1 { f = 1; next }
+    f && /^      - name: / { exit }
+    f { print }
+  ' "$CI_WORKFLOW"
 }
 
 echo "Guarding the shared binding generator..."
@@ -99,15 +141,17 @@ fi
 
 # ---------------------------------------------------------------------------
 # 2. Behavioral: run the real generator against a stub bindgen and check what
-#    it actually asked for — languages, output paths, and --no-format.
+#    it actually asked for — languages, output paths, UDL, and --no-format.
 # ---------------------------------------------------------------------------
 
 STUB_ROOT="$(mktemp -d)"
 trap 'rm -rf "$STUB_ROOT"' EXIT
 
-# Reports a patch version deliberately different from the crate pin, so the
-# run also proves the version gate tolerates patch drift (uniffi's FFI contract
-# is not patch-scoped) rather than only that it exists.
+# Logs argv NUL-separated, one file per call, so the assertions below can read
+# the arguments structurally. String-slicing the joined command line instead
+# would make a correct refactor (flag reordering, `--out-dir=X`, generating to
+# a temp dir and moving) report "never generated <language>" — a false failure
+# whose message points at the wrong thing entirely.
 make_stub() {
   local bin_dir="$1" reported="$2"
   mkdir -p "$bin_dir"
@@ -117,30 +161,76 @@ if [[ "\${1:-}" == "--version" ]]; then
   echo "uniffi-bindgen $reported"
   exit 0
 fi
-printf '%s\n' "\$*" >>"\$STUB_LOG"
+mkdir -p "\$STUB_LOG_DIR"
+printf '%s\0' "\$@" >"\$(mktemp "\$STUB_LOG_DIR/call-XXXXXX")"
 exit 0
 STUB
   chmod +x "$bin_dir/uniffi-bindgen"
 }
 
+# Value of `--flag value` or `--flag=value`, from a NUL-separated argv file.
+arg_value() {
+  local file="$1" flag="$2" arg take=""
+  while IFS= read -r -d '' arg; do
+    if [[ -n "$take" ]]; then
+      printf '%s' "$arg"
+      return 0
+    fi
+    case "$arg" in
+      "$flag") take=1 ;;
+      "$flag"=*) printf '%s' "${arg#*=}"; return 0 ;;
+    esac
+  done <"$file"
+  return 1
+}
+
+has_arg() {
+  local file="$1" flag="$2" arg
+  while IFS= read -r -d '' arg; do
+    [[ "$arg" == "$flag" || "$arg" == "$flag"=* ]] && return 0
+  done <"$file"
+  return 1
+}
+
 CRATE_PIN="$(sed -n 's/^uniffi = "\([0-9.]*\)"$/\1/p' crates/offline-protocol-uniffi/Cargo.toml | head -1)"
-if [[ -z "$CRATE_PIN" ]]; then
-  fail "could not read the uniffi pin from crates/offline-protocol-uniffi/Cargo.toml"
-  CRATE_PIN="0.0"
+PIN_MAJOR="$(printf '%s' "$CRATE_PIN" | cut -d. -f1)"
+PIN_MINOR="$(printf '%s' "$CRATE_PIN" | cut -d. -f2)"
+if [[ ! "$PIN_MAJOR" =~ ^[0-9]+$ || ! "$PIN_MINOR" =~ ^[0-9]+$ ]]; then
+  fail "could not read a major.minor uniffi pin from crates/offline-protocol-uniffi/Cargo.toml (got '$CRATE_PIN') — the checks below cannot be trusted"
+  PIN_MAJOR=0
+  PIN_MINOR=0
+fi
+
+# Pulled once, and asserted non-empty: if a step is renamed these go blank and
+# every path check below would "pass" against an empty haystack.
+RM_STEP="$(ci_step_body 'Remove generated bindings so regeneration must replace them')"
+DRIFT_STEP="$(ci_step_body 'Fail on stale bindings')"
+if [[ -n "$RM_STEP" ]]; then
+  pass "$CI_WORKFLOW has the pre-regeneration delete step"
+else
+  fail "$CI_WORKFLOW has no 'Remove generated bindings...' step — the drift gate can no longer tell 'up to date' from 'never written', and the per-path checks below are vacuous"
+fi
+if [[ -n "$DRIFT_STEP" ]]; then
+  pass "$CI_WORKFLOW has the drift gate step"
+else
+  fail "$CI_WORKFLOW has no 'Fail on stale bindings' step — nothing checks the committed bindings, and the per-path checks below are vacuous"
 fi
 
 ok_bin="$STUB_ROOT/ok"
-call_log="$STUB_ROOT/calls.log"
-: >"$call_log"
-make_stub "$ok_bin" "$CRATE_PIN.99"
+call_dir="$STUB_ROOT/calls"
+mkdir -p "$call_dir"
+# A patch level the pin does not name, so a passing run also proves the version
+# gate tolerates patch drift (uniffi's FFI contract is not patch-scoped) rather
+# than only that the gate exists.
+make_stub "$ok_bin" "$PIN_MAJOR.$PIN_MINOR.99"
 
-if PATH="$ok_bin:$PATH" STUB_LOG="$call_log" bash "$GENERATOR" >"$STUB_ROOT/out" 2>&1; then
+if PATH="$ok_bin:$PATH" STUB_LOG_DIR="$call_dir" bash "$GENERATOR" >"$STUB_ROOT/out" 2>&1; then
   pass "$GENERATOR runs to completion (patch-level version drift tolerated)"
 else
   fail "$GENERATOR failed against a stub bindgen: $(tail -3 "$STUB_ROOT/out" | tr '\n' ' ')"
 fi
 
-call_count="$(grep -c . "$call_log" || true)"
+call_count="$(find "$call_dir" -type f | wc -l | tr -d ' ')"
 if [[ "$call_count" -eq 3 ]]; then
   pass "it invoked bindgen exactly 3 times — one per language"
 else
@@ -151,47 +241,79 @@ while IFS= read -r spec; do
   [[ -z "$spec" ]] && continue
   language="${spec%%:*}"
   expected_dir="${spec#*:}"
-  line="$(grep -- "--language $language " "$call_log" || true)"
-  if [[ -z "$line" ]]; then
+
+  call=""
+  for candidate in "$call_dir"/*; do
+    [[ -f "$candidate" ]] || continue
+    if [[ "$(arg_value "$candidate" --language || true)" == "$language" ]]; then
+      call="$candidate"
+      break
+    fi
+  done
+
+  if [[ -z "$call" ]]; then
     fail "$GENERATOR never generated $language — a caller would ship a partial set"
     continue
   fi
-  actual_dir="${line##*--out-dir }"
-  actual_dir="${actual_dir%% *}"
+
+  actual_dir="$(arg_value "$call" --out-dir || true)"
   actual_dir="${actual_dir#"$REPO_ROOT"/}"
   if [[ "$actual_dir" == "$expected_dir" ]]; then
     pass "$language -> $expected_dir"
   else
-    fail "$language written to '$actual_dir', but the drift gate checks '$expected_dir' — a mismatch here is invisible to CI (git diff on a path nothing wrote to reports no diff)"
-    # mkdir -p in the generator may have created the wrong path; take it back
-    # if it is empty so a failing run does not litter the tree.
-    rmdir "$actual_dir" 2>/dev/null || true
+    fail "$language written to '$actual_dir', but CI deletes and diffs '$expected_dir' — a mismatch here is invisible (git diff on a path nothing wrote to reports no diff)"
+    # The generator mkdir -p's its out-dir, so a wrong path may have just been
+    # created. Take it back if empty, but never climb outside the repo.
+    case "$actual_dir" in
+      /* | *..*) : ;;
+      "") : ;;
+      *) rmdir -p "$actual_dir" 2>/dev/null || true ;;
+    esac
+  fi
+
+  # The workflow's delete list and drift-gate list are two more copies of this
+  # path. Gutting either one restores the silent-stale-bindings hole without
+  # touching the generator, so pin them here.
+  if printf '%s' "$RM_STEP" | grep -Fq "$expected_dir"; then
+    pass "$CI_WORKFLOW deletes $language output before regenerating"
+  else
+    fail "$CI_WORKFLOW no longer deletes '$expected_dir' before regenerating — the drift gate can no longer tell 'up to date' from 'never written'"
+  fi
+  if printf '%s' "$DRIFT_STEP" | grep -Fq "$expected_dir"; then
+    pass "$CI_WORKFLOW diffs $language output"
+  else
+    fail "$CI_WORKFLOW no longer diffs '$expected_dir' — stale $language bindings would ship unnoticed"
+  fi
+
+  if has_arg "$call" --no-format; then
+    pass "$language is generated with --no-format"
+  else
+    fail "$language is generated without --no-format — output would depend on whether ktlint/swiftformat are installed"
+  fi
+
+  if grep -qa 'offline_protocol.udl' "$call"; then
+    pass "$language is generated from the UDL"
+  else
+    fail "$language was not generated from src/offline_protocol.udl"
   fi
 done <<EOF
 $EXPECTED_OUTPUTS
 EOF
-
-# --no-format is load-bearing: uniffi-bindgen post-processes with ktlint and
-# swiftformat when they are on PATH, so without it the committed bytes depend
-# on what the developer happens to have installed and a correct regeneration
-# can still fail the drift gate.
-unformatted="$(grep -c -- '--no-format' "$call_log" || true)"
-if [[ "$unformatted" -eq "$call_count" && "$call_count" -gt 0 ]]; then
-  pass "every invocation passes --no-format, so output does not vary by machine"
-else
-  fail "only $unformatted of $call_count invocations pass --no-format — output would depend on whether ktlint/swiftformat are installed"
-fi
 
 # ---------------------------------------------------------------------------
 # 3. Behavioral: the version gate actually rejects a mismatched bindgen.
 # ---------------------------------------------------------------------------
 
 bad_bin="$STUB_ROOT/bad"
-bad_major="${CRATE_PIN%%.*}"
-bad_minor="${CRATE_PIN#*.}"
-make_stub "$bad_bin" "$bad_major.$((bad_minor + 1)).0"
+make_stub "$bad_bin" "$PIN_MAJOR.$((PIN_MINOR + 1)).0"
 
-if PATH="$bad_bin:$PATH" STUB_LOG="$STUB_ROOT/bad.log" bash "$GENERATOR" >/dev/null 2>&1; then
+if [[ ! -x "$bad_bin/uniffi-bindgen" ]]; then
+  # Without this the check is worse than absent: with no stub on PATH and no
+  # real bindgen (the CI ordering — this runs before `cargo install uniffi`)
+  # the generator exits 1 with "not found", which reads exactly like "mismatch
+  # rejected" and reports ok.
+  fail "the mismatched-bindgen stub was not created — this check would pass vacuously"
+elif PATH="$bad_bin:$PATH" STUB_LOG_DIR="$STUB_ROOT/bad-calls" bash "$GENERATOR" >/dev/null 2>&1; then
   fail "$GENERATOR generated with a bindgen whose minor version disagrees with the crate pin — those bindings' checksums fail at runtime, not at build time"
 else
   pass "a bindgen disagreeing with the crate pin is rejected before anything is written"
@@ -228,9 +350,8 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 5. The enumerated callers still delegate. Without this, deleting the
-#    delegation from a build script leaves the guard green while that script
-#    builds a fresh native library against stale committed bindings.
+# 5. The enumerated callers still delegate, and the npm build scripts still
+#    route through a counterpart that does.
 # ---------------------------------------------------------------------------
 
 while IFS= read -r caller; do
@@ -246,6 +367,21 @@ done <<EOF
 $DELEGATING_CALLERS
 EOF
 
+while IFS= read -r spec; do
+  [[ -z "$spec" ]] && continue
+  alias_script="${spec%%:*}"
+  counterpart="${spec#*:}"
+  if [[ ! -f "$alias_script" ]]; then
+    fail "$alias_script is missing — package.json still exposes it as an npm build script"
+  elif grep -Eq "^[[:space:]]*(exec[[:space:]]+)?((bash|sh)[[:space:]]+)?[^|;&]*/$counterpart" "$alias_script"; then
+    pass "$(basename "$alias_script") routes through $counterpart"
+  else
+    fail "$alias_script no longer routes through $counterpart — it would build native artifacts without regenerating bindings"
+  fi
+done <<EOF
+$NATIVE_BUILD_ALIASES
+EOF
+
 # ---------------------------------------------------------------------------
 # 6. Negative controls for the scan regex. A detector that cannot fire is
 #    indistinguishable from one that passes vacuously, so prove it catches
@@ -255,12 +391,17 @@ EOF
 fixtures="$STUB_ROOT/fixtures"
 mkdir -p "$fixtures"
 
-printf 'uniffi-bindgen generate x.udl --language swift\n'          >"$fixtures/hit-inline"
-printf 'uniffi-bindgen \\\n  generate x.udl --language kotlin\n'   >"$fixtures/hit-continued"
-printf 'uniffi-bindgen --config u.toml generate x.udl\n'           >"$fixtures/hit-global-option"
-printf 'cargo run --bin uniffi-bindgen -- generate x.udl\n'        >"$fixtures/hit-cargo-run"
+printf 'uniffi-bindgen generate x.udl --language swift\n'            >"$fixtures/hit-inline"
+printf 'uniffi-bindgen \\\n  generate x.udl --language kotlin\n'     >"$fixtures/hit-continued"
+printf 'uniffi-bindgen --config u.toml generate x.udl\n'             >"$fixtures/hit-global-option"
+printf 'cargo run --bin uniffi-bindgen -- generate x.udl\n'          >"$fixtures/hit-cargo-run"
+printf 'commandLine("uniffi-bindgen", "generate", "x.udl")\n'        >"$fixtures/hit-gradle-kotlin"
+printf "commandLine 'uniffi-bindgen', 'generate', 'x.udl'\n"         >"$fixtures/hit-gradle-groovy"
+printf 'subprocess.run(["uniffi-bindgen", "generate", "x.udl"])\n'   >"$fixtures/hit-argv-list"
+printf "spawnSync('uniffi-bindgen', ['generate', 'x.udl'])\n"        >"$fixtures/hit-nested-list"
 printf 'if command -v uniffi-bindgen; then bash %s; fi\n' "$GENERATOR" >"$fixtures/miss-delegating"
-printf 'Run uniffi-bindgen to generate the Swift bindings.\n'      >"$fixtures/miss-prose"
+printf 'Run uniffi-bindgen to generate the Swift bindings.\n'        >"$fixtures/miss-prose"
+printf 'the uniffi-bindgen generator produces code\n'                >"$fixtures/miss-prose-adjacent"
 
 for fixture in "$fixtures"/hit-*; do
   if grep -Eq "$INVOCATION" "$fixture"; then


### PR DESCRIPTION
## What

`scripts/generate-bindings.sh` generates Swift, Kotlin and Python from the one UDL, in one run. Every other path delegates to it:

- `bindings/react-native/scripts/generate-bindings.sh` (so `npm run generate:bindings` now covers Python too)
- `bindings/python/scripts/build-desktop.sh` (still builds the cdylib pytest needs; only the codegen moved)
- `build-uniffi-ios.sh` / `build-uniffi-android.sh`
- `build-all.sh` / `build-ios.sh` / `build-android.sh` — now thin wrappers over the `build-uniffi-*` scripts
- `release.yml`'s Python **and Kotlin** steps, so what ships is produced the way CI's gate verified it

## Why

A UDL change obligates three regenerations, and the checklist item everyone reads — `npm run generate:bindings` — covered two of them. The three generated files are **one artifact set**: they carry the FFI checksums of the library they were generated against, so a partial regeneration fails nothing at build time and fails the app at its first call across the boundary. #330 shipped with that checklist ticked and the Python file stale; the Python drift gate then failed alone in an otherwise-green run, which reads like flake and isn't.

The script also refuses to run when `uniffi-bindgen` disagrees with the crate's `uniffi` pin to the minor version — same class of failure, silent until runtime — and reads the pin out of `Cargo.toml` rather than repeating it. Patch drift is deliberately tolerated: uniffi's FFI contract version is not patch-scoped.

It passes `--no-format`, which is load-bearing rather than tidiness: `uniffi-bindgen` post-processes with `ktlint` and `swiftformat` **when they happen to be on PATH**, so without it the committed bytes depend on what each developer has installed, and an Android or iOS contributor with those tools would regenerate correctly and still trip the drift gate.

## Two holes this closed along the way

Both were found by review after the first commit, and both are the failure this PR is about, reached from a direction the first version did not cover:

- **`release.yml` generated Kotlin directly.** That artifact is downloaded *over* the committed Android bindings in the publish job, so it — not the committed file — is what ships to npm, produced by a path the guard could not see and the version check never gated. The first version of this PR waved it off as "an ephemeral release directory"; it is not ephemeral, it is the released artifact.
- **`npm run build:all` regenerated nothing.** `build-all.sh`/`build-ios.sh`/`build-android.sh` were near-copies of the `build-uniffi-*` trio minus the codegen, so they paired fresh native artifacts with whatever was committed — on every run, and six example READMEs open with `npm run build:all`. Collapsing them into wrappers also fixed three unrelated regressions the copies had drifted into: no `check-elf-alignment.py` (Google Play's 16 KB requirement, which `release.yml` enforces), stale NDK toolchain resolution, and a missing `release/deps` staticlib fallback.

The iOS and Android scripts no longer warn-and-continue when `uniffi-bindgen` is missing. Pairing a freshly built native library with the previously committed bindings *is* the ABI mismatch this rule exists to prevent, and it surfaces at the app's first FFI call rather than at the build — so failing is strictly better than continuing.

## CI

One regeneration, one gate over all three paths, replacing two half-gates that a half-updated commit could satisfy one of. The generated files are **deleted before regenerating**, because `git diff --exit-code` on a path nothing wrote to reports no diff — without the delete, "up to date" and "never regenerated" are indistinguishable, and a mistyped output path would sail through green while every later UDL change shipped stale bindings.

Plus `scripts/tests/test-generate-bindings.sh`, which runs first (no bindgen, no toolchain, under a second). It asserts the rule *behaviorally*: it runs the real generator against a stub `uniffi-bindgen` and checks the languages, output paths, UDL and `--no-format` it asked for, then scans **every tracked file** by content for a direct invocation. Scanning only `*.sh` would have left the release workflow — the path that ships — exempt.

## Verification

- **Regeneration is byte-identical to what was committed** — the drift gate passes on a clean CI runner. This changes how they're produced, not what they say.
- All 15 CI checks green, including the full `Python Bindings` chain: guard → delete → regenerate → drift gate → cdylib build → pytest.
- The guard is mutation-tested both ways: a one-character output-path typo, a dropped language, a dropped `--no-format`, a gutted version gate, a gutted CI delete step, a path dropped from the drift gate, and a build script that stops routing are all **caught**; a refactor to a loop, `--language`/`--out-dir` reordering, `--flag=value` form, and direct-exec delegation are all **tolerated**.
- Its scan is negative-controlled against 10 invocation shapes (inline, line-continuation, `--config` before the subcommand, `cargo run --bin`, Gradle Kotlin and Groovy `commandLine`, `subprocess.run`, `spawnSync`, YAML list) and 4 benign ones, with zero false positives across every tracked file.
- Two vacuous-pass bugs *in the guard itself* were found and fixed by review: it accused itself in three of four invocation forms, and its version-gate control silently did nothing under a patch-level pin. Both now have explicit fixture-exists assertions so "setup never ran" can no longer read as "check passed".
- `shellcheck --severity=warning` clean on everything touched; both workflows parse; the guard runs under macOS bash 3.2.
- `release.yml`'s Kotlin artifact shape simulated end to end — identical to what the publish job's download path expects.

Not executed locally: the iOS/Android platform builds (need Xcode targets / NDK) — those edits are shellcheck- and syntax-verified only.

## Known gap (follow-up, not introduced here)

The drift gate compares tracked files, so a future `uniffi` upgrade that emits a **fourth** generated file would produce it, leave it untracked, and pass. Worth a `git ls-files --others` check; independent of this change.
