### PR TITLE
fix: stop promising resolution events a stopped engine cannot send, and read DORS config from the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,9 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   resolution can never hang on a lookup that was never started. The rejection
   code says which case, because they need different handling:
   `InvalidConfiguration` (discovery is off, so retrying cannot help),
-  `InvalidState` (too many lookups in flight, retry shortly), and
-  `InvalidArgument` (not a claimable name).
+  `InvalidState` (too many lookups in flight, retry shortly), `NotStarted` (the
+  protocol is not running, retry after `start()`), and `InvalidArgument` (not a
+  claimable name).
 
   The event also reports `truncated`, the number of *verified* claims dropped
   at the accumulator's ceiling. It is the opposite statement to `rejected`:
@@ -247,6 +248,39 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   having set it. Unreachable from typed TypeScript; reachable from JavaScript.
 
 ### Fixed
+
+- **`resolveUsername()` no longer promises an event the engine cannot send.**
+  It gated only on the discovery switches, which survive `stop()`, while the
+  event it promises is emitted from `process()`, which is inert unless the
+  protocol is running. A lookup requested on a stopped or paused instance
+  therefore returned `true` ("an answer is coming") with nothing able to
+  deliver one, and — the part that made it permanent — left its registration
+  behind, so every later attempt at that name answered `false`, which says the
+  same thing again. The caller was told twice that a resolution was in flight
+  and had no way to learn otherwise. It now rejects with `NotStarted`, after
+  the discovery checks, so an app with discovery switched off still learns
+  that first rather than being sent round a start-and-retry loop to find out.
+
+  `stop()` answers the lookups it is about to strand rather than dropping
+  them: a resolution that heard from some relays emits what it has, and one
+  that never reached a relay emits the empty set, both on the terms the
+  deadline sweep already uses. Discarding them silently would leave the
+  promise broken and the registrations standing.
+
+- **`getDorsConfig()` reports the engine's configuration, not a copy of the
+  last thing written through the FFI.** It answered from an FFI-local cache
+  that nothing populated until the first `updateDorsConfig`, falling back to
+  the core defaults until then — and `preferOnline` is the field whose default
+  (`false`) disagrees with what construction takes from `ProtocolConfig`. An
+  app created with `preferOnline: true` that then performed the documented
+  read-modify-write to change *any other* field read `false`, wrote it back,
+  and silently turned internet-first routing off. React Native was shielded
+  only by accident (its TypeScript layer sources the flag from the `dors`
+  section, whose create-time application populated the cache), so this bit
+  Swift, Kotlin and Python callers. The getter now reads the live selector,
+  the way `getMeshRelayTunables()` reads the governor, and the cache is gone
+  rather than corrected: a second copy of a value is a thing that can disagree
+  with it.
 
 - **Every mesh forwarding dial that could silently switch forwarding off is
   now refused at construction.** These share one failure and it is the worst

--- a/bindings/react-native/android/src/main/java/com/offlineprotocol/ProtocolErrorBridge.kt
+++ b/bindings/react-native/android/src/main/java/com/offlineprotocol/ProtocolErrorBridge.kt
@@ -43,6 +43,17 @@ internal fun mapProtocolBridgeError(error: Throwable): BridgeProtocolError? {
             code = "InvalidState",
             message = error.message ?: "Operation rejected by current state"
         )
+        // Also transient, and distinct from InvalidState because the retry is
+        // gated on something the app itself controls: resolveUsername refuses a
+        // lookup while the protocol is stopped or paused, since nothing would
+        // pump relays or sweep its deadline. Without this arm it fell to the
+        // caller's fallback code, which for that method is InvalidArgument —
+        // telling the app the *name* was unusable and that retrying could never
+        // help, when start() is all that was missing.
+        is ProtocolException.NotStarted -> BridgeProtocolError(
+            code = "NotStarted",
+            message = error.message ?: "Protocol not started"
+        )
         // Distinct from InvalidState on purpose: this one says the
         // *configuration* forbids the call, so retrying it unchanged can never
         // succeed, while InvalidState is transient and a retry is exactly

--- a/bindings/react-native/android/src/test/java/com/offlineprotocol/ProtocolErrorBridgeTest.kt
+++ b/bindings/react-native/android/src/test/java/com/offlineprotocol/ProtocolErrorBridgeTest.kt
@@ -17,6 +17,11 @@ class ProtocolErrorBridgeTest {
             ProtocolException.MediaTransferLimit("bob") to "MediaTransferLimit",
             ProtocolException.SendFailed("all transports failed") to "SendFailed",
             ProtocolException.InvalidState("cannot demote the last admin") to "InvalidState",
+            // resolveUsername raises this while the protocol is stopped or
+            // paused. Unmapped it fell to that method's fallback code,
+            // InvalidArgument, which tells an app the name was unusable when
+            // start() was all that was missing.
+            ProtocolException.NotStarted("Protocol not started") to "NotStarted",
             // resolveUsername raises this for "discovery is off", where a retry
             // can never succeed, beside InvalidState for "retry shortly". One
             // code for both is the difference between an app that stops and one

--- a/bindings/react-native/ios/ProtocolErrorBridge.swift
+++ b/bindings/react-native/ios/ProtocolErrorBridge.swift
@@ -30,6 +30,15 @@ func mapProtocolBridgeError(_ error: Error) -> (code: String, message: String)? 
         return ("SendFailed", message)
     case let .InvalidState(message):
         return ("InvalidState", message)
+    // Also transient, and distinct from InvalidState because the retry is
+    // gated on something the app itself controls: `resolveUsername` refuses a
+    // lookup while the protocol is stopped or paused, since nothing would pump
+    // relays or sweep its deadline. Without this arm it fell to the caller's
+    // fallback code, which for that method is InvalidArgument — telling the app
+    // the *name* was unusable and that retrying could never help, when
+    // `start()` is all that was missing.
+    case let .NotStarted(message):
+        return ("NotStarted", message)
     // Distinct from InvalidState on purpose: this one says the *configuration*
     // forbids the call, so retrying it unchanged can never succeed, while
     // InvalidState is transient and a retry is exactly right. `resolveUsername`

--- a/bindings/react-native/ios/tests/ProtocolErrorBridgeTests.swift
+++ b/bindings/react-native/ios/tests/ProtocolErrorBridgeTests.swift
@@ -14,6 +14,11 @@ final class ProtocolErrorBridgeTests: XCTestCase {
             (.MediaTransferLimit(message: "bob"), "MediaTransferLimit"),
             (.SendFailed(message: "all transports failed"), "SendFailed"),
             (.InvalidState(message: "cannot demote the last admin"), "InvalidState"),
+            // resolveUsername raises this while the protocol is stopped or
+            // paused. Unmapped it fell to that method's fallback code,
+            // InvalidArgument, which tells an app the name was unusable when
+            // start() was all that was missing.
+            (.NotStarted(message: "Protocol not started"), "NotStarted"),
             // resolveUsername raises this for "discovery is off", where a retry
             // can never succeed, beside InvalidState for "retry shortly". One
             // code for both is the difference between an app that stops and one

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -2769,6 +2769,9 @@ export class OfflineProtocol {
    * - `InvalidConfiguration` — discovery is off (it also requires
    *   `coldContactEnabled`). Retrying unchanged can never succeed.
    * - `InvalidState` — too many lookups in flight. Transient; retry shortly.
+   * - `NotStarted` — the protocol is not running, so nothing would pump relay
+   *   traffic or sweep the deadline for this lookup. Transient; retry after
+   *   `start()`.
    * - `InvalidArgument` — not a claimable username (empty, over 64 bytes once
    *   normalized, carrying a control or format character, or address-shaped).
    *
@@ -2788,8 +2791,8 @@ export class OfflineProtocol {
    * @param username - The name to look up; normalized to NFC and lowercase
    * @returns `true` if this call started the lookup, `false` if it joined one
    * @throws `InvalidConfiguration` if discovery is off, `InvalidState` if too
-   *   many lookups are in flight, `InvalidArgument` if the name is not
-   *   claimable
+   *   many lookups are in flight, `NotStarted` if the protocol is not running,
+   *   `InvalidArgument` if the name is not claimable
    */
   async resolveUsername(username: string): Promise<boolean> {
     return await OfflineProtocolNativeModule.resolveUsername(username);

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -2071,6 +2071,58 @@ pub struct DorsConfig {
     pub relay_optimal_connection_count: u8,
 }
 
+/// The one core-to-FFI mapping for this section.
+///
+/// Destructured exhaustively and without a rest pattern, so a field added to
+/// the core config fails this conversion to compile rather than going missing
+/// from what every binding reads back.
+impl From<CoreDorsConfig> for DorsConfig {
+    fn from(core: CoreDorsConfig) -> Self {
+        let CoreDorsConfig {
+            prefer_online,
+            switch_hysteresis,
+            switch_cooldown_secs,
+            ble_to_wifi_retry_threshold,
+            min_success_rate_before_escalation,
+            min_ble_samples_before_success_rate_escalation,
+            rssi_switch_threshold,
+            congestion_queue_threshold,
+            stability_window_secs,
+            poor_signal_duration_secs,
+            ttl_escalation_threshold,
+            congestion_duration_secs,
+            ttl_escalation_hold_secs,
+            history_window_size,
+            queue_recovery_ratio,
+            low_battery_threshold,
+            relay_min_battery_level,
+            relay_optimal_connection_count,
+        } = core;
+
+        Self {
+            prefer_online,
+            switch_hysteresis,
+            switch_cooldown_secs,
+            ble_to_wifi_retry_threshold,
+            min_success_rate_before_escalation,
+            min_ble_samples_before_success_rate_escalation:
+                min_ble_samples_before_success_rate_escalation as u64,
+            rssi_switch_threshold,
+            congestion_queue_threshold: congestion_queue_threshold as u64,
+            stability_window_secs,
+            poor_signal_duration_secs,
+            ttl_escalation_threshold,
+            congestion_duration_secs,
+            ttl_escalation_hold_secs,
+            history_window_size: history_window_size as u64,
+            queue_recovery_ratio,
+            low_battery_threshold,
+            relay_min_battery_level,
+            relay_optimal_connection_count,
+        }
+    }
+}
+
 /// ACK configuration
 #[derive(Debug, Clone)]
 pub struct AckConfig {
@@ -2796,7 +2848,6 @@ pub struct OfflineProtocol {
     visualizer: Mutex<NetworkVisualizer>,
     path_selector: Mutex<PathSelector>,
     forced_transport: RwLock<Option<TransportType>>,
-    dors_config: RwLock<Option<DorsConfig>>,
     /// Which transports this instance was configured with, so they can be
     /// rebuilt against the derived address once `initialize_mls` knows it.
     enabled_transports: EnabledTransports,
@@ -2963,7 +3014,6 @@ impl OfflineProtocol {
             visualizer: Mutex::new(NetworkVisualizer::new(user_id.clone())),
             path_selector: Mutex::new(PathSelector::new()),
             forced_transport: RwLock::new(None),
-            dors_config: RwLock::new(None),
             enabled_transports: EnabledTransports {
                 ble: ble_enabled,
                 internet: internet_enabled,
@@ -3263,15 +3313,6 @@ impl OfflineProtocol {
         self.forced_transport
             .write()
             .map_err(|e| ProtocolError::LockPoisoned(format!("forced_transport: {}", e)))
-    }
-
-    /// Write-lock the DORS config, converting poison errors.
-    fn write_dors_config(
-        &self,
-    ) -> Result<std::sync::RwLockWriteGuard<'_, Option<DorsConfig>>, ProtocolError> {
-        self.dors_config
-            .write()
-            .map_err(|e| ProtocolError::LockPoisoned(format!("dors_config: {}", e)))
     }
 
     // ========================================================================
@@ -5144,11 +5185,12 @@ impl OfflineProtocol {
     /// one already in flight. **Both mean an answer is coming**: exactly one
     /// `username_resolved` event follows either way. Every case where no event
     /// will ever arrive throws instead — `InvalidConfiguration` when discovery
-    /// is off, `InvalidState` when too many lookups are in flight, and
-    /// `InvalidArgument` when the string is not a claimable username — so a
-    /// caller that awaits the event can never be left waiting on one that has
-    /// no trigger. The three are distinct because they call for different
-    /// handling: never, later, and not with that name.
+    /// is off, `InvalidState` when too many lookups are in flight, `NotStarted`
+    /// when the protocol is not running, and `InvalidArgument` when the string
+    /// is not a claimable username — so a caller that awaits the event can
+    /// never be left waiting on one that has no trigger. They are distinct
+    /// because they call for different handling: never, later, after `start()`,
+    /// and not with that name.
     ///
     /// The answer carries **every** verified claim. There is deliberately no
     /// "best" claim and no ordering: anyone may publish any name, so what comes
@@ -5754,9 +5796,6 @@ impl OfflineProtocol {
 
     /// Updates DORS configuration at runtime
     pub fn update_dors_config(&self, config: DorsConfig) -> Result<(), ProtocolError> {
-        // Store locally for retrieval
-        *self.write_dors_config()? = Some(config.clone());
-
         // Convert to core DorsConfig and update the protocol
         let core_config = CoreDorsConfig {
             switch_hysteresis: config.switch_hysteresis,
@@ -5787,35 +5826,18 @@ impl OfflineProtocol {
         Ok(())
     }
 
-    /// Gets the current DORS configuration
+    /// Gets the DORS configuration transport selection is actually using.
+    ///
+    /// Read from the engine's selector, not from a copy held on this side.
+    /// A cache here answers with whatever last crossed the FFI, which is a
+    /// different thing: nothing wrote it before the first
+    /// [`Self::update_dors_config`], so it answered from core defaults and
+    /// dropped the `prefer_online` this instance was *constructed* with. The
+    /// documented read-modify-write then wrote that default back over the live
+    /// selector, so reading a section you had set and changing an unrelated
+    /// field silently turned internet-first routing off.
     pub fn get_dors_config(&self) -> DorsConfig {
-        if let Some(config) = recover_rwlock_read(&self.dors_config, "dors_config").clone() {
-            return config;
-        }
-
-        let core = CoreDorsConfig::default();
-        DorsConfig {
-            prefer_online: core.prefer_online,
-            switch_hysteresis: core.switch_hysteresis,
-            switch_cooldown_secs: core.switch_cooldown_secs,
-            ble_to_wifi_retry_threshold: core.ble_to_wifi_retry_threshold,
-            min_success_rate_before_escalation: core.min_success_rate_before_escalation,
-            min_ble_samples_before_success_rate_escalation: core
-                .min_ble_samples_before_success_rate_escalation
-                as u64,
-            rssi_switch_threshold: core.rssi_switch_threshold,
-            congestion_queue_threshold: core.congestion_queue_threshold as u64,
-            stability_window_secs: core.stability_window_secs,
-            poor_signal_duration_secs: core.poor_signal_duration_secs,
-            ttl_escalation_threshold: core.ttl_escalation_threshold,
-            congestion_duration_secs: core.congestion_duration_secs,
-            ttl_escalation_hold_secs: core.ttl_escalation_hold_secs,
-            history_window_size: core.history_window_size as u64,
-            queue_recovery_ratio: core.queue_recovery_ratio,
-            low_battery_threshold: core.low_battery_threshold,
-            relay_min_battery_level: core.relay_min_battery_level,
-            relay_optimal_connection_count: core.relay_optimal_connection_count,
-        }
+        DorsConfig::from(self.lock_inner_recovering().dors_config())
     }
 
     // ========================================================================
@@ -6008,8 +6030,9 @@ impl OfflineProtocol {
     ///
     /// Read from the governor, not from a copy held on this side. An FFI-local
     /// cache would round-trip the caller's own input and prove nothing about
-    /// what forwarding is using — the same vacuity `get_dors_config` has to
-    /// work around.
+    /// what forwarding is using; [`Self::get_dors_config`] reads the selector
+    /// for the same reason, having shipped the cached shape first and drifted
+    /// from the engine on its construction-time `prefer_online`.
     pub fn get_mesh_relay_tunables(&self) -> MeshRelayTunables {
         let protocol = self.lock_inner_recovering();
         protocol.mesh_relay_config().into()
@@ -13563,11 +13586,11 @@ mod tests {
 
     /// The tunables getter must read the governor, not a copy on this side.
     ///
-    /// `get_dors_config` returns the FFI's own stored value, which makes a
-    /// round-trip assertion against it vacuous — the reason its test has to
-    /// reach into the selector. This getter has no stored copy to be vacuous
-    /// against, and this pins that: the value comes back from the engine even
-    /// though nothing on the FFI side ever recorded it.
+    /// A getter answering from an FFI-local copy makes a round-trip assertion
+    /// vacuous, which is why the DORS test reaches into the selector rather
+    /// than trusting its read-back. Neither getter keeps a copy now, and this
+    /// pins it here: the value comes back from the engine even though nothing
+    /// on the FFI side ever recorded it.
     #[test]
     fn mesh_relay_tunables_are_read_from_the_governor() {
         let mut config = create_test_config();
@@ -14011,14 +14034,54 @@ mod tests {
         assert_eq!(read_back.stability_window_secs, 33);
 
         // ...and reached the DORS selector, which is what actually scores
-        // transports. Reading back through `get_dors_config` alone would be
-        // vacuous: it returns the FFI's own stored copy.
+        // transports. Asserted separately from the read-back so this stays a
+        // statement about the engine even if the getter ever grows a copy of
+        // its own again.
         let inner = protocol.lock_inner().unwrap();
         let core = inner.transport_manager().selector_config().clone();
         drop(inner);
         assert_eq!(core.low_battery_threshold, 11);
         assert_eq!(core.relay_min_battery_level, 44);
         assert_eq!(core.relay_optimal_connection_count, 7);
+        assert_eq!(core.stability_window_secs, 33);
+    }
+
+    /// The getter must answer from the engine, not from a copy on this side.
+    ///
+    /// It used to answer from an FFI-local cache that nothing wrote until the
+    /// first `update_dors_config`, so until then it fell back to
+    /// `CoreDorsConfig::default()` — and `prefer_online` is the field whose
+    /// default (`false`) disagrees with what construction seeds from
+    /// `ProtocolConfig`. An app that created with `prefer_online: true` and
+    /// then performed the documented read-modify-write to change *any other*
+    /// field read `false`, wrote it back, and silently turned internet-first
+    /// routing off. React Native was shielded only by accident, so this is a
+    /// direct-FFI (Swift/Kotlin/Python) defect.
+    #[test]
+    fn test_get_dors_config_reads_the_engine_not_an_ffi_copy() {
+        let mut config = create_test_config();
+        config.prefer_online = true;
+        let protocol = OfflineProtocol::new(config).unwrap();
+
+        assert!(
+            protocol.get_dors_config().prefer_online,
+            "the getter must report what this instance was constructed with, \
+             before any update has written a cache"
+        );
+
+        // The documented read-modify-write of an unrelated field must not
+        // carry a stale default back into the live selector.
+        let mut dors = protocol.get_dors_config();
+        dors.stability_window_secs = 33;
+        protocol.update_dors_config(dors).unwrap();
+
+        let inner = protocol.lock_inner().unwrap();
+        let core = inner.transport_manager().selector_config().clone();
+        drop(inner);
+        assert!(
+            core.prefer_online,
+            "changing one field must not turn internet-first routing off"
+        );
         assert_eq!(core.stability_window_secs, 33);
     }
 

--- a/crates/offline-protocol/src/protocol/config_accessors.rs
+++ b/crates/offline-protocol/src/protocol/config_accessors.rs
@@ -76,6 +76,18 @@ impl OfflineProtocol {
         self.transport_manager.update_selector_config(config);
     }
 
+    /// The DORS configuration transport selection is actually using.
+    ///
+    /// Read from the selector, not from the stored [`ProtocolConfig`], for the
+    /// reason [`Self::mesh_relay_config`] gives: a caller reading a section
+    /// back is asking what the consumer has, and a copy kept anywhere else is
+    /// one that can disagree with it. Here the two genuinely do diverge, since
+    /// [`Self::update_dors_config`] rewrites the selector and leaves the
+    /// stored config alone.
+    pub fn dors_config(&self) -> DorsConfig {
+        self.transport_manager.selector_config().clone()
+    }
+
     /// Records the host's battery reading for this device.
     ///
     /// The platform owns this number — no transport can observe it — and until

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -1494,6 +1494,10 @@ impl OfflineProtocol {
         // Same for the Nostr receive watermark: an un-flushed tail costs the
         // next launch a wider replay window.
         self.flush_nostr_watermark();
+        // Answer any lookup still in flight while the transport is still up to
+        // take the cancellations. Nothing pumps relays or sweeps deadlines once
+        // stopped, so a resolution left here is an event that never comes.
+        self.flush_username_resolutions_for_stop();
 
         // Clear event callbacks to release shared_state references.
         // NOTE: the routing-decision callback is deliberately NOT cleared

--- a/crates/offline-protocol/src/protocol/nostr_discovery.rs
+++ b/crates/offline-protocol/src/protocol/nostr_discovery.rs
@@ -31,7 +31,7 @@ use offline_protocol_transport::nostr_crypto::discovery_tag_for_username;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
-use super::{storage_keys, OfflineProtocol};
+use super::{lock_shared_state, storage_keys, OfflineProtocol, ProtocolState};
 use crate::events::{Event, UsernameClaim};
 use crate::{Error, Result};
 
@@ -557,6 +557,10 @@ impl OfflineProtocol {
     ///   dead-end one hop later.
     /// - [`Error::InvalidState`] if too many lookups are already in flight.
     ///   Transient: retry once earlier ones drain.
+    /// - [`Error::NotStarted`] if the protocol is not running. Nothing pumps
+    ///   relay traffic and nothing sweeps deadlines outside `Running`, so a
+    ///   lookup accepted here would be a promise with no machinery behind it.
+    ///   Transient: retry after `start()`.
     pub fn resolve_username(&mut self, username: &str) -> Result<bool> {
         let username: Username = username
             .parse()
@@ -568,6 +572,20 @@ impl OfflineProtocol {
                  (which also requires nostr_cold_contact_enabled)"
                     .to_string(),
             ));
+        }
+
+        // The event this returns a promise of is emitted from `process()`,
+        // either on a relay's answer or on the deadline sweep, and `process()`
+        // is inert unless the protocol is running. Accepting the lookup while
+        // stopped or paused would return `Ok(true)` for an event that cannot
+        // arrive, and would then answer every later call for the same name
+        // with `Ok(false)` off the registration left behind — the caller told
+        // an answer is coming, twice, with nothing able to deliver one.
+        {
+            let state = lock_shared_state(&self.shared_state)?;
+            if state.state != ProtocolState::Running {
+                return Err(Error::NotStarted);
+            }
         }
 
         // Deduplicated against both halves of "in flight", because the transport
@@ -845,6 +863,42 @@ impl OfflineProtocol {
             // the platform releases a query with no relay connected, so the
             // two unreachable paths report identically rather than one of them
             // being silent.
+            self.emit_event(Event::UsernameResolved {
+                username: username.into_string(),
+                claims: Vec::new(),
+                rejected: 0,
+                truncated: 0,
+            });
+        }
+    }
+
+    /// Answers every lookup still in flight, because after this nothing can.
+    ///
+    /// `stop()` takes down both halves of the promise [`Self::resolve_username`]
+    /// makes: relays stop being pumped, so no answer arrives, and `process()`
+    /// goes inert, so the deadline sweep that exists to turn silence into an
+    /// empty answer never runs either. A caller holding `Ok(true)` would wait
+    /// forever on an event with nothing left to emit it.
+    ///
+    /// Flushed rather than discarded, on the same terms the sweep uses:
+    /// discarding would leave the promise broken and would additionally leave
+    /// the registrations behind, so every later lookup for those names would
+    /// answer `Ok(false)` ("an answer is coming") for an answer that already
+    /// will not. A resolution that heard from some relays emits what it has; a
+    /// lookup that never reached one emits an empty set.
+    pub(crate) fn flush_username_resolutions_for_stop(&mut self) {
+        let in_flight: Vec<String> = self.nostr_resolutions.keys().cloned().collect();
+        for query_id in in_flight {
+            debug!(query_id = %query_id, "Protocol stopping; emitting what this resolution has");
+            self.flush_username_resolution(&query_id);
+        }
+
+        let unminted: Vec<Username> = self.nostr_resolution_requests.keys().cloned().collect();
+        for username in unminted {
+            debug!("Protocol stopping; answering a lookup that never reached a relay");
+            self.nostr_resolution_requests.remove(&username);
+            self.transport_manager
+                .cancel_nostr_username_resolution(&username);
             self.emit_event(Event::UsernameResolved {
                 username: username.into_string(),
                 claims: Vec::new(),

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -2258,10 +2258,26 @@ fn protocol_with_mls_storage(storage: Arc<InMemoryStorage>) -> OfflineProtocol {
 /// layer builds it when `nostr_enabled` is set.
 #[cfg(test)]
 fn protocol_with_nostr(user_id: &str) -> OfflineProtocol {
+    protocol_with_nostr_discovery(user_id, false)
+}
+
+/// Same, but with username discovery enabled in the **config**.
+///
+/// Setting the flag on the transport by hand does not survive `start()`, which
+/// re-applies the whole Nostr section from config — so any test that starts the
+/// protocol has to configure discovery the way an app does.
+#[cfg(test)]
+fn protocol_with_discovery(user_id: &str) -> OfflineProtocol {
+    protocol_with_nostr_discovery(user_id, true)
+}
+
+#[cfg(test)]
+fn protocol_with_nostr_discovery(user_id: &str, discovery: bool) -> OfflineProtocol {
     let mut config = create_test_config();
     config.profile = user_id.to_string();
     config.encryption.enabled = true;
     config.transport.nostr_enabled = true;
+    config.transport.nostr_username_discovery_enabled = discovery;
     let mut protocol = OfflineProtocol::new(config).unwrap();
     // Identity first: `NostrTransport` derives its routing tag and bootstrap
     // keypair from the id it is built with, so building it before the address
@@ -35076,6 +35092,110 @@ fn test_resolving_with_discovery_disabled_is_an_error_not_a_false() {
     assert!(protocol.nostr_resolution_requests.is_empty());
 }
 
+/// A lookup on a protocol that is not running is an **error**, not `Ok(true)`.
+///
+/// The promise `Ok(true)` makes is kept by `process()`, which is inert unless
+/// the protocol is running. Accepting the lookup here returned "an answer is
+/// coming" for an answer nothing could deliver, and — worse than the silence
+/// itself — left the registration behind, so every later attempt at the same
+/// name answered `Ok(false)`, which says the same thing again. The caller was
+/// told twice that a resolution was in flight and could never learn otherwise.
+#[test]
+fn test_resolving_while_stopped_is_an_error_not_a_promise() {
+    let mut protocol = protocol_with_discovery("resolver");
+    protocol.start().expect("start");
+    protocol.stop().expect("stop");
+
+    assert!(
+        matches!(protocol.resolve_username("alice"), Err(Error::NotStarted)),
+        "a stopped protocol cannot emit the event, so it must refuse the lookup"
+    );
+
+    // Nothing recorded, so the retry after `start()` is a fresh lookup rather
+    // than one deduplicated against a registration that outlived its engine.
+    assert!(protocol.nostr_resolution_requests.is_empty());
+    assert!(protocol.nostr_resolutions.is_empty());
+
+    // And the name is resolvable again once there is machinery behind it.
+    protocol.start().expect("restart");
+    assert!(
+        protocol.resolve_username("alice").expect("resolve"),
+        "after restart the lookup starts fresh"
+    );
+}
+
+/// Configuration errors outrank the state error, because only one of them is
+/// worth retrying.
+///
+/// Both are true of a stopped protocol with discovery off. Reporting
+/// `NotStarted` would send an app round a start-and-retry loop to arrive at
+/// the permanent problem it could have been told about first.
+#[test]
+fn test_a_disabled_lookup_reports_configuration_before_state() {
+    let mut protocol = protocol_with_nostr("resolver");
+    // Discovery deliberately left off, and the protocol never started.
+    assert!(matches!(
+        protocol.resolve_username("alice"),
+        Err(Error::InvalidConfiguration(_))
+    ));
+}
+
+/// Stopping answers the lookups it is about to strand.
+///
+/// `stop()` takes down both halves of the promise: relays stop being pumped,
+/// and `process()` stops sweeping deadlines. Without this the caller holding
+/// `Ok(true)` waits forever, and the registration left behind would answer
+/// every later lookup for that name with `Ok(false)` — an answer is coming,
+/// for an answer that already will not.
+#[test]
+fn test_stopping_answers_a_lookup_it_would_otherwise_strand() {
+    let mut protocol = protocol_with_discovery("resolver");
+    protocol.start().expect("start");
+
+    let events = capture_events(&mut protocol);
+    assert!(
+        protocol.resolve_username("alice").expect("resolve"),
+        "precondition: the lookup is accepted while running"
+    );
+    assert!(
+        !events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|e| matches!(e, Event::UsernameResolved { .. })),
+        "precondition: nothing has answered it yet"
+    );
+
+    protocol.stop().expect("stop");
+
+    let emitted = events.lock().unwrap();
+    let resolved: Vec<&Event> = emitted
+        .iter()
+        .filter(|e| matches!(e, Event::UsernameResolved { .. }))
+        .collect();
+    assert_eq!(
+        resolved.len(),
+        1,
+        "the promise is kept exactly once on the way down"
+    );
+    match resolved[0] {
+        Event::UsernameResolved {
+            username, claims, ..
+        } => {
+            assert_eq!(username, "alice");
+            assert!(
+                claims.is_empty(),
+                "it never reached a relay, so the honest answer is the empty set"
+            );
+        }
+        other => panic!("unexpected event: {:?}", other),
+    }
+
+    // The registration is gone with it, so a restart does not find a lookup
+    // that has already been answered.
+    assert!(protocol.nostr_resolution_requests.is_empty());
+}
+
 /// Deduplication must cover a lookup that has already been minted into a
 /// query, not only one still sitting in the transport's queue.
 ///
@@ -35086,10 +35206,10 @@ fn test_resolving_with_discovery_disabled_is_an_error_not_a_false() {
 /// property the whole set-shaped API rests on.
 #[test]
 fn test_a_second_lookup_joins_an_already_minted_resolution() {
-    let mut protocol = protocol_with_nostr("resolver");
-    protocol
-        .transport_manager_mut()
-        .set_nostr_username_discovery_enabled(true);
+    let mut protocol = protocol_with_discovery("resolver");
+    // A lookup is only accepted while running, because only `process()` emits
+    // the event it promises.
+    protocol.start().expect("start");
 
     let name = "alice";
     assert!(
@@ -35119,10 +35239,10 @@ fn test_a_second_lookup_joins_an_already_minted_resolution() {
 /// turning a transient offline moment into a permanent one.
 #[test]
 fn test_a_swept_lookup_can_be_requested_again() {
-    let mut protocol = protocol_with_nostr("resolver");
-    protocol
-        .transport_manager_mut()
-        .set_nostr_username_discovery_enabled(true);
+    let mut protocol = protocol_with_discovery("resolver");
+    // A lookup is only accepted while running, because only `process()` emits
+    // the event it promises.
+    protocol.start().expect("start");
 
     let name = "alice";
     assert!(

--- a/docs/nostr.md
+++ b/docs/nostr.md
@@ -514,8 +514,9 @@ safe to await it after either. Every case where no event will ever arrive
 rejects instead, so a `false` can never leave a spinner running forever. The
 rejection code says which case, and they need different handling:
 `InvalidConfiguration` (discovery is off, retrying cannot help),
-`InvalidState` (too many lookups in flight, retry shortly), and
-`InvalidArgument` (not a claimable name).
+`InvalidState` (too many lookups in flight, retry shortly), `NotStarted` (the
+protocol is not running, so nothing would pump relays or sweep deadlines for
+it; retry after `start()`), and `InvalidArgument` (not a claimable name).
 
 A resolution query is broadcast to every connected relay, and it completes when
 **all** of them have answered rather than when the first one has. That is a


### PR DESCRIPTION
Two defects found by auditing the unreleased range (`v0.21.0..35c2f94`) against the claims its own CHANGELOG and docs make. Both were invisible to the test suite because each lives in the seam *between* two features that were reviewed individually.

## 1. `resolveUsername()` promised an event the engine could not send

`resolve_username` gated only on the discovery switches, which survive `stop()`. The event it promises is emitted from `process()`, which early-returns unless the protocol is `Running`.

So on a stopped or paused instance the call returned `Ok(true)` — "an answer is coming" — with nothing able to deliver one. Worse, it left its registration behind, so every later attempt at that name returned `Ok(false)`, which says an answer is coming *too*. The caller was told twice that a resolution was in flight and had no way to learn otherwise. That directly contradicts the documented contract: *"Every case where no event will ever arrive rejects instead, so awaiting the resolution can never hang."*

- It now refuses with `NotStarted`, placed **after** the configuration checks. Both errors are true of a stopped instance with discovery off, and reporting the transient one first would send an app round a start-and-retry loop to arrive at the permanent problem it could have been told about immediately. `test_a_disabled_lookup_reports_configuration_before_state` pins that ordering.
- `stop()` now answers the lookups it is about to strand rather than dropping them: a resolution that heard from some relays emits what it has, one that never reached a relay emits the empty set — both on the terms the deadline sweep already uses. Discarding them silently would leave the promise broken *and* the registrations standing.
- **Neither bridge mapped `NotStarted`**, so it would have reached apps through `resolveUsername`'s fallback code, `InvalidArgument` — telling them the *name* was unusable and that retrying could never help, when `start()` was all that was missing. Added to both bridges with tests.

## 2. `getDorsConfig()` silently turned off internet-first routing

It answered from an FFI-local cache that nothing populated until the first `updateDorsConfig`, falling back to `CoreDorsConfig::default()` until then — and `prefer_online` is precisely the field whose default (`false`) disagrees with what construction seeds from `ProtocolConfig`.

An app created with `preferOnline: true` that then performed the **documented read-modify-write** to change any other field read `false`, wrote it back, and silently demoted internet-first routing. React Native was shielded only by accident (its TypeScript layer sources the flag from the `dors` section, whose create-time application populated the cache), so this bit **direct FFI callers: Swift, Kotlin and Python**.

The getter now reads the live selector, the way `getMeshRelayTunables()` reads the governor. The cache is **deleted rather than seeded** — a second copy of a value is a thing that can disagree with it. The single remaining core-to-FFI mapping destructures exhaustively, so a new DORS field fails the build rather than going missing from what every binding reads back.

## Verification

Every new test was checked against the unfixed code first. Four mutations, each failing the test that pins it:

| Mutation | Test that catches it |
|---|---|
| Remove the `Running` gate | `test_resolving_while_stopped_is_an_error_not_a_promise` |
| Remove the `stop()` flush | `test_stopping_answers_a_lookup_it_would_otherwise_strand` |
| Move the gate ahead of the config check | `test_a_disabled_lookup_reports_configuration_before_state` |
| Restore the default-fallback getter | `test_get_dors_config_reads_the_engine_not_an_ffi_copy` |

The Kotlin bridge arm was negative-controlled by removing it in the standalone harness (`ProtocolErrorBridgeTest` fails).

Green locally: `cargo fmt`, `clippy -D warnings`, `cargo test --workspace` (2262 tests), the rustdoc gate, TypeScript typecheck + 18 JS harness tests, 252 iOS Swift tests, 438 Android JVM tests, and `generate-bindings.sh` reports no drift (the UDL is untouched — `NotStarted` is a pre-existing variant, so the append-only error enum is unchanged).

Two notes for the reviewer:

- Two pre-existing tests now call `start()`. A new `protocol_with_discovery` helper enables discovery in the **config**, because setting the flag on the transport by hand does not survive `start()` — it re-applies the whole Nostr section from config.
- Refusing a pre-`start()` lookup is a deliberate behaviour change beyond the stopped case. Such a lookup could not reach a relay anyway and would resolve to the empty set after the 30s deadline, which reads as "nobody claims this name" — a false negative is worse than an error.

Both defects, and the rest of the audit findings not addressed here, are catalogued in the audit that produced this PR.