### PR TITLE
fix(protocol): ensure group names are carried during relay registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,8 +144,18 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   an offline-created group for the first time, sent no name; the bridge
   translator then substituted the group id, and the relay keeps the first name
   it sees for a mesh group id and echoed it back to every member as the
-  group's title. Every registration frame now carries the name from the
-  locally stored MLS group metadata when the caller has none.
+  group's title. A registration frame now falls back to the name in local MLS
+  group metadata whenever the caller has none.
+- **A member who joined a group by invite held no copy of its name, so its own
+  relay registration could rename the group for everyone.** The bridge sends a
+  `CreateGroup` for every member's registration, not just the creator's, so the
+  member who reconnects first is the one whose name the relay keeps. MLS
+  `join_group` put the Welcome's name on the group info it returned and
+  persisted nothing, leaving a joiner with no name to send and the group titled
+  `group:<uuid>` for the whole roster whenever a joiner reconnected first. The
+  Welcome's name is now stored alongside the roles and the creator of record,
+  which also carries it on down the invite chain: an invite sources the name it
+  sends from the inviter's stored metadata.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,16 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   stamping helper. Visible only as larger frames on the wire, with no error and
   no event, which is why it survived.
 
+- **A group created offline was titled `group:<uuid>` on the relay once the
+  device reconnected.** Only `create_group` passed the name into the relay
+  registration frame, and it only sends when Internet is up at that moment.
+  The reconnect re-sync and `request_group_relay_registration`, which register
+  an offline-created group for the first time, sent no name; the bridge
+  translator then substituted the group id, and the relay keeps the first name
+  it sees for a mesh group id and echoed it back to every member as the
+  group's title. Every registration frame now carries the name from the
+  locally stored MLS group metadata when the caller has none.
+
 ### Removed
 
 - **The gradient-routing and path-selection layer, in full.** `PathSelector`,

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -1486,16 +1486,33 @@ impl OfflineProtocol {
 
             self.group_mesh.members.insert(group_id.clone(), members);
 
-            // Store member roles and the creator of record from the welcome
-            // payload. The creator is what makes `check_is_admin`'s fallback
-            // reachable for a joiner: without it our metadata is materialized
-            // by `set_member_role` via `GroupMetadata::new(None)`, so a group
-            // whose role snapshot arrived incomplete would resolve to
-            // deny-by-default with no way back. Deliberately not bounded to
-            // the roster we just joined — the creator of record may already
-            // have left. `set_group_creator` is first-write-wins, so a
-            // duplicate or later Welcome cannot rewrite it.
-            if !payload.member_roles.is_empty() || payload.created_by.is_some() {
+            // Store the display name, the member roles, and the creator of
+            // record from the welcome payload. The creator is what makes
+            // `check_is_admin`'s fallback reachable for a joiner: without it
+            // our metadata is materialized by `set_member_role` via
+            // `GroupMetadata::new(None)`, so a group whose role snapshot
+            // arrived incomplete would resolve to deny-by-default with no way
+            // back. Deliberately not bounded to the roster we just joined —
+            // the creator of record may already have left.
+            // `set_group_creator` is first-write-wins, so a duplicate or
+            // later Welcome cannot rewrite it.
+            //
+            // This Welcome is the only copy of the name this device will ever
+            // be handed: MLS `join_group` puts it on the `GroupInfo` it
+            // returns and persists nothing. Without this write a joiner
+            // registers its groups with the relay namelessly, and because the
+            // bridge sends a `CreateGroup` for every member's registration
+            // while the relay keeps the first name it sees, a joiner that
+            // reconnects before the creator would title the group
+            // `group:<uuid>` for everyone (see `try_relay_register_group`).
+            // Writing it here also carries the name on down the invite chain,
+            // since an invite sources the Welcome's name from the inviter's
+            // stored metadata.
+            let welcome_name = Self::normalize_group_name(payload.group_name.as_deref());
+            if !payload.member_roles.is_empty()
+                || payload.created_by.is_some()
+                || welcome_name.is_some()
+            {
                 if let Ok(mls_guard) = self.read_mls_guard() {
                     for (user_id, role) in &payload.member_roles {
                         if let Err(e) = mls_guard.set_member_role(&gid, user_id, *role) {
@@ -1505,6 +1522,11 @@ impl OfflineProtocol {
                     if let Some(creator) = &payload.created_by {
                         if let Err(e) = mls_guard.set_group_creator(&gid, creator) {
                             warn!(creator = %creator, error = %e, "Failed to store group creator from welcome");
+                        }
+                    }
+                    if let Some(name) = &welcome_name {
+                        if let Err(e) = mls_guard.set_group_name(&gid, name) {
+                            warn!(group_id = %group_id, error = %e, "Failed to store group name from welcome");
                         }
                     }
                 }
@@ -4507,6 +4529,16 @@ impl OfflineProtocol {
             .map(|creator| creator == &self.local_id)
     }
 
+    /// Normalizes a display name to the form the relay should be told:
+    /// trimmed, with blank reading as absent. The bridge translator
+    /// substitutes the group id for a missing name, so letting `Some("  ")`
+    /// through would title the group `group:<uuid>` exactly as `None` does.
+    fn normalize_group_name(name: Option<&str>) -> Option<String> {
+        name.map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+    }
+
     /// The group's display name as stored in local MLS metadata, if the
     /// group is known and has one. Best-effort: any lookup failure reads as
     /// "no name", the caller decides what that means.
@@ -4514,12 +4546,7 @@ impl OfflineProtocol {
         let mls_guard = self.read_mls_guard().ok()?;
         let gid = offline_protocol_mls::GroupId::new(group_id).ok()?;
         let metadata = mls_guard.get_group_metadata(&gid).ok()??;
-        metadata
-            .name
-            .as_deref()
-            .map(str::trim)
-            .filter(|name| !name.is_empty())
-            .map(str::to_string)
+        Self::normalize_group_name(metadata.name.as_deref())
     }
 
     /// Attempts to register (or update) a group with the relay server.
@@ -4535,17 +4562,28 @@ impl OfflineProtocol {
     /// for the group), never here — otherwise `send_group_message` takes the
     /// O(1) broadcast path and the messages vanish into the echo.
     ///
-    /// Every registration frame carries the group's display name. The
-    /// relay stores the name it sees on the first `CreateGroup` for a mesh
-    /// group id and never rewrites it on later re-syncs, and the bridge
-    /// translator substitutes the group id for a missing name. So the
-    /// first registration to reach the relay decides the name forever:
-    /// a group created offline (creation's own registration skipped) and
-    /// first registered by the reconnect re-sync or by
-    /// `request_group_relay_registration`, both of which know no name,
-    /// would be stored as `group:<uuid>` and echoed back to every member
-    /// as its title. Callers that have the name pass it; otherwise it is
-    /// read from the locally stored MLS group metadata.
+    /// A registration frame carries the group's display name whenever this
+    /// device holds one. The relay stores the name it sees on the first
+    /// `CreateGroup` for a mesh group id and never rewrites it on later
+    /// re-syncs, and the bridge translator substitutes the group id for a
+    /// missing name, so the first registration to reach the relay decides
+    /// the name forever. That first registration is not necessarily the
+    /// creator's: the bridge sends `CreateGroup` for every member's
+    /// registration (the admin hint gates only the member deltas), so
+    /// whichever member reconnects first names the group. And a group
+    /// created offline skips creation's own registration, leaving the
+    /// first one to the reconnect re-sync or to
+    /// `request_group_relay_registration`, neither of which is given a
+    /// name. A nameless frame from any of those paths would title the
+    /// group `group:<uuid>` for every member.
+    ///
+    /// Callers that have the name pass it; otherwise it is read from the
+    /// locally stored MLS group metadata, which every member holds: the
+    /// creator writes it in `create_group`, a joiner in
+    /// `handle_group_mls_welcome`, and a rename updates it wherever it
+    /// lands. The residual case is a joiner whose Welcome carried no name,
+    /// which means the inviter had none to send (a device that joined
+    /// before the Welcome name was persisted, or an SDK predating it).
     ///
     /// Fire-and-forget: returns `Ok(true)` if sent, `Ok(false)` if Internet
     /// is unavailable, `Err` on serialization failure.
@@ -4559,11 +4597,8 @@ impl OfflineProtocol {
             return Ok(false);
         }
 
-        let group_name = group_name
-            .map(str::trim)
-            .filter(|name| !name.is_empty())
-            .map(str::to_string)
-            .or_else(|| self.stored_group_name(group_id));
+        let group_name =
+            Self::normalize_group_name(group_name).or_else(|| self.stored_group_name(group_id));
 
         let payload = RelayGroupRegistrationPayload {
             group_id: group_id.to_string(),

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -4507,6 +4507,21 @@ impl OfflineProtocol {
             .map(|creator| creator == &self.local_id)
     }
 
+    /// The group's display name as stored in local MLS metadata, if the
+    /// group is known and has one. Best-effort: any lookup failure reads as
+    /// "no name", the caller decides what that means.
+    fn stored_group_name(&self, group_id: &str) -> Option<String> {
+        let mls_guard = self.read_mls_guard().ok()?;
+        let gid = offline_protocol_mls::GroupId::new(group_id).ok()?;
+        let metadata = mls_guard.get_group_metadata(&gid).ok()??;
+        metadata
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+    }
+
     /// Attempts to register (or update) a group with the relay server.
     ///
     /// Sends a `__GRP_RELAY_REG__` message to the user's own ID via Internet
@@ -4520,6 +4535,18 @@ impl OfflineProtocol {
     /// for the group), never here — otherwise `send_group_message` takes the
     /// O(1) broadcast path and the messages vanish into the echo.
     ///
+    /// Every registration frame carries the group's display name. The
+    /// relay stores the name it sees on the first `CreateGroup` for a mesh
+    /// group id and never rewrites it on later re-syncs, and the bridge
+    /// translator substitutes the group id for a missing name. So the
+    /// first registration to reach the relay decides the name forever:
+    /// a group created offline (creation's own registration skipped) and
+    /// first registered by the reconnect re-sync or by
+    /// `request_group_relay_registration`, both of which know no name,
+    /// would be stored as `group:<uuid>` and echoed back to every member
+    /// as its title. Callers that have the name pass it; otherwise it is
+    /// read from the locally stored MLS group metadata.
+    ///
     /// Fire-and-forget: returns `Ok(true)` if sent, `Ok(false)` if Internet
     /// is unavailable, `Err` on serialization failure.
     fn try_relay_register_group(
@@ -4532,9 +4559,15 @@ impl OfflineProtocol {
             return Ok(false);
         }
 
+        let group_name = group_name
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+            .or_else(|| self.stored_group_name(group_id));
+
         let payload = RelayGroupRegistrationPayload {
             group_id: group_id.to_string(),
-            group_name: group_name.map(|s| s.to_string()),
+            group_name,
             members: members.to_vec(),
             is_admin: self.relay_registration_admin_hint(group_id),
         };

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -3220,6 +3220,81 @@ fn test_request_group_relay_registration() {
     protocol.stop().unwrap();
 }
 
+/// A group created without Internet is first registered by a later
+/// re-sync, which does not know the name. The relay keeps the first name it
+/// sees and the bridge substitutes the group id for a missing one, so a
+/// nameless first registration would title the group `group:<uuid>` for
+/// every member. The frame must therefore carry the stored MLS name.
+#[test]
+fn test_deferred_relay_registration_carries_stored_group_name() {
+    use offline_protocol_transport::mock::MockTransport;
+
+    let storage = Arc::new(crate::mls::InMemoryStorage::default());
+    let mut protocol = OfflineProtocol::new(create_test_config()).unwrap();
+    protocol.initialize_mls_for_test(storage).unwrap();
+    protocol.start().unwrap();
+
+    // Offline creation: no registration frame can be sent.
+    let info = protocol.create_group("Offline Created").unwrap();
+    let group_id = info.group_id.as_str().to_string();
+
+    let internet = MockTransport::new(TransportType::Internet);
+    internet.start().unwrap();
+    let internet_handle = internet.clone();
+    protocol
+        .transport_manager_mut()
+        .add_transport(TransportType::Internet, Box::new(internet));
+
+    let registration_names = |handle: &MockTransport| -> Vec<Option<String>> {
+        handle
+            .sent_messages()
+            .iter()
+            .filter_map(|m| {
+                m.content
+                    .strip_prefix(internal_prefixes::GROUP_RELAY_REGISTER)
+                    .map(str::to_string)
+            })
+            .map(|json| {
+                let payload: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_eq!(
+                    payload.get("group_id").and_then(|v| v.as_str()),
+                    Some(group_id.as_str())
+                );
+                payload
+                    .get("group_name")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect()
+    };
+
+    // Reconnect re-sync (the 0 -> 1 Internet transition) passes no name.
+    assert!(!protocol.group_mesh.internet_was_available);
+    protocol.check_relay_group_sync();
+    assert_eq!(
+        registration_names(&internet_handle),
+        vec![Some("Offline Created".to_string())],
+        "re-sync registration must carry the stored group name"
+    );
+
+    // The explicit registration request passes no name either.
+    protocol.group_mesh.relay_register_pending.remove(&group_id);
+    assert_eq!(
+        protocol.request_group_relay_registration(&group_id).ok(),
+        Some(true)
+    );
+    assert_eq!(
+        registration_names(&internet_handle),
+        vec![
+            Some("Offline Created".to_string()),
+            Some("Offline Created".to_string())
+        ],
+        "requested registration must carry the stored group name"
+    );
+
+    protocol.stop().unwrap();
+}
+
 #[test]
 fn test_relay_sync_disabled_config() {
     use offline_protocol_transport::mock::MockTransport;

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -3220,6 +3220,34 @@ fn test_request_group_relay_registration() {
     protocol.stop().unwrap();
 }
 
+/// The `group_name` of every `__GRP_RELAY_REG__` frame the transport sent,
+/// in order. Asserts in passing that each frame names `group_id`.
+fn relay_registration_names(
+    handle: &offline_protocol_transport::mock::MockTransport,
+    group_id: &str,
+) -> Vec<Option<String>> {
+    handle
+        .sent_messages()
+        .iter()
+        .filter_map(|m| {
+            m.content
+                .strip_prefix(internal_prefixes::GROUP_RELAY_REGISTER)
+                .map(str::to_string)
+        })
+        .map(|json| {
+            let payload: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                payload.get("group_id").and_then(|v| v.as_str()),
+                Some(group_id)
+            );
+            payload
+                .get("group_name")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
 /// A group created without Internet is first registered by a later
 /// re-sync, which does not know the name. The relay keeps the first name it
 /// sees and the bridge substitutes the group id for a missing one, so a
@@ -3245,34 +3273,11 @@ fn test_deferred_relay_registration_carries_stored_group_name() {
         .transport_manager_mut()
         .add_transport(TransportType::Internet, Box::new(internet));
 
-    let registration_names = |handle: &MockTransport| -> Vec<Option<String>> {
-        handle
-            .sent_messages()
-            .iter()
-            .filter_map(|m| {
-                m.content
-                    .strip_prefix(internal_prefixes::GROUP_RELAY_REGISTER)
-                    .map(str::to_string)
-            })
-            .map(|json| {
-                let payload: serde_json::Value = serde_json::from_str(&json).unwrap();
-                assert_eq!(
-                    payload.get("group_id").and_then(|v| v.as_str()),
-                    Some(group_id.as_str())
-                );
-                payload
-                    .get("group_name")
-                    .and_then(|v| v.as_str())
-                    .map(str::to_string)
-            })
-            .collect()
-    };
-
     // Reconnect re-sync (the 0 -> 1 Internet transition) passes no name.
     assert!(!protocol.group_mesh.internet_was_available);
     protocol.check_relay_group_sync();
     assert_eq!(
-        registration_names(&internet_handle),
+        relay_registration_names(&internet_handle, &group_id),
         vec![Some("Offline Created".to_string())],
         "re-sync registration must carry the stored group name"
     );
@@ -3284,7 +3289,7 @@ fn test_deferred_relay_registration_carries_stored_group_name() {
         Some(true)
     );
     assert_eq!(
-        registration_names(&internet_handle),
+        relay_registration_names(&internet_handle, &group_id),
         vec![
             Some("Offline Created".to_string()),
             Some("Offline Created".to_string())
@@ -3293,6 +3298,59 @@ fn test_deferred_relay_registration_carries_stored_group_name() {
     );
 
     protocol.stop().unwrap();
+}
+
+/// The name must survive on a joiner too, not just on the creator. The
+/// bridge sends a `CreateGroup` for every member's registration and the
+/// relay keeps the first name it sees, so whichever member reconnects first
+/// names the group for everyone. MLS `join_group` puts the Welcome's
+/// name only on the `GroupInfo` it returns, so unless the Welcome handler
+/// persists it, a joiner that reconnects first titles the group
+/// `group:<uuid>` for the whole roster.
+#[test]
+fn test_joiner_relay_registration_carries_welcome_group_name() {
+    use offline_protocol_transport::mock::MockTransport;
+
+    // Alice created "Race Group"; Bob has been invited but has not joined.
+    // Bob is the joiner, and the Welcome is his only source for the name.
+    let (_alice, mut bob, _events, group_id, welcome_json) = setup_race_alice_bob();
+    bob.start().unwrap();
+
+    bob.handle_group_mls_welcome("welcome-carries-name", &id("alice"), &welcome_json);
+
+    // Persisted, not merely returned by `join_group`: the relay registration
+    // reads stored metadata, and so does the next Welcome Bob sends on.
+    let persisted = {
+        let bob_mls = bob.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id).unwrap();
+        bob_mls
+            .get_group_metadata(&gid)
+            .unwrap()
+            .and_then(|m| m.name)
+    };
+    assert_eq!(
+        persisted.as_deref(),
+        Some("Race Group"),
+        "a joiner must persist the group name the Welcome carried"
+    );
+
+    let internet = MockTransport::new(TransportType::Internet);
+    internet.start().unwrap();
+    let internet_handle = internet.clone();
+    bob.transport_manager_mut()
+        .add_transport(TransportType::Internet, Box::new(internet));
+
+    // Bob reconnects before Alice, so his re-sync is the registration that
+    // names the group on the relay for every member.
+    assert!(!bob.group_mesh.internet_was_available);
+    bob.check_relay_group_sync();
+    assert_eq!(
+        relay_registration_names(&internet_handle, &group_id),
+        vec![Some("Race Group".to_string())],
+        "a joiner's re-sync registration must carry the group name"
+    );
+
+    bob.stop().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thanks for contributing to the Offline Protocol SDK!
Please fill out the sections below. Delete anything that doesn't apply.
-->

## Summary

<!-- What does this PR do, and why? -->

## Related issues

<!-- e.g. "Closes #123" / "Refs #456". Use "Closes" to auto-close on merge. -->

Closes #

## Type of change

<!-- Mark with an [x] all that apply. Matches our Conventional Commit types. -->

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `perf` — performance improvement
- [ ] `test` — adding or correcting tests
- [ ] `chore` — build, tooling, or dependency changes

## Checklist

<!-- These mirror the CI gates — PRs that fail them will be blocked. -->

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo-deny` is satisfied (no new license/advisory violations)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <subject>`)
- [x] Docs / `CHANGELOG.md` updated where relevant
- [x] No new `unsafe` in core crates (only the `offline-protocol-uniffi` FFI boundary may use it, with SAFETY comments)
- [x] If the UniFFI UDL changed, bindings were regenerated (`./scripts/generate-bindings.sh`) and **all three** — Swift, Kotlin, Python — committed together; a partial set fails at runtime, not build time

## Breaking changes

<!-- Describe any breaking API/wire/config changes and the migration path, or "None". -->

None

## Notes for reviewers

<!-- Anything that helps review: design decisions, areas needing extra scrutiny, follow-ups. -->

---

<!--
First-time contributor? Our CLA bot will comment on this PR with a link to
CLA.md. To sign, comment exactly:

  I have read the CLA Document and I hereby sign the CLA

You only sign once. PRs cannot be merged until the CLA check is green.
-->
