### PR TITLE
fix(protocol): release the group dedup entry on a mesh security refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,20 @@ archived by series under [docs/changelog/](docs/changelog/); see the
 
 ### Fixed
 
+- **A replayed group frame refused on identity grounds no longer earns a
+  delivery acknowledgement.** The mesh handler marks a message identifier
+  before attempting the decrypt, which bounds replay amplification to one
+  crypto operation per identifier, but it never released that mark when the
+  decrypt came back a security refusal (the wire sender and the
+  MLS-authenticated author disagree). The refusal withholds the ACK and clears
+  the transport-level mark, so a replayed copy reached the group handler
+  again, found its identifier marked but not pending, and was classified as
+  already delivered, which acknowledges it. Withholding that acknowledgement
+  from whoever forged the attribution is the entire point of refusing
+  silently: an ACK confirms the device is online and processing. The handler
+  now releases the identifier on refusal, matching the relay path and the
+  drain, at a cost of one crypto operation per replayed copy.
+
 - **`resolveUsername()` no longer promises an event the engine cannot send.**
   It gated only on the discovery switches, which survive `stop()`, while the
   event it promises is emitted from `process()`, which is inert unless the

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -1023,7 +1023,10 @@ impl OfflineProtocol {
     /// Returns [`InternalMessageResult::SecurityRejected`] when the wire
     /// sender does not match the MLS-authenticated sender (SEC-M1), so the
     /// caller suppresses the delivery ACK exactly like the `__MLS_ENC__`
-    /// path; a genuine crypto/parse failure consumes the message.
+    /// path; a genuine crypto/parse failure consumes the message. That
+    /// refusal also releases the group-level dedup entry marked below, so a
+    /// replayed copy is judged again on its own merits instead of reading as
+    /// already delivered in the duplicate branch and being re-ACKed.
     ///
     /// Deferred-ACK atom (mesh-group analog of the DM/media fix, PR #223): a
     /// message buffered because local group state is not ready yet returns
@@ -1155,7 +1158,22 @@ impl OfflineProtocol {
                 ));
                 InternalMessageResult::Consumed
             }
-            GroupDecryptOutcome::SecurityRejected => InternalMessageResult::SecurityRejected,
+            GroupDecryptOutcome::SecurityRejected => {
+                // Refused on attribution grounds: no ACK, and no dedup entry
+                // left behind either. Left marked, a replay of this frame
+                // reaches the duplicate branch above, reads as marked but not
+                // pending (that is, already delivered), and is Consumed, which
+                // the receive loop ACKs. That hands back exactly the liveness
+                // confirmation the silent refusal exists to withhold
+                // (invariant I4, ADR 0005). Only the envelope id can be marked
+                // at this point; the logical id is marked on a successful
+                // decrypt only. The transport-level unmark stays with the
+                // receive loop's `SecurityRejected` arm, which owns that layer
+                // for every rejected frame. Cost is one MLS crypto operation
+                // per replayed copy, the same trade the relay path accepts.
+                self.group_mesh.message_dedup.remove(&message.id.as_str());
+                InternalMessageResult::SecurityRejected
+            }
             GroupDecryptOutcome::Retriable => {
                 let group_id = payload.group_id.clone();
                 self.buffer_pending_group_message(

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -4528,6 +4528,95 @@ fn test_grp_mls_msg_failed_decrypt_does_not_poison_logical_id() {
     );
 }
 
+/// The mesh path's copy of the refusal-unmark obligation (#366). The handler
+/// marks the envelope id *before* decrypting, to bound replay amplification to
+/// one crypto operation per id. A SEC-M1 refusal then withholds the ACK and the
+/// receive loop unmarks the *transport* deduplicator, so a replay is not
+/// absorbed there and reaches this handler a second time. Left marked at the
+/// group level, that replay hits the duplicate branch, reads as marked but not
+/// pending (already delivered), and returns `Consumed`, which the receive loop
+/// ACKs: the replay earns the liveness confirmation the silent refusal exists
+/// to withhold (invariant I4, ADR 0005).
+///
+/// Pin the release, and pin what it can and cannot recover. The refused
+/// decrypt already spent the ciphertext's ratchet generation (OpenMLS persists
+/// message secrets through the storage provider before the identity check
+/// runs), so the replay cannot decrypt: the honest outcome is `Deferred`,
+/// buffered and un-ACKed, never `Consumed`.
+#[test]
+fn test_mesh_copy_sender_mismatch_rejected_releases_dedup_entry() {
+    let (alice, mut bob, group_id) = setup_alice_bob_group("Mesh Mismatch Group");
+    let events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = events.clone();
+    bob.on_event(move |event| {
+        events_clone.lock().unwrap().push(event);
+    });
+
+    let logical = "cafecafe-1111-2222-3333-444444444444";
+    let encrypted = {
+        let mls = alice.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id).unwrap();
+        mls.encrypt_for_group(&gid, b"mesh body").unwrap()
+    };
+    let payload = serde_json::json!({
+        "group_id": group_id,
+        "ciphertext": base64_encode(&encrypted.ciphertext),
+        "epoch": encrypted.epoch,
+        "message_id": logical,
+    })
+    .to_string();
+
+    // Alice's genuine ciphertext, injected on the mesh under mallory's wire
+    // identity: MLS authenticates alice as the author, the wire sender claims
+    // mallory, so SEC-M1 refuses to attribute the frame to anyone.
+    let wire = make_message(
+        &id("mallory"),
+        &id("bob"),
+        &format!("{}{}", internal_prefixes::GROUP_MLS_MSG, payload),
+    );
+    let res = bob.handle_group_mls_msg(&wire, &id("mallory"), &payload);
+    assert!(
+        matches!(res, InternalMessageResult::SecurityRejected),
+        "A wire sender that is not the MLS-authenticated author must be refused: got {:?}",
+        res
+    );
+    assert!(
+        !bob.group_mesh.message_dedup.contains_key(&wire.id.as_str()),
+        "A SecurityRejected mesh copy must not leave the envelope id marked, \
+         or the duplicate branch re-ACKs a replay as already delivered"
+    );
+    assert!(
+        !bob.group_mesh.message_dedup.contains_key(logical),
+        "The logical id is marked on a successful decrypt only"
+    );
+
+    // The verbatim replay an injector sends to fish for that ACK: same
+    // envelope, same ciphertext. It must be judged again rather than absorbed.
+    let res = bob.handle_group_mls_msg(&wire, &id("mallory"), &payload);
+    assert!(
+        matches!(res, InternalMessageResult::Deferred),
+        "A replayed refusal must not be absorbed as an already-delivered \
+         duplicate (Consumed), which the receive loop ACKs: got {:?}",
+        res
+    );
+    assert!(
+        bob.group_mesh
+            .pending_group_messages
+            .get(&group_id)
+            .is_some_and(|q| !q.is_empty()),
+        "Deferred means buffered: the generation was spent by the refused \
+         decrypt, so custody stays with the sender"
+    );
+
+    let events = events.lock().unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Event::GroupMessageReceived { .. })),
+        "A refused frame must never deliver"
+    );
+}
+
 /// The relay path's own copy of the poison hazard. Its handler marks the
 /// relay-supplied id (the logical id) pre-decrypt as replay defense — but a
 /// copy whose wire `sender` is not the MLS credential (a v2 relay

--- a/docs/spec/group-protocol.md
+++ b/docs/spec/group-protocol.md
@@ -117,19 +117,21 @@ row 1 refusals happen at the MLS layer, *after* the outer sender was proved,
 which is exactly what makes them attribution failures: the proved outer sender
 is contradicting the authenticated inner author.
 
-The unmark obligation in row 1 spans **both** deduplication layers, and the two
-group paths do not currently discharge it alike. The relay path removes its
-group-level entry on a security refusal. The mesh path does not: it marks the
-envelope identifier before decrypting (to bound replay amplification to one
-crypto operation per identifier) and never releases it on refusal, so a verbatim
-replay is absorbed by the duplicate branch, which treats a marked-but-not-pending
-identifier as already delivered and **acknowledges** it.
+The unmark obligation in row 1 spans **both** deduplication layers, and every
+inbound path discharges it. The receive loop releases the transport-level
+identifier for a refused frame that reached it. At the group level, the mesh
+handler, the relay handler and the drain each release their own entry.
 
-The mesh behaviour is a defect against this specification, not the specification
-describing itself. A conforming implementation MUST release the identifier on
-the refusal path, in the mesh handler as well as the relay handler; the
-replay-amplification bound survives, at a cost of one crypto operation per
-replayed copy, which is the same trade the relay path already accepts.
+Releasing is not optional, and the failure it prevents is specific. Both group
+handlers mark the identifier *before* attempting the decrypt, which bounds
+replay amplification to one crypto operation per identifier. An implementation
+that marks but does not release on refusal leaves the identifier marked and not
+pending, and the duplicate branch reads that state as already delivered: a
+verbatim replay is then **acknowledged**, handing whoever forged the
+attribution the liveness confirmation the refusal was designed to withhold. A
+conforming implementation MUST therefore release the identifier on the refusal
+path in every group handler. The replay-amplification bound survives, at a cost
+of one crypto operation per replayed copy.
 
 A refused commit MUST be classified **permanently** refused. An implementation
 that treats it as retriable buffers it, re-decrypts it on every drain, and,

--- a/docs/state-machines/group-message-lifecycle.md
+++ b/docs/state-machines/group-message-lifecycle.md
@@ -21,7 +21,9 @@ The relay path marks it at arrival.** Both are correct for their path, and each
 carries an obligation the other does not.
 
 **G4. Every relay-path arm that ends with the frame neither delivered, nor
-buffered, nor consumed by MLS must unmark before returning.**
+buffered, nor consumed by MLS must unmark before returning.** On the mesh path
+the same obligation binds the identity refusal, which releases both layers. Its
+other permanent verdicts are acknowledged and stay marked.
 
 ## Send
 
@@ -85,17 +87,17 @@ stateDiagram-v2
 
     Buffered --> Deferred: no ack, unmark transport dedup
     Deferred --> [*]
-    SecurityRejected --> [*]: no ack, unmark transport dedup only
+    SecurityRejected --> [*]: no ack, release both dedup layers
     PolicyRejected --> [*]: ack, stays marked
     Delivered --> [*]: ack
 ```
 
 Two group-specific differences from the direct-message deferred atom:
 
-**Difference 1: only the transport deduplication layer is unmarked.** The
-group-level layer stays marked for the whole pending lifetime. It is the
-replay-amplification defence and the authoritative double-delivery guard, so the
-drain does **not** re-mark the transport layer either.
+**Difference 1: a buffered message unmarks only the transport deduplication
+layer.** The group-level layer stays marked for the whole pending lifetime. It
+is the replay-amplification defence and the authoritative double-delivery guard,
+so the drain does **not** re-mark the transport layer either.
 
 **Difference 2: a duplicate of a still-pending message returns `Deferred`, not a
 re-acknowledgement.** It is checked before decrypt. Only a duplicate of an
@@ -108,6 +110,14 @@ deduplication layers.
 **The logical identifier is marked only after a successful decrypt**, so a
 failed decrypt cannot poison it. Failing to hold that line turns a rejected copy
 into an apparent delivery.
+
+**The envelope identifier is released on an identity refusal**, which is the
+other half of the same rule. It is marked before the decrypt to bound replay
+amplification, so a refusal that leaves it marked leaves it readable as marked
+and not pending, which the duplicate branch treats as already delivered: a
+verbatim replay is then acknowledged, and that acknowledgement is the liveness
+confirmation the refusal withheld. Releasing costs one crypto operation per
+replayed copy.
 
 ### Relay path
 


### PR DESCRIPTION
Closes #366.

## The bug

`handle_group_mls_msg_via` marks the envelope identifier in `message_dedup`
*before* attempting the decrypt, deliberately, to bound replay amplification to
one MLS crypto operation per identifier. The `SecurityRejected` arm then
returned without releasing that mark.

The relay path has released it since #337 (`group_mesh.rs:5789`) and the drain
releases it too (`group_mesh.rs:2697`). The mesh arm predates that discipline
and was never retrofitted.

The leak chain, each link verified against the code:

1. `SecurityRejected` withholds the ACK and unmarks the **transport**
   deduplicator (`protocol/receive.rs:232-244`), so a replay is not absorbed
   there.
2. The replay reaches the group handler again and hits the duplicate branch
   (`group_mesh.rs:1064-1094`).
3. The identifier is marked but not pending, so that branch classifies it as
   already delivered and returns `Consumed`.
4. The receive loop ACKs `Consumed`.

Replaying a frame we refused on identity grounds therefore earns an
acknowledgement, which is exactly the liveness confirmation the silent-refusal
rule exists to withhold (invariant I4 in `docs/state-machines/delivery-and-acks.md`,
and ADR 0005).

## The fix

Release the envelope identifier on the `SecurityRejected` arm of the mesh
handler. All three group paths now discharge the obligation: mesh, relay, and
the drain.

The transport-level unmark stays with the receive loop's `SecurityRejected`
arm, which already owns that layer for every rejected frame. That is why this
is a direct `message_dedup.remove` rather than a call to
`release_replay_protection`: the helper clears both layers, and its documented
scope is drain-time drops where no receive-loop pass exists to do it. Using it
here would double-unmark and make that doc comment stale.

Cost is one crypto operation per replayed copy, the trade the relay path
already accepts and the spec already endorses.

## What the replay does now

The refused decrypt has already spent the ciphertext's ratchet generation
(OpenMLS persists message secrets through the storage provider before the
identity check runs), so the replay cannot decrypt. It classifies `Retriable`,
buffers, and returns `Deferred`: still no ACK, custody stays with the sender,
the failure stays visible. This mirrors what the relay path's equivalent
regression test already pins.

## Test

`test_mesh_copy_sender_mismatch_rejected_releases_dedup_entry` replays a
refused frame and asserts no ACK is produced, as the issue asked for.

It was checked against the unfixed code in **both** directions:

- Remove the release: fails on the dedup assertion.
- Remove the release *and* bypass that assertion so execution reaches the
  replay: fails with **`got Consumed`**, which is the result the receive loop
  turns into a delivery ACK. That is the reported bug reproduced directly.

## Docs

The issue named one stale document; there were two.

- `docs/spec/group-protocol.md` (written in #365) called the mesh behaviour "a
  defect against this specification". It now states the uniform rule and keeps
  the MUST and the replay-amplification rationale.
- `docs/state-machines/group-message-lifecycle.md` had the old behaviour baked
  into a diagram edge as `no ack, unmark transport dedup only`, and its **G4**
  invariant scoped the unmark obligation to the relay path alone. Both
  corrected, plus "Difference 1" is now explicitly scoped to the buffered case
  so it does not read as covering the refusal arm.

The comment at `group_mesh.rs:1277-1278` that the issue flagged as stale
("it must withhold the ACK and unmark the id, which is what `SecurityRejected`
already carries") needed no edit: the fix makes it true.

## Blast radius

No FFI, UDL, wire-format, or config change, so no binding regeneration. The
only caller-visible behaviour change is that a replayed refused frame now
classifies `Deferred` instead of `Consumed`, and the receive loop already
handles `Deferred` correctly. Revert is a single-commit revert, safe: the state
involved is in-memory only.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace -- -D warnings` exit 0, zero warnings
- `cargo test --workspace --lib` 2253 passed, 0 failed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` exit 0