### PR TITLE
chore(release): cut v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Offline Protocol SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This changelog covers everything after the **v0.7.1** release.
 
-## [Unreleased]
+## [0.21.0] — 2026-08-13
 
 > **Your identity is no longer something your app picks.** `ProtocolConfig.userId`
 > is replaced by `profile`, and a device's identity on the wire becomes the
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 > what, and 1:1 session slots are named after the two ids. Old containers are
 > left intact rather than deleted; clean them up by passing the *old* user id to
 > `wipePersistedState`. Full migration guide in
-> [UPGRADING §14](./docs/UPGRADING.md#14-your-identity-is-derived-not-chosen-unreleased).
+> [UPGRADING §14](./docs/UPGRADING.md#14-your-identity-is-derived-not-chosen-v0210).
 
 ### Changed
 
@@ -96,6 +96,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   out in UPGRADING §14.
 - **BREAKING**: the MLS credential is the address, so peers on an older build
   fail cleanly at credential verification instead of interoperating.
+- **BREAKING**: BLE discovery announces the derived address. The advertised
+  `DEVICE_ID` characteristic carries this device's `off1…` address rather than
+  the profile, the central verifies it against the identity key it reads before
+  announcing the peer, and a mismatch drops the link. A peer still advertising
+  a profile is therefore *invisible* over BLE rather than degraded — its
+  control frames were already being rejected. Publication is gated on an
+  identity existing, and the `bleRecipientNotAmongPeers` diagnostic is exposed
+  over UniFFI. Wi-Fi Direct stops announcing or ingesting transport peer ids
+  entirely — nothing on that transport can prove one — and the `wifiDirect*`
+  React Native entry points are deprecated.
 - 1:1 session slots and the both-create tiebreaker order addresses by their hash
   bytes rather than their rendered string. The bech32 charset is not
   ASCII-monotonic, so string order contradicts every other address comparison.
@@ -230,6 +240,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   hex; set `scrub_ids: false` to opt out, as for every other identifier. Group
   and file names are unchanged, and stay raw: they label a shared thing, not an
   individual.
+- **Telemetry event `reason` fields no longer carry identifiers or text a
+  remote party wrote.** These fields ship to sinks verbatim by design — the
+  scrubber hashes identifier fields, not prose — and several producers rendered
+  errors into them that interpolated addresses, session slots, or wire text:
+  session-Welcome failures (`secure_session_failed`), the relay's
+  `__GROUP_ERROR__` wording (`GroupError.reason`), the control-gate and
+  relay-binding `security_warning` arms, and transport/relay send-failure text
+  on `messageDeferred`, `messageUndeliverable`,
+  `connectionRequestUndeliverable` and `welcomeSendFailed`. Each now carries a
+  fixed, locally chosen classification; the full wording stays in the device
+  log, and relay errors remain available verbatim through the raw
+  server-message frame both bridges already emit. `GroupError` gains an
+  additive `group_id` field, hashed by the scrubber like any other identifier.
+  Sinks parsing these strings will see the new vocabulary; the docs have
+  always said `reason` must not be parsed.
 - **Group members were trusted on an identity claim nobody checked.** The
   addressing work made a claim provable — an address is the hash of its
   identity key — and wired that check to the two places a claim was known to
@@ -302,6 +327,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **Messages now travel between devices that cannot hear each other.** A frame
+  addressed to a peer out of range is handed to nearby devices, which carry it
+  onward — and the delivery acknowledgement takes the same path back, so a
+  message that arrived across several devices is not retransmitted as though
+  it had been lost. Forwarding is governed: an id travels once, a frame waits
+  briefly so a nearer neighbor can cover it first, the hop budget a frame
+  claims is clamped to local policy, and the rate frames leave at is capped in
+  total and per neighbor. Carried traffic never settles this device's own
+  outbox or clock. Tunable via `ProtocolConfig.mesh_relay`;
+  `mesh_relay_stats()` reports what a device has been carrying. Apps that
+  implemented their own forwarding should remove it — a second forwarder
+  transmits copies the budgets do not account for. See `docs/mesh.md`.
 - **The Rust workspace publishes to crates.io, and its version is now the
   release version.** A `publish-crates` job runs beside the npm publish, behind
   the same build-and-test gates, and ships all eight crates in dependency order.
@@ -359,7 +396,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   reading: the relay verifies that the declared address derives from the key
   that signed the proof, so an echo naming anything else means it bound what it
   did not verify. `RELAY_ADDRESS_DECLARATION_REFUSED` is operational rather than
-  adversarial and carries the relay's own reason text verbatim. Neither is acted
+  adversarial; the relay's own wording stays in the device log, and the event
+  carries a fixed classification (see the telemetry `reason` entry under
+  Security). Neither is acted
   on — the refusal path is deliberately non-fatal on both sides, and against a
   hostile relay a local teardown protects nothing it does not already control —
   so the whole value is that the signal is loud and typed. Worth surfacing in
@@ -418,6 +457,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   to drain and the send-path half of the fix there is forward-looking; the
   send behaviour this changes in a shipped app is Nostr's and Reticulum's. The
   iOS browsing leak above is live now.
+
+- **The BLE path no longer runs protocol calls on the app's main thread.** On
+  iOS, every CoreBluetooth delegate is a main-queue callback and the fragment
+  stores made main-queue readers wait behind UniFFI calls holding the core's
+  global mutex — the top App Hang cluster reported against 0.20.1. Protocol
+  calls now route through the protocol queue and the fragment stores are
+  lock-guarded, so a read never waits behind MLS work. On Android, a peer
+  permanently unable to accept writes kept the fragment drain reposting at
+  20Hz on the main thread, contending with the 100ms process tick for the same
+  mutex — the reported ANR shape. The retry now backs off 50ms→2s and stops
+  re-arming after ~15s of failure (the 2s polling floor still flushes the
+  queue, so no fragment is abandoned), and the process tick runs with a fixed
+  delay rather than a fixed rate, so an overrunning tick no longer holds the
+  mutex back-to-back.
 
 - **The remaining transports no longer run protocol calls on the app's main
   thread.** Completing what the BLE fixes started: on Android all four
@@ -733,6 +786,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   a hyphenated branch name cannot trip it. This matters more than it used to:
   crates.io publishing treats an rc tag as a full rehearsal, which makes cutting
   one a routine thing to do rather than a rarity.
+- **Every third-party action in `release.yml` is pinned to a commit SHA.** The
+  workflow mints the provenance attestations consumers are told to trust, so
+  its supply chain no longer floats on mutable version tags.
 - **`cargo doc` is gated in CI.** A new `Rustdoc` job builds the workspace under
   `RUSTDOCFLAGS: -D warnings`. It caught six broken intra-doc links: four public
   items linking to private ones — which resolve to nothing for every reader not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "base64",
  "chacha20poly1305",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-bench"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "offline-protocol",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-core"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "base64",
  "bech32",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-mls"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-reliability"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "offline-protocol-core",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-router"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "offline-protocol-core",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-services"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "offline-protocol-core",
  "serde",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-transport"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "base64",
  "chacha20",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "offline-protocol-uniffi"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "offline-protocol",
  "offline-protocol-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 # publish a tag whose number does not match this one — crates.io versions are
 # immutable, so discovering the mismatch afterwards means the number is wrong
 # forever.
-version = "0.20.1"
+version = "0.21.0"
 edition = "2021"
 authors = ["Offline Protocol, Inc."]
 # Dual-licensed: AGPL-3.0-only for open-source use, with a separate commercial
@@ -106,13 +106,13 @@ chacha20poly1305 = "0.10"
 # Keep these in lockstep with `workspace.package.version` above — a crate can
 # only be published once its dependencies exist on the registry at the named
 # version, so all seven move together.
-offline-protocol-core = { path = "crates/offline-protocol-core", version = "0.20.1" }
-offline-protocol-transport = { path = "crates/offline-protocol-transport", version = "0.20.1" }
-offline-protocol-router = { path = "crates/offline-protocol-router", version = "0.20.1" }
-offline-protocol-reliability = { path = "crates/offline-protocol-reliability", version = "0.20.1" }
-offline-protocol-mls = { path = "crates/offline-protocol-mls", version = "0.20.1" }
-offline-protocol-services = { path = "crates/offline-protocol-services", version = "0.20.1" }
-offline-protocol = { path = "crates/offline-protocol", version = "0.20.1" }
+offline-protocol-core = { path = "crates/offline-protocol-core", version = "0.21.0" }
+offline-protocol-transport = { path = "crates/offline-protocol-transport", version = "0.21.0" }
+offline-protocol-router = { path = "crates/offline-protocol-router", version = "0.21.0" }
+offline-protocol-reliability = { path = "crates/offline-protocol-reliability", version = "0.21.0" }
+offline-protocol-mls = { path = "crates/offline-protocol-mls", version = "0.21.0" }
+offline-protocol-services = { path = "crates/offline-protocol-services", version = "0.21.0" }
+offline-protocol = { path = "crates/offline-protocol", version = "0.21.0" }
 
 [workspace.lints.clippy]
 unwrap_used = "deny"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ backports to earlier lines. If you are on an older line, upgrading is the fix.
 
 | Version                          | Supported          |
 | -------------------------------- | ------------------ |
-| Current line (`0.20.x`)          | :white_check_mark: |
-| Any earlier line (`≤ 0.19.x`)    | :x:                |
+| Current line (`0.21.x`)          | :white_check_mark: |
+| Any earlier line (`≤ 0.20.x`)    | :x:                |
 
 Report against the latest published release
 ([releases](https://github.com/Offline-Protocol/offline-protocol-sdk/releases),

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -38,14 +38,14 @@ upstream source on each crate's page) — the exact versions are listed below.
 
 Used by:
 
-- [offline-protocol 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-core 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-mls 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-reliability 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-router 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-services 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-transport 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-uniffi 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-core 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-mls 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-reliability 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-router 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-services 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-transport 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-uniffi 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
 
 ```
 GNU AFFERO GENERAL PUBLIC LICENSE

--- a/bindings/python/THIRD-PARTY-NOTICES.md
+++ b/bindings/python/THIRD-PARTY-NOTICES.md
@@ -38,14 +38,14 @@ upstream source on each crate's page) — the exact versions are listed below.
 
 Used by:
 
-- [offline-protocol 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-core 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-mls 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-reliability 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-router 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-services 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-transport 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-uniffi 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-core 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-mls 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-reliability 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-router 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-services 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-transport 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-uniffi 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
 
 ```
 GNU AFFERO GENERAL PUBLIC LICENSE

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "offline-protocol-sdk"
-version = "0.20.1"
+version = "0.21.0"
 description = "Python bindings for the Offline Protocol SDK — offline-first mesh networking with MLS encryption"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/bindings/react-native/THIRD-PARTY-NOTICES.md
+++ b/bindings/react-native/THIRD-PARTY-NOTICES.md
@@ -38,14 +38,14 @@ upstream source on each crate's page) — the exact versions are listed below.
 
 Used by:
 
-- [offline-protocol 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-core 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-mls 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-reliability 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-router 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-services 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-transport 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
-- [offline-protocol-uniffi 0.20.1](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-core 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-mls 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-reliability 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-router 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-services 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-transport 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
+- [offline-protocol-uniffi 0.21.0](https://github.com/Offline-Protocol/offline-protocol-sdk)
 
 ```
 GNU AFFERO GENERAL PUBLIC LICENSE

--- a/bindings/react-native/package-lock.json
+++ b/bindings/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@offline-protocol/mesh-sdk",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@offline-protocol/mesh-sdk",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@types/react-native": "^0.72.8",

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offline-protocol/mesh-sdk",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Offline-first mesh networking SDK with intelligent transport switching for React Native",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,19 +1,24 @@
 # Upgrading
 
 Everything an application team has to change to move off `v0.16.x` and onto the
-current `v0.20.x` line.
+current `v0.21.x` line.
 
 The breaking changes all landed in the **storage-split release**, `v0.17.0` —
 `initialize_mls` changes shape, three config updaters become fallible, and
 several previously-accepted inputs are now rejected at the boundary. Sections
 1–12 below cover that release and are the ones that can stop your build.
 
-Since `v0.17.0` exactly one change can break a build, and only for React Native
-on iOS: `v0.20.0` enables iOS autolinking, so a manual `pod 'MeshSdk'` line left
-in your `Podfile` now fails `pod install`. It is a one-line deletion —
+Since `v0.17.0` two releases can break a build. `v0.20.0` enables iOS
+autolinking, so a manual `pod 'MeshSdk'` line left in your `Podfile` now fails
+`pod install` — React Native on iOS only; it is a one-line deletion, and
 [§12.1](#121-react-native-ios-delete-your-manual-pod-meshsdk-line-v0200) has the
 full list of Podfile leftovers to remove, and the same release is what makes iOS
-**simulator** builds link correctly.
+**simulator** builds link correctly. `v0.21.0` is breaking on **every** surface:
+`ProtocolConfig.userId` is replaced by `profile`, and the device's identity on
+the wire becomes a self-certifying `off1…` address derived from an identity key
+it mints for itself. [§14](#14-your-identity-is-derived-not-chosen-v0210) is the
+migration guide — read it before bumping, because there is deliberately no
+in-place migration of existing sessions.
 
 Otherwise, where a later section documents an
 addition or a behaviour change, it is labelled inline with the release that
@@ -44,6 +49,12 @@ can deliver.
 [§11.1](#111-messagedecryptionfailed-is-advisory-not-terminal-v0201) has the
 full contract and the events to settle on instead.
 
+`v0.21.0`'s changes are otherwise compile-breaking rather than quiet, but it
+adds one more of these: `secure_session_failed` can now fire while the session
+with that peer stays **live**
+([§11.2](#112-secure_session_failed-no-longer-implies-the-session-is-gone-v0210)),
+so an app that tears down session state on that event alone must stop.
+
 Work through it in order. [§0](#0-before-you-ship-downgrade-is-not-a-rollback)
 is a release-engineering decision, not a code change, and it is the one that
 cannot be undone later.
@@ -69,7 +80,7 @@ cannot be undone later.
 | 12 | [Build & packaging](#12-build-and-packaging) | — | regenerate bindings | rebuild native | — |
 | 12.1 | [iOS: delete your manual `pod 'MeshSdk'` line](#121-react-native-ios-delete-your-manual-pod-meshsdk-line-v0200) | n/a | n/a | **breaking** (`pod install` fails) | n/a |
 | 13 | [Upgrade test checklist](#13-upgrade-test-checklist) | — | — | — | — |
-| 14 | [Your identity is derived, not chosen](#14-your-identity-is-derived-not-chosen-unreleased) | **breaking** | **breaking** | **breaking** | **breaking** |
+| 14 | [Your identity is derived, not chosen](#14-your-identity-is-derived-not-chosen-v0210) | **breaking** | **breaking** | **breaking** | **breaking** |
 
 ---
 
@@ -456,7 +467,7 @@ What changes in practice:
 *New in `v0.19.0`.* `peer_key_packages` is now a sealed category, and every use
 of a key package is checked against the peer's identity.
 
-> **Superseded by [§14](#14-your-identity-is-derived-not-chosen-unreleased).**
+> **Superseded by [§14](#14-your-identity-is-derived-not-chosen-v0210).**
 > In `v0.19.0` the check compared the key package against a TOFU-*pinned*
 > signature key. The pin store is gone; the check now re-derives the address
 > from the key package's own signature key and compares it to the peer id the
@@ -1026,6 +1037,23 @@ recovered. A repeated injection of the identical frame therefore re-emits
 `MEDIA_SENDER_GROUP_MISMATCH` on each attempt instead of being suppressed by
 dedup after the first — the rate is the signal, as with `SESSION_REKEY_TRIGGERED`.
 
+### 11.2 `secure_session_failed` no longer implies the session is gone *(v0.21.0)*
+
+The event has always meant "an establishment *attempt* failed", but until now
+every path that fired it also left no live session, so tearing down session
+state on it happened to work. `v0.21.0` adds the first counter-example: a
+session Welcome refused for carrying an unprovable identity
+([§14](#14-your-identity-is-derived-not-chosen-v0210)'s leaf binding) is
+refused **non-destructively** — the Welcome is declined, a
+`GROUP_LEAF_IDENTITY_UNPROVEN` security warning fires alongside it, and the
+session you already had with that peer keeps working.
+
+**What to change.** If your app clears conversation encryption state, resets a
+"secure" indicator, or re-triggers establishment on `secure_session_failed`
+alone, stop — the peer may still be reachable over the surviving session.
+Settle session liveness on `secure_session_established` and actual send
+results; treat `secure_session_failed` as a diagnostic about one attempt.
+
 ---
 
 ## 12. Build and packaging
@@ -1122,7 +1150,7 @@ Run these against a build of your **previous** version, then upgrade in place.
       is the sharpest failure mode — verify it explicitly.)*
 - [ ] MLS identity survives *within a release line*: existing sessions still
       decrypt and existing groups still work. **This does not hold across
-      [§14](#14-your-identity-is-derived-not-chosen-unreleased)** — the identity
+      [§14](#14-your-identity-is-derived-not-chosen-v0210)** — the identity
       becomes the MLS credential there, so every session and group from a
       pre-§14 build is invalidated by design. Upgrading across §14, verify the
       opposite: that peers re-establish cleanly from fresh key packages rather
@@ -1169,7 +1197,7 @@ Run these against a build of your **previous** version, then upgrade in place.
 
 ---
 
-## 14. Your identity is derived, not chosen (unreleased)
+## 14. Your identity is derived, not chosen (v0.21.0)
 
 **`ProtocolConfig.userId` is gone.** It is replaced by `profile`, and the two
 are not the same thing wearing a new name.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -106,7 +106,7 @@ generates for itself, and read back with `local_address()` (or the
 the storage namespace and nothing else. It never leaves the device and no peer
 can see it. On a device with one account, a constant like `"default"` is fine.
 
-See [UPGRADING §14](./UPGRADING.md#14-your-identity-is-derived-not-chosen-unreleased)
+See [UPGRADING §14](./UPGRADING.md#14-your-identity-is-derived-not-chosen-v0210)
 for the migration, including the two ways an app can lose data by re-keying its
 own storage to the address.
 

--- a/docs/mls-integration.md
+++ b/docs/mls-integration.md
@@ -8,7 +8,7 @@ This guide explains how to integrate MLS (Message Layer Security) end-to-end enc
 > `userId` name, but the value they take is an address — a username reaches
 > nobody. Get one from an invite/QR exchange or the `neighbor_discovered`
 > event, and read your own with `localAddress()`. See
-> [UPGRADING §14](./UPGRADING.md#14-your-identity-is-derived-not-chosen-unreleased).
+> [UPGRADING §14](./UPGRADING.md#14-your-identity-is-derived-not-chosen-v0210).
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Release cut for **v0.21.0** — the identity release. First release under the coupled versioning scheme (#357): the tag, npm, pyproject, Cargo workspace, and crates.io all carry `0.21.0`, and `release.yml`'s version gate verifies the manifests against the tag before either publish job runs.

### Version bumps
- `Cargo.toml` — `[workspace.package].version` + the seven internal-dependency requirements in `[workspace.dependencies]` (member crates inherit via `version.workspace = true`); `Cargo.lock` re-locked
- `bindings/python/pyproject.toml` → 0.21.0
- `bindings/react-native/package.json` + lockfile via `npm version` (podspec reads from package.json)
- `THIRD-PARTY-NOTICES.md` ×3 regenerated (they list our own crates by version; the drift gate fails on stale copies)

### Prose
- **CHANGELOG**: `[Unreleased]` → `[0.21.0] — 2026-08-13`. A coverage audit of all 55 commits since v0.20.1 found four missing user-visible clusters, now added: mesh forwarding (#324), the breaking BLE identity cutover (#330), the iOS/Android BLE main-thread fixes (#338/#341), and the telemetry `reason` classification (#353/#354/#358). Also amended the #335 entry that still claimed `RELAY_ADDRESS_DECLARATION_REFUSED` carries the relay's reason text verbatim — #358 changed exactly that — and added a CI/CD line for the SHA-pinned release workflow (#355).
- **SECURITY.md**: supported table → `0.21.x` current / `≤ 0.20.x` unsupported
- **UPGRADING.md**: current line → `v0.21.x`; the "only one build-breaking change since v0.17.0" intro corrected (v0.21.0 breaks every surface via §14); §14 stamped `(v0.21.0)` with all anchor references renamed across four docs; new **§11.2** for the one compile-fine-but-behaves-differently change (`secure_session_failed` can now fire while the session stays live)

### Verified
- `cargo fmt --all -- --check`, `scripts/check-license-consistency.sh`, `npx tsc --noEmit` (RN) — all green locally
- clippy + `cargo test --workspace --lib` running; only manifest/docs changed vs. main, where CI is green

After merge: tag `v0.21.0` on main fires `release.yml` (npm + crates.io + GitHub release). Optionally rehearse with a `v0.21.0-rc.1` tag first — it runs every gate and publishes npm under `next` without burning the crates.io number.