### PR TITLE
ci(release): publish the Cargo workspace to crates.io alongside npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,14 +49,18 @@ env:
 #     npm provenance), and reads NPM_TOKEN. Anything running there can sign a
 #     forged artifact with this workflow's own identity — which is exactly the
 #     signal consumers are told to trust over SHA256SUMS.txt.
+#   - The `publish-crates` job reads CARGO_REGISTRY_TOKEN. Anything running
+#     there can publish arbitrary code to crates.io under this project's crate
+#     names — and crates.io versions are immutable, so a poisoned publish can
+#     only be yanked, never replaced.
 #   - The build jobs hold no credentials, but they produce the .a/.so/.dylib/.dll
 #     that the release job then attests. Tampering there launders a backdoor
 #     through our provenance rather than around it.
 #
 # `actions/*` is GitHub's own org, served from the same trust root as the runner
 # and the token, so in the credential-free build jobs it is deliberately left on
-# major tags. The `release` job is the exception, because there the argument
-# above turns back on itself: `attest-build-provenance` is the action that
+# major tags. The `release` and `publish-crates` jobs are the exceptions,
+# because there the argument above turns back on itself: `attest-build-provenance` is the action that
 # *mints* the signature consumers are told to trust, `download-artifact` is what
 # hands it the binaries to sign, and `setup-node` configures the registry the
 # NPM_TOKEN publish authenticates against. Leaving those mutable would reopen
@@ -784,3 +788,122 @@ jobs:
         run: npm publish --access public ${{ steps.provenance.outputs.FLAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # crates.io
+  # ---------------------------------------------------------------------------
+
+  publish-crates:
+    name: Publish to crates.io
+    # Same gates as the npm release job, so the two publishes start together
+    # and run in parallel — and nothing publishes to either registry unless
+    # every build and test job is green. This job consumes none of those
+    # artifacts; the shared `needs` list exists purely for that all-or-nothing
+    # property.
+    needs: [build-ios, build-android, android-bindings, build-desktop-macos, build-desktop-linux, build-desktop-windows, python-bindings, test-python, audit-python]
+    runs-on: ubuntu-latest
+    env:
+      # crates.io publishes are immutable — a version can be yanked but never
+      # replaced — so a prerelease tag must not burn the workspace version the
+      # final tag will need. Prerelease runs get the dry-run verification only.
+      PRERELEASE_TAG: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+    steps:
+      # Fail in seconds, not after the verify builds: cargo only discovers a
+      # missing token at upload time, minutes of packaging work in.
+      - name: Ensure crates.io token is configured
+        if: inputs.dry_run != true && env.PRERELEASE_TAG != 'true'
+        env:
+          TOKEN_SET: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
+        run: |
+          if [ "$TOKEN_SET" != "true" ]; then
+            echo "::error title=CARGO_REGISTRY_TOKEN missing::Add a crates.io API token (scopes: publish-new, publish-update) as the CARGO_REGISTRY_TOKEN repository secret."
+            exit 1
+          fi
+
+      # SHA-pinned like the release job's actions: this job holds a publish
+      # credential, and these two actions decide what source gets packaged and
+      # which toolchain publishes it (see the pinning note at the top of this
+      # file).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
+
+      # No rust-cache here, unlike the build jobs: restored cache artifacts
+      # (dependency rlibs, build-script executables) execute inside the verify
+      # builds below, an injection vector a credential-holding job doesn't need
+      # to accept for one release-time build.
+
+      # Packages every publishable crate (bench is `publish = false`) and runs
+      # the verify builds, resolving workspace siblings from cargo's local
+      # overlay — so this works even before anything exists on the registry.
+      - name: Verify packaging (dry run)
+        if: inputs.dry_run == true || env.PRERELEASE_TAG == 'true'
+        run: cargo publish --workspace --locked --dry-run
+
+      # cargo-workspaces publishes every publishable crate in topological
+      # order and unconditionally skips versions that already exist on the
+      # registry. Both halves are load-bearing: the order means no
+      # hand-maintained crate list to drift when a workspace member is added,
+      # and the skip is what makes this step resumable — crates.io publishes
+      # are immutable and not atomic, so a run that dies partway (a rate
+      # limit, a network fault) leaves some crates published and some not,
+      # and the re-run must pick up where the last one stopped rather than
+      # choke on the crates that already landed. Native `cargo publish
+      # --workspace` covers neither: it refuses to proceed once any member
+      # already exists at the target version. All eight names are already
+      # reserved on crates.io at 0.0.0 under the offline-protocol maintainers
+      # team, so every publish here is a new version of an existing crate —
+      # the much stricter brand-new-crate-name rate limit does not apply.
+      #
+      # Compiled fresh with --locked rather than cached (wrkflw-style
+      # actions/cache would be faster): a cached binary executes with the
+      # registry token in its environment, the same poisoning vector the
+      # missing rust-cache note above declines.
+      - name: Install cargo-workspaces
+        if: inputs.dry_run != true && env.PRERELEASE_TAG != 'true'
+        run: cargo install cargo-workspaces@0.4.2 --locked
+
+      # The published version is the Cargo workspace version
+      # ([workspace.package] in Cargo.toml), NOT the release tag — the two are
+      # decoupled by design (CHANGELOG 0.11.0 "Licensing"). A tag that ships
+      # no Rust changes finds every crate already published and no-ops (the
+      # pre-check below makes that loud); shipping Rust changes means bumping
+      # [workspace.package].version and the internal-dependency versions
+      # beside it before tagging. --publish-as-is (hidden alias: --from-git)
+      # publishes the manifests exactly as committed, which keeps that
+      # contract — without it, `cargo workspaces publish` runs its interactive
+      # version-bump/commit/tag flow first, which must never happen here.
+      #
+      # Deliberately NOT --locked, unlike every other cargo invocation in this
+      # workflow: cargo-workspaces temporarily strips [dev-dependencies] from
+      # any crate whose dev-deps name workspace siblings with versions
+      # (offline-protocol-uniffi), and a manifest whose dep set shrank needs a
+      # lockfile update, which --locked refuses — so the run would publish
+      # seven crates and then die on the eighth. The dry-run pre-flight above
+      # keeps --locked, because native workspace publish leaves manifests
+      # alone; it, not this step, is where lockfile drift gets caught.
+      - name: Publish crates
+        if: inputs.dry_run != true && env.PRERELEASE_TAG != 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          VERSION="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "offline-protocol") | .version')"
+
+          # All workspace crates version in lockstep, and offline-protocol sits
+          # atop the internal dependency graph — so if it is already published
+          # at this version, the whole run is a no-op. Say so as a warning
+          # annotation rather than letting eight "skipping" lines scroll by:
+          # the likely cause is a tag that meant to ship Rust changes without
+          # bumping the workspace version, which can't be fixed by re-running.
+          url="https://index.crates.io/of/fl/offline-protocol"
+          if curl -fsS --retry 3 "$url" 2>/dev/null \
+            | jq -e --arg v "$VERSION" 'select(.vers == $v)' >/dev/null; then
+            echo "::warning title=crates.io publish is a no-op::offline-protocol@$VERSION already exists, so every crate below it does too. If this tag was meant to ship Rust changes, bump [workspace.package].version (and the internal-dependency versions beside it in [workspace.dependencies]) and cut a new tag."
+          fi
+
+          cargo workspaces publish --publish-as-is --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -698,6 +698,26 @@ jobs:
 
           printf 'VERSION=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
 
+          # A prerelease must not become what a plain `npm install` resolves to.
+          # npm dist-tags every publish `latest` unless told otherwise, so
+          # without this an `-rc` tag would quietly become the default version
+          # for every consumer. That matters more now than it used to: the
+          # crates job treats prerelease tags as free rehearsal — every gate and
+          # the full packaging verification run, only the immutable upload is
+          # skipped — which makes cutting one a reasonable thing to do rather
+          # than a rarity.
+          #
+          # Derived from the resolved, semver-validated version rather than the
+          # ref, so a branch dispatch off a hyphenated branch name cannot trip
+          # it.
+          if [[ "$VERSION" == *-* ]]; then
+            NPM_TAG=next
+          else
+            NPM_TAG=latest
+          fi
+          printf 'NPM_TAG=%s\n' "$NPM_TAG" >> "$GITHUB_OUTPUT"
+          echo "Version $VERSION publishes under the '$NPM_TAG' npm dist-tag."
+
       - name: Update package.json version
         working-directory: bindings/react-native
         env:
@@ -787,9 +807,10 @@ jobs:
       - name: Publish to npm
         if: inputs.dry_run != true
         working-directory: bindings/react-native
-        run: npm publish --access public ${{ steps.provenance.outputs.FLAG }}
+        run: npm publish --access public --tag "$NPM_TAG" ${{ steps.provenance.outputs.FLAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TAG: ${{ steps.version.outputs.NPM_TAG }}
 
   # ---------------------------------------------------------------------------
   # crates.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,12 @@ env:
 # `actions/*` is GitHub's own org, served from the same trust root as the runner
 # and the token, so in the credential-free build jobs it is deliberately left on
 # major tags. The `release` and `publish-crates` jobs are the exceptions,
-# because there the argument above turns back on itself: `attest-build-provenance` is the action that
-# *mints* the signature consumers are told to trust, `download-artifact` is what
-# hands it the binaries to sign, and `setup-node` configures the registry the
-# NPM_TOKEN publish authenticates against. Leaving those mutable would reopen
+# because there the argument above turns back on itself:
+# `attest-build-provenance` is the action that *mints* the signature consumers
+# are told to trust, `download-artifact` is what hands it the binaries to sign,
+# `setup-node` configures the registry the NPM_TOKEN publish authenticates
+# against, and `checkout` decides which source gets packaged into the .crate
+# files CARGO_REGISTRY_TOKEN uploads. Leaving those mutable would reopen
 # exactly the hole the rest of this pinning closes. Org membership does not cover
 # it either — the attack that actually happens is tag re-pointing from a
 # compromised maintainer account (tj-actions/changed-files, March 2025), not a
@@ -803,15 +805,27 @@ jobs:
     needs: [build-ios, build-android, android-bindings, build-desktop-macos, build-desktop-linux, build-desktop-windows, python-bindings, test-python, audit-python]
     runs-on: ubuntu-latest
     env:
-      # crates.io publishes are immutable — a version can be yanked but never
-      # replaced — so a prerelease tag must not burn the workspace version the
-      # final tag will need. Prerelease runs get the dry-run verification only.
-      PRERELEASE_TAG: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+      # The single gate on every step that uploads. Three conditions, each
+      # guarding a failure this registry cannot undo:
+      #
+      #   - a tag ref, because a `workflow_dispatch` from a branch with the
+      #     dry-run box unchecked would otherwise publish branch code and burn
+      #     the workspace version permanently. npm survives that mistake (72h
+      #     unpublish window, and its version comes from the tag or falls to
+      #     0.0.0-dev); crates.io has no equivalent escape.
+      #   - not a dry run, matching the npm job.
+      #   - not a prerelease, because crates.io versions are immutable — a
+      #     version can be yanked but never replaced — so an -rc tag must not
+      #     burn the version its final tag will need.
+      #
+      # Dry runs and prerelease tags still run the version gate and the full
+      # packaging verification below; they just stop short of uploading.
+      REAL_PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true && !contains(github.ref, '-alpha') && !contains(github.ref, '-beta') && !contains(github.ref, '-rc') }}
     steps:
       # Fail in seconds, not after the verify builds: cargo only discovers a
       # missing token at upload time, minutes of packaging work in.
       - name: Ensure crates.io token is configured
-        if: inputs.dry_run != true && env.PRERELEASE_TAG != 'true'
+        if: env.REAL_PUBLISH == 'true'
         env:
           TOKEN_SET: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
         run: |
@@ -831,15 +845,74 @@ jobs:
           toolchain: stable
 
       # No rust-cache here, unlike the build jobs: restored cache artifacts
-      # (dependency rlibs, build-script executables) execute inside the verify
-      # builds below, an injection vector a credential-holding job doesn't need
-      # to accept for one release-time build.
+      # (dependency rlibs, build-script executables) execute during the
+      # packaging verification and the cargo-workspaces build below, both of
+      # them inside a job that holds a publish credential. Not an injection
+      # vector worth accepting to save one release-time build.
+
+      # The crate version is the workspace version, and it must equal the tag —
+      # the two version in lockstep with the npm package, so `offline-protocol
+      # 0.21.0` on crates.io is the same release as `v0.21.0` and
+      # `@offline-protocol/mesh-sdk@0.21.0`.
+      #
+      # This is verified rather than written. The npm job sets its version from
+      # the tag, but the same trick is unavailable here and would be wrong
+      # anyway: Cargo.lock pins the workspace members' own versions, so
+      # rewriting the manifests at release time invalidates it and the --locked
+      # verification below stops working — and the published .crate would no
+      # longer match the tag it claims to come from, which is the property the
+      # release attestations exist to make checkable.
+      #
+      # So the bump is part of the release cut (see CONTRIBUTING.md) and this
+      # step is what makes forgetting it loud. Failing here costs a re-tag;
+      # not failing costs a permanent, immutable, wrongly-numbered publish.
+      # Runs on prerelease and dry-run tags too, where it is free rehearsal.
+      - name: Verify the workspace version matches the tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          # A prerelease suffix lives on the tag only: v0.21.0-rc.1 rehearses
+          # the 0.21.0 the workspace already carries. Compare the release cores.
+          TAG_CORE="${TAG_VERSION%%-*}"
+          TAG_CORE="${TAG_CORE%%+*}"
+
+          CARGO_VERSION="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "offline-protocol") | .version')"
+
+          if [ "$TAG_CORE" != "$CARGO_VERSION" ]; then
+            echo "::error title=Workspace version does not match the tag::Tag v$TAG_VERSION wants crates at $TAG_CORE, but [workspace.package].version is $CARGO_VERSION. Bump it and the seven internal-dependency versions in [workspace.dependencies] together (they must agree or the workspace will not resolve), refresh Cargo.lock, and re-tag."
+            exit 1
+          fi
+
+          echo "Workspace version $CARGO_VERSION matches tag v$TAG_VERSION."
 
       # Packages every publishable crate (bench is `publish = false`) and runs
       # the verify builds, resolving workspace siblings from cargo's local
       # overlay — so this works even before anything exists on the registry.
-      - name: Verify packaging (dry run)
-        if: inputs.dry_run == true || env.PRERELEASE_TAG == 'true'
+      #
+      # Unconditional, and that is the point: this is the only verification the
+      # real publish gets. crates.io uploads are immutable and not atomic, so a
+      # packaging defect discovered at crate six leaves five published at a
+      # version the run can never complete — and since all eight version in
+      # lockstep, the whole workspace has to skip to the next number with that
+      # one half-published forever. The skip-already-published resumability
+      # below rescues transient faults (a rate limit, a dropped connection),
+      # never a deterministic one. Running this first turns that class into a
+      # failed job with nothing uploaded.
+      #
+      # It also runs with no token in the environment, which is what lets the
+      # publish step below skip its own verify builds — see there.
+      #
+      # Safe to run unconditionally only because dry-run mode downgrades an
+      # already-published version to `warning: crate X@Y already exists on
+      # crates.io index` and still exits 0 (verified against the real registry
+      # on cargo 1.97). Were it an error, this step would break exactly the
+      # re-run it exists to protect. Note that is dry-run behaviour only — in
+      # real mode native workspace publish does refuse, which is the whole
+      # reason the publish below goes through cargo-workspaces.
+      - name: Verify packaging
         run: cargo publish --workspace --locked --dry-run
 
       # cargo-workspaces publishes every publishable crate in topological
@@ -862,30 +935,36 @@ jobs:
       # registry token in its environment, the same poisoning vector the
       # missing rust-cache note above declines.
       - name: Install cargo-workspaces
-        if: inputs.dry_run != true && env.PRERELEASE_TAG != 'true'
+        if: env.REAL_PUBLISH == 'true'
         run: cargo install cargo-workspaces@0.4.2 --locked
 
-      # The published version is the Cargo workspace version
-      # ([workspace.package] in Cargo.toml), NOT the release tag — the two are
-      # decoupled by design (CHANGELOG 0.11.0 "Licensing"). A tag that ships
-      # no Rust changes finds every crate already published and no-ops (the
-      # pre-check below makes that loud); shipping Rust changes means bumping
-      # [workspace.package].version and the internal-dependency versions
-      # beside it before tagging. --publish-as-is (hidden alias: --from-git)
-      # publishes the manifests exactly as committed, which keeps that
-      # contract — without it, `cargo workspaces publish` runs its interactive
-      # version-bump/commit/tag flow first, which must never happen here.
+      # --publish-as-is (hidden alias: --from-git) publishes the manifests
+      # exactly as committed. Without it, `cargo workspaces publish` runs its
+      # interactive version-bump/commit/tag flow first, which must never happen
+      # here — the version gate above already established that what is
+      # committed is what this tag is supposed to ship.
+      #
+      # --no-verify, because the verification already ran: the packaging step
+      # above builds every crate from the committed manifests, with --locked
+      # and with no credential in the environment. Repeating it here would
+      # compile build scripts and proc macros — third-party code, at versions
+      # this invocation cannot pin (see --locked below) — in a step holding the
+      # registry token. That is the same poisoning vector the missing
+      # rust-cache and the uncached cargo-workspaces binary above both decline,
+      # and declining it twice while accepting it here would be incoherent.
+      # Stripped dev-deps only shrink the build, so nothing verified above can
+      # break here.
       #
       # Deliberately NOT --locked, unlike every other cargo invocation in this
       # workflow: cargo-workspaces temporarily strips [dev-dependencies] from
       # any crate whose dev-deps name workspace siblings with versions
-      # (offline-protocol-uniffi), and a manifest whose dep set shrank needs a
-      # lockfile update, which --locked refuses — so the run would publish
-      # seven crates and then die on the eighth. The dry-run pre-flight above
-      # keeps --locked, because native workspace publish leaves manifests
-      # alone; it, not this step, is where lockfile drift gets caught.
+      # (offline-protocol and offline-protocol-uniffi), and a manifest whose
+      # dep set shrank needs a lockfile update, which --locked refuses — so the
+      # run would publish six crates and then die on the seventh. The packaging
+      # step above keeps --locked, because native workspace publish leaves
+      # manifests alone; it, not this step, is where lockfile drift gets caught.
       - name: Publish crates
-        if: inputs.dry_run != true && env.PRERELEASE_TAG != 'true'
+        if: env.REAL_PUBLISH == 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
@@ -897,13 +976,15 @@ jobs:
           # All workspace crates version in lockstep, and offline-protocol sits
           # atop the internal dependency graph — so if it is already published
           # at this version, the whole run is a no-op. Say so as a warning
-          # annotation rather than letting eight "skipping" lines scroll by:
-          # the likely cause is a tag that meant to ship Rust changes without
-          # bumping the workspace version, which can't be fixed by re-running.
+          # annotation rather than letting eight "skipping" lines scroll by.
+          # Since the version gate above pins the version to the tag, this can
+          # only mean a re-run of a release that already published, which is
+          # exactly what the skip below exists to make safe — but it is worth
+          # saying out loud, because the run reports success either way.
           url="https://index.crates.io/of/fl/offline-protocol"
           if curl -fsS --retry 3 "$url" 2>/dev/null \
             | jq -e --arg v "$VERSION" 'select(.vers == $v)' >/dev/null; then
-            echo "::warning title=crates.io publish is a no-op::offline-protocol@$VERSION already exists, so every crate below it does too. If this tag was meant to ship Rust changes, bump [workspace.package].version (and the internal-dependency versions beside it in [workspace.dependencies]) and cut a new tag."
+            echo "::warning title=crates.io publish is a no-op::offline-protocol@$VERSION already exists, so every crate below it does too. This run published nothing — expected when re-running a release that already reached crates.io."
           fi
 
-          cargo workspaces publish --publish-as-is --yes
+          cargo workspaces publish --publish-as-is --no-verify --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -814,13 +814,24 @@ jobs:
       #     unpublish window, and its version comes from the tag or falls to
       #     0.0.0-dev); crates.io has no equivalent escape.
       #   - not a dry run, matching the npm job.
-      #   - not a prerelease, because crates.io versions are immutable — a
-      #     version can be yanked but never replaced — so an -rc tag must not
-      #     burn the version its final tag will need.
+      #   - no hyphen anywhere in the tag, because crates.io versions are
+      #     immutable — a version can be yanked but never replaced — so an -rc
+      #     tag must not burn the version its final tag will need.
+      #
+      # That last one is a blanket hyphen test rather than the release job's
+      # `-alpha`/`-beta`/`-rc` list, and the difference matters here in a way it
+      # does not there. A suffix the list misses (`-pre.1`, `-next.1`, a typo
+      # like `-cr.1`) still clears the version gate below, which compares
+      # release cores — so `v0.21.0-pre.1` against a 0.21.0 workspace would
+      # really publish the final, immutable 0.21.0 from prerelease code, and the
+      # eventual v0.21.0 tag would then no-op on crates.io while npm and the
+      # GitHub release ship the real thing. Nothing is lost by the broader test:
+      # a hyphenated *workspace* version can never match a core-compared tag, so
+      # no hyphenated tag can legitimately reach a real publish anyway.
       #
       # Dry runs and prerelease tags still run the version gate and the full
       # packaging verification below; they just stop short of uploading.
-      REAL_PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true && !contains(github.ref, '-alpha') && !contains(github.ref, '-beta') && !contains(github.ref, '-rc') }}
+      REAL_PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true && !contains(github.ref, '-') }}
     steps:
       # Fail in seconds, not after the verify builds: cargo only discovers a
       # missing token at upload time, minutes of packaging work in.
@@ -867,7 +878,14 @@ jobs:
       # step is what makes forgetting it loud. Failing here costs a re-tag;
       # not failing costs a permanent, immutable, wrongly-numbered publish.
       # Runs on prerelease and dry-run tags too, where it is free rehearsal.
-      - name: Verify the workspace version matches the tag
+      #
+      # pyproject.toml is checked alongside it because it tracks this same
+      # number — it followed the Cargo version before this job existed, and
+      # leaving it unchecked is how it quietly becomes a third scheme. A
+      # mismatch there fails the crates job rather than the wheel build, which
+      # is the useful direction: this is the publish that cannot be corrected
+      # afterwards, so it is the one that should refuse an inconsistent release.
+      - name: Verify the release versions match the tag
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           set -euo pipefail
@@ -882,11 +900,21 @@ jobs:
             | jq -r '.packages[] | select(.name == "offline-protocol") | .version')"
 
           if [ "$TAG_CORE" != "$CARGO_VERSION" ]; then
-            echo "::error title=Workspace version does not match the tag::Tag v$TAG_VERSION wants crates at $TAG_CORE, but [workspace.package].version is $CARGO_VERSION. Bump it and the seven internal-dependency versions in [workspace.dependencies] together (they must agree or the workspace will not resolve), refresh Cargo.lock, and re-tag."
+            echo "::error title=Workspace version does not match the tag::Tag v$TAG_VERSION wants crates at $TAG_CORE, but [workspace.package].version is $CARGO_VERSION. Bump it together with the seven internal-dependency versions in [workspace.dependencies], refresh Cargo.lock, and re-tag."
             exit 1
           fi
 
-          echo "Workspace version $CARGO_VERSION matches tag v$TAG_VERSION."
+          # `|| true` so a missing or renamed key reports through the annotation
+          # below rather than aborting the step with no explanation.
+          PY_VERSION="$(grep -m1 '^version = ' bindings/python/pyproject.toml \
+            | cut -d'"' -f2 || true)"
+
+          if [ "$TAG_CORE" != "$PY_VERSION" ]; then
+            echo "::error title=Python package version does not match the tag::Tag v$TAG_VERSION wants $TAG_CORE, but bindings/python/pyproject.toml reads '${PY_VERSION}'. It moves with the workspace version — bump it and re-tag."
+            exit 1
+          fi
+
+          echo "Workspace and Python versions ($CARGO_VERSION) match tag v$TAG_VERSION."
 
       # Packages every publishable crate (bench is `publish = false`) and runs
       # the verify builds, resolving workspace siblings from cargo's local
@@ -973,18 +1001,26 @@ jobs:
           VERSION="$(cargo metadata --no-deps --format-version 1 \
             | jq -r '.packages[] | select(.name == "offline-protocol") | .version')"
 
-          # All workspace crates version in lockstep, and offline-protocol sits
-          # atop the internal dependency graph — so if it is already published
-          # at this version, the whole run is a no-op. Say so as a warning
-          # annotation rather than letting eight "skipping" lines scroll by.
-          # Since the version gate above pins the version to the tag, this can
-          # only mean a re-run of a release that already published, which is
-          # exactly what the skip below exists to make safe — but it is worth
-          # saying out loud, because the run reports success either way.
-          url="https://index.crates.io/of/fl/offline-protocol"
+          # All workspace crates version in lockstep, and offline-protocol-uniffi
+          # sits atop the internal dependency graph — it is what the topological
+          # publish below reaches last — so if it is already published at this
+          # version, every other crate is too and the whole run is a no-op. Say
+          # so as a warning annotation rather than letting eight "skipping"
+          # lines scroll by. Since the version gate above pins the version to
+          # the tag, this can only mean a re-run of a release that already
+          # published, which is exactly what the skip below exists to make safe
+          # — but it is worth saying out loud, because the run reports success
+          # either way.
+          #
+          # Probing the *last* crate rather than offline-protocol is what makes
+          # the annotation true during the incident it is read in: a run that
+          # died partway leaves the lower crates published and the top one not,
+          # and a probe aimed lower would tell the operator resuming it that
+          # nothing was left to do while the resume went on to publish.
+          url="https://index.crates.io/of/fl/offline-protocol-uniffi"
           if curl -fsS --retry 3 "$url" 2>/dev/null \
             | jq -e --arg v "$VERSION" 'select(.vers == $v)' >/dev/null; then
-            echo "::warning title=crates.io publish is a no-op::offline-protocol@$VERSION already exists, so every crate below it does too. This run published nothing — expected when re-running a release that already reached crates.io."
+            echo "::warning title=crates.io publish is a no-op::offline-protocol-uniffi@$VERSION already exists, and it is the last crate this job publishes, so every other crate does too. This run published nothing — expected when re-running a release that already reached crates.io."
           fi
 
           cargo workspaces publish --publish-as-is --no-verify --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -565,12 +565,116 @@ jobs:
           retention-days: 5
 
   # ---------------------------------------------------------------------------
+  # Release gate
+  # ---------------------------------------------------------------------------
+
+  # One number identifies a release on every channel — the `vX.Y.Z` tag, the npm
+  # package, the crates on crates.io — and this job refuses the release when the
+  # repo and the tag disagree about what that number is.
+  #
+  # It gates *both* publish jobs, and that is the whole reason it is a job at all
+  # rather than a step inside `publish-crates`, where this check started out.
+  # The two publish jobs are independent siblings behind an identical `needs`
+  # list, so a check living in one has no hold over the other. For every other
+  # way `publish-crates` can fail — a missing token, a rate limit, a dropped
+  # connection — that independence is harmless, because those are all
+  # recoverable by re-running the job against the same tag. A forgotten version
+  # bump is the exception, and it is also the mistake this whole design invites:
+  # every release through v0.20.1 was cut without touching Cargo.toml at all.
+  # Checked inside the crates job, it fails there in seconds while the npm job
+  # publishes that number to npm and cuts the GitHub release anyway — and
+  # nothing recovers that. Re-running checks out the same unbumped source, and
+  # moving the tag onto a bumped commit is precisely the force-move CONTRIBUTING
+  # now forbids. The number would be burned and the release split across
+  # registries permanently.
+  #
+  # Hoisted here, that same mistake fails the entire release with nothing
+  # published anywhere, and the tag can simply be deleted and re-pushed — which
+  # is what the error annotations below tell you to do, and it is only true
+  # because this job runs ahead of both.
+  #
+  # It `needs` nothing, so it reports within a minute of the tag push instead of
+  # queueing behind the build fan-out. The CARGO_REGISTRY_TOKEN presence check
+  # deliberately stays in `publish-crates`: that one *is* re-runnable on the same
+  # tag, so it has no business blocking npm.
+  version-gate:
+    name: Verify Release Versions
+    runs-on: ubuntu-latest
+    steps:
+      # Credential-free and artifact-free, so `actions/*` stays on a major tag
+      # per the pinning note at the top of this file. A compromise here could
+      # wave a version mismatch through; it could not publish anything, because
+      # both publish jobs check out the source they package themselves.
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
+
+      # The crate version is the workspace version, and it must equal the tag —
+      # the two version in lockstep with the npm package, so `offline-protocol
+      # 0.21.0` on crates.io is the same release as `v0.21.0` and
+      # `@offline-protocol/mesh-sdk@0.21.0`.
+      #
+      # This is verified rather than written. The npm job sets its version from
+      # the tag, but the same trick is unavailable here and would be wrong
+      # anyway: Cargo.lock pins the workspace members' own versions, so
+      # rewriting the manifests at release time invalidates it and the --locked
+      # packaging verification in `publish-crates` stops working — and the
+      # published .crate would no longer match the tag it claims to come from,
+      # which is the property the release attestations exist to make checkable.
+      #
+      # So the bump is part of the release cut (see CONTRIBUTING.md) and this
+      # step is what makes forgetting it loud. Failing here costs a re-tag; not
+      # failing costs a permanent, immutable, wrongly-numbered publish. Runs on
+      # prerelease and dry-run tags too, where it is free rehearsal.
+      #
+      # pyproject.toml is checked alongside it because it tracks this same
+      # number — it followed the Cargo version before crates.io publishing
+      # existed, and leaving it unchecked is how it quietly becomes a third
+      # scheme.
+      - name: Verify the release versions match the tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          # A prerelease suffix lives on the tag only: v0.21.0-rc.1 rehearses
+          # the 0.21.0 the workspace already carries. Compare the release cores.
+          TAG_CORE="${TAG_VERSION%%-*}"
+          TAG_CORE="${TAG_CORE%%+*}"
+
+          CARGO_VERSION="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "offline-protocol") | .version')"
+
+          if [ "$TAG_CORE" != "$CARGO_VERSION" ]; then
+            echo "::error title=Workspace version does not match the tag::Tag v$TAG_VERSION wants crates at $TAG_CORE, but [workspace.package].version is $CARGO_VERSION. Bump it together with the seven internal-dependency versions in [workspace.dependencies], refresh Cargo.lock, then delete and re-push the tag. This gate runs ahead of both publish jobs, so nothing has shipped yet and re-tagging is still safe — which it stops being the moment a release publishes."
+            exit 1
+          fi
+
+          # `|| true` so a missing or renamed key reports through the annotation
+          # below rather than aborting the step with no explanation.
+          PY_VERSION="$(grep -m1 '^version = ' bindings/python/pyproject.toml \
+            | cut -d'"' -f2 || true)"
+
+          if [ "$TAG_CORE" != "$PY_VERSION" ]; then
+            echo "::error title=Python package version does not match the tag::Tag v$TAG_VERSION wants $TAG_CORE, but bindings/python/pyproject.toml reads '${PY_VERSION}'. It moves with the workspace version — bump it, then delete and re-push the tag (nothing has published yet)."
+            exit 1
+          fi
+
+          echo "Workspace and Python versions ($CARGO_VERSION) match tag v$TAG_VERSION."
+
+  # ---------------------------------------------------------------------------
   # Release
   # ---------------------------------------------------------------------------
 
   release:
     name: Create Release & Publish to npm
-    needs: [build-ios, build-android, android-bindings, build-desktop-macos, build-desktop-linux, build-desktop-windows, python-bindings, test-python, audit-python]
+    # `version-gate` is in this list, and not only in `publish-crates`, on
+    # purpose: a version mismatch has to stop npm too. Left to fail the crates
+    # job alone, it splits the release across registries with no way back — see
+    # the long note on that job.
+    needs: [version-gate, build-ios, build-android, android-bindings, build-desktop-macos, build-desktop-linux, build-desktop-windows, python-bindings, test-python, audit-python]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -820,13 +924,15 @@ jobs:
     name: Publish to crates.io
     # Same gates as the npm release job, so the two publishes start together
     # and run in parallel — and nothing publishes to either registry unless
-    # every build and test job is green. This job consumes none of those
+    # every build and test job is green and `version-gate` has agreed the repo
+    # and the tag name the same version. This job consumes none of those
     # artifacts; the shared `needs` list exists purely for that all-or-nothing
-    # property.
-    needs: [build-ios, build-android, android-bindings, build-desktop-macos, build-desktop-linux, build-desktop-windows, python-bindings, test-python, audit-python]
+    # property, and sharing it with `release` is what keeps a version mismatch
+    # from failing one registry while the other publishes regardless.
+    needs: [version-gate, build-ios, build-android, android-bindings, build-desktop-macos, build-desktop-linux, build-desktop-windows, python-bindings, test-python, audit-python]
     runs-on: ubuntu-latest
     env:
-      # The single gate on every step that uploads. Three conditions, each
+      # The single gate on every step that uploads. Four conditions, each
       # guarding a failure this registry cannot undo:
       #
       #   - a tag ref, because a `workflow_dispatch` from a branch with the
@@ -838,21 +944,26 @@ jobs:
       #   - no hyphen anywhere in the tag, because crates.io versions are
       #     immutable — a version can be yanked but never replaced — so an -rc
       #     tag must not burn the version its final tag will need.
+      #   - no `+` either, by the same argument: `version-gate` strips build
+      #     metadata before comparing, so `v0.21.0+hotfix` would otherwise clear
+      #     it and really publish an immutable 0.21.0. `+` is legal in a git
+      #     refname, so this is reachable, not theoretical.
       #
-      # That last one is a blanket hyphen test rather than the release job's
+      # Those last two are blanket character tests rather than the release job's
       # `-alpha`/`-beta`/`-rc` list, and the difference matters here in a way it
       # does not there. A suffix the list misses (`-pre.1`, `-next.1`, a typo
-      # like `-cr.1`) still clears the version gate below, which compares
-      # release cores — so `v0.21.0-pre.1` against a 0.21.0 workspace would
-      # really publish the final, immutable 0.21.0 from prerelease code, and the
-      # eventual v0.21.0 tag would then no-op on crates.io while npm and the
-      # GitHub release ship the real thing. Nothing is lost by the broader test:
-      # a hyphenated *workspace* version can never match a core-compared tag, so
-      # no hyphenated tag can legitimately reach a real publish anyway.
+      # like `-cr.1`) still clears `version-gate`, which compares release cores
+      # — so `v0.21.0-pre.1` against a 0.21.0 workspace would really publish the
+      # final, immutable 0.21.0 from prerelease code, and the eventual v0.21.0
+      # tag would then no-op on crates.io while npm and the GitHub release ship
+      # the real thing. Nothing is lost by the broader test: a workspace version
+      # carrying either character can never match a core-compared tag, so no
+      # such tag can legitimately reach a real publish anyway.
       #
-      # Dry runs and prerelease tags still run the version gate and the full
-      # packaging verification below; they just stop short of uploading.
-      REAL_PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true && !contains(github.ref, '-') }}
+      # Dry runs and prerelease tags still pass through `version-gate` and run
+      # the full packaging verification below; they just stop short of
+      # uploading.
+      REAL_PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true && !contains(github.ref, '-') && !contains(github.ref, '+') }}
     steps:
       # Fail in seconds, not after the verify builds: cargo only discovers a
       # missing token at upload time, minutes of packaging work in.
@@ -881,61 +992,6 @@ jobs:
       # packaging verification and the cargo-workspaces build below, both of
       # them inside a job that holds a publish credential. Not an injection
       # vector worth accepting to save one release-time build.
-
-      # The crate version is the workspace version, and it must equal the tag —
-      # the two version in lockstep with the npm package, so `offline-protocol
-      # 0.21.0` on crates.io is the same release as `v0.21.0` and
-      # `@offline-protocol/mesh-sdk@0.21.0`.
-      #
-      # This is verified rather than written. The npm job sets its version from
-      # the tag, but the same trick is unavailable here and would be wrong
-      # anyway: Cargo.lock pins the workspace members' own versions, so
-      # rewriting the manifests at release time invalidates it and the --locked
-      # verification below stops working — and the published .crate would no
-      # longer match the tag it claims to come from, which is the property the
-      # release attestations exist to make checkable.
-      #
-      # So the bump is part of the release cut (see CONTRIBUTING.md) and this
-      # step is what makes forgetting it loud. Failing here costs a re-tag;
-      # not failing costs a permanent, immutable, wrongly-numbered publish.
-      # Runs on prerelease and dry-run tags too, where it is free rehearsal.
-      #
-      # pyproject.toml is checked alongside it because it tracks this same
-      # number — it followed the Cargo version before this job existed, and
-      # leaving it unchecked is how it quietly becomes a third scheme. A
-      # mismatch there fails the crates job rather than the wheel build, which
-      # is the useful direction: this is the publish that cannot be corrected
-      # afterwards, so it is the one that should refuse an inconsistent release.
-      - name: Verify the release versions match the tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          set -euo pipefail
-
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          # A prerelease suffix lives on the tag only: v0.21.0-rc.1 rehearses
-          # the 0.21.0 the workspace already carries. Compare the release cores.
-          TAG_CORE="${TAG_VERSION%%-*}"
-          TAG_CORE="${TAG_CORE%%+*}"
-
-          CARGO_VERSION="$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[] | select(.name == "offline-protocol") | .version')"
-
-          if [ "$TAG_CORE" != "$CARGO_VERSION" ]; then
-            echo "::error title=Workspace version does not match the tag::Tag v$TAG_VERSION wants crates at $TAG_CORE, but [workspace.package].version is $CARGO_VERSION. Bump it together with the seven internal-dependency versions in [workspace.dependencies], refresh Cargo.lock, and re-tag."
-            exit 1
-          fi
-
-          # `|| true` so a missing or renamed key reports through the annotation
-          # below rather than aborting the step with no explanation.
-          PY_VERSION="$(grep -m1 '^version = ' bindings/python/pyproject.toml \
-            | cut -d'"' -f2 || true)"
-
-          if [ "$TAG_CORE" != "$PY_VERSION" ]; then
-            echo "::error title=Python package version does not match the tag::Tag v$TAG_VERSION wants $TAG_CORE, but bindings/python/pyproject.toml reads '${PY_VERSION}'. It moves with the workspace version — bump it and re-tag."
-            exit 1
-          fi
-
-          echo "Workspace and Python versions ($CARGO_VERSION) match tag v$TAG_VERSION."
 
       # Packages every publishable crate (bench is `publish = false`) and runs
       # the verify builds, resolving workspace siblings from cargo's local
@@ -990,8 +1046,8 @@ jobs:
       # --publish-as-is (hidden alias: --from-git) publishes the manifests
       # exactly as committed. Without it, `cargo workspaces publish` runs its
       # interactive version-bump/commit/tag flow first, which must never happen
-      # here — the version gate above already established that what is
-      # committed is what this tag is supposed to ship.
+      # here — `version-gate` already established that what is committed is
+      # what this tag is supposed to ship.
       #
       # --no-verify, because the verification already ran: the packaging step
       # above builds every crate from the committed manifests, with --locked
@@ -1027,17 +1083,22 @@ jobs:
           # publish below reaches last — so if it is already published at this
           # version, every other crate is too and the whole run is a no-op. Say
           # so as a warning annotation rather than letting eight "skipping"
-          # lines scroll by. Since the version gate above pins the version to
-          # the tag, this can only mean a re-run of a release that already
-          # published, which is exactly what the skip below exists to make safe
-          # — but it is worth saying out loud, because the run reports success
-          # either way.
+          # lines scroll by. Since `version-gate` pins the version to the tag,
+          # this can only mean a re-run of a release that already published,
+          # which is exactly what the skip below exists to make safe — but it is
+          # worth saying out loud, because the run reports success either way.
           #
           # Probing the *last* crate rather than offline-protocol is what makes
           # the annotation true during the incident it is read in: a run that
           # died partway leaves the lower crates published and the top one not,
           # and a probe aimed lower would tell the operator resuming it that
           # nothing was left to do while the resume went on to publish.
+          #
+          # This URL is the one place in the job that names a crate — the
+          # publish itself is topological and needs no list — so if a workspace
+          # member is ever added *above* offline-protocol-uniffi in the internal
+          # dependency graph, this has to move with it or the annotation goes
+          # quietly wrong. Nothing else breaks; it is a warning, not a gate.
           url="https://index.crates.io/of/fl/offline-protocol-uniffi"
           if curl -fsS --retry 3 "$url" 2>/dev/null \
             | jq -e --arg v "$VERSION" 'select(.vers == $v)' >/dev/null; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **The Rust workspace publishes to crates.io, and its version is now the
+  release version.** A `publish-crates` job runs beside the npm publish, behind
+  the same build-and-test gates, and ships all eight crates in dependency order.
+  Two things had to change for that to be safe. The workspace version moves from
+  the decoupled internal `0.2.0` to `0.20.1`, in lockstep with the git tag and
+  the npm package — two numbers for one release is a fine trade while nothing is
+  published, and a bad one once `cargo add offline-protocol` is how people
+  consume the SDK, because crates.io would then carry a version nothing else in
+  the project answers to. (`bindings/python/pyproject.toml` moves with it; it
+  tracked the Cargo version and would otherwise have become a third scheme.) And
+  because crates.io versions are immutable — yankable, never replaceable — the
+  release workflow now *verifies* the version rather than writing it: publishing
+  is refused unless `[workspace.package].version` equals the tag, unless the ref
+  is a tag at all, and unless packaging has already verified cleanly with
+  `--locked` and no credential in the environment. Bumping the version is part
+  of the release cut, now written down in
+  [CONTRIBUTING](./CONTRIBUTING.md#cutting-a-release). Consumers of the npm,
+  Python, or binary artifacts see no change; the crates are a new distribution
+  channel, published under the same AGPL-3.0-only terms.
 - `getBleDiagnostics()` (React Native) returns the three BLE degraded-path
   counters — `fragmentFallbacks`, `recipientNotAmongPeers`,
   `undersizedMtuReports` — which previously stopped at the UniFFI layer and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -721,6 +721,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### CI/CD
 
+- **A prerelease tag no longer takes over the npm `latest` dist-tag.** `npm
+  publish` defaults every upload to `latest`, so a `vX.Y.Z-rc.N` tag — or a
+  branch dispatch, which falls back to `0.0.0-dev` — became what a plain `npm
+  install @offline-protocol/mesh-sdk` resolved to. Prerelease versions now
+  publish under `next`, derived from the resolved version rather than the ref so
+  a hyphenated branch name cannot trip it. This matters more than it used to:
+  crates.io publishing treats an rc tag as a full rehearsal, which makes cutting
+  one a routine thing to do rather than a rarity.
 - **`cargo doc` is gated in CI.** A new `Rustdoc` job builds the workspace under
   `RUSTDOCFLAGS: -D warnings`. It caught six broken intra-doc links: four public
   items linking to private ones — which resolve to nothing for every reader not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,8 +316,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   release workflow now *verifies* the version rather than writing it: publishing
   is refused unless `[workspace.package].version` and `pyproject.toml` both
   equal the tag, unless the ref is a tag at all, unless the tag is free of any
-  prerelease suffix, and unless packaging has already verified cleanly with
-  `--locked` and no credential in the environment. Bumping the version is part
+  prerelease suffix or build metadata, and unless packaging has already verified
+  cleanly with `--locked` and no credential in the environment. The version
+  check is its own job, ahead of *both* publishes, so a forgotten bump stops npm
+  too — checked inside the crates job alone it would fail there while npm
+  shipped the number regardless, leaving a version that can never be completed
+  on crates.io and can only be abandoned. Bumping the version is part
   of the release cut, now written down in
   [CONTRIBUTING](./CONTRIBUTING.md#cutting-a-release) — which also records why
   force-moving a released tag, previously the cheap fix for a post-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,13 +314,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   tracked the Cargo version and would otherwise have become a third scheme.) And
   because crates.io versions are immutable — yankable, never replaceable — the
   release workflow now *verifies* the version rather than writing it: publishing
-  is refused unless `[workspace.package].version` equals the tag, unless the ref
-  is a tag at all, and unless packaging has already verified cleanly with
+  is refused unless `[workspace.package].version` and `pyproject.toml` both
+  equal the tag, unless the ref is a tag at all, unless the tag is free of any
+  prerelease suffix, and unless packaging has already verified cleanly with
   `--locked` and no credential in the environment. Bumping the version is part
   of the release cut, now written down in
-  [CONTRIBUTING](./CONTRIBUTING.md#cutting-a-release). Consumers of the npm,
-  Python, or binary artifacts see no change; the crates are a new distribution
-  channel, published under the same AGPL-3.0-only terms.
+  [CONTRIBUTING](./CONTRIBUTING.md#cutting-a-release) — which also records why
+  force-moving a released tag, previously the cheap fix for a post-release
+  failure, is no longer one. Consumers of the npm, Python, or binary artifacts
+  see no change; the crates are a new distribution channel, published under the
+  same AGPL-3.0-only terms.
 - `getBleDiagnostics()` (React Native) returns the three BLE degraded-path
   counters — `fragmentFallbacks`, `recipientNotAmongPeers`,
   `undersizedMtuReports` — which previously stopped at the UniFFI layer and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,40 @@ cargo bench --package offline-protocol-bench --bench '*' --locked -- \
   --baseline-lenient before
 ```
 
+## Cutting a Release
+
+One number identifies a release across every channel: the `vX.Y.Z` git tag, the
+`@offline-protocol/mesh-sdk` npm package, the `offline-protocol*` crates on
+crates.io, and the GitHub release assets. Pushing the tag is what publishes, so
+everything below happens on a `chore/release-X.Y.Z` branch that merges first.
+
+Version files to bump together:
+
+| File | How |
+| --- | --- |
+| `Cargo.toml` | `[workspace.package].version` **and** the seven internal-dependency versions in `[workspace.dependencies]` — the workspace will not resolve if they disagree, so a partial bump fails immediately and locally |
+| `Cargo.lock` | any `cargo` command refreshes it once the manifests change |
+| `bindings/python/pyproject.toml` | `version` |
+| `bindings/react-native/package.json` + `package-lock.json` | `npm version X.Y.Z --no-git-tag-version --allow-same-version` from `bindings/react-native/` |
+| `THIRD-PARTY-NOTICES.md` (×3) | `scripts/generate-third-party-notices.sh` — the notices list our own crates by version, and the CI drift gate fails on a stale copy |
+
+Then the prose: `CHANGELOG.md` (replace `## [Unreleased]` with
+`## [X.Y.Z] — <date>`, leaving no empty `[Unreleased]` behind), `SECURITY.md`
+(the supported-versions table — minor bumps only; a patch stays on its line),
+and `docs/UPGRADING.md` (the current-line reference, and a labelled subsection
+for anything that compiles fine but behaves differently).
+
+Two failure modes worth naming:
+
+- **`release.yml` refuses to publish a tag whose number does not match
+  `[workspace.package].version`.** That gate exists because crates.io versions
+  are immutable — a wrong number can be yanked but never corrected, so the
+  release has to fail before it uploads rather than after.
+- **The npm version is written from the tag at release time; the Cargo version
+  is not.** Rewriting manifests in CI would invalidate `Cargo.lock` and leave
+  the published `.crate` no longer matching the tag it names, so the repo is
+  the source of truth and the tag is checked against it.
+
 ## Architecture Decisions
 
 When making significant changes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,9 +250,9 @@ Version files to bump together:
 
 | File | How |
 | --- | --- |
-| `Cargo.toml` | `[workspace.package].version` **and** the seven internal-dependency versions in `[workspace.dependencies]` — the workspace will not resolve if they disagree, so a partial bump fails immediately and locally |
+| `Cargo.toml` | `[workspace.package].version` **and** the seven internal-dependency versions in `[workspace.dependencies]`. A partial *minor* bump fails to resolve immediately and locally; a partial *patch* bump resolves silently, because `version = "X.Y.Z"` is a caret requirement that a sibling one patch ahead still satisfies. Harmless if it ships, but move them together |
 | `Cargo.lock` | any `cargo` command refreshes it once the manifests change |
-| `bindings/python/pyproject.toml` | `version` |
+| `bindings/python/pyproject.toml` | `version` — release.yml gates this one against the tag too |
 | `bindings/react-native/package.json` + `package-lock.json` | `npm version X.Y.Z --no-git-tag-version --allow-same-version` from `bindings/react-native/` |
 | `THIRD-PARTY-NOTICES.md` (×3) | `scripts/generate-third-party-notices.sh` — the notices list our own crates by version, and the CI drift gate fails on a stale copy |
 
@@ -262,16 +262,28 @@ Then the prose: `CHANGELOG.md` (replace `## [Unreleased]` with
 and `docs/UPGRADING.md` (the current-line reference, and a labelled subsection
 for anything that compiles fine but behaves differently).
 
-Two failure modes worth naming:
+Three failure modes worth naming:
 
 - **`release.yml` refuses to publish a tag whose number does not match
-  `[workspace.package].version`.** That gate exists because crates.io versions
-  are immutable — a wrong number can be yanked but never corrected, so the
-  release has to fail before it uploads rather than after.
+  `[workspace.package].version`** (and `pyproject.toml`'s). That gate exists
+  because crates.io versions are immutable — a wrong number can be yanked but
+  never corrected, so the release has to fail before it uploads rather than
+  after.
 - **The npm version is written from the tag at release time; the Cargo version
   is not.** Rewriting manifests in CI would invalidate `Cargo.lock` and leave
   the published `.crate` no longer matching the tag it names, so the repo is
   the source of truth and the tag is checked against it.
+- **Never force-move a released tag — that recovery move stopped working when
+  crates.io publishing landed.** It used to be the cheap fix for a failure
+  after the GitHub release (the `v0.20.1` npm-provenance 422, for instance):
+  move the tag, re-run, done. Now it silently splits the release across
+  registries in either direction. If the tag already published crates, the
+  re-run skips them as already-present and crates.io keeps serving the *old*
+  source while npm and the release assets get the new. If the tag predates
+  crates.io publishing — every tag through `v0.20.1` — moving it onto a commit
+  that carries the `publish-crates` job passes every gate and publishes crates
+  built from source that the npm package of the same number never contained.
+  Both are permanent. Recover by cutting the next patch version instead.
 
 ## Architecture Decisions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,13 +262,25 @@ Then the prose: `CHANGELOG.md` (replace `## [Unreleased]` with
 and `docs/UPGRADING.md` (the current-line reference, and a labelled subsection
 for anything that compiles fine but behaves differently).
 
+To rehearse the whole thing, push a `vX.Y.Z-rc.N` tag. Every gate runs, every
+crate is packaged and verify-built, and npm publishes under the `next`
+dist-tag — but crates.io gets nothing, because those versions are immutable and
+an rc must never burn the number the final tag needs. Point the rc at the same
+`X.Y.Z` the workspace already carries; the gate compares release cores and
+ignores the suffix.
+
 Three failure modes worth naming:
 
 - **`release.yml` refuses to publish a tag whose number does not match
   `[workspace.package].version`** (and `pyproject.toml`'s). That gate exists
   because crates.io versions are immutable — a wrong number can be yanked but
   never corrected, so the release has to fail before it uploads rather than
-  after.
+  after. It runs as its own `version-gate` job ahead of *both* publish jobs, so
+  a forgotten bump stops npm as well: caught inside the crates job alone, it
+  would fail there while npm published the number anyway, and that split is one
+  of the permanent ones below. Because it lands before anything ships, deleting
+  and re-pushing the tag is the correct fix here — the one point in the release
+  where re-tagging is still safe.
 - **The npm version is written from the tag at release time; the Cargo version
   is not.** Rewriting manifests in CI would invalidate `Cargo.lock` and leave
   the published `.crate` no longer matching the tag it names, so the repo is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol"
-version = "0.2.0"
+version = "0.20.1"
 dependencies = [
  "base64",
  "chacha20poly1305",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-bench"
-version = "0.2.0"
+version = "0.20.1"
 dependencies = [
  "criterion",
  "offline-protocol",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-core"
-version = "0.2.0"
+version = "0.20.1"
 dependencies = [
  "base64",
  "bech32",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-mls"
-version = "0.2.0"
+version = "0.20.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-reliability"
-version = "0.2.0"
+version = "0.20.1"
 dependencies = [
  "chrono",
  "offline-protocol-core",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-router"
-version = "0.2.0"
+version = "0.20.1"
 dependencies = [
  "chrono",
  "offline-protocol-core",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-services"
-version = "0.2.0"
+version = "0.20.1"
 dependencies = [
  "offline-protocol-core",
  "serde",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-transport"
-version = "0.2.0"
+version = "0.20.1"
 dependencies = [
  "base64",
  "chacha20",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-uniffi"
-version = "0.2.0"
+version = "0.20.1"
 dependencies = [
  "offline-protocol",
  "offline-protocol-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,20 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+# The release version, shared with the `vX.Y.Z` git tag and the npm package —
+# `offline-protocol 0.20.1` on crates.io is the same release as `v0.20.1` and
+# `@offline-protocol/mesh-sdk@0.20.1`. This was a decoupled internal `0.x`
+# until crates.io publishing landed; two numbers for one release is a
+# reasonable trade while nothing is published, and a bad one once `cargo add`
+# is how people consume the SDK, because crates.io then carries a version
+# nothing else in the project answers to.
+#
+# Bump this as part of the release cut, together with the internal-dependency
+# versions below (the workspace will not resolve if they disagree) and
+# `bindings/python/pyproject.toml`. release.yml refuses to publish a tag whose
+# number does not match this one — crates.io versions are immutable, so
+# discovering the mismatch afterwards means the number is wrong forever.
+version = "0.20.1"
 edition = "2021"
 authors = ["Offline Protocol, Inc."]
 # Dual-licensed: AGPL-3.0-only for open-source use, with a separate commercial
@@ -93,13 +106,13 @@ chacha20poly1305 = "0.10"
 # Keep these in lockstep with `workspace.package.version` above — a crate can
 # only be published once its dependencies exist on the registry at the named
 # version, so all seven move together.
-offline-protocol-core = { path = "crates/offline-protocol-core", version = "0.2.0" }
-offline-protocol-transport = { path = "crates/offline-protocol-transport", version = "0.2.0" }
-offline-protocol-router = { path = "crates/offline-protocol-router", version = "0.2.0" }
-offline-protocol-reliability = { path = "crates/offline-protocol-reliability", version = "0.2.0" }
-offline-protocol-mls = { path = "crates/offline-protocol-mls", version = "0.2.0" }
-offline-protocol-services = { path = "crates/offline-protocol-services", version = "0.2.0" }
-offline-protocol = { path = "crates/offline-protocol", version = "0.2.0" }
+offline-protocol-core = { path = "crates/offline-protocol-core", version = "0.20.1" }
+offline-protocol-transport = { path = "crates/offline-protocol-transport", version = "0.20.1" }
+offline-protocol-router = { path = "crates/offline-protocol-router", version = "0.20.1" }
+offline-protocol-reliability = { path = "crates/offline-protocol-reliability", version = "0.20.1" }
+offline-protocol-mls = { path = "crates/offline-protocol-mls", version = "0.20.1" }
+offline-protocol-services = { path = "crates/offline-protocol-services", version = "0.20.1" }
+offline-protocol = { path = "crates/offline-protocol", version = "0.20.1" }
 
 [workspace.lints.clippy]
 unwrap_used = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ members = [
 # nothing else in the project answers to.
 #
 # Bump this as part of the release cut, together with the internal-dependency
-# versions below (the workspace will not resolve if they disagree) and
-# `bindings/python/pyproject.toml`. release.yml refuses to publish a tag whose
-# number does not match this one — crates.io versions are immutable, so
-# discovering the mismatch afterwards means the number is wrong forever.
+# versions below and `bindings/python/pyproject.toml`. release.yml refuses to
+# publish a tag whose number does not match this one — crates.io versions are
+# immutable, so discovering the mismatch afterwards means the number is wrong
+# forever.
 version = "0.20.1"
 edition = "2021"
 authors = ["Offline Protocol, Inc."]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,10 +13,10 @@ backports to earlier lines. If you are on an older line, upgrading is the fix.
 Report against the latest published release
 ([releases](https://github.com/Offline-Protocol/offline-protocol-sdk/releases),
 `npm view @offline-protocol/mesh-sdk version`); a fix ships in the next release
-on the current line. These are release versions — the git tag and the
-`@offline-protocol/mesh-sdk` npm package, which share a number. The workspace
-`Cargo.toml` version is an internal, deliberately decoupled `0.x` and is not
-what this table refers to.
+on the current line. One number covers every channel: the git tag, the
+`@offline-protocol/mesh-sdk` npm package, and the `offline-protocol*` crates on
+crates.io all share it. Releases up to and including `v0.20.1` predate crates.io
+publishing and exist as tags and npm packages only.
 
 ## Reporting a Vulnerability
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -38,14 +38,14 @@ upstream source on each crate's page) — the exact versions are listed below.
 
 Used by:
 
-- [offline-protocol 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-core 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-mls 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-reliability 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-router 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-services 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-transport 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-uniffi 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-core 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-mls 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-reliability 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-router 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-services 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-transport 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-uniffi 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
 
 ```
 GNU AFFERO GENERAL PUBLIC LICENSE

--- a/bindings/python/THIRD-PARTY-NOTICES.md
+++ b/bindings/python/THIRD-PARTY-NOTICES.md
@@ -38,14 +38,14 @@ upstream source on each crate's page) — the exact versions are listed below.
 
 Used by:
 
-- [offline-protocol 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-core 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-mls 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-reliability 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-router 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-services 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-transport 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-uniffi 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-core 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-mls 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-reliability 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-router 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-services 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-transport 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-uniffi 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
 
 ```
 GNU AFFERO GENERAL PUBLIC LICENSE

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "offline-protocol-sdk"
-version = "0.2.0"
+version = "0.20.1"
 description = "Python bindings for the Offline Protocol SDK — offline-first mesh networking with MLS encryption"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/bindings/react-native/THIRD-PARTY-NOTICES.md
+++ b/bindings/react-native/THIRD-PARTY-NOTICES.md
@@ -38,14 +38,14 @@ upstream source on each crate's page) — the exact versions are listed below.
 
 Used by:
 
-- [offline-protocol 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-core 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-mls 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-reliability 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-router 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-services 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-transport 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-uniffi 0.2.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-core 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-mls 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-reliability 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-router 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-services 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-transport 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-uniffi 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
 
 ```
 GNU AFFERO GENERAL PUBLIC LICENSE


### PR DESCRIPTION
## What

Publishes the Rust workspace to crates.io, and makes the workspace version *the* release version.

A `publish-crates` job runs beside the npm publish, behind the same build/test gates, and ships all 8 crates in dependency order. Nothing publishes to either registry unless every build and test job is green **and** the repo and the tag agree on what version this is.

## The version becomes one number

`[workspace.package].version` moves from the decoupled internal `0.2.0` to `0.20.1`, in lockstep with the git tag and the npm package. Two numbers for one release is a fine trade while nothing is published; it's a bad one once `cargo add offline-protocol` is how people consume the SDK, because crates.io would carry a version nothing else in the project answers to. `bindings/python/pyproject.toml` moves with it — it already tracked the Cargo version, and leaving it out is how it quietly becomes a third scheme.

**The version is verified, not written.** The npm job sets its version from the tag; the same trick would be wrong here. `Cargo.lock` pins the workspace members' own versions, so rewriting manifests at release time invalidates it (and `--locked` verification stops working), and the published `.crate` would no longer match the tag it claims to come from — the exact property the release attestations exist to make checkable. So the bump is part of the release cut, now written down in `CONTRIBUTING.md` under "Cutting a Release", and CI's job is to refuse a tag that disagrees.

## The gate is a shared job, not a step

`version-gate` is its own job that **both** publish jobs depend on. This is the correctness core of the PR, and the first draft got it wrong by putting the check inside `publish-crates`.

The two publish jobs are independent siblings behind an identical `needs` list, so a check living in one has no hold over the other. For every other way `publish-crates` can fail — missing token, rate limit, dropped connection — that's harmless, because all of those are recoverable by re-running against the same tag. A forgotten version bump is the exception, and it's also the mistake this design invites: every release through `v0.20.1` was cut without touching `Cargo.toml` at all. Checked inside the crates job, it fails there in seconds while the npm job publishes the number and cuts the GitHub release anyway — and nothing recovers that. Re-running checks out the same unbumped source; moving the tag onto a bumped commit is the force-move CONTRIBUTING now forbids. The number is burned and the release split permanently.

As a shared prerequisite, the same mistake fails everything with nothing published anywhere, within a minute of the tag push (the job `needs` nothing, so it doesn't queue behind the build fan-out). That also makes the error message honest — it says *delete and re-push the tag*, which is correct only because the gate runs first.

The `CARGO_REGISTRY_TOKEN` presence check deliberately stays inside `publish-crates`: it *is* re-runnable on the same tag, so it has no business blocking npm.

## What can reach a real crates.io upload

`REAL_PUBLISH` requires a `v*` tag ref, not a dry run, and no `-` or `+` anywhere in the tag.

The suffix test is blanket rather than the release job's `-alpha`/`-beta`/`-rc` list, because the gate compares release *cores*: a suffix the list misses (`-pre.1`, a typo like `-cr.1`) would clear it, and `v0.21.0-pre.1` against a `0.21.0` workspace would really publish the final, immutable `0.21.0` from prerelease code — after which the eventual `v0.21.0` tag no-ops on crates.io while npm and the GitHub release ship the real thing. `+` is the same hole one character over (build metadata is stripped before comparing, and `+` is legal in a refname). Nothing is lost by the broader test: a workspace version carrying either character can never match a core-compared tag.

Dry runs and prerelease tags still pass the gate and run the full packaging verification — they just stop short of uploading. That makes a `vX.Y.Z-rc.N` tag a genuine full rehearsal, which is worth having.

## Publisher mechanics

- **`cargo-workspaces@0.4.2`** (`publish --publish-as-is --no-verify --yes`) — topological order, so there's no hand-maintained crate list to drift when a member is added, and it unconditionally skips versions already on the registry, which is what makes a partially-failed run resumable. Native `cargo publish --workspace` gives neither.
- **Verification runs first, separately** — `cargo publish --workspace --locked --dry-run`, unconditional, with no token in the environment. crates.io uploads are immutable and not atomic, so a packaging defect discovered at crate six leaves five published at a version the run can never complete; since all eight version in lockstep, the whole workspace would have to skip to the next number with one crate half-published forever. Skip-already-published rescues *transient* faults, never deterministic ones.
- **Supply-chain posture matches the release job** — every action SHA-pinned (the top-of-file rationale now covers this job and `checkout`'s role in deciding what gets packaged), no rust-cache, no cached `cargo-workspaces` binary, and `--no-verify` on the publish itself: all three decline the same vector, which is executing third-party build scripts in a step holding the registry token.

## Traps found and documented in the job

1. **`--locked` must stay off the cargo-workspaces invocation.** It temporarily strips `[dev-dependencies]` from crates whose dev-deps name workspace siblings with versions; the shrunken dep set needs a lockfile update, and `--locked` refuses. Reproduced on a synthetic workspace: seven crates published, death on the eighth. The dry-run pre-flight keeps `--locked` and is where lock drift gets caught.
2. **cargo-workspaces' own dry-run mode exits 0 even when publishes fail** (downgrades them to warnings) — which is why the pre-flight uses native cargo. Real-mode failures return a proper error.
3. **`--from-git`** (as used elsewhere) is a hidden clap alias of `--publish-as-is`; the job uses the documented spelling.

## Also fixed here

**Prereleases no longer hijack the npm `latest` dist-tag** (own commit). `npm publish` tags every upload `latest` unless told otherwise, so a `vX.Y.Z-rc.N` tag — or a branch dispatch, which falls back to `0.0.0-dev` — became what a plain `npm install` resolves to. Latent until now because we never cut rc tags; this PR makes cutting one a reasonable thing to do, so it stops being latent. Prerelease versions go to `next`, derived from the resolved semver-validated version rather than the ref (plenty of our branch names have hyphens).

## Verification

- Job graph parses and resolves: `version-gate` is in both publish jobs' `needs`; 13 jobs, no dangling dependencies.
- Gate script executed against the real repo: matching tag passes, `v0.20.1-rc.1` passes on core comparison, `v0.21.0` (the forgotten-bump case) fails with the annotation.
- Dist-tag derivation checked across `0.21.0` → `latest`, `0.21.0-rc.1` / `-pre.1` / `0.0.0-dev` → `next`.
- Every `run:` block in the workflow shellchecked at `-S warning`; the three findings are pre-existing and in jobs this PR doesn't touch.
- `cargo publish --workspace --dry-run` packages all 8 crates cleanly in dependency order (bench auto-skipped via `publish = false`).
- Skip-already-published confirmed in cargo-workspaces 0.4.2 source (`is_published` → `continue`); real-mode failure returns `Err(Error::Publish)`.
- All 8 crate names are already reserved on crates.io at 0.0.0 under the maintainers team, so these are new-*version* publishes and the strict brand-new-crate rate limit doesn't apply.

## Before the next tag

Add the **`CARGO_REGISTRY_TOKEN`** repository secret (crates.io API token from an owner account; publish-update scope suffices since all names exist). The job fails fast with instructions if it's missing — and that failure is re-runnable on the same tag, which is why it isn't in the shared gate.

Known pre-existing loose end (unchanged by this PR): the repo-relative drift-guard tests panic under `cargo test` inside a published tarball (noted in #273 review) — doesn't affect publishing, since verify builds don't run tests.
