### PR TITLE
docs(bindings): ship a README with every publishable crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
       - name: License consistency check
         run: ./scripts/check-license-consistency.sh
 
+      # crates.io renders a crate's README from its archive and a published
+      # version is immutable, so a crate that ships without one stays bare on
+      # the registry until the next release. Cargo infers the README silently
+      # and omits it just as silently, so nothing else catches the miss.
+      - name: Crate README presence
+        run: ./scripts/check-crate-readmes.sh
+
       # The NIP-44 vectors are a crypto conformance fixture vendored into the
       # tree. Pinning them to the checksum the spec publishes is what stops a
       # green suite from being achieved by editing the vectors.

--- a/crates/offline-protocol-core/README.md
+++ b/crates/offline-protocol-core/README.md
@@ -1,0 +1,16 @@
+# offline-protocol-core
+
+Core types and data structures for the [Offline Protocol SDK](https://github.com/Offline-Protocol/offline-protocol-sdk) — the foundation layer every other crate in the workspace builds on.
+
+Provides:
+
+- The `Message` envelope and its identifiers (`UserId`, `AppId`), TTL and hop-count bookkeeping, and timestamps
+- The compact binary wire codec (wire v1), negotiated per peer with JSON as the permanent fallback format
+
+This crate is an internal layer of the SDK. Most Rust consumers want the main [`offline-protocol`](https://crates.io/crates/offline-protocol) crate instead, and app developers want the [React Native](https://www.npmjs.com/package/@offline-protocol/mesh-sdk) or [Python](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/bindings/python/README.md) bindings.
+
+## License
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+Dual-licensed: [AGPL-3.0-only](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE) for open-source use, or a [commercial license](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE-COMMERCIAL.md) for proprietary use.

--- a/crates/offline-protocol-mls/README.md
+++ b/crates/offline-protocol-mls/README.md
@@ -1,0 +1,17 @@
+# offline-protocol-mls
+
+MLS (Message Layer Security, [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420)) integration for end-to-end encryption in the [Offline Protocol SDK](https://github.com/Offline-Protocol/offline-protocol-sdk), built on [OpenMLS](https://github.com/openmls/openmls).
+
+Provides:
+
+- `MlsManager` — key package lifecycle, 1:1 session establishment, and group encryption state
+- The `MlsStorage` trait — a platform-agnostic secure storage interface that apps back with iOS Keychain, Android Keystore, or an equivalent
+- Session and group encrypt/decrypt used by the protocol engine's automatic end-to-end encryption
+
+This crate is an internal layer of the SDK. Most Rust consumers want the main [`offline-protocol`](https://crates.io/crates/offline-protocol) crate instead, which drives key exchange and encryption automatically — see the [MLS integration guide](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/mls-integration.md).
+
+## License
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+Dual-licensed: [AGPL-3.0-only](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE) for open-source use, or a [commercial license](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE-COMMERCIAL.md) for proprietary use.

--- a/crates/offline-protocol-reliability/README.md
+++ b/crates/offline-protocol-reliability/README.md
@@ -1,0 +1,18 @@
+# offline-protocol-reliability
+
+Reliability layer for the [Offline Protocol SDK](https://github.com/Offline-Protocol/offline-protocol-sdk): delivery acknowledgements, retries, and deduplication.
+
+Provides:
+
+- `AckManager` — tracks per-message delivery acknowledgements
+- `RetryQueue` — retransmission with exponential backoff
+- `Deduplicator` — drops duplicate frames arriving over multiple paths or retries
+- `AckOptimizer` — batches and prunes ACK traffic
+
+This crate is an internal layer of the SDK. Most Rust consumers want the main [`offline-protocol`](https://crates.io/crates/offline-protocol) crate instead, which wires these pieces into its delivery pipeline — see the [message delivery guide](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/message-delivery.md).
+
+## License
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+Dual-licensed: [AGPL-3.0-only](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE) for open-source use, or a [commercial license](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE-COMMERCIAL.md) for proprietary use.

--- a/crates/offline-protocol-router/README.md
+++ b/crates/offline-protocol-router/README.md
@@ -1,0 +1,17 @@
+# offline-protocol-router
+
+Routing layer for the [Offline Protocol SDK](https://github.com/Offline-Protocol/offline-protocol-sdk): transport selection, relay management, and mesh routing.
+
+Provides:
+
+- **DORS** (Dynamic Offline Relay Switch) — multi-factor transport scoring (signal strength, congestion, bandwidth, battery, reliability, capacity) with hysteresis, cooldown, and a stability window to prevent transport flapping
+- `RelayManager` and `PathSelector` — relay coordination and path choice for multi-hop delivery
+- Gossip-based routing state exchange
+
+This crate is an internal layer of the SDK. Most Rust consumers want the main [`offline-protocol`](https://crates.io/crates/offline-protocol) crate instead — see the [DORS deep dive](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/dors.md) and [DORS configuration guide](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/dors-configuration.md).
+
+## License
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+Dual-licensed: [AGPL-3.0-only](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE) for open-source use, or a [commercial license](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE-COMMERCIAL.md) for proprietary use.

--- a/crates/offline-protocol-services/README.md
+++ b/crates/offline-protocol-services/README.md
@@ -1,0 +1,17 @@
+# offline-protocol-services
+
+Mesh services layer for the [Offline Protocol SDK](https://github.com/Offline-Protocol/offline-protocol-sdk): service registry, discovery, and request/response over the mesh.
+
+Provides:
+
+- `MeshServices` — register named services a device offers to the mesh
+- Gossip-based service discovery across peers
+- A request/response exchange on top of the mesh's store-and-forward delivery
+
+This crate is an internal layer of the SDK. Most Rust consumers want the main [`offline-protocol`](https://crates.io/crates/offline-protocol) crate instead — see the [service discovery guide](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/service-discovery.md).
+
+## License
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+Dual-licensed: [AGPL-3.0-only](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE) for open-source use, or a [commercial license](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE-COMMERCIAL.md) for proprietary use.

--- a/crates/offline-protocol-transport/README.md
+++ b/crates/offline-protocol-transport/README.md
@@ -1,0 +1,19 @@
+# offline-protocol-transport
+
+Transport abstraction layer for the [Offline Protocol SDK](https://github.com/Offline-Protocol/offline-protocol-sdk).
+
+Provides:
+
+- The `Transport` trait that all transports implement, plus `TransportMetrics` for the scoring signals DORS routing consumes
+- Queue-based implementations for BLE, WiFi Direct, Internet, Reticulum, and Nostr
+- `MockTransport` for tests
+
+**These transports are I/O-free protocol engines** — they queue outbound frames and accept inbound bytes, but never open a socket or touch a radio. A *platform bridge* does the actual I/O: it drains each transport's outbound queue, performs the send, reports the outcome, and injects inbound bytes. The bridge contract is documented in this crate's API docs. The SDK's [React Native](https://www.npmjs.com/package/@offline-protocol/mesh-sdk) and [Python](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/bindings/python/README.md) bindings ship ready-made bridges; direct Rust consumers write their own.
+
+This crate is an internal layer of the SDK. Most Rust consumers want the main [`offline-protocol`](https://crates.io/crates/offline-protocol) crate instead.
+
+## License
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+Dual-licensed: [AGPL-3.0-only](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE) for open-source use, or a [commercial license](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE-COMMERCIAL.md) for proprietary use.

--- a/crates/offline-protocol-uniffi/README.md
+++ b/crates/offline-protocol-uniffi/README.md
@@ -1,0 +1,17 @@
+# offline-protocol-uniffi
+
+[UniFFI](https://mozilla.github.io/uniffi-rs/) bindings crate for the [Offline Protocol SDK](https://github.com/Offline-Protocol/offline-protocol-sdk). Builds the `cdylib`/`staticlib` and FFI scaffolding from which the SDK's Swift, Kotlin, and Python bindings are generated.
+
+This crate is not meant to be consumed directly:
+
+- **Rust** consumers want the main [`offline-protocol`](https://crates.io/crates/offline-protocol) crate
+- **React Native** (iOS/Android) apps want [`@offline-protocol/mesh-sdk`](https://www.npmjs.com/package/@offline-protocol/mesh-sdk)
+- **Python** (macOS/Linux/Windows) apps want the [Python binding](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/bindings/python/README.md)
+
+The generated bindings carry FFI checksums of the exact library they were generated against, so the library and all three language bindings are regenerated together from one script — see [the repository](https://github.com/Offline-Protocol/offline-protocol-sdk#regenerate-bindings-after-a-udl-change) for the build workflow.
+
+## License
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+Dual-licensed: [AGPL-3.0-only](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE) for open-source use, or a [commercial license](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE-COMMERCIAL.md) for proprietary use.

--- a/crates/offline-protocol/README.md
+++ b/crates/offline-protocol/README.md
@@ -1,0 +1,36 @@
+# offline-protocol
+
+Main protocol engine of the [Offline Protocol SDK](https://github.com/Offline-Protocol/offline-protocol-sdk): an offline-first messaging protocol with intelligent multi-transport switching, mesh networking, and automatic end-to-end encryption.
+
+This is the crate to depend on if you are consuming the SDK from Rust — it re-exports and orchestrates the lower layers (core types, transports, routing, reliability, MLS encryption, mesh services) behind one engine.
+
+## Features
+
+- **Multi-transport**: automatically switches between BLE, WiFi Direct, Internet, Reticulum, and Nostr relays via DORS (Dynamic Offline Relay Switch)
+- **Mesh networking**: peer discovery, cluster formation, and bounded multi-hop message relay
+- **End-to-end encryption**: automatic MLS (RFC 9420) for direct messages and groups, fail-closed by default
+- **Reliability**: delivery ACKs, retries with exponential backoff, and deduplication built in
+- **Event-driven**: the engine surfaces `MessageReceived`, `PeerDiscovered`, `TransportChanged`, and the rest of its lifecycle through an event callback
+
+## What you must implement
+
+The Rust crates are I/O-free protocol engines — they queue, route, encrypt, and select transports, but never open a socket or touch a radio. A *platform bridge* does the actual I/O: it drains each transport's outbound queue, performs the send, reports the outcome, and injects inbound bytes. If you consume this crate directly, you write that bridge yourself; the contract is documented in the [`offline-protocol-transport`](https://crates.io/crates/offline-protocol-transport) crate docs.
+
+Ready-made bridges ship with the higher-level bindings instead:
+
+- **React Native** (iOS/Android): [`@offline-protocol/mesh-sdk`](https://www.npmjs.com/package/@offline-protocol/mesh-sdk)
+- **Python** (macOS/Linux/Windows): [Python binding guide](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/bindings/python/README.md)
+
+## Documentation
+
+- [Architecture deep dive](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/architecture.md)
+- [Configuration guide](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/configuration.md)
+- [Message delivery](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/message-delivery.md) — ACK ladder, retries, offline park/push, group delivery reports
+- [MLS encryption integration](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/mls-integration.md)
+- [Full documentation index](https://github.com/Offline-Protocol/offline-protocol-sdk#documentation)
+
+## License
+
+Copyright © 2025-2026 Offline Protocol, Inc.
+
+Dual-licensed: [AGPL-3.0-only](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE) for open-source use, or a [commercial license](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/LICENSE-COMMERCIAL.md) for proprietary use. You may use the SDK under either license; you do not need both.

--- a/scripts/check-crate-readmes.sh
+++ b/scripts/check-crate-readmes.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Asserts every publishable crate carries a README.
+#
+# crates.io renders the README from the .crate archive, and a published version
+# is immutable -- there is no edit-metadata API, so a crate that ships without
+# one shows nothing but its one-line `description` on its page until the *next*
+# release goes out. That is precisely how all eight crates reached the registry
+# bare: cargo infers `readme = "README.md"` when the file sits beside
+# Cargo.toml and silently infers nothing when it does not, so the omission
+# produces no warning at package time, no failure at publish time, and is only
+# visible by looking at the rendered page afterwards.
+#
+# A crate added later inherits nothing from the others, which makes this the
+# same shape as the license-copy assertion next door: cheap to check, invisible
+# until too late to fix in place.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+status=0
+
+for manifest in crates/*/Cargo.toml; do
+  crate_dir="$(dirname "$manifest")"
+  # Harness and internal crates opt out via publish = false, as cargo enforces.
+  # Nothing is rendered for something never distributed.
+  if grep -qE '^publish[[:space:]]*=[[:space:]]*false' "$manifest"; then
+    continue
+  fi
+
+  # An explicit `readme` key overrides the inferred README.md, so follow it
+  # rather than checking a file cargo may not be reading. `readme = false`
+  # suppresses the README outright -- legal, but not what a published crate
+  # wants, so name it as the error it is here.
+  declared="$(sed -nE 's/^[[:space:]]*readme[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$manifest" | head -n1)"
+  if grep -qE '^[[:space:]]*readme[[:space:]]*=[[:space:]]*false' "$manifest"; then
+    echo "error: $manifest sets readme = false but is publishable" >&2
+    echo "       crates.io would render no README for it -- drop the key" >&2
+    status=1
+    continue
+  fi
+
+  readme_path="$crate_dir/${declared:-README.md}"
+  if [ ! -f "$readme_path" ]; then
+    echo "error: $crate_dir is publishable but has no README at $readme_path" >&2
+    echo "       add one -- crates.io renders it from the archive, and a" >&2
+    echo "       published version cannot be amended afterwards" >&2
+    status=1
+  fi
+done
+
+if [ "$status" -eq 0 ]; then
+  echo "Every publishable crate ships a README."
+fi
+exit "$status"

--- a/scripts/check-license-consistency.sh
+++ b/scripts/check-license-consistency.sh
@@ -78,6 +78,14 @@ for manifest in crates/*/Cargo.toml; do
     echo "       run 'cp LICENSE $crate_dir/LICENSE' to resync" >&2
     status=1
   fi
+  # The crate README is the front door of the crates.io page, the same role the
+  # root and per-binding READMEs above play for their packages, so it carries
+  # the same notice. scripts/check-crate-readmes.sh asserts the file exists at
+  # all; this asserts what it must say.
+  if [ -f "$crate_dir/README.md" ] && ! grep -qF "$NOTICE" "$crate_dir/README.md"; then
+    echo "error: $crate_dir/README.md is missing the copyright notice: $NOTICE" >&2
+    status=1
+  fi
   # Belt and braces: the two fields together are what produced the warning.
   # Matches an active key only -- the comment above it mentions the name too.
   if grep -qE '^[[:space:]]*license-file[[:space:]]*=' "$manifest"; then


### PR DESCRIPTION
## What

Adds a `README.md` to each of the eight publishable crates, and guards the omission from recurring.

## Why

None of the crates had a README, so all eight crates.io pages show nothing but their one-line `description`.

This is fixable only *forward*. A crates.io version is immutable — the README is extracted from the `.crate` archive at publish time, there is no edit-metadata API, and docs.rs builds from the same frozen tarball. The pages fill in when the next release publishes; no already-published version's page changes.

The reason it went unnoticed is worth naming, because it is the same trap for the next crate: cargo infers `readme = "README.md"` when the file sits beside `Cargo.toml`, and infers nothing — silently — when it does not. No warning at package time, no failure at publish time, and the omission is visible only on the rendered page afterwards.

## Per-crate text, not the root README shared eight ways

`offline-protocol` gets the fullest page, including the "the crates are I/O-free, you must implement the platform bridge" caveat from the root README, since it is the crate someone actually reaches for with `cargo add`.

The internal layers get short pages that say what the layer is and point at `offline-protocol` and the RN/Python bindings — the question someone landing on `offline-protocol-core` actually has. Sharing one README across all eight would put an SDK-wide quick-start on pages where it is misleading.

All links are absolute GitHub URLs; relative links do not resolve on crates.io.

`offline-protocol-bench` is `publish = false` and is correctly skipped.

## Guards

A crate added later inherits nothing from these, and the consequence lands after an immutable publish — the same shape as the existing per-crate LICENSE assertion, so it is enforced the same way:

- **`scripts/check-crate-readmes.sh`** (new) — asserts a README exists for every crate not marked `publish = false`. Follows an explicit `readme = "..."` key if one is set rather than checking a file cargo may not be reading, and rejects `readme = false` on a publishable crate.
- **`scripts/check-license-consistency.sh`** (extended, +8 lines) — asserts each crate README carries the copyright notice. These now ship inside redistributed archives, which is the same reason the root and per-binding READMEs already must, and that script already owns the notice check.

Both run in CI's existing **License Consistency** job.

## Verification

- `cargo metadata` confirms all eight crates now resolve `readme='README.md'` (auto-detection, no manifest change needed).
- `cargo package --list` confirms `README.md` is actually inside all eight tarballs.
- Both guards were negative-controlled — hid a README, stripped a notice — and each fails with the intended message rather than passing vacuously.

No Rust code changes; nothing compiles differently.