### PR TITLE
fix(protocol): fall back to the mesh when the relay says a peer is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to the Offline Protocol SDK are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This changelog covers everything after the **v0.7.1** release.
 
+## [Unreleased]
+
+### Fixed
+
+- **A device with internet no longer keeps messages from the mesh standing
+  next to it.** Reachability was decided from local carrier status alone: any
+  carrier that does its own routing being up — Internet, Nostr, Reticulum —
+  counted as reachable for *every* recipient, so nothing was ever handed to
+  the neighbors. That is right in the case forwarding was built for, where
+  nobody has infrastructure, and wrong in a mixed neighborhood. Two halves,
+  and the second was the one that bit: a message to a peer reachable only
+  across the mesh went to the relay, earned the "recipient unreachable"
+  verdict, and parked waiting for someone who was never going to come online;
+  and an online *recipient* answered a mesh-delivered message over the relay,
+  where an offline sender could not see it — so the sender retransmitted a
+  message that had been delivered and read, and eventually reported it failed.
+
+  The initial send is unchanged, so an online device still does not spend its
+  neighbors' battery on traffic the relay serves. What changed is what happens
+  after the relay contradicts it:
+
+  - The relay's `recipient_unreachable` verdict — the one per-peer
+    reachability fact a device receives — now hands the message to the mesh as
+    well as parking it, on every park rather than only the first, so a
+    recipient who was out of range at the first park is still reached later.
+    Media chunks are offered the same way.
+  - An acknowledgement for a message that arrived across the mesh travels back
+    the way it came, whatever the answering device's own carriers say. When
+    that device is also online the answer goes both ways; the duplicate costs
+    one frame, which the sender's ack handling already absorbs.
+  - Because parking removes the pending ACK, a parked message delivered across
+    the mesh is now settled from the acknowledgement alone, firing the ordinary
+    `message_delivered`. Without this the mesh hand-off would have delivered
+    messages the sender never learned about.
+
+  Still not covered: a device whose only infrastructure is Nostr or Reticulum
+  gets no unreachable verdict from either, so nothing contradicts the initial
+  answer and no fallback fires. Carrier status is also platform-reported and
+  means "this carrier is up", not "the relay connection is authenticated".
+  (#326)
+
 ## [0.21.0] — 2026-08-13
 
 > **Your identity is no longer something your app picks.** `ProtocolConfig.userId`

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -22,6 +22,7 @@ use crate::events::{DecryptionFailureCode, Event, PresenceStatus};
 use crate::file_transfer::{FileChunk, OutboundTransferState};
 use crate::media_envelope::{encode_media_envelope, MediaChunkPlaintext, MediaRichExtras};
 use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsOperationContext};
+use crate::transport_manager::TransportManager;
 use crate::{Error, Result};
 use chrono::{DateTime, Utc};
 use offline_protocol_core::{
@@ -3398,6 +3399,10 @@ impl OfflineProtocol {
         };
         let recipient = entry.message.recipient.as_str().to_string();
         let attempt_count = entry.attempt_count;
+        // Media never parks, so the mesh offer the park performs for a DM has
+        // to happen here instead. Cloned while the entry is still borrowed;
+        // only on a verdict, so not a per-chunk cost.
+        let media_frame = is_media.then(|| entry.message.clone());
         let file_id = self
             .outbound_media_chunks
             .get(&parsed_id)
@@ -3414,7 +3419,20 @@ impl OfflineProtocol {
             reason,
             file_id,
         ));
-        if is_media {
+        if let Some(frame) = media_frame {
+            // The recipient is not on the relay, but they may be a few devices
+            // away. A chunk keeps its pending ACK (media is never parked), so
+            // an answer coming back over the mesh settles it through the
+            // ordinary path — nothing else is needed here.
+            let handed_to_mesh = self.offer_to_mesh(&frame);
+            if handed_to_mesh > 0 {
+                debug!(
+                    message_id = %message_id,
+                    recipient = %recipient,
+                    handed_to_mesh,
+                    "Relay cannot reach this chunk's recipient; handed it to neighbors"
+                );
+            }
             return;
         }
 
@@ -3425,7 +3443,14 @@ impl OfflineProtocol {
     /// ([`Self::handle_recipient_unreachable_for_message`]) and the
     /// exhausted-probe path ([`Self::try_repark_exhausted_dm`]): drops the
     /// pending ACK and any scheduled retry so nothing burns budget against
-    /// the offline peer, then schedules the escalating reachability probe.
+    /// the offline peer, offers the frame to the mesh, then schedules the
+    /// escalating reachability probe.
+    ///
+    /// The mesh offer is here rather than at either caller so both parks make
+    /// it, and because this is where the frame is already at hand. Its rationale
+    /// is inline below; the short version is that a relay verdict is the only
+    /// per-peer reachability fact this device ever receives, and it says the
+    /// recipient is somewhere the relay cannot go.
     ///
     /// The probe is carrier-agnostic — DORS picks its transport like any
     /// other send — because an internet-only device is the common
@@ -3495,8 +3520,32 @@ impl OfflineProtocol {
         // pre-cap value — no overflow risk.
         let retry_in_secs = (WELCOME_NO_CARRIER_RETRY_SECS << (parks - 1).min(6))
             .min(WELCOME_UNREACHABLE_RETRY_CAP_SECS);
+        let mut handed_to_mesh = 0usize;
         if let Some(entry) = self.outbox.get(message_id) {
             let message = entry.message.clone();
+            // Ask the neighbors. The relay has just told us something no local
+            // transport status can: that *this peer* is not on it. That is the
+            // peer-specific fact `can_reach_without_carrying` cannot supply —
+            // it answers yes for every recipient while an infrastructure
+            // carrier is up, which is why the send-time offer never fires on an
+            // online device and why the whole mixed-neighborhood case (an
+            // online sender, a recipient reachable only across the mesh) used
+            // to wait here for a peer that was never going to come online.
+            //
+            // Additive, exactly like the send-time offer: the outbox entry and
+            // the probe below stand either way, since a neighbor taking a copy
+            // is not proof of arrival. What settles it is the acknowledgement
+            // coming back — over the mesh, for a message the relay could not
+            // deliver, which is why parked DMs must be settleable without a
+            // pending ACK (`settle_parked_dm_from_ack`). Without that arm this
+            // offer would deliver messages the sender never learns about.
+            //
+            // Re-offering on every park is cheap by construction: neighbors
+            // suppress a copy of an id they have already carried for the whole
+            // `RelaySeenCache` retention window, the escalation (15s → 600s)
+            // bounds how often we ask, and each offer spends the same own-send
+            // tokens as any other frame of ours.
+            handed_to_mesh = self.offer_to_mesh(&message);
             let _ = self.retry_queue.enqueue_with_delay(
                 message,
                 attempt_count,
@@ -3508,6 +3557,7 @@ impl OfflineProtocol {
             recipient = %recipient,
             retry_in_secs = retry_in_secs,
             parks = parks,
+            handed_to_mesh,
             "Parked unreachable DM with escalating reachability probe"
         );
     }
@@ -3833,11 +3883,25 @@ impl OfflineProtocol {
     ///
     /// 1. **The link it arrived on**, when that carrier can actually address
     ///    the sender. Preferred because it is known to work for this peer.
-    /// 2. **The mesh**, when nothing we hold reaches the sender directly: the
-    ///    answer travels back the way the message came, carried by the devices
-    ///    in between. Without this, multi-hop delivery looks like failure to a
-    ///    sender who retransmits a message we already have and read.
+    /// 2. **The mesh**, when the sender is not a direct mesh neighbor and
+    ///    either nothing we hold reaches them directly *or* the message itself
+    ///    arrived over a mesh carrier: the answer travels back the way the
+    ///    message came, carried by the devices in between. Without this,
+    ///    multi-hop delivery looks like failure to a sender who retransmits a
+    ///    message we already have and read.
     /// 3. **DORS**, which picks among whatever else is available.
+    ///
+    /// The arrival-over-mesh half of step 2 is what makes this work in a mixed
+    /// neighborhood. A frame that reached us across the mesh came from someone
+    /// the mesh can reach and — having failed step 1 — someone we cannot hand it
+    /// straight back to, which says nothing about whether *our* internet is up.
+    /// Deciding from local carrier status alone, an online recipient answers a
+    /// mesh-delivered message over the relay, where an offline sender cannot see
+    /// it: delivered and read, reported failed. In that case the answer goes to
+    /// the mesh **and** on to step 3, since an online sender is equally
+    /// plausible and a duplicate acknowledgement costs one frame the sender's
+    /// ack handling already absorbs. When nothing reaches the sender directly
+    /// the mesh remains the whole answer and step 3 is skipped, as before.
     ///
     /// Step 1 is *gated on addressability* rather than on a send error, and
     /// that gate is load-bearing. A transport returning `Ok` is not evidence
@@ -3867,17 +3931,36 @@ impl OfflineProtocol {
             "Inbound transport cannot answer this sender; looking for another route"
         );
 
-        if !self.transport_manager.can_reach_without_carrying(&ack_to)
-            && self.offer_to_mesh(ack_message) > 0
-        {
-            debug!(
-                ack_to = %ack_to,
-                "Sender is not directly reachable; handed the acknowledgement to the mesh"
-            );
-            return Ok(());
+        // No route at all without help: the mesh is the entire answer.
+        let no_direct_route = !self.transport_manager.can_reach_without_carrying(&ack_to);
+        // Reached us through other devices, and we cannot hand it straight
+        // back: the way it came is a route we know exists, whatever our own
+        // carriers claim.
+        let carried_to_us = TransportManager::is_mesh_transport(inbound_transport)
+            && !self.transport_manager.mesh_can_address(&ack_to);
+
+        let mut handed_to_mesh = 0usize;
+        if no_direct_route || carried_to_us {
+            handed_to_mesh = self.offer_to_mesh(ack_message);
+            if handed_to_mesh > 0 {
+                debug!(
+                    ack_to = %ack_to,
+                    handed_to_mesh,
+                    "Handed the acknowledgement to the mesh"
+                );
+                if no_direct_route {
+                    return Ok(());
+                }
+            }
         }
 
         if self.transport_manager.send(ack_message).is_ok() {
+            return Ok(());
+        }
+
+        // Neighbors took it, so the answer is on its way even though nothing
+        // else could carry it.
+        if handed_to_mesh > 0 {
             return Ok(());
         }
 
@@ -4006,9 +4089,117 @@ impl OfflineProtocol {
                             self.flush_outbox_for_peer_via(&recipient, redrive_via);
                         }
                     }
+                } else {
+                    // No pending ACK. Ordinarily that means a duplicate answer
+                    // or one arriving after the message already settled — but a
+                    // *parked* DM has no pending ACK either, because parking
+                    // removed it, and its delivery is the one this device has
+                    // no other way to learn about.
+                    self.settle_parked_dm_from_ack(&message_id, message);
                 }
             }
         }
+    }
+
+    /// Settles a parked DM whose acknowledgement arrived with no pending ACK to
+    /// match it — the delivery a park can otherwise never learn about.
+    ///
+    /// Parking is what makes this necessary: it removes the pending ACK so the
+    /// retry budget stops burning against a peer the relay says is offline. Once
+    /// the park also hands the frame to the mesh
+    /// ([`Self::park_unreachable_dm`]), a neighbor can carry it to a recipient
+    /// the relay could not reach — and the answer coming back would land here,
+    /// on the branch that used to drop it. The message would sit in the outbox
+    /// being probed until its lifetime expired, delivered and read the whole
+    /// time. The offer and this arm are one change; neither is correct alone.
+    ///
+    /// Gated four ways, because an acknowledgement is unauthenticated (it
+    /// carries no internal prefix, so it never reaches the control gate, and it
+    /// is handled before the security gate runs on the receive path):
+    ///
+    /// 1. the id is a parkable plain DM — connection requests keep their typed
+    ///    terminal path, welcomes their own lifecycle, media chunks are never
+    ///    parked and keep their pending ACK;
+    /// 2. it is still in the outbox;
+    /// 3. its recipient holds a live park counter, so the relay did declare this
+    ///    peer unreachable and no edge has cleared it since;
+    /// 4. the acknowledgement comes from that recipient.
+    ///
+    /// Those bound the forgery to someone who saw the frame *and* knows the
+    /// relay refused it — the carriers and the relay, parties who can already
+    /// deny delivery outright. What they gain is making a parked message look
+    /// delivered rather than staying parked, which is the same class as forging
+    /// an acknowledgement for an in-flight message, already possible today.
+    ///
+    /// Reports latency end to end (from the first send) rather than per attempt:
+    /// there is no pending record to measure the last attempt against, and for a
+    /// message that waited out a park the honest number is how long delivery
+    /// actually took. For the same reason no transport metric is recorded — the
+    /// carrier label is peer-supplied and there is no attempt to attribute it
+    /// to.
+    fn settle_parked_dm_from_ack(&mut self, message_id: &MessageId, ack: &Message) {
+        if !self.is_parkable_plain_dm(message_id) {
+            return;
+        }
+        let Some(entry) = self.outbox.get(message_id) else {
+            return;
+        };
+        let recipient = entry.message.recipient.as_str().to_string();
+        if !self.dm_unreachable_parks.contains_key(&recipient) {
+            return;
+        }
+        if ack.sender.as_str() != recipient {
+            return;
+        }
+
+        let latency = Utc::now()
+            .signed_duration_since(entry.first_sent_at)
+            .num_milliseconds()
+            .max(0) as u64;
+        let hop_count = ack
+            .metadata
+            .get(ACK_HOP_COUNT_KEY)
+            .and_then(|v| v.parse::<u8>().ok())
+            .unwrap_or(0);
+        let transport = ack
+            .metadata
+            .get(ACK_TRANSPORT_KEY)
+            .map(|label| Self::transport_from_label(label))
+            .unwrap_or(TransportType::BLE);
+
+        debug!(
+            message_id = %message_id,
+            recipient = %recipient,
+            latency_ms = latency,
+            "Parked DM was delivered after all; settling from its acknowledgement"
+        );
+
+        self.retry_queue.remove(&message_id.as_str());
+        let redrive_via = self.remove_outbox_entry(message_id).and_then(|entry| {
+            // Same reasoning as the pending-ACK path: our own record of where
+            // the delivered send went, never the peer-supplied label, and only
+            // while that carrier is still up. The park counter stays for the
+            // flush to reset, so a re-drive that fails everywhere restores it.
+            entry.last_transport.filter(|t| {
+                self.transport_manager
+                    .get_available_transports()
+                    .contains_key(t)
+            })
+        });
+        if let Ok(state) = lock_shared_state(&self.shared_state) {
+            state.emit_event(Event::message_delivered(
+                message_id.clone(),
+                latency,
+                hop_count,
+                transport,
+            ));
+            drop(state);
+        } else {
+            error!("Failed to lock shared state for parked-ACK event, skipping event emission");
+        }
+        // The peer answered, so the rest of their parked traffic can go now
+        // rather than waiting out its own escalated probe timers.
+        self.flush_outbox_for_peer_via(&recipient, redrive_via);
     }
 
     pub(super) fn handle_missing_outbox_entry(

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::constants::ACK_FOR_KEY;
+use crate::constants::{ACK_FOR_KEY, ACK_HOP_COUNT_KEY, ACK_TRANSPORT_KEY};
 use crate::events::{DecryptionFailureCode, PresenceSource, PresenceStatus, SecurityWarningCode};
 use crate::mls_observability::{
     DecryptionFailureKind, MlsErrorCategory, MlsLifecycleEvent, MlsOperationContext,
@@ -8734,6 +8734,342 @@ fn test_unreachable_media_chunk_is_not_parked() {
         "Media chunk must keep its pending ACK (not parked)"
     );
     assert!(protocol.media_outbox.contains_key(&chunk_id));
+    assert!(protocol.dm_unreachable_parks.is_empty());
+}
+
+// ============================================================================
+// MESH FALLBACK ON THE RELAY'S UNREACHABLE VERDICT
+//
+// An infrastructure carrier being up says nothing about whether a particular
+// recipient is on it, but it is what the send-time reachability check asks —
+// so an online device used to keep every frame to itself, whatever the relay
+// then said about the peer. These cover the one per-peer reachability fact
+// that does arrive, the relay's `recipient_unreachable` verdict, driving the
+// mesh hand-off the check cannot.
+// ============================================================================
+
+/// A device with a working relay connection and one neighbor standing next to
+/// it — `carol`, who is not the recipient of anything here and can only carry.
+///
+/// The radio refuses recipients it holds no link to, the way BLE does, so a
+/// frame for a distant peer really does leave over the relay rather than being
+/// swallowed by the mesh carrier.
+fn online_device_with_a_neighbor() -> (OfflineProtocol, MockTransport, MockTransport) {
+    let mut protocol = OfflineProtocol::new(create_relay_test_config_for_user("user123")).unwrap();
+
+    let internet = MockTransport::new(TransportType::Internet);
+    internet.start().unwrap();
+    let ble = MockTransport::new(TransportType::BLE);
+    ble.start().unwrap();
+    ble.set_reject_unknown_recipients(true);
+    ble.add_connected_peer("carol", -55);
+
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::Internet, Box::new(internet.clone()));
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(ble.clone()));
+    protocol.start().unwrap();
+
+    (protocol, internet, ble)
+}
+
+/// The acknowledgement a recipient sends back, as it looks arriving here.
+fn delivery_ack_frame(from: &str, to: &str, acked: &MessageId) -> Message {
+    Message::builder(
+        UserId::new(from).unwrap(),
+        UserId::new(to).unwrap(),
+        AppId::new("test-app").unwrap(),
+    )
+    .content(String::new())
+    .requires_ack(false)
+    .metadata(ACK_FOR_KEY, acked.as_str())
+    .metadata(ACK_HOP_COUNT_KEY, "2")
+    .metadata(ACK_TRANSPORT_KEY, "ble")
+    .build()
+}
+
+#[test]
+fn test_unreachable_verdict_offers_a_parked_dm_to_the_mesh() {
+    // The mixed neighborhood: this device is online, the recipient is not on
+    // the relay, and somebody who might reach them is standing right here.
+    let (mut protocol, internet, ble) = online_device_with_a_neighbor();
+
+    let message_id = protocol
+        .send_message("bob", "hello", None::<MessagePriority>, None::<String>)
+        .unwrap();
+
+    assert_eq!(
+        internet.sent_messages().len(),
+        1,
+        "with the relay up the frame goes to the relay"
+    );
+    assert!(
+        ble.peer_sends().is_empty(),
+        "and the mesh is not spent before the relay has said anything about this peer"
+    );
+
+    protocol
+        .on_transport_send_failed(
+            &message_id.as_str(),
+            Some("recipient_unreachable: peer offline".to_string()),
+        )
+        .unwrap();
+
+    let handed = ble.peer_sends();
+    assert_eq!(
+        handed.len(),
+        1,
+        "the relay declaring this peer unreachable is the per-peer fact the \
+         send-time check cannot have; the neighbors must be asked"
+    );
+    assert_eq!(handed[0].0, "carol");
+    assert_eq!(handed[0].1.id, message_id);
+
+    // A neighbor taking a copy is not proof of arrival, so the park stands.
+    assert_eq!(protocol.dm_unreachable_parks.get("bob"), Some(&1));
+    assert!(protocol.outbox.contains_key(&message_id));
+    assert!(
+        !protocol.ack_manager.is_waiting_for_ack(&message_id),
+        "parking still drops the pending ACK"
+    );
+}
+
+#[test]
+fn test_a_later_park_offers_the_dm_to_whoever_is_around_then() {
+    // Neighbors come and go. A DM parked while nobody was in range must be
+    // offered again to whoever turns up, not only on the first park — the
+    // offer belongs to the park action, not to the first verdict.
+    let mut protocol = OfflineProtocol::new(create_relay_test_config_for_user("user123")).unwrap();
+
+    let internet = MockTransport::new(TransportType::Internet);
+    internet.start().unwrap();
+    let ble = MockTransport::new(TransportType::BLE);
+    ble.start().unwrap();
+    ble.set_reject_unknown_recipients(true);
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::Internet, Box::new(internet));
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::BLE, Box::new(ble.clone()));
+    protocol.start().unwrap();
+
+    let message_id = protocol
+        .send_message("bob", "hello", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    protocol
+        .on_transport_send_failed(
+            &message_id.as_str(),
+            Some("recipient_unreachable: peer offline".to_string()),
+        )
+        .unwrap();
+    assert!(
+        ble.peer_sends().is_empty(),
+        "nobody is around to carry it yet"
+    );
+
+    // Someone walks up, and the probe earns a second verdict.
+    ble.add_connected_peer("carol", -55);
+    protocol
+        .on_transport_send_failed(
+            &message_id.as_str(),
+            Some("recipient_unreachable: peer offline".to_string()),
+        )
+        .unwrap();
+
+    let handed = ble.peer_sends();
+    assert_eq!(handed.len(), 1, "the second park must ask the new neighbor");
+    assert_eq!(handed[0].1.id, message_id);
+    assert_eq!(
+        protocol.dm_unreachable_parks.get("bob"),
+        Some(&2),
+        "and the escalation continues as before"
+    );
+}
+
+#[test]
+fn test_a_parked_dm_is_settled_by_an_acknowledgement_carried_back() {
+    // The other half of the offer. Parking removed the pending ACK, so the
+    // answer to a mesh-carried delivery lands on the branch that used to drop
+    // it — leaving a delivered, read message being probed until its outbox
+    // lifetime ran out. Without this the offer would be worse than useless.
+    let (mut protocol, _internet, ble) = online_device_with_a_neighbor();
+
+    let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_handle = Arc::clone(&events);
+    protocol.on_event(move |event| {
+        events_handle.lock().unwrap().push(event);
+    });
+
+    let message_id = protocol
+        .send_message("bob", "hello", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    protocol
+        .on_transport_send_failed(
+            &message_id.as_str(),
+            Some("recipient_unreachable: peer offline".to_string()),
+        )
+        .unwrap();
+    assert!(protocol.outbox.contains_key(&message_id));
+
+    // Bob answers, and the answer is carried back to us by carol.
+    ble.queue_message_from(
+        delivery_ack_frame("bob", "user123", &message_id),
+        "carol".to_string(),
+    );
+    assert!(
+        protocol.receive_message().is_none(),
+        "an acknowledgement is not app traffic"
+    );
+
+    assert!(
+        !protocol.outbox.contains_key(&message_id),
+        "the message was delivered; it must not keep being probed"
+    );
+    assert!(
+        !protocol.retry_queue.contains(&message_id.as_str()),
+        "and its reachability probe must be gone with it"
+    );
+    let captured = events.lock().unwrap();
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            Event::MessageDelivered { message_id: delivered, .. } if *delivered == message_id.as_str()
+        )),
+        "the app must be told it was delivered: {:?}",
+        *captured
+    );
+}
+
+#[test]
+fn test_a_parked_dm_is_not_settled_by_anyone_elses_acknowledgement() {
+    // An acknowledgement carries no signature, so the settle path is gated on
+    // what it cannot choose: the message must be parked, and the answer must
+    // come from the peer it was addressed to.
+    let (mut protocol, _internet, ble) = online_device_with_a_neighbor();
+
+    let message_id = protocol
+        .send_message("bob", "hello", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    protocol
+        .on_transport_send_failed(
+            &message_id.as_str(),
+            Some("recipient_unreachable: peer offline".to_string()),
+        )
+        .unwrap();
+
+    ble.queue_message_from(
+        delivery_ack_frame("mallory", "user123", &message_id),
+        "carol".to_string(),
+    );
+    assert!(protocol.receive_message().is_none());
+    assert!(
+        protocol.outbox.contains_key(&message_id),
+        "only the recipient's own answer settles a parked message"
+    );
+
+    // With no park counter this is an ordinary late or duplicate answer, and
+    // the outbox entry is not this path's to remove: a reachability edge that
+    // cleared the counter also re-drove the message, which registers a fresh
+    // pending ACK for the ordinary path to settle.
+    protocol.dm_unreachable_parks.remove("bob");
+    ble.queue_message_from(
+        delivery_ack_frame("bob", "user123", &message_id),
+        "carol".to_string(),
+    );
+    assert!(protocol.receive_message().is_none());
+    assert!(
+        protocol.outbox.contains_key(&message_id),
+        "without a live park this is a late answer, not a park settlement"
+    );
+}
+
+#[test]
+fn test_an_answer_to_a_carried_message_goes_back_over_the_mesh_even_when_online() {
+    // The half that bites: a message reached us across the mesh, so its sender
+    // is somewhere the mesh goes. Answering over the relay because our own
+    // internet happens to be up leaves an offline sender retransmitting a
+    // message we have already read.
+    let (mut protocol, internet, ble) = online_device_with_a_neighbor();
+
+    let inbound = signed_frame(&id("alice"), "user123", "carried to you");
+    let inbound_id = inbound.id.as_str();
+    ble.queue_message_from(inbound, "carol".to_string());
+
+    assert!(
+        protocol.receive_message().is_some(),
+        "the message is for us and must be delivered"
+    );
+
+    let handed = ble.peer_sends();
+    assert_eq!(
+        handed.len(),
+        1,
+        "the answer must travel back the way the message came"
+    );
+    assert_eq!(handed[0].0, "carol");
+    assert_eq!(
+        handed[0].1.metadata.get(ACK_FOR_KEY).map(String::as_str),
+        Some(inbound_id.as_str())
+    );
+    assert_eq!(handed[0].1.recipient.as_str(), id("alice"));
+
+    assert!(
+        internet
+            .sent_messages()
+            .iter()
+            .any(|m| m.metadata.get(ACK_FOR_KEY).map(String::as_str) == Some(inbound_id.as_str())),
+        "and also over the relay: an online sender is equally plausible, and a \
+         duplicate acknowledgement costs one frame"
+    );
+}
+
+#[test]
+fn test_unreachable_media_chunk_is_offered_to_the_mesh() {
+    // Media is never parked — a chunk keeps its pending ACK, so an answer
+    // carried back settles it through the ordinary path — but the relay's
+    // verdict says the same thing about the recipient either way, and a
+    // transfer that can complete across the room should.
+    let (mut protocol, _internet, ble) = online_device_with_a_neighbor();
+
+    let chunk_message = signed_frame(&id("user123"), "bob", "chunk-bytes");
+    let chunk_id = chunk_message.id.clone();
+    protocol.media_outbox.insert(
+        chunk_id.clone(),
+        OutboxEntry {
+            message: chunk_message,
+            attempt_count: 1,
+            first_sent_at: chrono::Utc::now(),
+            last_sent_at: chrono::Utc::now(),
+            last_transport: Some(TransportType::Internet),
+            reseal: None,
+        },
+    );
+    protocol
+        .ack_manager
+        .register_pending_ack(chunk_id.clone(), None)
+        .unwrap();
+
+    protocol
+        .on_transport_send_failed(
+            &chunk_id.as_str(),
+            Some("recipient_unreachable: peer offline".to_string()),
+        )
+        .unwrap();
+
+    let handed = ble.peer_sends();
+    assert_eq!(
+        handed.len(),
+        1,
+        "the chunk must be offered to the neighbors"
+    );
+    assert_eq!(handed[0].1.id, chunk_id);
+    assert!(
+        protocol.ack_manager.is_waiting_for_ack(&chunk_id),
+        "and it must still be the ordinary ACK machinery that settles it"
+    );
     assert!(protocol.dm_unreachable_parks.is_empty());
 }
 

--- a/crates/offline-protocol/src/transport_manager.rs
+++ b/crates/offline-protocol/src/transport_manager.rs
@@ -946,15 +946,38 @@ impl TransportManager {
     ///
     /// Checked in that order so the common online case costs a status scan and
     /// never enumerates links.
+    ///
+    /// **This answer is deliberately peer-blind on its first arm**, and that is
+    /// a real limit rather than an oversight: an infrastructure carrier being up
+    /// says nothing about whether *this* recipient is on it. Callers that hold a
+    /// peer-specific fact must not settle for this answer — the relay's own
+    /// `recipient_unreachable` verdict is exactly such a fact, and the park it
+    /// drives offers the frame to the mesh regardless of what this returns (see
+    /// `park_unreachable_dm`).
     pub fn can_reach_without_carrying(&self, peer_id: &str) -> bool {
-        let has_infrastructure = self.transports.iter().any(|(transport_type, transport)| {
+        self.has_infrastructure_carrier() || self.mesh_can_address(peer_id)
+    }
+
+    /// Whether any carrier that does its own routing is available.
+    ///
+    /// Peer-blind by nature: these carriers reach peers we hold no radio link
+    /// to, so there is no per-peer link to consult. Note the status is
+    /// bridge-reported and means "the platform says this carrier is up", not
+    /// "the relay connection is authenticated" — a distinction that matters
+    /// wherever this stands in for reachability.
+    pub fn has_infrastructure_carrier(&self) -> bool {
+        self.transports.iter().any(|(transport_type, transport)| {
             !MESH_TRANSPORTS.contains(transport_type)
                 && transport.status() == TransportStatus::Available
-        });
-        if has_infrastructure {
-            return true;
-        }
+        })
+    }
 
+    /// Whether a mesh carrier holds a live link straight to `peer_id`.
+    ///
+    /// The peer-specific half of [`Self::can_reach_without_carrying`], split out
+    /// because callers that already know infrastructure is up still need to ask
+    /// whether the mesh can hand a frame over without anyone carrying it.
+    pub fn mesh_can_address(&self, peer_id: &str) -> bool {
         MESH_TRANSPORTS.iter().any(|transport_type| {
             self.transports
                 .get(transport_type)
@@ -966,6 +989,16 @@ impl TransportManager {
                         .any(|link| link.peer_id == peer_id)
                 })
         })
+    }
+
+    /// Whether `transport_type` is a short-range carrier that can only address
+    /// peers it holds a live link to — as opposed to an infrastructure carrier
+    /// that does its own routing.
+    ///
+    /// A frame that arrived over one of these travelled either from a neighbor
+    /// or through them, which is what makes it evidence about the route back.
+    pub fn is_mesh_transport(transport_type: TransportType) -> bool {
+        MESH_TRANSPORTS.contains(&transport_type)
     }
 
     /// Whether `transport_type` can actually put a frame in front of `peer_id`.

--- a/crates/offline-protocol/tests/mesh_forwarding.rs
+++ b/crates/offline-protocol/tests/mesh_forwarding.rs
@@ -14,10 +14,11 @@
 //!   Reach alone is easy to get by repeating everything endlessly; the counts in
 //!   these tests are what separate a working mesh from one that floods.
 
-use offline_protocol::{OfflineProtocol, ProtocolConfig};
+use offline_protocol::{Event, OfflineProtocol, ProtocolConfig};
 use offline_protocol_core::{AppId, Message, UserId};
 use offline_protocol_transport::{mock::MockTransport, Transport, TransportType};
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 /// A simulated neighborhood of devices.
 ///
@@ -56,6 +57,20 @@ impl Neighborhood {
     /// Adds one device, which may be configured differently from the rest —
     /// a device that declines to carry traffic, for instance.
     fn add_node(&mut self, id: &str, config: ProtocolConfig) {
+        self.add_node_inner(id, config, false);
+    }
+
+    /// Adds a device that also has a working relay connection.
+    ///
+    /// Its relay is a hole in the ground: frames written to it leave the
+    /// simulation, because the whole point of the case this exists for is a
+    /// recipient the relay cannot deliver to. What comes back instead is the
+    /// relay's verdict, delivered by [`Self::relay_says_unreachable`].
+    fn add_online_node(&mut self, id: &str) {
+        self.add_node_inner(id, default_config(id), true);
+    }
+
+    fn add_node_inner(&mut self, id: &str, config: ProtocolConfig, online: bool) {
         let radio = MockTransport::new(TransportType::BLE);
         radio.start().unwrap();
         // A device can only put a frame on a link it actually has.
@@ -65,12 +80,32 @@ impl Neighborhood {
         let mut node = OfflineProtocol::new(config).unwrap();
         node.transport_manager_mut()
             .add_transport(TransportType::BLE, Box::new(radio));
+        if online {
+            let relay = MockTransport::new(TransportType::Internet);
+            relay.start().unwrap();
+            node.transport_manager_mut()
+                .add_transport(TransportType::Internet, Box::new(relay));
+        }
         node.start().unwrap();
 
         self.nodes.insert(id.to_string(), node);
         self.radios.insert(id.to_string(), handle);
         self.links.insert(id.to_string(), Vec::new());
         self.inboxes.insert(id.to_string(), Vec::new());
+    }
+
+    /// The relay answering that it cannot reach the recipient of `message_id` —
+    /// the one thing a device learns about a *particular* peer, as opposed to
+    /// whether its own carriers are up.
+    fn relay_says_unreachable(&mut self, id: &str, message_id: &str) {
+        self.nodes
+            .get_mut(id)
+            .unwrap()
+            .on_transport_send_failed(
+                message_id,
+                Some("recipient_unreachable: peer offline".to_string()),
+            )
+            .unwrap();
     }
 
     /// Puts two devices in range of each other.
@@ -279,6 +314,58 @@ fn the_answer_finds_its_way_back() {
     assert!(
         acked_back,
         "carol's answer must be carried back toward alice"
+    );
+}
+
+#[test]
+fn an_online_sender_reaches_a_recipient_only_the_mesh_can_see() {
+    // The mixed neighborhood, end to end. Alice has internet; carol does not
+    // and is two links away. Having a relay connection says nothing about
+    // whether carol is on it — and when the relay says she is not, the devices
+    // standing next to alice are the only way there.
+    let mut net = Neighborhood::new(&["bob", "carol"]);
+    net.add_online_node("alice");
+    net.link("alice", "bob");
+    net.link("bob", "carol");
+
+    let delivered: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let delivered_handle = Arc::clone(&delivered);
+    net.node("alice").on_event(move |event| {
+        if let Event::MessageDelivered { message_id, .. } = event {
+            delivered_handle.lock().unwrap().push(message_id);
+        }
+    });
+
+    let msg_id = net.send("alice", "carol", "meet at the north gate");
+
+    // With the relay up the frame goes to the relay, and the neighbors are not
+    // asked. (Without this the test would pass on the pre-existing failure
+    // path, which offers to the mesh when no transport accepts the send.)
+    net.step();
+    assert_eq!(
+        net.transmission_count(&msg_id),
+        0,
+        "an online device must not spend the mesh before the relay has spoken"
+    );
+
+    net.relay_says_unreachable("alice", &msg_id);
+    net.run_until_quiet(12);
+
+    assert_eq!(
+        net.inbox("carol"),
+        vec!["meet at the north gate".to_string()],
+        "the relay's verdict must send the message to the neighbors instead"
+    );
+    assert_eq!(
+        net.deliveries_to("carol", &msg_id),
+        1,
+        "and it must arrive exactly once"
+    );
+    assert_eq!(
+        *delivered.lock().unwrap(),
+        vec![msg_id.clone()],
+        "alice must learn it was delivered — parking removed the pending ACK, \
+         so a delivery she cannot settle would be probed until it expired"
     );
 }
 

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -547,11 +547,18 @@ The device's own sends draw on the same per-second budget — it is one radio �
 
 Tunables live in `ProtocolConfig::mesh_relay`. Both the tunables and these counters are **Rust-core surfaces today**: neither is mirrored over UniFFI or React Native yet, so apps get the defaults and cannot read the counters from JS or native.
 
-#### What forwarding does not cover
+#### An online device in a mixed neighborhood
 
-A device offers frames to its neighbors only when it holds no other way to reach the recipient. If any carrier that does its own routing is up — Internet, Nostr, Reticulum — that counts as reachable for **every** recipient, and nothing is handed to the mesh.
+At the moment of sending, a device offers frames to its neighbors only when it holds no other way to reach the recipient. If any carrier that does its own routing is up — Internet, Nostr, Reticulum — that counts as reachable for **every** recipient, and nothing is handed to the mesh. That keeps the ordinary online case free: a device with a working relay connection does not spend its neighbors' battery on traffic the relay serves perfectly well.
 
-That is right for the case this is built for, where nobody has infrastructure, but it leaves a gap in a mixed neighborhood: a device with internet will send to the relay rather than across the mesh, even when the recipient is reachable only by a multi-hop mesh path. It applies to acknowledgements too, so an online recipient answers a mesh-delivered message over the relay, where an offline sender cannot see it. Closing this means letting the relay's own "recipient unreachable" verdict fall back to the mesh, which is future work.
+The catch is that the question being asked there is about this device's own carriers, not about the recipient. So a mixed neighborhood — someone online standing next to someone who is not — needs a second answer, and two things provide it:
+
+- **The relay's verdict.** When the relay reports it cannot reach the recipient, that is the one per-peer reachability fact a device ever receives, and it contradicts what the carrier status implied. The message is parked as before *and* handed to the neighbors, who may well be able to reach someone the relay cannot. Re-offered on each subsequent park, so a recipient who was out of range when the message was first parked is still reached later. Media chunks are offered the same way.
+- **How the message arrived.** An acknowledgement for a message that reached this device across the mesh goes back the way it came, whatever this device's own carriers say. Otherwise an online recipient answers over the relay, where an offline sender cannot see it — and that sender retransmits a message that was delivered and read, eventually reporting it failed. When this device is also online, the answer goes both ways; the duplicate costs one frame.
+
+Because parking removes the pending acknowledgement, a parked message that is then delivered across the mesh is settled from the acknowledgement alone. Apps see the ordinary `message_delivered` event.
+
+What is still not covered: a device whose only infrastructure is **Nostr or Reticulum** never receives an unreachable verdict at all — neither reports per-recipient delivery — so nothing contradicts the initial "reachable" answer and no mesh fallback fires for it. Note also that carrier status is reported by the platform bridge and means "this carrier is up", not "the relay connection is authenticated"; a bridge that reports a connection it never authenticates produces no verdicts either, and its messages settle by acknowledgement timeout as they always did.
 
 ### Path Scoring
 

--- a/docs/message-delivery.md
+++ b/docs/message-delivery.md
@@ -217,6 +217,9 @@ When the internet relay reports a recipient unreachable for an in-flight regular
 1. A non-terminal `MessageUndeliverable` event fires (`message_id`, `recipient`, `reason`, and `file_id` when the message is a media chunk)
 2. The pending ACK and the retry-queue entry are dropped — the retry machinery goes quiet
 3. The outbox entry stays put, so the message remains "in flight" and subject only to the outbox lifetime
+4. The message is offered to any mesh neighbors, who may be able to reach a recipient the relay cannot — see [An online device in a mixed neighborhood](./mesh.md#an-online-device-in-a-mixed-neighborhood)
+
+The mesh offer repeats on each subsequent park, so a recipient who was out of range when the message was first parked is still reached later. Handing a copy to a neighbor is not proof of arrival, so the park and its probe stand regardless; what settles the message is the acknowledgement coming back. Since parking removed the pending ACK, that acknowledgement settles the parked entry on its own and fires the ordinary `MessageDelivered`.
 
 A parked message is re-driven with a fresh ACK budget on every reachability edge:
 
@@ -237,8 +240,8 @@ The outbox lifetime bounds the entry itself, with one caveat worth knowing: each
 
 | Message kind | Behavior on `recipient_unreachable` |
 |--------------|-------------------------------------|
-| Regular DM | Parked (as above) |
-| Media chunk | Not parked — normal retry exhaustion → transfer abort → `media_resend_required` |
+| Regular DM | Parked (as above), and offered to mesh neighbors |
+| Media chunk | Not parked — normal retry exhaustion → transfer abort → `media_resend_required` — but offered to mesh neighbors, and it keeps its pending ACK, so an answer carried back settles it the ordinary way |
 | Connection request | Not parked — settles immediately via `connection_request_undeliverable` |
 
 **Contract**: `MessageUndeliverable` is the "recipient is offline" signal and may fire repeatedly for the same message while the peer stays offline. Terminal settlement happens only at delivery (`MessageDelivered`) or outbox-lifetime expiry (`MessageFailed`). Apps that previously keyed "recipient offline" UX off the ~15-minute terminal `message_failed` should key it off `message_undeliverable` instead.


### PR DESCRIPTION
Closes #326.

## The gap

Reachability was decided from local carrier status alone. `TransportManager::can_reach_without_carrying` answers yes for **every** recipient while any carrier that does its own routing is up — Internet, Nostr, Reticulum — so an online device never handed anything to its neighbors.

That is right for the case forwarding was built for, where nobody has infrastructure. In a mixed neighborhood it cost delivery both ways:

- **Outbound** — a DM to a peer reachable only across the mesh went to the relay, earned the `recipient_unreachable` verdict, and parked waiting for someone who was never coming online. The park loop never consulted the mesh.
- **Inbound (the half that bites)** — an online recipient answered a mesh-delivered message over the relay, where an offline sender could not see it. The sender retransmitted a message that had been delivered and read, and eventually reported it failed.

## A third piece the issue did not name

Parking removes the pending ACK. `handle_ack_message` settles delivery only inside `Some(pending) = remove_ack(..)`, so an acknowledgement for a parked message was **dropped**. Offering parked messages to the mesh without fixing that would deliver messages the sender never learns about — probed until the outbox lifetime expired, delivered and read the whole time. That is worse than not offering, so the three pieces here are one atom.

## What changed

The send-time check is untouched, so the ordinary online case still costs the mesh nothing (`a_device_with_infrastructure_does_not_spend_the_mesh_on_its_own_traffic` still pins it). What changed is what happens after the relay contradicts it:

- `park_unreachable_dm` offers the frame to the mesh — the relay's verdict is the only per-peer reachability fact this device receives. On every park, not just the first, so a recipient out of range at the first park is still reached later. Media chunks are offered from `handle_recipient_unreachable_for_message`, where they leave the park path; they keep their pending ACK, so nothing else is needed for them.
- `route_ack` answers over the mesh when the message arrived over a mesh carrier and the sender is not a direct neighbor, whatever our own carriers say. With infrastructure up the answer goes both ways; the sender's ack handling already absorbs the duplicate.
- `settle_parked_dm_from_ack` settles a parked DM from an acknowledgement with no pending ACK to match. Gated on: parkable plain DM, still in the outbox, recipient holds a live park counter, and the answer comes from that recipient. An acknowledgement is unauthenticated (no internal prefix, handled before the security gate), so the gates are things it cannot choose — bounding the forgery to parties who saw the frame *and* know the relay refused it, i.e. the carriers and the relay, who can already deny delivery outright.

`TransportManager` grows `mesh_can_address` / `has_infrastructure_carrier` — the two halves `can_reach_without_carrying` was already composed of — plus `is_mesh_transport`.

## Scope

No FFI, UDL, wire-format, config, or persisted-state changes; no bindings regeneration. Group per-member sends and group delivery ACKs inherit both halves, since they ride the DM ladder.

## Not covered (documented, not fixed)

- Nostr and Reticulum report no per-recipient verdict, so nothing contradicts the initial answer on a device whose only infrastructure is one of those.
- Carrier status is bridge-reported and means "this carrier is up", not "the relay connection is authenticated" — the issue's secondary point. A bridge that reports a connection it never authenticates produces no verdicts either, and its messages settle by ACK timeout as before.

## Verification

`cargo clippy --workspace -- -D warnings`, `cargo test --workspace` (2115 tests, 0 failures), `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — all clean.

7 new tests, each **mutation-checked** against a sabotage of the line it covers (park offer removed → 2 unit tests + the e2e fail; settle arm removed → settle test + e2e fail; `route_ack` reverted → answer test fails; media offer removed → media test fails):

- `test_unreachable_verdict_offers_a_parked_dm_to_the_mesh`
- `test_a_later_park_offers_the_dm_to_whoever_is_around_then`
- `test_a_parked_dm_is_settled_by_an_acknowledgement_carried_back`
- `test_a_parked_dm_is_not_settled_by_anyone_elses_acknowledgement`
- `test_an_answer_to_a_carried_message_goes_back_over_the_mesh_even_when_online`
- `test_unreachable_media_chunk_is_offered_to_the_mesh`
- `an_online_sender_reaches_a_recipient_only_the_mesh_can_see` (neighborhood simulator, full loop: send → relay verdict → carried two hops → delivered → answer carried back → settled)

The e2e test asserts **zero** transmissions before the verdict, so it cannot pass on the pre-existing send-failure path — the vacuity trap this suite has hit before.