### PR TITLE
fix(transport)!: refuse the unsealed Nostr whole-message poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- **BREAKING**: `NostrTransport::get_next_message` — the generic
+  `Transport` whole-message poll — now returns
+  `Error::ConfigurationError` instead of the next queued frame. It never
+  sealed, signed, or wrapped: it returned the bare serialized `Message`, the
+  whole protocol envelope with both endpoints on it, so anything that
+  published the result put in front of every relay exactly the cleartext
+  sealing exists to prevent — and did so regardless of
+  `nostr_sealing_enabled`, which this path never consulted. It had carried a
+  doc comment warning callers off it since gift wrapping landed, but the
+  method sits on the `Transport` trait and the engine hands that out as
+  `dyn Transport` from `TransportManager::get_transport`, so reaching the
+  cleartext took no downcast and no unsafe. **No bundled bridge or UniFFI
+  entry is affected** — `nostrGetNextMessage` routes to
+  `get_next_signed_event`, which returns a signed, sealed `["EVENT", …]`
+  relay message, and the iOS and Android bridges call it. Only a Rust
+  embedder polling Nostr through `dyn Transport` changes behavior, and such
+  an embedder was publishing cleartext. The refusal returns before the send
+  queue or the pending-confirmation map are read, so it cannot strand the
+  frame it declines to hand over: the message stays queued and the next
+  `get_next_signed_event` serves it.
 - **BREAKING**: `GroupManager::remove_member` now takes `&[LeafNodeIndex]`
   instead of a single `LeafNodeIndex`, and `MlsManager::remove_group_member`
   removes *every* leaf whose credential names the member rather than the first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   an embedder was publishing cleartext. The refusal returns before the send
   queue or the pending-confirmation map are read, so it cannot strand the
   frame it declines to hand over: the message stays queued and the next
-  `get_next_signed_event` serves it.
+  `get_next_signed_event` serves it. The refusal is also logged at `error`
+  level **once per transport**, because every in-tree caller of this trait
+  method takes the shape `if let Ok(Some(..)) = t.get_next_message()`, which
+  discards an `Err` down the same silent path as `Ok(None)` — the log is what
+  makes the misintegration visible to a caller that swallows the error, and
+  the one-shot is what keeps a polling caller from burying it.
 - **BREAKING**: `GroupManager::remove_member` now takes `&[LeafNodeIndex]`
   instead of a single `LeafNodeIndex`, and `MlsManager::remove_group_member`
   removes *every* leaf whose credential names the member rather than the first

--- a/crates/offline-protocol-transport/src/nostr.rs
+++ b/crates/offline-protocol-transport/src/nostr.rs
@@ -32,6 +32,7 @@ use base64::Engine;
 use offline_protocol_core::{Address, Message, MutexExt, RwLockExt};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
@@ -314,6 +315,14 @@ pub struct NostrTransport {
     reconnect_attempts: Arc<Mutex<u32>>,
     platform_handle: Arc<Mutex<Option<usize>>>,
     on_messages_available: SharedCallback,
+    /// Whether the [`Transport::get_next_message`] refusal has already been
+    /// logged for this transport.
+    ///
+    /// The refusal reports a *misintegration* — a caller polling the wrong
+    /// drain — which is a standing condition, not an event: the caller is on a
+    /// timer or a wake callback and will hit it again on every tick. One
+    /// report identifies the bug; the rest are noise that would bury it.
+    generic_poll_refusal_logged: AtomicBool,
 }
 
 impl NostrTransport {
@@ -384,6 +393,7 @@ impl NostrTransport {
             reconnect_attempts: Arc::new(Mutex::new(0)),
             platform_handle: Arc::new(Mutex::new(None)),
             on_messages_available: Arc::new(Mutex::new(None)),
+            generic_poll_refusal_logged: AtomicBool::new(false),
         })
     }
 
@@ -1566,8 +1576,33 @@ impl Transport for NostrTransport {
     /// **Nothing is consumed here.** The refusal returns before the send queue
     /// or `pending_confirmation` are read, so a caller that reaches this by
     /// mistake cannot also steal a frame out from under the sealed drain — it
-    /// stays queued, and the next `get_next_signed_event` serves it.
+    /// stays queued, and the next `get_next_signed_event` serves it. What such
+    /// a caller *will* observe is a queue that only grows: `queue_depth` rises,
+    /// `congestion` saturates at 1.0 by depth 50, and DORS stops selecting
+    /// Nostr. That is the intended shape of the failure — traffic reroutes
+    /// instead of publishing cleartext — but it is a misintegration, not
+    /// backpressure, which is why it is also logged.
+    ///
+    /// The refusal is logged **once** per transport, not per call. Every
+    /// in-tree caller of this trait method takes the shape
+    /// `if let Ok(Some((..))) = t.get_next_message()`, which discards an `Err`
+    /// down the same silent path as `Ok(None)` — so for exactly the mistake
+    /// this guard exists to catch, returning `Err` is no louder than the
+    /// `Ok(None)` it was chosen over. The log is what makes it loud; the
+    /// one-shot is what keeps a polling caller from burying it.
     fn get_next_message(&self) -> Result<Option<(String, Vec<u8>)>> {
+        if !self
+            .generic_poll_refusal_logged
+            .swap(true, Ordering::Relaxed)
+        {
+            tracing::error!(
+                "Nostr get_next_message() refused: this transport has no \
+                 unsealed whole-message drain. Poll get_next_signed_event() \
+                 instead. Outbound frames stay queued until it is polled. \
+                 Logged once per transport."
+            );
+        }
+
         Err(crate::Error::ConfigurationError(
             "Nostr has no unsealed message drain: get_next_message() would \
              return the bare protocol envelope in cleartext. Poll \
@@ -2171,10 +2206,26 @@ mod tests {
 
         let generic: &dyn Transport = &transport;
         let err = generic.get_next_message().unwrap_err();
+        // Asserted on `code()` rather than the variant or the message text:
+        // `Error` documents the code as the stable contract and `Display` as
+        // free to change, so this is the surface a caller is entitled to
+        // classify on.
+        assert_eq!(err.code(), "CONFIGURATION_ERROR", "got {err:?}");
+
+        // The other generic egress door must stay shut too. Nostr is safe here
+        // only because it does not override the trait's `Ok(None)` default —
+        // nothing else records that as a requirement, so a later fragmenting
+        // implementation would reopen this leak on a method nobody thinks of
+        // as a leak surface.
         assert!(
-            matches!(err, crate::Error::ConfigurationError(_)),
-            "expected a refusal, got {err:?}"
+            generic.get_next_fragment().unwrap().is_none(),
+            "Nostr must expose no generic fragment drain either"
         );
+
+        // The one-shot on the log must gate the *log*, never the refusal: a
+        // second caller has to be refused exactly as loudly as the first.
+        let second = generic.get_next_message().unwrap_err();
+        assert_eq!(second.code(), "CONFIGURATION_ERROR", "got {second:?}");
 
         // The refusal returns before the queue or the pending map are touched,
         // so a caller that lands here by mistake cannot also strand the frame

--- a/crates/offline-protocol-transport/src/nostr.rs
+++ b/crates/offline-protocol-transport/src/nostr.rs
@@ -1540,43 +1540,42 @@ impl Transport for NostrTransport {
         crate::common::on_data_received_from(&self.receive_queue, data, peer_id)
     }
 
-    /// Gets the next message to send (for platform implementation).
+    /// **Refused.** This transport has no unsealed whole-message drain.
     ///
-    /// Returns `(message_id, serialized_bytes)` or `None` if no messages.
-    /// The message enters the pending-confirmation state until the platform
-    /// calls [`Transport::confirm_sent`] or [`Transport::report_send_failure`].
+    /// The signature can only return a bare serialized `Message` — the entire
+    /// protocol envelope, both endpoints included — with no gift wrap, no
+    /// signature and no event around it, so publishing the result would put
+    /// exactly the cleartext this transport exists to avoid in front of every
+    /// relay. There is nowhere to put a signed, sealed event in a
+    /// `(String, Vec<u8>)`, and a Nostr frame without its event envelope is
+    /// not deliverable anyway.
     ///
-    /// **This path does not seal, and no Nostr bridge should use it.** It
-    /// returns the bare serialized `Message` — the entire protocol envelope,
-    /// both usernames included — with no gift wrap and no event around it, so
-    /// publishing the result puts exactly the cleartext this transport now
-    /// avoids in front of every relay. There is nowhere to put a sealed event
-    /// in this signature; it exists only to satisfy the generic [`Transport`]
-    /// trait.
+    /// It used to return that cleartext, with this comment warning callers off
+    /// it. A doc comment is not a control: this method sits on the generic
+    /// [`Transport`] trait, which the engine hands out as `dyn Transport` from
+    /// `TransportManager::get_transport`, so reaching the unsealed bytes took
+    /// no downcast and no unsafe — and the leak ran regardless of
+    /// `nostr_sealing_enabled`, since this path never consulted it. The
+    /// refusal is the enforcement.
     ///
     /// Poll [`NostrTransport::get_next_signed_event`] instead: it produces a
     /// complete signed, sealed `["EVENT", …]` message ready for the wire. That
     /// is what the bundled bridges and the UniFFI `nostr_get_next_message`
     /// entry call.
+    ///
+    /// **Nothing is consumed here.** The refusal returns before the send queue
+    /// or `pending_confirmation` are read, so a caller that reaches this by
+    /// mistake cannot also steal a frame out from under the sealed drain — it
+    /// stays queued, and the next `get_next_signed_event` serves it.
     fn get_next_message(&self) -> Result<Option<(String, Vec<u8>)>> {
-        self.drain_expired_pending();
-
-        let message = {
-            let mut queue = self.send_queue.lock_or_recover();
-            match queue.pop_front() {
-                Some(m) => m,
-                None => return Ok(None),
-            }
-        };
-
-        let message_id = message.id.to_string();
-        let data = self.serialize_message(&message)?;
-
-        self.pending_confirmation
-            .lock_or_recover()
-            .insert(message_id.clone(), Instant::now());
-
-        Ok(Some((message_id, data)))
+        Err(crate::Error::ConfigurationError(
+            "Nostr has no unsealed message drain: get_next_message() would \
+             return the bare protocol envelope in cleartext. Poll \
+             NostrTransport::get_next_signed_event() instead, which returns a \
+             signed, sealed [\"EVENT\", …] relay message. The queued frame is \
+             untouched."
+                .to_string(),
+        ))
     }
 
     /// Sets the callback invoked when outgoing messages are queued.
@@ -1851,22 +1850,11 @@ mod tests {
         assert_eq!(transport.config().max_reconnect_attempts, 5);
     }
 
-    #[test]
-    fn test_send_receive() {
-        let transport = NostrTransport::new(addr("device1")).unwrap();
-        transport.start().unwrap();
-        transport.on_status_changed(TransportStatus::Available);
-
-        let msg = create_test_message();
-        transport.send(&msg).unwrap();
-
-        let (msg_id, data) = transport.get_next_message().unwrap().unwrap();
-        assert!(!msg_id.is_empty());
-        assert!(!data.is_empty());
-
-        let deserialized = transport.deserialize_message(&data).unwrap();
-        assert_eq!(deserialized.id, msg.id);
-    }
+    // `test_send_receive` lived here. Its two assertions moved to the sealed
+    // drain rather than being duplicated onto it: the queue-to-pending
+    // transition is `test_get_next_signed_event`, and the content round trip
+    // is `test_sealed_frame_round_trips_through_the_recipients_transport`,
+    // which asserts the sender as well as the id.
 
     #[test]
     fn test_send_when_unavailable_fails() {
@@ -1890,8 +1878,8 @@ mod tests {
         let msg = create_test_message();
         transport.send(&msg).unwrap();
 
-        let (msg_id, _) = transport.get_next_message().unwrap().unwrap();
-        transport.confirm_sent(&msg_id);
+        let signed = transport.get_next_signed_event().unwrap().unwrap();
+        transport.confirm_sent(&signed.message_id);
 
         let metrics = transport.metrics();
         assert_eq!(metrics.success_count, 1);
@@ -1907,8 +1895,8 @@ mod tests {
         let msg = create_test_message();
         transport.send(&msg).unwrap();
 
-        let (msg_id, _) = transport.get_next_message().unwrap().unwrap();
-        transport.report_send_failure(&msg_id);
+        let signed = transport.get_next_signed_event().unwrap().unwrap();
+        transport.report_send_failure(&signed.message_id);
 
         let metrics = transport.metrics();
         assert_eq!(metrics.success_count, 0);
@@ -1923,7 +1911,7 @@ mod tests {
 
         let msg = create_test_message();
         transport.send(&msg).unwrap();
-        let _ = transport.get_next_message().unwrap();
+        let _ = transport.get_next_signed_event().unwrap();
 
         transport.on_status_changed(TransportStatus::Disconnected);
 
@@ -1939,7 +1927,7 @@ mod tests {
 
         let msg = create_test_message();
         transport.send(&msg).unwrap();
-        let _ = transport.get_next_message().unwrap();
+        let _ = transport.get_next_signed_event().unwrap();
 
         transport.stop().unwrap();
 
@@ -2037,8 +2025,8 @@ mod tests {
 
         let msg = create_test_message();
         transport.send(&msg).unwrap();
-        let (msg_id, _) = transport.get_next_message().unwrap().unwrap();
-        transport.confirm_sent(&msg_id);
+        let signed = transport.get_next_signed_event().unwrap().unwrap();
+        transport.confirm_sent(&signed.message_id);
 
         let mut new_metrics = TransportMetrics::default();
         new_metrics.rssi = Some(-70);
@@ -2122,7 +2110,7 @@ mod tests {
 
         let msg = create_test_message();
         transport.send(&msg).unwrap();
-        let _ = transport.get_next_message().unwrap();
+        let _ = transport.get_next_signed_event().unwrap();
 
         assert_eq!(transport.pending_confirmation_count(), 1);
     }
@@ -2162,6 +2150,50 @@ mod tests {
 
         // No more messages
         assert!(transport.get_next_signed_event().unwrap().is_none());
+    }
+
+    /// The generic whole-message poll must refuse rather than hand back the
+    /// unsealed envelope, and must cost the sealed drain nothing.
+    ///
+    /// Dispatched through `&dyn Transport` on purpose: that is the shape the
+    /// leak had. `TransportManager::get_transport` hands out an
+    /// `Arc<dyn Transport>`, so this was reachable with no downcast and no
+    /// unsafe, and a concrete-typed call here would not pin the vtable entry
+    /// that actually mattered.
+    #[test]
+    fn test_generic_transport_poll_refuses_rather_than_leaking_cleartext() {
+        let transport = NostrTransport::new(addr("device1")).unwrap();
+        transport.start().unwrap();
+        transport.on_status_changed(TransportStatus::Available);
+
+        let msg = create_test_message();
+        transport.send(&msg).unwrap();
+
+        let generic: &dyn Transport = &transport;
+        let err = generic.get_next_message().unwrap_err();
+        assert!(
+            matches!(err, crate::Error::ConfigurationError(_)),
+            "expected a refusal, got {err:?}"
+        );
+
+        // The refusal returns before the queue or the pending map are touched,
+        // so a caller that lands here by mistake cannot also strand the frame
+        // it failed to get: nothing is dequeued, and nothing is left awaiting a
+        // confirmation that no bridge will ever send.
+        assert!(
+            transport.has_pending_sends(),
+            "the refused frame must stay queued"
+        );
+        assert_eq!(
+            transport.pending_confirmation_count(),
+            0,
+            "a refusal must not enter the confirmation loop"
+        );
+
+        // ...and the sealed drain still serves that same frame.
+        let signed = transport.get_next_signed_event().unwrap().unwrap();
+        assert_eq!(signed.message_id, msg.id.to_string());
+        assert!(signed.event_json.starts_with("[\"EVENT\",{"));
     }
 
     #[test]

--- a/crates/offline-protocol-transport/src/traits.rs
+++ b/crates/offline-protocol-transport/src/traits.rs
@@ -224,10 +224,23 @@ pub trait Transport: Send + Sync + Any {
     /// Returns `(key, serialized_bytes)` where the `key` is
     /// transport-specific: a recipient address for peer-to-peer transports
     /// (WiFi Direct), or the message id for confirmation-loop transports
-    /// (Internet, Nostr, Reticulum — pair with [`Transport::confirm_sent`] /
+    /// (Internet, Reticulum — pair with [`Transport::confirm_sent`] /
     /// [`Transport::report_send_failure`]). The default returns `Ok(None)`:
     /// fragmenting transports (BLE) expose
     /// [`Transport::get_next_fragment`] instead.
+    ///
+    /// **One transport refuses, and the poll calibration has that one
+    /// exception.** Nostr returns `ConfigurationError` here rather than
+    /// `Ok(None)` or bytes: this signature can carry only a bare serialized
+    /// `Message` — the whole protocol envelope, both endpoints included —
+    /// with no gift wrap, no signature and no event around it, so a caller
+    /// that published the result would put in front of every relay exactly
+    /// the cleartext that transport exists to avoid. There is nowhere in a
+    /// `(String, Vec<u8>)` to put a signed, sealed event. Poll
+    /// `NostrTransport::get_next_signed_event` instead. A transport whose
+    /// wire form cannot be expressed in this signature should follow that
+    /// precedent and refuse, rather than returning something publishable
+    /// that is not what the transport actually promises.
     fn get_next_message(&self) -> Result<Option<(String, Vec<u8>)>> {
         Ok(None)
     }


### PR DESCRIPTION
## The gap

`NostrTransport::get_next_message` — the generic `Transport` whole-message poll — implemented itself by popping the send queue, serializing the bare `Message`, and returning it. It never sealed, signed, or wrapped. The result was the whole protocol envelope with both endpoints on it, so anything that published it put in front of every relay exactly the cleartext gift wrapping exists to prevent — and did so **regardless of `nostr_sealing_enabled`**, which this path never consulted.

It has carried a doc comment warning callers off it since #288 sealed the transport. A doc comment is not a control.

## Why it was reachable

Two commits set this up between them:

- `c5d2888` moved the method from an inherent method onto the `Transport` trait, so it no longer required a downcast.
- `b272352` (#288) sealed the transport, hardened the **ingress** seam — `on_data_received` refuses a still-sealed frame — and for the **egress** seam rewrote the doc comment while leaving the body byte-identical.

So reaching the cleartext was a composition of two public methods, no downcast and no unsafe:

\`\`\`rust
OfflineProtocol::transport_manager()      // pub, config_accessors.rs:51
  .get_transport(TransportType::Nostr)    // pub, transport_manager.rs:1201 -> Arc<dyn Transport>
  .get_next_message()                     // cleartext envelope, both endpoints
\`\`\`

A secondary hazard rode along: because the old body popped the queue and inserted into `pending_confirmation`, a caller landing there didn't just leak — it stole the frame out from under the sealed drain.

## The change

`get_next_message` now returns `Error::ConfigurationError` naming `get_next_signed_event` as the drain. The refusal returns **before** the send queue or `pending_confirmation` are read, so it cannot strand the frame it declines to hand over: the message stays queued and the next `get_next_signed_event` serves it.

## Blast radius

**No bundled bridge or UniFFI entry is affected.** `nostrGetNextMessage` routes to `get_next_signed_event` (uniffi/src/lib.rs:4730), and both bridges call it (\`NostrManager.swift:1117\`, \`NostrManager.kt:807\`). The three FFI callers of the trait method are type-pinned to Internet, WiFi Direct and Reticulum. No UDL change, no binding regeneration, no wire-format change.

Only a Rust embedder polling Nostr through \`dyn Transport\` changes behavior — and such an embedder was publishing cleartext, so failing loudly is the correct outcome.

## Choices worth reviewing

- **\`ConfigurationError\`** over \`SendFailed\` (special-cased by \`map_send_error\`, and this is an integration bug rather than a delivery failure) and over \`TransportNotAvailable\` (which would lie about transport health). No new variant added — \`Error\` is \`#[non_exhaustive]\` so one would have been non-breaking, but a single call site doesn't earn it.
- **\`Err\` over deleting the override** (which would inherit the trait's \`Ok(None)\`, matching BLE's precedent and the documented default calibration). Rejected because this seam already failed once by being quiet: \`Ok(None)\` makes a misused drain look like an idle queue, whereas the mistake being guarded against is precisely "a bridge author believes this is the drain."
- **\`test_send_receive\` deleted, not converted.** Its assertions are each already covered — the queue-to-pending transition by \`test_get_next_signed_event\`, the content round trip by \`test_sealed_frame_round_trips_through_the_recipients_transport\` (which also asserts the sender). A tombstone comment at its old location points at both.

## Tests

Six tests used the method only as a fixture step to move a frame into \`pending_confirmation\`; they now use \`get_next_signed_event\`, which performs the identical transition from identical setup.

\`test_generic_transport_poll_refuses_rather_than_leaking_cleartext\` dispatches through \`&dyn Transport\` on purpose — that is the shape the leak had, and a concrete-typed call would not pin the vtable entry that mattered. It asserts the refusal, that the frame stays queued, that nothing enters the confirmation loop, and that the sealed drain still serves that same frame.

## Verification

| Gate | Result |
|---|---|
| \`cargo test -p offline-protocol-transport --lib nostr\` | 92 passed, 0 failed |
| \`cargo test --workspace --lib\` | 2075 passed, 0 failed |
| \`cargo clippy --workspace -- -D warnings\` | clean |
| \`cargo fmt --all -- --check\` | clean |

Mutation-checked: restoring the old body fails the new test, and the panic output decodes to the cleartext envelope — \`"sender":"off1qy4a…"\`, \`"recipient":"off1qxqm…"\`, \`"content":"Test message"\` — which is exactly what would have reached the relay.