### PR TITLE
chore(ci): SHA-pin every third-party action in release.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,10 @@ updates:
       # `rust-version = "1.87"`, and bumping it silently stops testing MSRV
       # rather than upgrading anything. Dependabot read it as a version pin and
       # proposed 1.100.0, a Rust release that does not exist (#184).
-      # Our four other uses of this action are `@stable`, which Dependabot does
-      # not version-bump, so ignoring the action outright costs us nothing.
+      # Ignoring the action outright still costs us nothing, because no other use
+      # is version-bumpable either: ci.yml's remaining uses are `@stable`, a
+      # branch rather than a version, and release.yml's are commit SHAs commented
+      # `# stable` for the same reason — there is no semver tag for Dependabot to
+      # compare against in either case. release.yml's pins are therefore bumped by
+      # hand; its header comment carries the procedure.
       - dependency-name: dtolnay/rust-toolchain

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,10 +49,13 @@ updates:
       # `rust-version = "1.87"`, and bumping it silently stops testing MSRV
       # rather than upgrading anything. Dependabot read it as a version pin and
       # proposed 1.100.0, a Rust release that does not exist (#184).
-      # Ignoring the action outright still costs us nothing, because no other use
-      # is version-bumpable either: ci.yml's remaining uses are `@stable`, a
-      # branch rather than a version, and release.yml's are commit SHAs commented
-      # `# stable` for the same reason — there is no semver tag for Dependabot to
-      # compare against in either case. release.yml's pins are therefore bumped by
-      # hand; its header comment carries the procedure.
+      # Ignoring the action outright costs us nothing to *upgrade*, and since the
+      # release.yml pins landed it actively protects them. The action's only tag
+      # is a stale major `v1` (e97e2d8, Aug 2025), which is not the `stable`
+      # branch head those SHAs pin — so with this ignore lifted, Dependabot would
+      # have a semver tag to compare against and could re-point seven current
+      # pins at a year-old commit. ci.yml's remaining uses are `@stable`, a
+      # branch rather than a version, so there is nothing to bump there either.
+      # release.yml's pins are therefore bumped by hand; its header comment
+      # carries the procedure.
       - dependency-name: dtolnay/rust-toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,47 @@ env:
   # install hints the scripts print).
   UNIFFI_VERSION: "0.30.0"
 
+# ---------------------------------------------------------------------------
+# Third-party action pinning
+#
+# Every non-`actions/*` action below is pinned to an immutable commit SHA, with
+# the human-readable version in the trailing comment. A tag like `@v3` is a
+# mutable pointer the upstream owner can re-point at any commit, so an upstream
+# account compromise lands in the next release build with no change on our side
+# and nothing in the diff to review.
+#
+# This workflow is where that matters most, and the blast radius is wider than
+# "a bad binary":
+#   - The `release` job holds `contents: write` (publishes the GitHub release),
+#     `id-token: write` and `attestations: write` (mints GitHub attestations and
+#     npm provenance), and reads NPM_TOKEN. Anything running there can sign a
+#     forged artifact with this workflow's own identity — which is exactly the
+#     signal consumers are told to trust over SHA256SUMS.txt.
+#   - The build jobs hold no credentials, but they produce the .a/.so/.dylib/.dll
+#     that the release job then attests. Tampering there launders a backdoor
+#     through our provenance rather than around it.
+#
+# `actions/*` is GitHub's own org, served from the same trust root as the runner
+# and the token; it is deliberately left on major tags. cla.yml pins its one
+# third-party action the same way.
+#
+# To bump: replace the SHA and the trailing version comment together. Dependabot
+# does this automatically for actions that publish semver tags (`github-actions`
+# ecosystem in .github/dependabot.yml). Verify a SHA with:
+#   gh api repos/<owner>/<repo>/commits/<sha> --jq .commit.message
+#
+# dtolnay/rust-toolchain is the exception to both halves of that. It publishes no
+# per-release tags — `stable` is a *branch*, so the pin is that branch's head and
+# the trailing comment names the branch rather than a version. It is also on
+# dependabot.yml's ignore list (for ci.yml's MSRV pin), so these SHAs are bumped
+# by hand; re-pin from `gh api repos/dtolnay/rust-toolchain/commits/stable`.
+# Pinning does not freeze the Rust version — rustup still resolves `stable` at
+# run time — but it does freeze which toolchain the action *defaults* to, which
+# the ref used to carry and a SHA does not. Hence the explicit `toolchain:
+# stable` at every call site: without it, re-pinning from a version branch such
+# as `1.87.0` would silently change the toolchain instead of failing loudly.
+# ---------------------------------------------------------------------------
+
 jobs:
   build-ios:
     name: Build iOS Libraries
@@ -40,11 +81,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: release-ios
 
@@ -99,16 +141,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: release-android-${{ matrix.abi }}
 
       - name: Setup Android NDK
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1.6.0
         id: setup-ndk
         with:
           ndk-version: r26b
@@ -156,7 +199,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Cache uniffi-bindgen
         id: cache-uniffi
@@ -212,11 +257,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: release-desktop-macos-${{ matrix.arch }}
 
@@ -261,11 +307,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: release-desktop-linux-${{ matrix.arch }}
 
@@ -308,11 +355,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           targets: x86_64-pc-windows-msvc
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: release-desktop-windows
 
@@ -350,7 +398,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Cache uniffi-bindgen
         id: cache-uniffi
@@ -520,9 +570,7 @@ jobs:
           fetch-depth: 0
 
       # Pre-built binary — no Rust toolchain needed
-      # Pinned because this job later receives release credentials. Update the
-      # SHA when intentionally upgrading taiki-e/install-action v2.
-      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2
+      - uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: git-cliff
 
@@ -674,7 +722,7 @@ jobs:
 
       - name: Create GitHub Release
         if: inputs.dry_run != true
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           body_path: RELEASE_NOTES.md
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ env:
 # ---------------------------------------------------------------------------
 # Third-party action pinning
 #
-# Every non-`actions/*` action below is pinned to an immutable commit SHA, with
-# the human-readable version in the trailing comment. A tag like `@v3` is a
-# mutable pointer the upstream owner can re-point at any commit, so an upstream
-# account compromise lands in the next release build with no change on our side
-# and nothing in the diff to review.
+# Every third-party action below, and every `actions/*` action in the `release`
+# job, is pinned to an immutable commit SHA with the human-readable version in
+# the trailing comment. A tag like `@v3` is a mutable pointer the upstream owner
+# can re-point at any commit, so an upstream account compromise lands in the next
+# release build with no change on our side and nothing in the diff to review.
 #
 # This workflow is where that matters most, and the blast radius is wider than
 # "a bad binary":
@@ -54,19 +54,31 @@ env:
 #     through our provenance rather than around it.
 #
 # `actions/*` is GitHub's own org, served from the same trust root as the runner
-# and the token; it is deliberately left on major tags. cla.yml pins its one
-# third-party action the same way.
+# and the token, so in the credential-free build jobs it is deliberately left on
+# major tags. The `release` job is the exception, because there the argument
+# above turns back on itself: `attest-build-provenance` is the action that
+# *mints* the signature consumers are told to trust, `download-artifact` is what
+# hands it the binaries to sign, and `setup-node` configures the registry the
+# NPM_TOKEN publish authenticates against. Leaving those mutable would reopen
+# exactly the hole the rest of this pinning closes. Org membership does not cover
+# it either — the attack that actually happens is tag re-pointing from a
+# compromised maintainer account (tj-actions/changed-files, March 2025), not a
+# breach of GitHub itself. All of them publish semver tags, so Dependabot keeps
+# these current. cla.yml pins its one third-party action the same way.
 #
 # To bump: replace the SHA and the trailing version comment together. Dependabot
 # does this automatically for actions that publish semver tags (`github-actions`
 # ecosystem in .github/dependabot.yml). Verify a SHA with:
 #   gh api repos/<owner>/<repo>/commits/<sha> --jq .commit.message
 #
-# dtolnay/rust-toolchain is the exception to both halves of that. It publishes no
-# per-release tags — `stable` is a *branch*, so the pin is that branch's head and
-# the trailing comment names the branch rather than a version. It is also on
-# dependabot.yml's ignore list (for ci.yml's MSRV pin), so these SHAs are bumped
-# by hand; re-pin from `gh api repos/dtolnay/rust-toolchain/commits/stable`.
+# dtolnay/rust-toolchain is the exception to both halves of that. Its only tag is
+# a stale major `v1` (e97e2d8, Aug 2025) — it publishes no per-release tags, and
+# `stable` is a *branch*, so the pin is that branch's head and the trailing
+# comment names the branch rather than a version. It is also on dependabot.yml's
+# ignore list, which does double duty: it keeps ci.yml's MSRV pin intact, and it
+# stops Dependabot re-pointing the SHAs below at that year-old `v1`. So these are
+# bumped by hand; re-pin from
+# `gh api repos/dtolnay/rust-toolchain/commits/stable`.
 # Pinning does not freeze the Rust version — rustup still resolves `stable` at
 # run time — but it does freeze which toolchain the action *defaults* to, which
 # the ref used to carry and a SHA does not. Hence the explicit `toolchain:
@@ -565,7 +577,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -578,20 +590,20 @@ jobs:
         run: git-cliff --latest --strip header -o RELEASE_NOTES.md
 
       - name: Download iOS Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ios-libs
           path: bindings/react-native/ios
 
       - name: Download Android Libraries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: android-jniLibs-*
           path: bindings/react-native/android/src/main/jniLibs
           merge-multiple: true
 
       - name: Download Android Bindings
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: android-uniffi-bindings
           path: bindings/react-native/android/src/main/java
@@ -600,7 +612,7 @@ jobs:
       # release. Each build-desktop job uploads under desktop-libs/<platform>/,
       # so merging the four is collision-free.
       - name: Download desktop libraries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: desktop-*
           path: desktop-libs
@@ -610,7 +622,7 @@ jobs:
       # module, because the cdylib alone is not usable: it is what calls into
       # the library, and until now it shipped only inside the Python wheels.
       - name: Download Python bindings
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-bindings
           path: bindings/python/offline_protocol_sdk
@@ -655,7 +667,7 @@ jobs:
           echo "All artifacts verified."
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -716,7 +728,7 @@ jobs:
       # with `gh attestation verify <asset> --repo ${{ github.repository }}`.
       - name: Attest release asset provenance
         if: inputs.dry_run != true
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: 'release-assets/*'
 


### PR DESCRIPTION
## What

Pins the four unpinned third-party actions in `release.yml` to immutable commit SHAs, and folds in Dependabot #340 so the one action that *was* already pinned lands current.

| action | before | after |
|---|---|---|
| `dtolnay/rust-toolchain` ×7 | `@stable` (a **branch**) | `4360b52` `# stable` |
| `Swatinem/rust-cache` ×5 | `@v2` | `6323deb` `# v2.9.2` |
| `nttld/setup-ndk` ×1 | `@v1` | `ed92fe6` `# v1.6.0` |
| `softprops/action-gh-release` ×1 | `@v3` | `3d0d988` `# v3.0.2` |
| `taiki-e/install-action` ×1 | `43aecc8` `# v2` | `cb33e69` `# v2.85.8` |

**Functionally a no-op.** Every SHA is the commit its mutable ref resolves to *right now*, verified against upstream:

```
$ gh api repos/<owner>/<repo>/commits/<sha> --jq .commit.message
dtolnay/rust-toolchain       4360b52  ->  "toolchain: stable"   (= stable branch head)
Swatinem/rust-cache          6323deb  ->  "2.9.2"               (= v2 tag head)
nttld/setup-ndk              ed92fe6  ->  "1.6.0"               (= v1 tag head)
softprops/action-gh-release  3d0d988  ->  "release 3.0.2 (#818)" (= v3 tag head)
taiki-e/install-action       cb33e69  ->  "Release 2.85.8"
```

## Why

`taiki-e/install-action` already carried the comment *"Pinned because this job later receives release credentials."* The reasoning was right; it just wasn't applied to the other four — one of which runs **in that same job**.

A tag is a mutable pointer the upstream owner can re-point at any commit. An upstream account compromise therefore lands in the next release build with no change on our side and nothing in the diff to review. `dtolnay/rust-toolchain` was worse than a tag: `stable` is a *branch*.

The blast radius grew when #314 added attestations:

- The **`release` job** holds `contents: write`, `id-token: write`, `attestations: write`, and reads `NPM_TOKEN`. `softprops/action-gh-release@v3` runs there. Anything executing in that job can mint GitHub attestations and npm provenance signed by this workflow's own identity — forging exactly the signal [we tell consumers to trust over `SHA256SUMS.txt`](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/.github/workflows/release.yml) ("whoever can replace an asset can replace the manifest in the same operation").
- The **build jobs** hold no credentials, but they produce the `.a`/`.so`/`.dylib`/`.dll` the release job then attests. Tampering there launders a backdoor *through* our provenance rather than around it.

## Notes for review

**1. `actions/*` deliberately left on major tags.** GitHub's own org, served from the same trust root as the runner and the token. This matches `cla.yml`, which pins its one third-party action and nothing else. Say the word if you'd rather pin everything.

**2. Every `dtolnay/rust-toolchain` site gains an explicit `toolchain: stable`.** This is a necessary companion to the pin, not scope creep. The action reads its default toolchain from the *branch's own* `action.yml` (`stable` branch → `default: stable`), so the ref used to carry that information and an opaque SHA does not. Without the input, re-pinning from a version branch such as `1.87.0` — plausible here, since `ci.yml` pins exactly that for MSRV — would **silently** change the toolchain rather than fail loudly.

Pinning does **not** freeze the Rust version: rustup still resolves `stable` at run time. Only the action's code is frozen.

**3. `dependabot.yml` comment corrected.** Its rationale for ignoring `dtolnay/rust-toolchain` was *"Our four other uses of this action are `@stable`, which Dependabot does not version-bump, so ignoring the action outright costs us nothing."* The conclusion still holds but the stated reason no longer does. The comment now gives the real one: `dtolnay/rust-toolchain` publishes no per-release tags at all, so there is nothing for Dependabot to compare against in either file, and `release.yml`'s pins are bumped by hand (procedure is in the new header comment).

The other four **are** semver-tagged, so Dependabot will keep those pins current automatically via the existing `github-actions` ecosystem entry — including its 7-day cooldown.

**4. Supersedes #340.** That PR bumps `taiki-e/install-action` 2.83.2 → 2.85.8 on a line this PR also touches. I verified `cb33e69` is exactly the commit tagged `v2.85.8` and folded it in. Both make the identical one-line change, so this merges cleanly regardless of ordering.

## Out of scope

`ci.yml` has the same unpinned third-party actions (`dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `android-actions/setup-android`, `EmbarkStudios/cargo-deny-action`, `gradle/actions/setup-gradle`). It runs with `permissions: contents: read` and publishes nothing, so the exposure is materially lower and the audit item was scoped to `release.yml`. Happy to do it as a follow-up.

## Testing

YAML-parse-checked (`release.yml`, `ci.yml`, `cla.yml`, `dependabot.yml`), and every pinned SHA re-resolved against upstream from the edited file. No Rust code touched, so no test run.

The real proof is a `workflow_dispatch` dry run (`dry_run: true` skips only the publish steps) — worth doing before the next tag.