### PR TITLE
fix(protocol): settle a message only from the peer it was sent to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Only the recipient can mark a message delivered.** A delivery
+  acknowledgement names a message id and nothing else tied it to a delivery, so
+  an acknowledgement from any party that had merely seen the frame settled it:
+  the outbox entry was dropped, the retries stopped, and the app was told
+  `message_delivered` for a message that arrived nowhere. Every device that
+  carries a frame across the mesh knows its id, and the mesh fall-back below
+  hands frames to exactly those devices — so the two belong together.
+  Acknowledgements naming a message sent to somebody else are now ignored on
+  both settlement paths, and a rejected one leaves the message's retry record
+  untouched so it keeps being retried. This is an attribution check rather than
+  authentication: acknowledgements carry no signature, so it removes the
+  unattributed answer, not a determined forgery by someone who saw the frame.
+
 - **A device with internet no longer keeps messages from the mesh standing
   next to it.** Reachability was decided from local carrier status alone: any
   carrier that does its own routing being up — Internet, Nostr, Reticulum —

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -4003,6 +4003,50 @@ impl OfflineProtocol {
     pub(super) fn handle_ack_message(&mut self, message: &Message) {
         if let Some(ack_for) = message.metadata.get(ACK_FOR_KEY) {
             if let Ok(message_id) = MessageId::from_str(ack_for) {
+                // Whoever answers has to be whoever we sent it to. An
+                // acknowledgement names a message id and nothing else ties it
+                // to a delivery, so without this any third party that merely
+                // saw the frame — a mesh carrier that took a copy, the relay —
+                // settles it: the outbox entry is dropped, the retries stop and
+                // the app is told `message_delivered` for a message that
+                // arrived nowhere. Refusing delivery is something those parties
+                // could always do; a false confirmation is the strictly worse
+                // one, because it is the version the sender never finds out
+                // about.
+                //
+                // Checked before anything is removed. The settle work below
+                // starts by taking the pending ACK, and a frame rejected after
+                // that point would have already cost the message its retry
+                // record — turning a refused acknowledgement into the silent
+                // loss this exists to prevent.
+                //
+                // Safe on this path — which every delivery passes through —
+                // because delivery already implies the equality: a device
+                // processes a frame only when its own `local_id` equals the
+                // frame's recipient (`receive_message` forwards anything else),
+                // and the acknowledgement it builds carries that same
+                // `local_id` as its sender. A genuine confirmation therefore
+                // matches whatever identifier namespace the app addresses peers
+                // in — the profile before MLS initialization, the `off1…`
+                // address after it.
+                //
+                // It is **not** authentication and must not be read as one: an
+                // acknowledgement carries no signature (empty content is not a
+                // security-gated prefix, and the receive loop handles it before
+                // the gate would run anyway), so a forger who saw the frame saw
+                // its recipient too and can simply write that name. What this
+                // removes is the unattributed forgery, and the divergence
+                // between the two settle paths below. Binding an
+                // acknowledgement to its sender for real needs signed acks.
+                if !self.ack_is_from_the_message_recipient(&message_id, message) {
+                    debug!(
+                        message_id = %message_id,
+                        claimed_sender = %message.sender,
+                        "Ignoring an acknowledgement from someone this message was not sent to"
+                    );
+                    return;
+                }
+
                 // A delivery ack settles an outbound connection request:
                 // the recipient provably received it, so a later stale
                 // recipient_unreachable signal must not fire a false
@@ -4101,6 +4145,31 @@ impl OfflineProtocol {
         }
     }
 
+    /// Whether `ack` comes from the peer the message it answers was addressed
+    /// to — the one thing about an acknowledgement that is not simply asserted
+    /// by whoever sent it. See [`Self::handle_ack_message`] for what that does
+    /// and does not buy.
+    ///
+    /// Both outboxes are consulted because both hold ack-bearing sends: plain
+    /// DMs and control frames in `outbox`, media chunks in `media_outbox`.
+    ///
+    /// Answers `true` when neither holds the id, which is the ordinary shape of
+    /// a duplicate answer arriving after the message already settled — there is
+    /// no record left to judge against, and inventing a verdict would start
+    /// dropping the answers this device has always accepted. The fail-open is
+    /// not reachable by an attacker: it needs our own outbox entry to be gone,
+    /// which nothing a peer sends can arrange.
+    fn ack_is_from_the_message_recipient(&self, message_id: &MessageId, ack: &Message) -> bool {
+        let Some(entry) = self
+            .outbox
+            .get(message_id)
+            .or_else(|| self.media_outbox.get(message_id))
+        else {
+            return true;
+        };
+        ack.sender.as_str() == entry.message.recipient.as_str()
+    }
+
     /// Settles a parked DM whose acknowledgement arrived with no pending ACK to
     /// match it — the delivery a park can otherwise never learn about.
     ///
@@ -4113,23 +4182,37 @@ impl OfflineProtocol {
     /// being probed until its lifetime expired, delivered and read the whole
     /// time. The offer and this arm are one change; neither is correct alone.
     ///
-    /// Gated four ways, because an acknowledgement is unauthenticated (it
+    /// Gated three ways, because an acknowledgement is unauthenticated (it
     /// carries no internal prefix, so it never reaches the control gate, and it
     /// is handled before the security gate runs on the receive path):
     ///
-    /// 1. the id is a parkable plain DM — connection requests keep their typed
-    ///    terminal path, welcomes their own lifecycle, media chunks are never
-    ///    parked and keep their pending ACK;
+    /// 1. the id is a parkable plain DM — welcomes keep their own lifecycle,
+    ///    and media chunks are never parked, so they keep their pending ACK and
+    ///    settle on the branch above. This gate does **not** exclude connection
+    ///    requests, whatever [`Self::is_parkable_plain_dm`] looks like it
+    ///    promises: the caller retires their typed tracking a few lines earlier
+    ///    and unconditionally, so by the time that check runs the map no longer
+    ///    holds the id. The outcome is the wanted one — a request whose typed
+    ///    window has already lapsed, carried to its recipient and answered, was
+    ///    delivered, and settling it is the same proof the pending-ACK branch
+    ///    acts on for an already-untracked request — but it is the caller's
+    ///    ordering that decides it, not this gate;
     /// 2. it is still in the outbox;
     /// 3. its recipient holds a live park counter, so the relay did declare this
-    ///    peer unreachable and no edge has cleared it since;
-    /// 4. the acknowledgement comes from that recipient.
+    ///    peer unreachable and no edge has cleared it since.
     ///
-    /// Those bound the forgery to someone who saw the frame *and* knows the
-    /// relay refused it — the carriers and the relay, parties who can already
-    /// deny delivery outright. What they gain is making a parked message look
-    /// delivered rather than staying parked, which is the same class as forging
-    /// an acknowledgement for an in-flight message, already possible today.
+    /// Attribution — that the answer comes from the recipient rather than from
+    /// any party that handled the frame — is deliberately *not* a fourth gate
+    /// here. [`Self::handle_ack_message`] now applies it to every
+    /// acknowledgement it accepts, so both settle paths judge by one rule
+    /// against one record; a copy of it here would be unreachable, and the kind
+    /// of unreachable that reads as load-bearing to the next person.
+    ///
+    /// What remains after all of them is a forgery by someone who saw the frame
+    /// *and* knows the relay refused it — the carriers and the relay, parties
+    /// who can already deny delivery outright. What they gain is making a
+    /// parked message look delivered rather than staying parked, which is the
+    /// same class as forging an acknowledgement for an in-flight message.
     ///
     /// Reports latency end to end (from the first send) rather than per attempt:
     /// there is no pending record to measure the last attempt against, and for a
@@ -4146,9 +4229,6 @@ impl OfflineProtocol {
         };
         let recipient = entry.message.recipient.as_str().to_string();
         if !self.dm_unreachable_parks.contains_key(&recipient) {
-            return;
-        }
-        if ack.sender.as_str() != recipient {
             return;
         }
 

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -9074,6 +9074,118 @@ fn test_unreachable_media_chunk_is_offered_to_the_mesh() {
 }
 
 #[test]
+fn test_an_acknowledgement_from_a_third_party_does_not_settle_an_in_flight_dm() {
+    // An acknowledgement names a message id and nothing else binds it to a
+    // delivery. Everyone who carried the frame knows that id, so answering for
+    // someone else must not settle the message: doing so drops the outbox
+    // entry and reports `message_delivered` for a message that arrived nowhere,
+    // which is the one failure the sender never finds out about.
+    let (mut protocol, _internet, ble) = online_device_with_a_neighbor();
+
+    let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_handle = Arc::clone(&events);
+    protocol.on_event(move |event| {
+        events_handle.lock().unwrap().push(event);
+    });
+
+    let message_id = protocol
+        .send_message("bob", "hello", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    assert!(protocol.ack_manager.is_waiting_for_ack(&message_id));
+
+    // Carol carried it, so carol knows the id. That is not permission to
+    // answer for bob.
+    ble.queue_message_from(
+        delivery_ack_frame("carol", "user123", &message_id),
+        "carol".to_string(),
+    );
+    assert!(protocol.receive_message().is_none());
+
+    assert!(
+        protocol.outbox.contains_key(&message_id),
+        "only the peer it was sent to can settle it"
+    );
+    assert!(
+        protocol.ack_manager.is_waiting_for_ack(&message_id),
+        "and the refusal must not cost the message its retry record — a frame \
+         rejected after the pending ACK was taken would stop being retried, \
+         which is the silent loss this check exists to prevent"
+    );
+    assert!(
+        !events.lock().unwrap().iter().any(|event| matches!(
+            event,
+            Event::MessageDelivered { message_id: delivered, .. }
+                if *delivered == message_id.as_str()
+        )),
+        "and the app must not be told it was delivered"
+    );
+
+    // The real recipient's answer still settles it the ordinary way.
+    ble.queue_message_from(
+        delivery_ack_frame("bob", "user123", &message_id),
+        "carol".to_string(),
+    );
+    assert!(protocol.receive_message().is_none());
+    assert!(
+        !protocol.outbox.contains_key(&message_id),
+        "the recipient's own acknowledgement must still settle the message"
+    );
+    assert!(
+        events.lock().unwrap().iter().any(|event| matches!(
+            event,
+            Event::MessageDelivered { message_id: delivered, .. }
+                if *delivered == message_id.as_str()
+        )),
+        "and it must still be reported delivered"
+    );
+}
+
+#[test]
+fn test_settling_a_parked_dm_redrives_the_recipients_other_parked_dms() {
+    // The park counter is per-peer while the probes are per-message, so a
+    // burst to an offline peer leaves the later messages sitting on an
+    // escalated timer. An acknowledgement for any one of them proves the rest
+    // can go now — the same edge the pending-ACK branch acts on, which the
+    // parked branch has to reproduce because parking left it no pending ACK.
+    let (mut protocol, internet, ble) = online_device_with_a_neighbor();
+
+    let first = protocol
+        .send_message("bob", "first", None::<MessagePriority>, None::<String>)
+        .unwrap();
+    let second = protocol
+        .send_message("bob", "second", None::<MessagePriority>, None::<String>)
+        .unwrap();
+
+    for id in [&first, &second] {
+        protocol
+            .on_transport_send_failed(
+                &id.as_str(),
+                Some("recipient_unreachable: peer offline".to_string()),
+            )
+            .unwrap();
+    }
+    assert_eq!(protocol.dm_unreachable_parks.get("bob"), Some(&2));
+    internet.clear_sent_messages();
+
+    // Bob answers the first one, carried back by carol.
+    ble.queue_message_from(
+        delivery_ack_frame("bob", "user123", &first),
+        "carol".to_string(),
+    );
+    assert!(protocol.receive_message().is_none());
+
+    assert!(
+        internet.sent_messages().iter().any(|m| m.id == second),
+        "the peer answered, so their other parked traffic must go now rather \
+         than waiting out its own escalated probe timer"
+    );
+    assert!(
+        !protocol.dm_unreachable_parks.contains_key("bob"),
+        "and the escalation starts over, the flush owning that reset"
+    );
+}
+
+#[test]
 fn test_parked_dm_redriven_with_fresh_ack_budget() {
     // Every re-drive registers a fresh pending ACK, so the retry budget
     // only ever burns against a peer believed reachable — attempts spent

--- a/docs/message-delivery.md
+++ b/docs/message-delivery.md
@@ -38,6 +38,8 @@ send_message()
 3. When the recipient sends an ACK, a `MessageDelivered` event fires
 4. The message is removed from outbox and retry queue
 
+Only the recipient settles a message. An acknowledgement naming a message sent to somebody else is ignored, whichever carrier it arrives on — every device that carried a frame knows its id, and settling on the id alone would let any of them drop the outbox entry and report a delivery that never happened. This is an attribution check, not authentication: acknowledgements are not signed, so it removes the unattributed answer rather than a determined forgery by someone who saw the frame — and who therefore also saw the recipient's name.
+
 ### Deferred Send
 
 1. `send_message()` returns `Ok(message_id)` even when the transport send fails


### PR DESCRIPTION
Follow-up to #361, from its review.

## The gap

A delivery acknowledgement names a message id and nothing else tied it to a delivery. `handle_ack_message` settled on that id alone, so an acknowledgement from **any** party that had merely seen the frame settled the message: the outbox entry dropped, the retries stopped, and the app was told `message_delivered` for a message that arrived nowhere.

Refusing delivery is something the carriers and the relay could always do. A false confirmation is the strictly worse one, because it is the version the sender never finds out about.

Every device that carries a frame across the mesh knows its id, and #361 hands frames to exactly those devices — so this belongs with it rather than after it.

## Not a security fix, and the code says so

The review that asked for this framed it as security hardening. That framing was wrong and the code does not repeat it.

An acknowledgement carries **no signature**: `Message` has no signature field, empty content is not a security-gated prefix (`is_security_gated_prefix`), and the receive loop handles ACKs and `continue`s before the control gate would run anyway. So `sender` is self-declared, and a forger who saw the frame saw its recipient too and can simply write that name.

What this removes is the *unattributed* answer — a carrier or relay settling a message under its own name — and the divergence between the two settlement paths. Binding an acknowledgement to its sender for real needs signed acks, which is a negotiated wire change rather than a follow-up: unsigned acks must keep working for old peers, so during any transition a forger just omits the signature. Left out deliberately, noted in place.

## Why it is safe on a path every delivery passes through

This was the question worth answering before adding a rejection here. Identity namespaces are not uniform — `local_id` is the profile before `initialize_mls` and the `off1…` address after, and `UserId::new` accepts either — so a naive check could plausibly have dropped legitimate acknowledgements fleet-wide.

It cannot, because **delivery already implies the equality**: a device processes a frame only when its own `local_id` equals the frame's recipient (`receive_message` forwards anything else), and the acknowledgement it builds carries that same `local_id` as its sender. A genuine confirmation therefore matches in either namespace.

The check fails open when neither outbox holds the id — the ordinary shape of a duplicate answer arriving after the message already settled. That fail-open needs our own outbox entry to be gone, which nothing a peer sends can arrange.

## The ordering is load-bearing

The guard runs **before** anything is removed. The settle work starts by taking the pending ACK, and a frame rejected after that point would have already cost the message its retry record — turning a refused acknowledgement into exactly the silent loss this exists to prevent. Pinned by its own assertion.

## Two consequences in `settle_parked_dm_from_ack`

- Its own sender gate is now provably dead (the caller applies the same test against the same record) and is **removed**, rather than left as the kind of unreachable that reads as load-bearing to the next person.
- Its doc claimed gate 1 excluded connection requests. That was never true: the caller retires their typed tracking a few lines earlier and unconditionally, so `is_parkable_plain_dm`'s check has nothing left to find by the time it runs. The outcome is the wanted one — an already-untracked request, carried to its recipient and answered, was delivered — but the caller's ordering is what decides it, not the gate. Documented as such.

## Scope

No FFI, UDL, wire-format, config, or persisted-state changes; no bindings regeneration. `PendingAck` is untouched — the recipient is read from the outbox record both paths already use, so the two cannot drift.

## Verification

`cargo test --workspace` (2117 tests, 0 failures — was 2115), `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — all clean.

2 new tests, each **mutation-checked** against a sabotage of the line it covers:

- `test_an_acknowledgement_from_a_third_party_does_not_settle_an_in_flight_dm` — deleting the guard fails this **and** #361's own `test_a_parked_dm_is_not_settled_by_anyone_elses_acknowledgement`, so removing the dead gate cost no coverage. Taking the pending ACK before the guard fails only the retry-record assertion, proving it pins the ordering specifically.
- `test_settling_a_parked_dm_redrives_the_recipients_other_parked_dms` — pins the sibling re-drive the parked settle path performs, unpinned since #361. Removing the re-drive fails it.