### PR TITLE
docs(spec,security,adr): specify the gateway contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,53 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   governor. The DORS tie-break comments claimed an order ending at Reticulum
   when Nostr, not Reticulum, is lowest.
 
+- **The gateway contract is specified** in
+  [docs/spec/gateway-contract.md](./docs/spec/gateway-contract.md): what a
+  gateway is, the five verbs it must implement (Attach, Submit, Verdict,
+  Presence, Capabilities), the newline-JSON wire protocol a device speaks to a
+  gateway daemon, and how the Reticulum backbone carries traffic between zones.
+
+  The framing is deliberately a reframing rather than an invention: **the
+  internet relay already implements every verb**, so everything the SDK does
+  with the relay's answers today (parking, escalating probes, mesh offers,
+  presence-driven flush) is gateway machinery that predates the name. Verdict is
+  the load-bearing verb, and the contract states plainly that verdicts are
+  unauthenticated claims which may open a path and must never close one, because
+  nothing settles a message except the recipient's own acknowledgement.
+
+  The device-to-daemon protocol promotes the one both mobile bridges already
+  speak, extended with the verbs that make a gateway a gateway: a version field,
+  an address declaration under a new `offline-gateway-addr-v1` signing domain
+  (registered in the spec's signing-domain table as reserved), per-recipient
+  verdicts, presence and capability advertisement.
+
+- **Two decisions recorded.**
+  [ADR 0016](./docs/adr/0016-gateways-are-provisioned-not-emergent.md): gateways
+  are provisioned, never emergent — the forwarding-bias shape does not transfer
+  to bridging, because most devices structurally cannot bridge and there is no
+  in-zone redundancy to cover a bridge that leaves, so self-promotion produces
+  silent partitions.
+  [ADR 0017](./docs/adr/0017-nostr-is-a-carrier-not-a-gateway.md): Nostr is a
+  carrier and never a gateway, because a broadcast relay reports no
+  per-recipient delivery. The resulting gap is recorded as permanent so it stops
+  being rediscovered as a bug, and so nobody "fixes" it by inferring verdicts
+  from evidence that is really about the relay.
+
+- **Threat model grows a gateway section.** New adversary class A7 (hostile
+  gateway) and residual R10, covering blackholing, verdicts that lie in either
+  direction, zone-membership exposure to the operator, and backbone exhaustion —
+  with the reason each is bounded to latency rather than loss.
+
+- **`docs/reticulum.md` stops describing a daemon that does not exist.** The
+  "Daemon TCP Protocol" section implied `rnsd` speaks this protocol; it does
+  not, and no counterpart has ever existed in any repository. It now points at
+  the contract spec and says so. Also corrected: "fourth transport" predated
+  Nostr; the reconnection table presented inert Rust `ReticulumConfig` fields as
+  live behaviour when reconnection is entirely owned by the native managers
+  (1s doubling to 30s, not configurable) and configured from app config; and
+  `RETICULUM_MAX_PAYLOAD_SIZE` is documented as a limit but has no reader.
+  `docs/transport-architecture.md` aligned to match.
+
 ## [0.22.0] — 2026-08-18
 
 > **The battery-aware relay policy was complete and unreachable; it now runs.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,22 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   speak, extended with the verbs that make a gateway a gateway: a version field,
   an address declaration under a new `offline-gateway-addr-v1` signing domain
   (registered in the spec's signing-domain table as reserved), per-recipient
-  verdicts, presence and capability advertisement.
+  verdicts, presence and capability advertisement. Attach is specified from both
+  sides: the gateway verifies the proof, the address against the declared key,
+  and its own single-use challenge, while the device verifies the address it is
+  bound to. Neither check substitutes for the other, and a gateway that skips
+  its half attaches sessions under addresses the attaching device does not
+  control. Inbound delivery is specified alongside the five verbs (without being
+  a sixth), because the daemon link is the only inbound path a device attached
+  over local IP has, and a daemon built to the verbs alone would deliver nothing
+  to the devices attached to it.
+
+- **The reserved signing domain is pinned by the guard that owns that
+  property.** `offline-gateway-addr-v1` joins the non-prefixing and distinctness
+  tests in `protocol::types::signing_domain_tests` even though nothing emits it
+  yet. Non-prefixing is a property of the whole set, so a guard watching only
+  live domains would accept a future live domain that prefixes this one, and the
+  collision would surface in whichever implementation first signed under it.
 
 - **Two decisions recorded.**
   [ADR 0016](./docs/adr/0016-gateways-are-provisioned-not-emergent.md): gateways
@@ -168,7 +183,11 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   live behaviour when reconnection is entirely owned by the native managers
   (1s doubling to 30s, not configurable) and configured from app config; and
   `RETICULUM_MAX_PAYLOAD_SIZE` is documented as a limit but has no reader.
-  `docs/transport-architecture.md` aligned to match.
+  `docs/transport-architecture.md` aligned to match. The daemon section now
+  also records what the shipped clients do *not* do: they confirm a send on the
+  socket write and ignore `MessageSent` and `DeliveryError` entirely, so a
+  daemon answering the contract correctly gets no verdict handling from today's
+  bridges.
 
 ## [0.22.0] — 2026-08-18
 

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -1889,7 +1889,7 @@ pub(crate) enum OutboundSendPreparation {
     Queued(MessageId),
 }
 
-/// Pins that every live signing domain is mutually non-prefixing.
+/// Pins that every signing domain, live or reserved, is mutually non-prefixing.
 ///
 /// # Why this test exists here, of all places
 ///
@@ -1900,6 +1900,13 @@ pub(crate) enum OutboundSendPreparation {
 /// can import all four, so this module is the one place they can be compared at
 /// all: it is the highest crate that can see two of them, and the fourth is
 /// pinned as a literal.
+///
+/// A fifth is reserved and covered here too, for the reason reservation exists:
+/// non-prefixing is a property of the whole set, so a domain that is specified
+/// but not yet emitted still has to be held against every other one. A guard
+/// that watched only live domains would happily accept a new live domain that
+/// prefixes a reserved one, and the collision would be discovered by the
+/// implementation that finally emits it.
 #[cfg(test)]
 mod signing_domain_tests {
     use offline_protocol_mls::discovery::DISCOVERY_SIGN_DOMAIN;
@@ -1917,7 +1924,17 @@ mod signing_domain_tests {
     /// why it is spelled out with this comment attached.
     const RELAY_ADDR_SIGN_DOMAIN: &[u8] = b"offline-relay-addr-v1";
 
-    /// No live domain may be a prefix of another.
+    /// The gateway's address-proof domain: **reserved, not yet emitted.**
+    ///
+    /// Specified by `docs/spec/gateway-contract.md` and registered in the
+    /// signing-domain table of `docs/spec/username-discovery.md`. No code signs
+    /// under it yet, which is precisely why it is pinned before anything does:
+    /// it must be chosen against the whole set, and it must stay distinct from
+    /// [`RELAY_ADDR_SIGN_DOMAIN`] so a proof harvested by a hostile gateway
+    /// cannot be replayed against the relay, or the reverse.
+    const GATEWAY_ADDR_SIGN_DOMAIN: &[u8] = b"offline-gateway-addr-v1";
+
+    /// No domain, live or reserved, may be a prefix of another.
     ///
     /// The canonical payload is `domain ‖ Σ(u32be(len) ‖ field)`, and the
     /// **domain itself is not length-prefixed**. So if one domain were a prefix
@@ -1933,11 +1950,12 @@ mod signing_domain_tests {
     /// every device that ever authenticated to it.
     #[test]
     fn signing_domains_are_mutually_non_prefixing() {
-        let domains: [(&str, &[u8]); 4] = [
+        let domains: [(&str, &[u8]); 5] = [
             ("offline-ctrl-v1", CTRL_SIGN_DOMAIN),
             ("offline-disc-v1", DISCOVERY_SIGN_DOMAIN),
             ("offline-invite-v1", INVITE_SIGN_DOMAIN),
             ("offline-relay-addr-v1", RELAY_ADDR_SIGN_DOMAIN),
+            ("offline-gateway-addr-v1", GATEWAY_ADDR_SIGN_DOMAIN),
         ];
 
         for (a_name, a) in domains {
@@ -1971,18 +1989,20 @@ mod signing_domain_tests {
         assert_eq!(DISCOVERY_SIGN_DOMAIN, b"offline-disc-v1");
         assert_eq!(INVITE_SIGN_DOMAIN, b"offline-invite-v1");
         assert_eq!(RELAY_ADDR_SIGN_DOMAIN, b"offline-relay-addr-v1");
+        assert_eq!(GATEWAY_ADDR_SIGN_DOMAIN, b"offline-gateway-addr-v1");
     }
 
-    /// All four must be distinct, which non-prefixing already implies for
+    /// All five must be distinct, which non-prefixing already implies for
     /// unequal strings but not for equal ones: two identical domains are
     /// prefixes of each other, and the loop above skips same-name pairs.
     #[test]
     fn signing_domains_are_distinct() {
-        let domains: [&[u8]; 4] = [
+        let domains: [&[u8]; 5] = [
             CTRL_SIGN_DOMAIN,
             DISCOVERY_SIGN_DOMAIN,
             INVITE_SIGN_DOMAIN,
             RELAY_ADDR_SIGN_DOMAIN,
+            GATEWAY_ADDR_SIGN_DOMAIN,
         ];
         for (i, a) in domains.iter().enumerate() {
             for b in domains.iter().skip(i + 1) {

--- a/docs/adr/0016-gateways-are-provisioned-not-emergent.md
+++ b/docs/adr/0016-gateways-are-provisioned-not-emergent.md
@@ -1,0 +1,71 @@
+# 0016. Gateways are provisioned, never emergent
+
+**Status:** Accepted
+
+## Context
+
+A gateway bridges a zone to the internet or to a wide-area backbone. The
+question is how a zone acquires one: does a person install it, or does a capable
+device promote itself when it notices it could bridge?
+
+Self-promotion is the obvious design, and this codebase already does something
+that looks like it. Mesh forwarding is role-blind: every device may forward, and
+a device that is charging and well-connected wins forwarding races through a
+continuous scoring bias rather than through a role it claims. That worked, and
+it removed a whole class of role-state bugs. Applying the same shape one layer
+up is a natural instinct.
+
+## Decision
+
+A gateway is a deployment: a powered, stationary box someone installs and
+configures, attached to at least one zone and at least one wide-area carrier. It
+is never a runtime state a device reaches on its own.
+
+Inside its zone a gateway is an ordinary peer, with no role and no state
+machine, exactly as before.
+
+## Consequences
+
+### Why the forwarding-bias shape does not transfer
+
+Relay bias is safe inside the zone because of two properties that do not hold
+for bridging:
+
+1. **Every device can forward.** The bias picks among a population that is
+   entirely capable, so a wrong pick costs a little redundancy.
+2. **Suppression makes redundancy cheap.** A neighbour that hears someone else
+   carry a frame stands down, so several devices trying is nearly as cheap as
+   one.
+
+Backbone attachment has neither. Most devices structurally *cannot* bridge: no
+Reticulum interface, no fixed power, no stable address. So "everyone can, the
+capable win" has almost no population to draw from. And there is no in-zone
+redundancy covering a bridge that leaves or misjudges, because the other devices
+were never candidates.
+
+The failure that produces is a **silent partition**: inter-zone traffic stops,
+and nothing reports it, because from inside the zone an absent gateway and a
+gateway that decided it was not needed look identical.
+
+### What provisioning buys
+
+A zone has exactly the gateways someone installed. "Zero gateways" becomes a
+visible operational fact rather than an emergent condition, and it degrades to
+the behaviour a zone with no gateway should have anyway: absent facts mean
+today's behaviour, so a zone with no gateway simply routes as it always did.
+
+### What it costs
+
+Someone has to install a box, and a zone whose only gateway is switched off has
+no bridge until a person acts. That is the intended trade: an outage a human can
+see beats a partition no one can.
+
+## What would undo this
+
+An "auto-promote to gateway" heuristic: a device noticing it has a Reticulum
+interface and a charger and enrolling itself. It would look like a natural
+extension of the forwarding bias and would reintroduce exactly the silent
+partition above.
+
+Provisioned-ness is also what makes the operational advice ("install two")
+meaningful. If gateways were emergent there would be nothing to install twice.

--- a/docs/adr/0017-nostr-is-a-carrier-not-a-gateway.md
+++ b/docs/adr/0017-nostr-is-a-carrier-not-a-gateway.md
@@ -1,0 +1,64 @@
+# 0017. Nostr is a carrier, never a gateway
+
+**Status:** Accepted
+
+## Context
+
+The [gateway contract](../spec/gateway-contract.md) requires five verbs, of
+which Verdict is load-bearing: a per-recipient answer that a frame was forwarded
+or that the recipient is unreachable. Verdict is what lets a sender discover
+that a carrier which is *up* cannot reach a *particular* recipient, which is the
+one fact ordinary transport selection cannot supply.
+
+Nostr is one of this protocol's carriers. It reaches peers over relays that do
+their own routing, so it looks like the same class of thing as the internet
+relay, and it is natural to expect it to become a gateway once gateways exist.
+
+It cannot. A Nostr relay accepts an event and reports whether it accepted it. It
+does not know, and does not report, whether any particular recipient received
+it. There is no per-recipient delivery signal to translate into a verdict, and
+no amount of implementation work on our side creates one.
+
+## Decision
+
+Nostr remains a carrier and is never a gateway. It advertises no gateway
+capability, produces no verdicts, and keeps the peer-blind reachability claim it
+has today: while a Nostr transport is available, it counts as a way to reach
+every recipient.
+
+Record the resulting gap as permanent rather than outstanding.
+
+## Consequences
+
+A device whose only infrastructure carrier is Nostr never receives an
+unreachable verdict. Nothing contradicts the initial "reachable" answer, so no
+mesh fallback fires for it on the send path, and its messages settle by
+acknowledgement or expiry exactly as they always have.
+
+This is a real limitation and it is worth stating plainly: in a mixed
+neighbourhood, a Nostr-only sender standing next to an unreachable recipient
+will not hand the frame to its neighbours before the acknowledgement ladder runs
+out. The live-mesh-link preference still applies, because that needs no verdict:
+a recipient this device holds a link to is reached over that link. What is
+missing is only the case where the recipient is reachable through *someone
+else's* radio.
+
+Recipient-aware policy is written to make this degradation structural rather
+than accidental: a carrier that produces no facts keeps its blanket claim. A
+verdict from a different carrier must never silence Nostr, or the residual would
+close by accident in some configurations and not others, which is worse than a
+consistent limitation.
+
+## What would undo this
+
+A Nostr extension that reports per-recipient delivery, or a deployment placing a
+verdict-capable component in front of Nostr relays. Either would make Nostr
+gateway-eligible with no change to the contract, since the contract is semantic
+and says nothing about wire format.
+
+Absent that, the thing to guard against is someone reading the residual as an
+unfinished feature and "fixing" it by inferring verdicts: treating a relay's
+`OK` rejection, or a send timeout, as evidence about the recipient. Both are
+evidence about the *relay*. Inferring recipient state from them would produce
+confident wrong claims, which is worse than the honest silence this decision
+accepts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,8 @@ silently undo it. Decisions that follow from the obvious default do not need one
 | [0013](0013-exhaustive-privacy-classifier.md) | Remote-influenced text is classified to a fixed vocabulary by an exhaustive match | Accepted |
 | [0014](0014-dedicated-ffi-entry-points.md) | Security-relevant relay answers arrive through dedicated entry points | Accepted |
 | [0015](0015-relay-hint-frames-unacked-and-pinned.md) | Relay hint frames are unacknowledged and transport-pinned | Accepted |
+| [0016](0016-gateways-are-provisioned-not-emergent.md) | Gateways are provisioned, never emergent | Accepted |
+| [0017](0017-nostr-is-a-carrier-not-a-gateway.md) | Nostr is a carrier, never a gateway | Accepted |
 
 ## Format
 

--- a/docs/reticulum.md
+++ b/docs/reticulum.md
@@ -163,8 +163,8 @@ let config = ProtocolConfig(
 |----------|-------|-------------|
 | Connection timeout | 60s | Enforced by the native managers, which each hold their own constant. The identically-valued Rust `ReticulumConfig` field is not read by anything. |
 | Pending confirmation timeout | 120s | Time before treating an unconfirmed send as failed (vs 15s for Internet). Enforced in Rust. |
-| Max payload size | 64 KB | Declared as `RETICULUM_MAX_PAYLOAD_SIZE` and **not currently enforced anywhere** — no code reads it. Treat it as intent, not as a limit you can rely on. |
-| Reticulum encrypted MDU | 383 bytes | Single-packet maximum for encrypted data; plain MDU is 464 bytes |
+| Max payload size | 64 KB | Declared as `RETICULUM_MAX_PAYLOAD_SIZE` and **not currently enforced anywhere**: no code reads it. Treat it as intent, not as a limit you can rely on. |
+| Reticulum encrypted MDU | 383 bytes | Single-packet maximum for encrypted data; plain MDU is 465 bytes |
 | Reticulum MTU | 500 bytes | Total wire-format maximum including headers |
 
 The longer timeouts reflect the high-latency reality of LoRa multi-hop paths.
@@ -187,9 +187,18 @@ Regardless of which integration strategy you choose, the platform bridge interac
 > **Normative home:** this protocol is specified in
 > [the gateway contract](spec/gateway-contract.md#gateway-daemon-contract-v1),
 > which is the document to implement against. What follows describes what the
-> shipped managers do today, which is contract v1 minus the verbs that make a
-> gateway a gateway (address declaration, per-recipient verdicts, presence,
-> capabilities, the version field).
+> shipped managers do today: contract v1 minus the verbs that make a gateway a
+> gateway (address declaration, per-recipient verdicts, presence, capabilities,
+> the version field). `Identify`, `SendMessage`, `MessageReceived` and
+> `StatusUpdate` are the whole of what they speak.
+>
+> One difference is easy to miss when implementing the daemon side, because it
+> is a silence rather than a message: **the shipped clients confirm a send on
+> the socket write, not on a daemon answer.** They call
+> `reticulumConfirmSent()` as soon as the line is written and ignore both
+> `MessageSent` and `DeliveryError`, so a daemon that answers contract v1
+> correctly gets no verdict handling from today's bridges. Teaching them to
+> settle on the daemon's answer is part of the transport work, not the daemon's.
 >
 > Note what this section used to imply and does not: **no Reticulum daemon
 > speaks this protocol.** `rnsd`'s own shared-instance IPC is HDLC-framed
@@ -452,7 +461,7 @@ The `update_metrics` method preserves confirmation loop counts (success/failure)
 ## Reconnection
 
 Reconnection is owned entirely by the native managers, and is configured from
-the app's transport config — **not** from the Rust `ReticulumConfig`, whose
+the app's transport config, **not** from the Rust `ReticulumConfig`, whose
 fields are inert (nothing constructs it with non-default values, and
 `reconnect_delay` has no reader at all).
 

--- a/docs/reticulum.md
+++ b/docs/reticulum.md
@@ -4,7 +4,9 @@
 
 The Reticulum transport provides long-range, resilient mesh networking via the [Reticulum](https://reticulum.network/) network stack. It supports LoRa, TCP, UDP, serial, I2P, and other mediums, making it ideal for off-grid communication, disaster recovery, and infrastructure-sparse environments where BLE range is insufficient and Internet connectivity is unavailable.
 
-Reticulum is the fourth transport in the Offline Protocol SDK, alongside BLE, WiFi Direct, and Internet. It is disabled by default because it requires external infrastructure (a running Reticulum instance, an RNode radio, or a network gateway).
+Reticulum is one of five transports in the Offline Protocol SDK, alongside BLE, Wi-Fi Direct, Internet and Nostr. It is disabled by default because it requires external infrastructure (a running Reticulum instance, an RNode radio, or a gateway).
+
+> **No counterpart daemon ships yet.** The Rust transport opens no Reticulum link of its own: it manages queues, metrics and the send-confirmation loop, and expects the platform to bridge to a real Reticulum stack. Both mobile managers speak the protocol below to a configurable address, and nothing in this repository or any companion repository answers on the other end. Until a daemon exists, enabling Reticulum gives you a transport that queues and never drains. See [the gateway contract](spec/gateway-contract.md), which specifies what that daemon has to be.
 
 ## When to Use Reticulum
 
@@ -159,9 +161,9 @@ let config = ProtocolConfig(
 
 | Constant | Value | Description |
 |----------|-------|-------------|
-| Connection timeout | 60s | Time to wait for Reticulum connection (vs 30s for Internet) |
-| Pending confirmation timeout | 120s | Time before treating an unconfirmed send as failed (vs 15s for Internet) |
-| Max payload size | 64 KB | SDK-imposed limit; Reticulum's Resource mechanism has no inherent cap |
+| Connection timeout | 60s | Enforced by the native managers, which each hold their own constant. The identically-valued Rust `ReticulumConfig` field is not read by anything. |
+| Pending confirmation timeout | 120s | Time before treating an unconfirmed send as failed (vs 15s for Internet). Enforced in Rust. |
+| Max payload size | 64 KB | Declared as `RETICULUM_MAX_PAYLOAD_SIZE` and **not currently enforced anywhere** — no code reads it. Treat it as intent, not as a limit you can rely on. |
 | Reticulum encrypted MDU | 383 bytes | Single-packet maximum for encrypted data; plain MDU is 464 bytes |
 | Reticulum MTU | 500 bytes | Total wire-format maximum including headers |
 
@@ -182,7 +184,20 @@ Regardless of which integration strategy you choose, the platform bridge interac
 
 ### Daemon TCP Protocol
 
-The built-in `ReticulumManager` (iOS and Android) communicates with a Reticulum daemon over a newline-delimited JSON protocol on TCP (default `localhost:4242`). Both platforms must implement the same message types to stay in sync.
+> **Normative home:** this protocol is specified in
+> [the gateway contract](spec/gateway-contract.md#gateway-daemon-contract-v1),
+> which is the document to implement against. What follows describes what the
+> shipped managers do today, which is contract v1 minus the verbs that make a
+> gateway a gateway (address declaration, per-recipient verdicts, presence,
+> capabilities, the version field).
+>
+> Note what this section used to imply and does not: **no Reticulum daemon
+> speaks this protocol.** `rnsd`'s own shared-instance IPC is HDLC-framed
+> Reticulum packets over a Unix domain socket (Strategy 3 above), not this. This
+> is a bespoke protocol whose counterpart has never existed, which is why the
+> gateway contract promotes it rather than inventing a third one.
+
+The built-in `ReticulumManager` (iOS and Android) speaks a newline-delimited JSON protocol over TCP to a configurable `daemonAddress` (default `localhost:4242`). Both platforms implement the same message types to stay in sync.
 
 **Client-to-daemon messages:**
 
@@ -436,18 +451,22 @@ The `update_metrics` method preserves confirmation loop counts (success/failure)
 
 ## Reconnection
 
-Reticulum transport supports automatic reconnection:
+Reconnection is owned entirely by the native managers, and is configured from
+the app's transport config — **not** from the Rust `ReticulumConfig`, whose
+fields are inert (nothing constructs it with non-default values, and
+`reconnect_delay` has no reader at all).
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `auto_reconnect` | `true` | Automatically reconnect after disconnection |
-| `reconnect_delay` | 5 seconds | Delay between reconnection attempts |
-| `max_reconnect_attempts` | 0 (infinite) | Maximum attempts before giving up |
+| Parameter | Where it lives | Default | Description |
+|-----------|----------------|---------|-------------|
+| `daemonAddress` | app config (`transports.reticulum`) | `localhost:4242` | Host and port of the daemon |
+| `autoReconnect` | app config | `true` | Reconnect after disconnection |
+| `maxReconnectAttempts` | app config | `0` (infinite) | Attempts before giving up |
+| Backoff | native managers | 1s doubling to 30s | Not configurable |
 
 On disconnection:
 1. All pending confirmations are failed immediately
 2. Send queue is preserved (messages will be sent after reconnection)
-3. Reconnection attempts begin after `reconnect_delay`
+3. Reconnection attempts begin after the current backoff interval
 4. Reconnect counter resets on successful connection
 
 ## Troubleshooting

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -367,19 +367,20 @@ acknowledgement or terminal outbox expiry, so no gateway answer settles
 anything.
 
 **Mitigations in place today**, carrying the internet relay as the one shipped
-gateway: the settlement invariant, verdicts-never-close-a-path, and MLS end to
-end so a gateway sees ciphertext plus routing metadata. These hold for a hostile
-relay right now, which is why an A7 gateway inherits a bounded blast radius
-rather than a new one.
+gateway: the settlement invariant, verdicts-never-close-a-path, MLS end to end
+so a gateway sees ciphertext plus routing metadata, and the recipient-aware
+decay that reverts every gateway claim to "no opinion" on a TTL (ten minutes for
+a verdict, five for a presence answer) rather than letting it stand
+indefinitely. These hold against a hostile relay right now, which is why an A7
+gateway inherits a bounded blast radius rather than a new one.
 
 **Mitigations specified but not yet implemented**, and therefore not yet
 protecting anyone: address-bound attach under `offline-gateway-addr-v1` (the
 domain is [reserved, not emitted](../spec/username-discovery.md#signing-domains)),
-per-device and per-peer token-bucket budgets at the gateway against exhaustion,
-and the recipient-aware decay that reverts a stale or malicious claim to "no
-opinion" rather than letting it stand indefinitely. They are listed separately
-on purpose: a threat model that reads as protection when the protection is prose
-is the failure this document exists to prevent.
+and per-device and per-peer token-bucket budgets at the gateway against
+exhaustion. They are listed apart from the others on purpose: a threat model
+that reads as protection when the protection is still prose is the failure this
+document exists to prevent.
 
 **What would close it:** nothing closes the lying-gateway case, because the lie
 is about someone else's state. Provisioning is the real control: gateways are

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -366,12 +366,20 @@ the acknowledgement ladder. Delivery settles only on the recipient's end-to-end
 acknowledgement or terminal outbox expiry, so no gateway answer settles
 anything.
 
-**Mitigations in place:** the settlement invariant, verdicts-never-close-a-path,
-address-bound attach under a distinct signing domain, MLS end to end so a
-gateway sees ciphertext plus routing metadata, and per-device and per-peer
-token-bucket budgets at the gateway against exhaustion. Recipient-aware policy
-also decays every gateway claim, so a stale or malicious one reverts to "no
-opinion" rather than standing indefinitely.
+**Mitigations in place today**, carrying the internet relay as the one shipped
+gateway: the settlement invariant, verdicts-never-close-a-path, and MLS end to
+end so a gateway sees ciphertext plus routing metadata. These hold for a hostile
+relay right now, which is why an A7 gateway inherits a bounded blast radius
+rather than a new one.
+
+**Mitigations specified but not yet implemented**, and therefore not yet
+protecting anyone: address-bound attach under `offline-gateway-addr-v1` (the
+domain is [reserved, not emitted](../spec/username-discovery.md#signing-domains)),
+per-device and per-peer token-bucket budgets at the gateway against exhaustion,
+and the recipient-aware decay that reverts a stale or malicious claim to "no
+opinion" rather than letting it stand indefinitely. They are listed separately
+on purpose: a threat model that reads as protection when the protection is prose
+is the failure this document exists to prevent.
 
 **What would close it:** nothing closes the lying-gateway case, because the lie
 is about someone else's state. Provisioning is the real control: gateways are

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -33,6 +33,7 @@ reduces but does not eliminate what that reveals.
 | **A4. Group insider** | Holds a legitimate leaf in a group | Everything a member can do, plus can craft frames as a member |
 | **A5. Malicious application** | Runs above the SDK on the same device | Full access to the SDK's public API |
 | **A6. Device compromise** | Root or equivalent on the device | Everything |
+| **A7. Hostile gateway** | Operates or has compromised a gateway a device attached to | Everything A3 has, at a zone's bridge to the wider network: originates verdicts and presence answers, and observes attach sessions |
 
 A6 is out of scope. The protocol assumes platform secure storage holds. A5 is
 partly in scope: the SDK refuses control-frame injection through public send
@@ -330,6 +331,56 @@ request and response bodies is not implemented.
 
 **What application teams must do today:** treat a service body as public, and
 encrypt anything sensitive above the SDK before handing it over.
+
+### R10. Gateways are unauthenticated for delivery, and see who is in the zone
+
+A [gateway](../spec/gateway-contract.md) bridges a zone to the internet or to a
+wide-area backbone. Attaching to one binds the session to the device's address
+with a domain-separated proof under `offline-gateway-addr-v1`, which stops a
+gateway from attaching a session under an address the device does not control,
+and stops a proof harvested by one gateway being replayed against the relay. It
+does **not** make the gateway trusted for delivery, and nothing about the design
+tries to.
+
+**Impact:** an A7 gateway can do four things.
+
+*Blackhole.* Accept frames and forward none. Costs latency and battery.
+
+*Lie "unreachable".* Trigger parking for a recipient who is reachable. Retries
+quiet down and the sender's probes stretch out, so delivery is delayed. Mesh
+offers and probes continue, and the outbox still holds the message, so it
+remains deliverable by every other path.
+
+*Lie "reachable".* Attract traffic to a path that goes nowhere, bounded exactly
+as the blackhole is.
+
+*Observe.* Attach sessions and presence queries reveal which addresses are in
+the zone, and when they are active, to the gateway operator. This is the same
+exposure relay attach already gives the relay operator, at zone granularity.
+
+**Why it stands:** verdicts are not authenticated and cannot be. They are claims
+about a third party's connectivity, and no signature makes a claim true. The
+design answers this at the policy layer instead: a verdict MAY open a path and
+economise retries, and MUST NOT close one; a "reachable" claim never suppresses
+the acknowledgement ladder. Delivery settles only on the recipient's end-to-end
+acknowledgement or terminal outbox expiry, so no gateway answer settles
+anything.
+
+**Mitigations in place:** the settlement invariant, verdicts-never-close-a-path,
+address-bound attach under a distinct signing domain, MLS end to end so a
+gateway sees ciphertext plus routing metadata, and per-device and per-peer
+token-bucket budgets at the gateway against exhaustion. Recipient-aware policy
+also decays every gateway claim, so a stale or malicious one reverts to "no
+opinion" rather than standing indefinitely.
+
+**What would close it:** nothing closes the lying-gateway case, because the lie
+is about someone else's state. Provisioning is the real control: gateways are
+installed by a person ([ADR 0016](../adr/0016-gateways-are-provisioned-not-emergent.md)),
+so "which gateways can my device attach to" is an operational decision rather
+than an emergent one. Multiple gateways per zone reduce the blast radius of any
+single hostile or broken one. Zone-membership exposure would need a design that
+does not name recipients to the bridge at all, which no addressing scheme here
+provides; it is the same open problem as relay-side metadata.
 
 ## The telemetry producer rule
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -20,6 +20,7 @@ document says which reading is normative for the wire.
 | [Group protocol](group-protocol.md) | Group frames, membership commits, leaf identity binding, relay broadcast and the delivery report |
 | [Capability negotiation](capability-negotiation.md) | What peers advertise, what each capability gates, and what happens on absence |
 | [Username discovery and invites](username-discovery.md) | The self-certifying invite payload, and the non-authoritative username directory |
+| [The gateway contract](gateway-contract.md) | What a gateway is, the five verbs it implements, the gateway-daemon wire protocol, and the backbone |
 
 ## Conformance language
 

--- a/docs/spec/gateway-contract.md
+++ b/docs/spec/gateway-contract.md
@@ -212,7 +212,10 @@ on this carrier exactly as on every other.
 ```
 
 A gateway MAY answer unsolicited when a watched peer's state changes. Presence
-answers are claims with the same standing as verdicts, and decay the same way.
+answers are claims with the same standing as verdicts: they may open a path, they
+may not close one, and they decay. They decay faster, on a shorter TTL than a
+verdict, because presence is a statement about a moment and a verdict is a
+statement about an attempt.
 
 ### Capabilities
 

--- a/docs/spec/gateway-contract.md
+++ b/docs/spec/gateway-contract.md
@@ -1,0 +1,279 @@
+# The gateway contract
+
+A **gateway** bridges a zone (a governed BLE / Wi-Fi Direct flood) to somewhere
+a zone cannot reach: the internet, or a wide-area Reticulum backbone. This
+document specifies what a gateway must do to be one, and the wire protocol a
+device speaks to a gateway daemon over local IP.
+
+The contract is deliberately a *reframing* rather than an invention. The
+internet relay already implements every verb below; naming them is what lets a
+second kind of gateway plug into machinery that was written for the first.
+
+## Invariants
+
+These outrank every mechanism in this document. A gateway implementation that
+preserves the mechanisms but breaks an invariant is wrong.
+
+**1. Only the recipient settles a message.** Delivery settles on the
+recipient's end-to-end acknowledgement, or terminally on outbox expiry. A
+gateway accepting a frame, forwarding it, or reporting anything about it settles
+nothing. This is what makes a lying or broken gateway a latency-and-battery
+problem instead of a data-loss problem, and it is why every other invariant here
+can be as permissive as it is.
+
+**2. Layer 1 stays role-blind.** A gateway inside its zone is an ordinary peer.
+No frame is marked "for the gateway", no forwarding decision consults a role,
+and the flood has no gateway state machine. Being powered and stationary, a
+gateway wins forwarding races through the same continuous relay bias as a
+charging phone, which is a scoring outcome and not a role.
+
+**3. No facts, no change.** Absent any claim from a gateway, a device MUST
+behave exactly as it would with no gateway present. A gateway's answers may open
+paths and economise retries; they MUST NOT be required for correctness.
+
+**4. End-to-end encryption regardless of path.** Every gateway is an untrusted
+transport that sees ciphertext plus routing metadata. A backbone's own link
+encryption is a transport-layer courtesy and forms no part of the trust
+argument.
+
+## The five verbs
+
+A carrier is a gateway if and only if it implements these five. The contract is
+semantic: each gateway type MAY carry it over its own wire.
+
+| Verb | Meaning |
+|------|---------|
+| Attach | Establish an authenticated session bound to the device's `off1` address |
+| Submit | Accept one frame for a named `off1` recipient |
+| Verdict | Answer, per recipient, whether that frame was forwarded or the recipient is unreachable; refuse rather than silently hold |
+| Presence | Answer and watch per-recipient reachability |
+| Capabilities | Advertise what this gateway can do, at attach time |
+
+### The internet relay already implements all five
+
+| Verb | Relay mechanism |
+|------|-----------------|
+| Attach | WebSocket + JWT, plus an address declaration over `offline-relay-addr-v1` (`AddressDeclared` / `AddressError`) |
+| Submit | `SendMessage` / `MessageSent` |
+| Verdict | `DeliveryError`, classified at the SDK boundary to the `recipient_unreachable` token |
+| Presence | `CheckPresence` / `PresenceStatus`, against an SDK-owned watchlist |
+| Capabilities | Capability tokens delivered on `Authenticated` |
+
+So "relay-as-gateway" requires no server work. Everything the SDK already does
+with the relay's answers (parking, escalating probes, mesh offers,
+presence-driven flush) is gateway-verdict machinery that predates the name.
+
+### Verdict is the load-bearing verb
+
+It is the reason the contract exists. A device's transport policy is otherwise
+blind to where the recipient is: a carrier being up counts as reachable for
+every recipient. The verdict is the only thing that contradicts that.
+
+- A Reticulum gateway MUST implement Verdict, or it is not a gateway. This is
+  what closes the Reticulum half of the mixed-neighbourhood residual.
+- **Nostr structurally cannot implement Verdict.** A broadcast relay reports no
+  per-recipient delivery. Nostr therefore remains a carrier and never becomes a
+  gateway, and its half of the residual is permanent. This is recorded so the
+  gap stops being rediscovered as a bug; see
+  [ADR 0017](../adr/0017-nostr-is-a-carrier-not-a-gateway.md).
+
+Verdicts are **claims, not settlement**, and they are unauthenticated. A verdict
+MAY open a path (a mesh offer, a probe) and MAY economise retries. A verdict
+MUST NOT close a path, and a "reachable" claim MUST NOT suppress the
+acknowledgement ladder. That rule is the entire answer to their being
+unauthenticated: a hostile gateway lying in either direction costs delay, never
+delivery.
+
+## Gateway-daemon contract v1
+
+The wire protocol between a zone device and a gateway daemon reachable over
+local IP (venue Wi-Fi, or a hotspot the gateway box provides).
+
+This promotes the protocol both mobile bridges already speak to a configurable
+`daemonAddress` (default `localhost:4242`), rather than designing a fresh one:
+the client side is already implemented twice, and no daemon exists anywhere yet,
+so extending it breaks nobody.
+
+### Framing
+
+Newline-delimited UTF-8 JSON objects, one per line. Each object MUST carry a
+`type` field. A receiver MUST ignore an object whose `type` it does not
+recognise, and MUST NOT close the connection because of one: that is what allows
+a version to add messages without a flag day.
+
+### Versioning
+
+`Identify` carries `protocol_version`, an integer, `1` for this document. The
+daemon answers with its own. A daemon that does not recognise the client's
+version MUST still answer, so the client can decide; a client that does not
+recognise the daemon's version SHOULD proceed and rely on unknown-type tolerance
+above.
+
+### Attach
+
+```
+→ {"type":"Identify","device_id":"<off1…>","protocol_version":1}
+← {"type":"Challenge","challenge":"<base64, 32 bytes>","protocol_version":1}
+→ {"type":"DeclareAddress","address":"<off1…>","public_key":"<base64>","signature":"<base64>"}
+← {"type":"AddressDeclared","address":"<off1…>"}
+  or
+← {"type":"AddressError","reason":"<text>"}
+```
+
+The signature is over the canonical bytes
+
+```
+"offline-gateway-addr-v1" ‖ u32be(len(address_utf8)) ‖ address_utf8 ‖ challenge
+```
+
+matching the relay's address-declaration layout exactly, under a **different
+domain**. The domain MUST be `offline-gateway-addr-v1` and MUST NOT be
+`offline-relay-addr-v1`: a shared domain would let a signature harvested by a
+hostile gateway be replayed against the relay, and vice versa. The domain itself
+is not length-prefixed, so it MUST remain mutually non-prefixing with every
+other live domain (see [Signing domains](username-discovery.md#signing-domains)).
+
+The address is inside the signed bytes deliberately. A signature over a bare
+gateway-chosen challenge would be a signing oracle: the gateway picks challenge
+bytes that are also a valid control-frame payload and replays the result.
+
+A device MUST verify that the address in `AddressDeclared` is its own. A
+mismatch is a security event, not a retry: it means the gateway bound the
+session to an address this device does not control.
+
+### Submit and Verdict
+
+```
+→ {"type":"SendMessage","recipient":"<off1…>","content":"<base64>","encoding":"base64","reply_to_msg":"<id>"}
+← {"type":"MessageSent","message_id":"<id>"}
+  or
+← {"type":"DeliveryError","message_id":"<id>","reason":"recipient_unreachable: <text>"}
+```
+
+A gateway MUST answer every `SendMessage` with exactly one of these. Silence is
+not permitted: the sender's outbox holds the message either way, but a gateway
+that neither forwards nor refuses converts a routing decision into a timeout.
+
+`reason` MUST begin with `recipient_unreachable` when the recipient is not
+reachable through this gateway. That token is the one the SDK classifier matches
+by prefix, and it drives parking, the mesh offer and the escalating probe. Any
+trailing prose after the token is for human logs and MUST NOT be relied on: the
+SDK discards it at the classification boundary and never carries it into an
+event.
+
+### Presence
+
+```
+→ {"type":"CheckPresence","peers":["<off1…>", …]}
+← {"type":"PresenceStatus","peer":"<off1…>","online":true,"last_seen_ms":1234567890}
+```
+
+A gateway MAY answer unsolicited when a watched peer's state changes. Presence
+answers are claims with the same standing as verdicts, and decay the same way.
+
+### Capabilities
+
+```
+← {"type":"Capabilities","tokens":["gateway_v1","backbone_reticulum_v1"]}
+```
+
+Delivered at attach, before the device is told the carrier is available.
+Tokens are opaque strings compared exactly. A receiver MUST bound what it
+stores: at most 64 tokens of at most 128 bytes each, matching the relay
+capability rules in [capability negotiation](capability-negotiation.md#relay-capabilities).
+Capabilities MUST be cleared when the session drops, or a stale advertisement
+outlives the gateway that made it.
+
+Capability tokens MUST NOT drive a security decision. They gate features, and
+an attacker who can set them is already the gateway.
+
+### Status
+
+```
+← {"type":"StatusUpdate","status":"connected"|"degraded"|"disconnected"}
+```
+
+Advisory. A device MUST NOT treat `StatusUpdate` as a delivery signal for any
+particular frame.
+
+### No new zone control prefixes
+
+The daemon protocol is its own wire between a device and its gateway. It
+introduces **no** new reserved control-message prefixes, and therefore adds no
+entries to the [reserved prefix registry](control-messages.md#reserved-prefix-registry).
+A gateway that wants to speak to the zone speaks ordinary frames.
+
+## The backbone
+
+Between gateways, the wide-area carrier is Reticulum. Wide-area routing over
+intermittent, slow, heterogeneous links is the problem Reticulum spent a decade
+solving, and this protocol does not reinvent it.
+
+### Gateway-owned destinations
+
+Reticulum announces are signed by the destination's own identity key.
+Per-device backbone destinations would therefore require either phones running a
+Reticulum stack (they do not) or gateways holding device private keys
+(unacceptable). So:
+
+- Each gateway announces **one** destination under its own Reticulum identity.
+- An egress frame is wrapped: the outer layer is a link to the destination
+  gateway, the inner layer is the ordinary Offline Protocol wire message naming
+  the `off1` recipient. The gateway sees ciphertext and routing metadata only.
+- A gateway locates a recipient's gateway from its own attach sessions and zone
+  presence, and by asking its peer gateways (the Presence verb, reused
+  gateway-to-gateway). The peer list is provisioned configuration; announce-based
+  discovery MAY layer on later without changing the query shape.
+
+Recorded alternative, rejected for v1: device-signed announce blobs, where a
+phone pre-signs its own announce and gateways republish it. It buys true device
+mobility across zones at the cost of a new device-side crypto surface, lifetime
+coupling between the `off1` identity and a Reticulum identity, and pressure on
+the announce bandwidth budget.
+
+### Framing and the scarce path
+
+The Reticulum MDU is 465 bytes and this protocol's frames routinely exceed it.
+Gateway-to-gateway transfer therefore uses links with resources, which handle
+sequencing, compression and integrity for arbitrary sizes, and gateways keep
+long-lived links to provisioned peers.
+
+Backbone links range from LoRa-class kbps down to a few bps, so **backbone
+egress is a scarce path by default**: direct messages, acknowledgements and
+control frames only. Media MUST be excluded unless a capability says otherwise.
+
+### Re-origination into the zone
+
+A frame arriving from the backbone is re-originated into the zone as an
+**ordinary frame from the gateway**. It MUST NOT be a relay-hint frame, and it
+inherits no zone-internal signature exemption. Hint frames are self-addressed
+frames the local bridge intercepts and replaces, with acknowledgement disabled
+and transport pinned ([ADR 0015](../adr/0015-relay-hint-frames-unacked-and-pinned.md));
+a re-originated frame is the opposite disposition in both respects and needs no
+amendment to that decision.
+
+## Provisioning
+
+A gateway is a **deployment**, never a runtime state a phone reaches: a powered,
+stationary box someone installs and configures, attached to at least one zone
+and at least one wide-area carrier. The reasoning is in
+[ADR 0016](../adr/0016-gateways-are-provisioned-not-emergent.md).
+
+A zone MAY have any number of gateways and a device treats them as a set. A zone
+with **zero** gateways is a state the policy MUST be able to surface rather than
+hide: absent facts mean today's behaviour (invariant 3), which is exactly what a
+zone with no gateway should experience.
+
+Operational guidance for anyone deploying: install two. One gateway per zone is
+a chokepoint, and nothing in this contract prevents a second.
+
+## Abuse and exhaustion
+
+A gateway MUST bound what one attached device can consume: token-bucket budgets
+per attached device and per peer gateway, the pattern the zone's own forwarding
+governor already applies per peer. Combined with the scarce-path rule, this caps
+what a single device can do to a multi-bps backbone link.
+
+The threats a gateway introduces (a fake gateway, verdict abuse, zone metadata
+at the operator, backbone exhaustion) are enumerated in the
+[threat model](../security/threat-model.md).

--- a/docs/spec/gateway-contract.md
+++ b/docs/spec/gateway-contract.md
@@ -131,13 +131,33 @@ domain**. The domain MUST be `offline-gateway-addr-v1` and MUST NOT be
 `offline-relay-addr-v1`: a shared domain would let a signature harvested by a
 hostile gateway be replayed against the relay, and vice versa. The domain itself
 is not length-prefixed, so it MUST remain mutually non-prefixing with every
-other live domain (see [Signing domains](username-discovery.md#signing-domains)).
+other domain, live or reserved (see
+[Signing domains](username-discovery.md#signing-domains)).
 
 The address is inside the signed bytes deliberately. A signature over a bare
 gateway-chosen challenge would be a signing oracle: the gateway picks challenge
 bytes that are also a valid control-frame payload and replays the result.
 
-A device MUST verify that the address in `AddressDeclared` is its own. A
+Both ends have something to verify, and neither check substitutes for the other.
+
+**The gateway** MUST verify all three of the following before answering
+`AddressDeclared`, and MUST answer `AddressError` otherwise:
+
+1. The signature verifies over the canonical bytes above under `public_key`.
+2. `address` is the address derived from `public_key`. Addresses are
+   self-certifying (bech32m over `0x01 ‖ SHA-256(ed25519_pub)[..20]`), so this
+   is the check that makes the binding mean anything: without it, a signature
+   made under any key the sender holds attaches the session to any address it
+   cares to name.
+3. `challenge` is the one this gateway minted for this connection, and has not
+   been accepted before. A challenge honoured twice turns one captured
+   `DeclareAddress` into a reusable credential.
+
+A gateway that skips these attaches sessions under addresses the attaching
+device does not control, which is how a hostile device draws another device's
+inbound traffic to itself and poisons the presence answers given about it.
+
+**The device** MUST verify that the address in `AddressDeclared` is its own. A
 mismatch is a security event, not a retry: it means the gateway bound the
 session to an address this device does not control.
 
@@ -161,11 +181,34 @@ trailing prose after the token is for human logs and MUST NOT be relied on: the
 SDK discards it at the classification boundary and never carries it into an
 event.
 
+### Deliver
+
+```
+← {"type":"MessageReceived","sender":"<off1…>","content":"<base64>","encoding":"base64"}
+```
+
+A frame the gateway holds for this device, handed to it over the attach
+connection. `encoding` is optional; absent means UTF-8 text, and every binary
+frame uses `base64`.
+
+Delivery is deliberately **not** a sixth verb. It is what any carrier does, not
+what makes a carrier a gateway, and the internet relay's own inbound path is not
+a verb either. It is specified here because the daemon link is the only inbound
+path a device attached over local IP has: such a device need not be inside the
+flood a gateway re-originates into, so a daemon built to the five verbs alone
+would attach devices, accept their frames, answer their verdicts, and never
+deliver anything to them. A gateway MUST implement it.
+
+`sender` is a **claim** by the gateway, with the same standing as a verdict. It
+supplies peer attribution and reachability, and it MUST NOT be read as
+authentication of the frame's origin: what authenticates a frame is the frame,
+on this carrier exactly as on every other.
+
 ### Presence
 
 ```
 → {"type":"CheckPresence","peers":["<off1…>", …]}
-← {"type":"PresenceStatus","peer":"<off1…>","online":true,"last_seen_ms":1234567890}
+← {"type":"PresenceStatus","peer":"<off1…>","online":true,"last_seen_ms":1786924800000}
 ```
 
 A gateway MAY answer unsolicited when a watched peer's state changes. Presence

--- a/docs/spec/username-discovery.md
+++ b/docs/spec/username-discovery.md
@@ -79,15 +79,24 @@ would let a record verify against a tag it was never published at.
 
 ## Signing domains
 
-Four domains are live across this protocol, and they MUST be mutually
-non-prefixing:
+Four domains are live across this protocol, and a fifth is reserved. All of
+them MUST be mutually non-prefixing:
 
-| Domain | Signs |
-|--------|-------|
-| `offline-ctrl-v1` | Control-plane frames |
-| `offline-relay-addr-v1` | The relay address-declaration proof |
-| `offline-disc-v1` | Discovery records |
-| `offline-invite-v1` | Invite payloads |
+| Domain | Signs | Status |
+|--------|-------|--------|
+| `offline-ctrl-v1` | Control-plane frames | Live |
+| `offline-relay-addr-v1` | The relay address-declaration proof | Live |
+| `offline-disc-v1` | Discovery records | Live |
+| `offline-invite-v1` | Invite payloads | Live |
+| `offline-gateway-addr-v1` | The gateway address-declaration proof ([gateway contract](gateway-contract.md#attach)) | Reserved |
+
+The gateway domain is reserved rather than live: the
+[gateway contract](gateway-contract.md) specifies it, and no implementation
+emits it yet. It is registered here in advance precisely because the
+non-prefixing rule is a property of the whole set, so a domain cannot be chosen
+in isolation. Note it MUST stay distinct from `offline-relay-addr-v1` for a
+second reason as well: an identical layout under a shared domain would let a
+signature harvested by one kind of gateway be replayed against the other.
 
 Every signature is taken over `domain ‖ Σ(u32be(len) ‖ field_bytes)`. The
 **domain itself is not length-prefixed**, so if one domain were a prefix of

--- a/docs/transport-architecture.md
+++ b/docs/transport-architecture.md
@@ -173,7 +173,7 @@ This feeds real delivery data into DORS so it can make accurate routing decision
 Device ←→ Platform Bridge ←→ Reticulum Stack ←→ LoRa/TCP/UDP/I2P ←→ Remote Device
 ```
 
-**Platform bridge pattern**: The platform bridges to a Reticulum stack via embedded Python (most proven for mobile, used by Sideband), the emerging `reticulum-rs` Rust crate, HDLC shared instance IPC (desktop), or a TCP gateway. The Rust transport manages queues, metrics, and the confirmation loop.
+**Platform bridge pattern**: The platform bridges to a Reticulum stack via embedded Python (most proven for mobile, used by Sideband), the emerging `reticulum-rs` Rust crate, HDLC shared instance IPC (desktop), or a gateway daemon speaking [the gateway contract](spec/gateway-contract.md). The Rust transport manages queues, metrics, and the confirmation loop, and opens no Reticulum link itself. No gateway daemon ships yet, so this transport has no working counterpart today.
 
 **Send confirmation loop**: Like Internet transport, the platform drains the outgoing queue via `reticulumGetNextMessage()`, sends through the Reticulum daemon, and **must** report the outcome via `reticulumConfirmSent(messageId)` or `reticulumSendFailed(messageId)`. Pending confirmations time out after 120 seconds (longer than Internet's 15s due to high-latency LoRa paths).
 


### PR DESCRIPTION
**Workstream D1.2 (spec half), D1.4 and D1.6** from the gateway design record. Documents plus one test guard, independent of #375 and #376, mergeable in any order.

## Why

Layer 2 of the program architecture existed only as a concept. "Gateway" and "backbone" appeared in this repo solely as Reticulum integration prose, and `docs/reticulum.md` documented a daemon TCP protocol **as though a counterpart shipped** — it never has, in this or any companion repository, and `rnsd`'s actual IPC is a different protocol entirely (which the same document describes three sections earlier, contradicting itself).

## What is specified

`docs/spec/gateway-contract.md` — four invariants, five verbs, the daemon wire protocol, the backbone.

The key move is that this is a **reframing, not an invention**: the internet relay already implements all five verbs. So the SDK's existing machinery around relay answers (parking, escalating probes, mesh offers, presence-driven flush) turns out to be gateway-verdict machinery that predates the name, and a Reticulum gateway plugs into it rather than needing its own path. Likewise the daemon protocol promotes the one both mobile bridges already speak, rather than designing a third — the client side is implemented twice already, and since no daemon exists, extending it breaks nobody.

**Verdict is the load-bearing verb**, and the spec is explicit that verdicts are unauthenticated claims: they MAY open a path, MUST NOT close one, and settle nothing. That single rule is the entire answer to a hostile gateway, and it is why the rest of the contract can be as permissive as it is.

New signing domain `offline-gateway-addr-v1`, registered in the spec's signing-domain table as **reserved** (specified, not yet emitted). It is registered in advance because mutual non-prefixing is a property of the whole set, so a domain cannot be chosen in isolation — and it must stay distinct from `offline-relay-addr-v1` so a proof harvested by one gateway cannot be replayed against the other.

## Decisions recorded

- **ADR 0016 — gateways are provisioned, never emergent.** Self-promotion is the obvious design and this codebase already does something that looks like it (role-blind forwarding with a capability bias). That shape does not transfer: it works in-zone because *every* device can forward and suppression makes redundancy cheap. Most devices structurally cannot bridge, and no in-zone redundancy covers a bridge that leaves, so an emergent gateway produces a **silent partition** — from inside the zone, an absent gateway and one that decided it wasn't needed look identical.
- **ADR 0017 — Nostr is a carrier, never a gateway.** A broadcast relay reports no per-recipient delivery, so there is no verdict to be had. Recorded as permanent so it stops being rediscovered as a bug, and specifically so nobody "fixes" it by inferring verdicts from a relay `OK` rejection or a send timeout — both are evidence about the *relay*, and inferring recipient state from them yields confident wrong claims, which is worse than honest silence.

## Threat model

Adversary **A7** (hostile gateway) and residual **R10**: blackholing, verdicts lying in both directions, zone-membership exposure to the operator, backbone exhaustion — each with why it is bounded to latency rather than loss, and an honest "nothing closes the lying-gateway case, because the lie is about someone else's state."

## Corrections (D1.4)

- `docs/reticulum.md`: the phantom daemon section now points at the contract and says plainly that no counterpart exists; "fourth transport" predated Nostr; the reconnection table presented **inert** Rust `ReticulumConfig` fields as live behaviour when reconnection is entirely owned by the native managers (1s doubling to 30s, not configurable); `RETICULUM_MAX_PAYLOAD_SIZE` is documented as a limit but has no reader anywhere.
- `docs/transport-architecture.md` aligned.


## Review round 1

Five gaps found in review, all fixed in the follow-up commits on this branch:

- **Contract v1 specified no inbound delivery.** Both shipped Reticulum managers handle `MessageReceived` and it is the transport's whole inbound path, but the contract, which now calls itself the document to implement against, never mentioned it: a daemon built to the five verbs alone would attach devices, accept their frames, answer their verdicts and deliver nothing to any of them. Added as `Deliver`, deliberately not as a sixth verb (delivery is what any carrier does, not what makes one a gateway), with `sender` marked as a gateway claim rather than authentication.
- **Attach had verification obligations on one side only.** Every MUST pointed at the device. The gateway is now required to verify the signature, that `address` is the address derived from `public_key`, and that the challenge is its own and single-use. Without those a conforming daemon attaches any device under anybody's address, which draws a victim's inbound traffic to a hostile device and poisons the presence answers about them.
- **R10 listed unimplemented mechanisms as "in place":** gateway token buckets, attach under a domain that is reserved and unemitted, and the recipient-aware decay that lives in #376. Split into what holds today and what is only specified.
- **The reserved signing domain was prose only.** `offline-gateway-addr-v1` now sits in the non-prefixing and distinctness guards in `protocol::types::signing_domain_tests`, since non-prefixing is a property of the whole set and a guard watching only live domains would accept a future live domain that prefixes this one. Negative-controlled: pointing the constant at a prefixing value fails the guard.
- **The MDU contradicted itself** across `docs/reticulum.md` (464) and the new spec (465). 465 is correct (MTU 500 minus 35 header).

Also recorded, because it is a silence rather than a message and a daemon author will otherwise miss it: today's bridges confirm a send on the socket write and ignore `MessageSent` and `DeliveryError` entirely, so a daemon that answers contract v1 correctly gets no verdict handling until the transport work lands.

Rebased onto main after #375 and #376 merged, resolving one `CHANGELOG.md` conflict (both sides opened an `[Unreleased]` section; the gateway entries now sit inside the existing `### Documentation` subsection, per the house ordering that puts it last).

The rebase invalidated one of the fixes above, which is worth stating rather than quietly correcting: R10's "specified but not yet implemented" list named the recipient-aware decay, and **#376 is the branch that shipped it.** The decay is now in the tree (ten-minute TTL for a verdict, five for a presence answer) and has moved into the mitigations that hold today. The Presence section's claim that presence answers "decay the same way" as verdicts is likewise now checkable and was not quite right; they decay on a shorter TTL, and the spec says so with the reason.

Verified locally on the rebased tree: `cargo fmt --all --check`, CI-parity `cargo clippy --workspace -D warnings`, `cargo test --workspace --lib` (2,226 pass), `RUSTDOCFLAGS=-D warnings cargo doc`, and a scripted relative-link and anchor check across every touched document (0 broken).

## Verification

All relative links resolve (scripted check across every touched file). No em dashes in the new documents, per house style.

