### PR TITLE
fix(protocol,bindings): classify GroupError instead of shipping relay wire text (#349)

### DIFF
--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -1407,11 +1407,27 @@ export interface UserGroupsEvent extends BaseEvent {
 }
 
 /**
- * Group error event (from relay)
+ * Group error event (from relay).
+ *
+ * `reason` is a **fixed code minted locally**, not the relay's wording:
+ * `not_found` (the relay has no such group — invite links and relay fan-out
+ * for it are dead, not merely refused), `sync_denied` (the relay refused to
+ * register or sync the group for this caller), or `error` (any other
+ * refusal). Do not parse it as prose or show it to users as-is.
+ *
+ * The relay's text is deliberately not carried here: `__GROUP_ERROR__` is
+ * accepted unsigned on the relay ingest path, so its wording is chosen by
+ * whoever put the frame on that socket. Apps that genuinely need the exact
+ * wording — invite-link flows correlating by `request_id`, for instance —
+ * should read the raw `GroupError` frame, which both bridges still dual-emit
+ * on the server-message channel.
+ *
+ * `group_id` is present when the relay scoped the error to a group.
  */
 export interface GroupErrorEvent extends BaseEvent {
   type: 'group_error';
-  reason: string;
+  reason: 'not_found' | 'sync_denied' | 'error';
+  group_id?: string;
 }
 
 /**

--- a/crates/offline-protocol/src/events.rs
+++ b/crates/offline-protocol/src/events.rs
@@ -1105,9 +1105,31 @@ pub enum Event {
     },
 
     /// A group operation failed (from relay).
+    ///
+    /// The relay's own wording is **not** carried here. `__GROUP_ERROR__` is
+    /// a relay answer, accepted unsigned on the relay ingest path (the
+    /// bridges inject it unattributed), so its text is chosen by whoever put
+    /// the frame on that socket — arbitrary content, arbitrary length, and
+    /// not something this SDK can vouch for. `reason` is a fixed code
+    /// classified locally instead; the
+    /// relay's exact text is logged on-device and reaches apps, when they
+    /// want it, as the raw `GroupError` frame the bridges dual-emit on the
+    /// server-message channel.
     GroupError {
-        /// Human-readable error reason.
+        /// Why the operation failed, from a fixed set: `not_found` (the
+        /// relay has no such group — invite links and relay fan-out for it
+        /// are dead, not merely refused), `sync_denied` (the relay refused
+        /// to register or sync the group for this caller), or `error` (any
+        /// other refusal).
         reason: String,
+        /// Group the error concerns, when the relay scoped it. Absent for
+        /// unscoped errors.
+        ///
+        /// This is the group-scoping the free-text `reason` used to smuggle
+        /// past the telemetry scrubber — as a real field it is hashed like
+        /// every other `group_id` instead.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        group_id: Option<String>,
     },
 
     /// The relay-side registration state of a group changed.
@@ -2152,8 +2174,11 @@ impl Event {
     }
 
     /// Creates a GroupError event.
-    pub fn group_error(reason: String) -> Self {
-        Self::GroupError { reason }
+    ///
+    /// `reason` must be a locally-minted code, never relay text — callers on
+    /// the wire path get theirs from `GroupErrorPayload::classify_reason`.
+    pub fn group_error(reason: String, group_id: Option<String>) -> Self {
+        Self::GroupError { reason, group_id }
     }
 
     /// Creates a GroupRelaySyncChanged event.
@@ -3064,9 +3089,10 @@ impl fmt::Debug for Event {
                 .debug_struct("UserGroups")
                 .field("groups_count", &groups.len())
                 .finish(),
-            Self::GroupError { reason } => f
+            Self::GroupError { reason, group_id } => f
                 .debug_struct("GroupError")
                 .field("reason", reason)
+                .field("group_id", group_id)
                 .finish(),
             Self::GroupRelaySyncChanged {
                 group_id,
@@ -3473,6 +3499,23 @@ mod tests {
             None,
         );
         assert!(!received.to_json().unwrap().contains("initial_message"));
+    }
+
+    /// Pins the `group_error` wire shape (#349).
+    ///
+    /// `group_id` is additive, so a build that never scopes an error must
+    /// serialize byte-identically to pre-change builds — the same
+    /// `skip_serializing_if` contract `initial_message` is pinned on above.
+    #[test]
+    fn test_group_error_event_wire_shape() {
+        let scoped = Event::group_error("sync_denied".to_string(), Some("g-1".to_string()));
+        let json: serde_json::Value = serde_json::from_str(&scoped.to_json().unwrap()).unwrap();
+        assert_eq!(json["type"], "group_error");
+        assert_eq!(json["reason"], "sync_denied");
+        assert_eq!(json["group_id"], "g-1");
+
+        let unscoped = Event::group_error("error".to_string(), None);
+        assert!(!unscoped.to_json().unwrap().contains("group_id"));
     }
 
     #[test]

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -2929,6 +2929,100 @@ fn test_group_relay_sync_changed_event_lifecycle() {
     protocol.stop().unwrap();
 }
 
+/// #349: the relay's `GroupError` wording must never reach an event.
+///
+/// `__GROUP_ERROR__` is a relay answer, so on the relay ingest shape
+/// (Internet arrival, no transport peer identity) the control gate admits it
+/// **unsigned** — reaching this needs no key material, no session and no
+/// prior contact. Its `reason` used to be copied verbatim onto
+/// `Event::GroupError`, which the telemetry scrubber ships as-is because
+/// free text is content and content scrubbing is deliberately out of its
+/// scope. So a stranger chose a string and the SDK handed it to the sink.
+///
+/// Two things are asserted, and the premise guard is what keeps them honest:
+/// the injected frame really does carry a marker and an address, otherwise
+/// "the event contains neither" would pass with the fix reverted.
+#[test]
+fn test_group_error_reason_is_classified_not_quoted_from_the_wire() {
+    let (mut protocol, events) = setup_started_with_events();
+
+    // The shape of text a hostile sender would pick: a marker, a third
+    // party's address, and a group id smuggled into prose — none of which a
+    // scrubber that hashes *fields* can reach.
+    let victim = id("victim");
+    let planted =
+        format!("LEAKMARKER-9f3: {victim} was denied in group secret-group-42 (see audit)");
+    let frame =
+        format!("__GROUP_ERROR__{{\"reason\":\"{planted}\",\"group_id\":\"secret-group-42\"}}");
+    // Premise guard: without this the assertions below can pass vacuously.
+    assert!(
+        frame.contains("LEAKMARKER-9f3") && frame.contains(victim.as_str()),
+        "fixture must actually carry the marker and the address"
+    );
+
+    // Unsigned on purpose, on the arrival shape the gate exempts — that is
+    // the whole reachability claim, not an incidental fixture detail.
+    let msg = make_unsigned_message("relay", &id("user123"), &frame);
+    protocol.process_internal_message_via(&msg, Some(TransportType::Internet));
+
+    let collected = events.lock().unwrap();
+    let errors: Vec<(&String, &Option<String>)> = collected
+        .iter()
+        .filter_map(|e| match e {
+            Event::GroupError { reason, group_id } => Some((reason, group_id)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(errors.len(), 1, "expected exactly one GroupError event");
+    let (reason, group_id) = errors[0];
+
+    assert_eq!(
+        reason, "error",
+        "unrecognized relay wording must classify to the closed fallback"
+    );
+    assert!(
+        !reason.contains("LEAKMARKER-9f3"),
+        "relay-chosen text reached the event: {reason}"
+    );
+    assert!(
+        !reason.contains(victim.as_str()),
+        "an address the sender wrote reached the event: {reason}"
+    );
+    // The scoping the prose used to smuggle now rides a real field, where
+    // the scrubber can hash it like any other group id.
+    assert_eq!(group_id.as_deref(), Some("secret-group-42"));
+}
+
+/// The two wordings the relay does mint map to distinct codes, so apps can
+/// still tell "relay has no such group" from "relay refused to sync it".
+#[test]
+fn test_group_error_known_relay_wordings_map_to_distinct_codes() {
+    let cases = [
+        ("Group not found", "not_found"),
+        ("Only admins can sync this group", "sync_denied"),
+        // Anything else, including an honest relay's interpolated prose,
+        // falls closed rather than travelling.
+        ("Not a member of group secret-group-42", "error"),
+    ];
+
+    for (wording, expected) in cases {
+        let (mut protocol, events) = setup_started_with_events();
+        let frame = format!("__GROUP_ERROR__{{\"reason\":\"{wording}\",\"group_id\":\"g-1\"}}");
+        let msg = make_unsigned_message("relay", &id("user123"), &frame);
+        protocol.process_internal_message_via(&msg, Some(TransportType::Internet));
+
+        let collected = events.lock().unwrap();
+        let reason = collected
+            .iter()
+            .find_map(|e| match e {
+                Event::GroupError { reason, .. } => Some(reason.clone()),
+                _ => None,
+            })
+            .expect("GroupError event");
+        assert_eq!(reason, expected, "wording {wording:?} misclassified");
+    }
+}
+
 #[test]
 fn test_relay_register_ack_timeout_emits_sync_changed() {
     use offline_protocol_transport::mock::MockTransport;

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -19,6 +19,28 @@ use offline_protocol_services::ServiceAction;
 use offline_protocol_transport::TransportType;
 use tracing::{debug, error, info, warn};
 
+/// Renders wire-supplied text for a device log, bounded.
+///
+/// The relay-answer frames this module handles are accepted unsigned, so any
+/// text they carry is attacker-chosen and attacker-sized. The classification
+/// at the emit site keeps that text off events; this keeps the one remaining
+/// diagnostic use — the local `warn!` — from being a place to dump megabytes.
+fn bounded_wire_text(text: &str) -> String {
+    const MAX_LOGGED_WIRE_TEXT_BYTES: usize = 200;
+
+    if text.len() <= MAX_LOGGED_WIRE_TEXT_BYTES {
+        return text.to_string();
+    }
+    // `str::get(..n)` yields `None` mid-codepoint, and the usual
+    // `.unwrap_or(text)` fallback would then log the whole untruncated
+    // string — so walk back to a boundary rather than fall back.
+    let end = (0..=MAX_LOGGED_WIRE_TEXT_BYTES)
+        .rev()
+        .find(|&i| text.is_char_boundary(i))
+        .unwrap_or(0);
+    format!("{}… (truncated)", &text[..end])
+}
+
 impl OfflineProtocol {
     /// Handles an incoming MLS key package message.
     ///
@@ -1838,7 +1860,13 @@ impl OfflineProtocol {
 
         if let Some(data) = content.strip_prefix(internal_prefixes::GROUP_ERROR) {
             if let Ok(payload) = serde_json::from_str::<GroupErrorPayload>(data) {
-                warn!(reason = %payload.reason, group_id = ?payload.group_id, "Group error");
+                // The relay's wording stops here: this log is device-local,
+                // while the event below carries only the local classification.
+                warn!(
+                    reason = %bounded_wire_text(&payload.reason),
+                    group_id = ?payload.group_id,
+                    "Group error"
+                );
                 // A group-scoped relay error (registration denied, not a
                 // member, ...) means relay-side fan-out cannot be trusted for
                 // this group: drop the sync flag so sends fall back to the
@@ -1870,8 +1898,12 @@ impl OfflineProtocol {
                         }
                     }
                 }
+                // Classified, never quoted: `reason` is unsigned wire input,
+                // so an event carries a local code and the scoping group id
+                // (a real field the scrubber hashes) instead of the text.
+                let code = payload.classify_reason();
                 if let Ok(state) = lock_shared_state(&self.shared_state) {
-                    state.emit_event(Event::group_error(payload.reason));
+                    state.emit_event(Event::group_error(code.to_string(), payload.group_id));
                 }
             } else {
                 warn!("Failed to parse GroupError payload");

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -899,12 +899,57 @@ pub(crate) struct UserGroupsPayload {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct GroupErrorPayload {
+    /// The relay's own wording. **Never emitted on an event** — see
+    /// [`GroupErrorPayload::classify_reason`]. Treat every read of this
+    /// field as a read of untrusted, unbounded wire input.
     pub(crate) reason: String,
     /// Group the error concerns, when the relay scoped it (e.g. a
     /// registration sync denial). Used to drop the group from
     /// `relay_synced` so sends fall back to per-member delivery.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) group_id: Option<String>,
+}
+
+impl GroupErrorPayload {
+    /// Maps the relay's free-text `reason` onto a fixed local vocabulary.
+    ///
+    /// `__GROUP_ERROR__` is a relay answer: it rides
+    /// `RELAY_ANSWER_PREFIXES`, so on the relay ingest shape (Internet
+    /// arrival, no transport peer identity) it is accepted **unsigned** —
+    /// no key material, no session, no prior contact, just a frame on that
+    /// socket. Signed, it is reachable to any peer over any transport, since
+    /// the handler is deliberately not gated on the Internet path the way
+    /// the `GROUP_CREATED` ack is. Either way `reason` is whatever the
+    /// sender wrote: arbitrary content, arbitrary length, not ours.
+    ///
+    /// So the text does not travel any further. Nothing downstream needs it
+    /// — the sync revocation keys off `group_id`, and the platform bridges
+    /// already dual-emit the raw relay frame on the server-message channel
+    /// for apps that want the relay's exact wording. What an event carries
+    /// is this classification instead, which an attacker can at most steer
+    /// between three harmless codes.
+    ///
+    /// Even an *honest* relay makes this necessary: its `Not a member of
+    /// group {id}` renders an identifier into prose, smuggling past a
+    /// telemetry scrubber that hashes `group_id` fields but ships free text
+    /// verbatim by design.
+    ///
+    /// The `&'static str` return is load-bearing, the same way
+    /// `MlsError::privacy_safe_reason` is: it makes interpolating wire input
+    /// unrepresentable rather than merely discouraged. Matching is exact and
+    /// the fallback is closed, so a relay rewording an error degrades to
+    /// `error` — never back to shipping its text.
+    pub(crate) fn classify_reason(&self) -> &'static str {
+        match self.reason.as_str() {
+            // Relay has no such group: invite links and relay fan-out for it
+            // are dead, not merely refused.
+            "Group not found" => "not_found",
+            // Relay refused to register/sync the group for this caller.
+            "Only admins can sync this group" => "sync_denied",
+            // Everything else, including anything a forged frame chose.
+            _ => "error",
+        }
+    }
 }
 
 /// A received key package awaiting use for session creation.

--- a/crates/offline-protocol/src/telemetry/record.rs
+++ b/crates/offline-protocol/src/telemetry/record.rs
@@ -625,6 +625,7 @@ mod tests {
             Event::UserGroups { groups: Vec::new() },
             Event::GroupError {
                 reason: String::new(),
+                group_id: None,
             },
             Event::GroupRelaySyncChanged {
                 group_id: String::new(),

--- a/crates/offline-protocol/src/telemetry/scrub_event.rs
+++ b/crates/offline-protocol/src/telemetry/scrub_event.rs
@@ -98,6 +98,26 @@
 //! `emit_content` knob so the identifier-scrubbing and payload-scrubbing
 //! concerns don't get conflated.
 //!
+//! # Producer rule: no wire-sourced free text on an event
+//!
+//! Because this scrubber ships free text verbatim by design, the burden sits
+//! entirely on producers, and there the rule is absolute: **an event field
+//! never carries text chosen by a remote party.** Not shortened, not
+//! sanitized in place — classified, to a fixed local vocabulary, with the
+//! remote wording kept (bounded) in a device log if it is worth keeping at
+//! all. `Event::GroupError::reason` is the worked example: it renders a
+//! relay answer that is accepted *unsigned*, so it used to be free text a
+//! stranger could choose, and it is now one of three locally-minted codes
+//! (see `GroupErrorPayload::classify_reason`).
+//!
+//! Two habits follow from it. Return `&'static str` from these
+//! classifications, so interpolating wire input is unrepresentable rather
+//! than merely discouraged (`MlsError::privacy_safe_reason` does the same
+//! for error renderings). And when the dropped text was carrying real
+//! structure — `GroupError`'s wording named the group it concerned — add
+//! that back as a *typed field*, which the scrubber can then hash, rather
+//! than leaving it smuggled inside prose.
+//!
 //! # Compile-time coverage
 //!
 //! [`event_variant_exhaustiveness_ward`] mirrors the pattern shipped in
@@ -543,7 +563,17 @@ fn scrub_in_place(event: &mut Event, scrubber: &Scrubber) {
                 hash_string(&mut summary.group_id, scrubber);
             }
         }
-        Event::GroupError { reason: _ } => {}
+        // `reason` is a locally-minted code, not the relay's text — the
+        // producer classifies it precisely so nothing unscrubbable arrives
+        // here. `group_id` is an actor identifier like any other.
+        Event::GroupError {
+            group_id,
+            reason: _,
+        } => {
+            if let Some(group_id) = group_id {
+                hash_string(group_id, scrubber);
+            }
+        }
         Event::GroupRelaySyncChanged {
             group_id,
             synced: _,
@@ -1323,6 +1353,37 @@ mod tests {
                 assert_eq!(sender, "alice");
                 assert_eq!(sender_name, "Alice A.");
             }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    /// `GroupError` used to have nothing to scrub, because the only thing it
+    /// carried was relay-chosen prose this scrubber ships verbatim by design
+    /// (#349). The producer now classifies that prose away and hands over the
+    /// group id as a real field — so the id must be hashed here, and the code
+    /// beside it must survive untouched or apps lose the ability to switch on
+    /// it.
+    #[test]
+    fn group_error_hashes_its_group_id_and_leaves_the_code_alone() {
+        let event = Event::GroupError {
+            reason: "sync_denied".into(),
+            group_id: Some("g-secret".into()),
+        };
+        match scrub_event(&event, &scrubber_enabled()).into_owned() {
+            Event::GroupError { reason, group_id } => {
+                assert_eq!(reason, "sync_denied");
+                assert_eq!(group_id.as_deref(), Some(hashed("g-secret").as_str()));
+            }
+            _ => panic!("unexpected variant"),
+        }
+
+        // An unscoped error has no id to hash and must not grow one.
+        let unscoped = Event::GroupError {
+            reason: "error".into(),
+            group_id: None,
+        };
+        match scrub_event(&unscoped, &scrubber_enabled()).into_owned() {
+            Event::GroupError { group_id, .. } => assert_eq!(group_id, None),
             _ => panic!("unexpected variant"),
         }
     }


### PR DESCRIPTION
Fixes #349.

## The bug, confirmed

`__GROUP_ERROR__` is a relay answer. Its `reason` was copied straight onto an event:

```rust
state.emit_event(Event::group_error(payload.reason));   // message_dispatch.rs:1874
```

and the scrubber had nothing to do, because the event had no hashed field at all:

```rust
Event::GroupError { reason: _ } => {}                   // scrub_event.rs:546
```

Reachability is as the issue describes, with one correction worth stating precisely: the control gate's exemption is *narrower* than "unsigned" — `is_unsignable_relay_answer` requires all three of the prefix, Internet arrival, **and** no transport peer identity (`security.rs:437`). So the no-key-material path is the relay ingest shape specifically. A mesh peer needs a valid signature — but the handler is deliberately not Internet-gated (`message_dispatch.rs:1845`), so any signed peer reaches it too. Either way the text is remote-chosen.

Two findings from tracing it that the issue did not have:

- **The honest relay leaks through this field too.** `websocket.rs:2213` sends `format!("Not a member of group {}", group_id)` — a group id rendered into prose, past a scrubber that hashes `group_id` *fields*. This is not only an attacker story.
- **Nothing downstream wanted the text.** The sync revocation keys off `payload.group_id`; the bridges' admin-denial matching runs on the raw relay frame *before* injection; and both bridges already **dual-emit** the raw frame on the server-message channel (`InternetManager.swift:1897`, `InternetManager.kt`). Apps that need the relay's exact wording still have it.

## The fix

Producer-side, per the issue's first option and the #346 / PR #353 precedent — a scrubber-side regex would contradict that file's own architecture.

- `GroupErrorPayload::classify_reason() -> &'static str` maps the wire text to `not_found` / `sync_denied` / `error`. The return type is load-bearing: it makes interpolating wire input unrepresentable, not merely discouraged. Matching is exact and the fallback closed, so a relay rewording an error degrades to `error` — never back to shipping text.
- **The structure the prose carried comes back as a typed field.** `Event::GroupError` gains `group_id: Option<String>` (additive, `skip_serializing_if`), which the scrubber hashes like every other group id. Dropping the text without this would have lost real information; smuggling it inside prose was the actual defect.
- The relay's wording stays in the device `warn!`, bounded (`bounded_wire_text`, 200 bytes, char-boundary safe — note `str::get(..n)` returns `None` mid-codepoint, so the usual `.unwrap_or(text)` fallback would log the whole untruncated string).

I checked that `tracing` has no bridge to `TelemetrySink` before keeping the raw text in the log — there is none, so it stays device-local.

## The general rule the issue asked about

> Worth deciding alongside: whether an event with no scrubbed field at all should be able to carry free text sourced from the wire, as a general rule.

Settled in the scrubber's own policy doc, where the rest of the policy lives: **an event field never carries text chosen by a remote party** — not shortened, not sanitized in place, but classified, with remote wording kept bounded in a device log if it is worth keeping. Plus the two habits: return `&'static str`, and when the dropped text was carrying structure, add it back as a typed field.

## Blast radius

Wire-shape additive and the type tag is unchanged, so the types.ts tag guard is unaffected and no UDL/binding regeneration is needed (events cross UniFFI as JSON). `reason` changes meaning from relay prose to a fixed code — RN `GroupErrorEvent.reason` is now a union; no producer of that type exists in the package, and neither fernweh app consumes `group_error` at all (the two example apps display/log it and degrade to showing a code).

## Verification

`cargo fmt --all`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace --lib` all clean. (`--all-targets` clippy reports ~1445 pre-existing `unwrap_used` findings in test code on the base commit too — unrelated.)

New tests: `test_group_error_reason_is_classified_not_quoted_from_the_wire`, `test_group_error_known_relay_wordings_map_to_distinct_codes`, `group_error_hashes_its_group_id_and_leaves_the_code_alone`, `test_group_error_event_wire_shape`.

The producer test is **premise-guarded** — it asserts the injected frame really does carry the marker and the address, because otherwise "the event contains neither" passes vacuously. Mutation-checked by restoring the verbatim emit; the failure states the defect better than prose could:

```
assertion `left == right` failed: unrecognized relay wording must classify to the closed fallback
  left: "LEAKMARKER-9f3: off1q9f9vz4hxl7qd8dd8u6ymseyay29hz509ytuwzpx was denied in group secret-group-42 (see audit)"
 right: "error"
```

## Not in scope

#350–#352 (the other sinks from the same audit). Moving relay answers off the message plane onto dedicated FFI entry points — the fix for the *authentication* half — remains the follow-up `prefixes.rs` already names; it would not remove the need for this change, since the honest relay interpolates identifiers too. A machine-readable `code` field on the relay's `GroupError` is the durable upgrade, and belongs in the relay-server repo.
