### PR TITLE
fix(protocol): close the two #382 review residuals (#384, #385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,10 @@ archived by series under [docs/changelog/](docs/changelog/); see the
 
   **A custom backend brings one obligation:** `wipePersistedState()` clears the
   *default* provider's account directory, which a custom backend is not inside,
-  so call `DataStore.wipeAll()` on logout as well.
+  so call `DataStore.wipeAll()` on logout as well. Stop the engine before
+  wiping: there are no deletion tombstones, so a wipe on a running engine with
+  live sessions is undone by the peer's next version offer, which recreates and
+  refills every document with no error and no event.
 
   Native Rust consumers who only want messaging can opt out of the engine
   entirely with `default-features = false`; the mobile artifact carries it
@@ -178,6 +181,20 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   behaviour a gateway's Verdict verb plugs into.
 
 ### Fixed
+
+- **A local document edit could be stranded by a storage write that failed
+  once and then recovered.** Edits pending when a remote change arrives are
+  flushed first, so they leave on their own delta rather than being folded
+  into the imported change and suppressed as an echo toward the one peer they
+  were owed to. That pre-flush was reported and stepped over for every error
+  alike, but the delta-write failure rewinds the commit back into the pending
+  set, and the import's own flush then performs exactly the fold the pre-flush
+  exists to prevent. A failed pre-flush followed by an import that applied now
+  offers versions, so the peer asks for what it is missing instead of both
+  replicas believing they agree. `DocTooLarge` is told apart from the rest: on
+  that path the delta was written, pushed and announced before the size
+  verdict failed, so nothing is pending and the old message said the opposite
+  on the one document an operator is most likely to be reading about.
 
 - **Messages sent over an explicitly chosen transport skipped the negotiated
   binary wire codec.** `send_via_transport` never stamped it, while the
@@ -232,6 +249,18 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   the same 30-second cadence.
 
 ### Documentation
+
+- **`DataStore.wipeAll()` says that it is only durable once replication has
+  stopped.** There are no deletion tombstones, so nothing distinguishes a
+  space this device wiped from one it has never seen: called on a running
+  engine with live sessions, the peer's next version offer recreates and
+  refills every document, and an offer of our own naming nothing reads to the
+  peer as a replica that has never seen the space. Every mention of the call
+  framed it as the logout path, where the engine is being torn down anyway,
+  and none said what happens anywhere else. Stated at the API reference, the
+  upgrade guide, the configuration guide, the React Native and Python bridge
+  docs, the bridge contracts, the storage adapter references and the method's
+  own documentation.
 
 - **`docs/mesh.md` no longer documents the dormant layer as the delivery path.**
   The "Path Scoring" section and everything under it (route entries, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,19 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   verdict failed, so nothing is pending and the old message said the opposite
   on the one document an operator is most likely to be reading about.
 
+- **A remote change applied into a document over its cap was reported as
+  refused.** The import flushes what it applied, and that flush answers
+  `DocTooLarge` once the document is over its cap: the change is written and
+  the size verdict that follows it is what failed. Reporting it as an error
+  logged an applied change as `Remote change refused`, skipped the space
+  record, and withheld the stranded-edit offer above, which is gated on the
+  import having applied. That is the case the offer matters most in: the one
+  edit a document past its cap still accepts is a deletion, which is its route
+  back under. The import now answers `Applied`, and `Err` means the change is
+  not durable. `flushAll()` drew the same distinction on shutdown, where it
+  logged `Failed to flush document` for a document whose change had reached
+  disk; it no longer does.
+
 - **Messages sent over an explicitly chosen transport skipped the negotiated
   binary wire codec.** `send_via_transport` never stamped it, while the
   selection path did, so a peer known to support the binary codec silently fell

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -4082,6 +4082,13 @@ export class DataStore {
    * supplied: `wipePersistedState()` clears the default provider's account
    * directory, which a custom backend is not inside. Skipping it there
    * leaves documents behind after the account that made them is gone.
+   *
+   * Only durable once replication has stopped. There are no deletion
+   * tombstones, so a peer cannot tell a wiped space from one this device has
+   * never seen, and with the engine running and sessions live its next
+   * version offer recreates and refills every document, with no error and no
+   * event. Logout tears the engine down anyway; call `destroy()` first if you
+   * are wiping for any other reason.
    */
   async wipeAll(): Promise<void> {
     await OfflineProtocolNativeModule.dataWipeAll();

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -4088,7 +4088,9 @@ export class DataStore {
    * never seen, and with the engine running and sessions live its next
    * version offer recreates and refills every document, with no error and no
    * event. Logout tears the engine down anyway; call `destroy()` first if you
-   * are wiping for any other reason.
+   * are wiping for any other reason, and only for as long as it stays stopped:
+   * the peer still holds the documents, so they return when replication
+   * resumes. This clears the device, it does not delete content.
    */
   async wipeAll(): Promise<void> {
     await OfflineProtocolNativeModule.dataWipeAll();

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -7186,7 +7186,10 @@ impl DataStore {
     /// tombstones, so a peer cannot tell a wiped space from one this device
     /// has never seen, and on a running engine with live sessions its next
     /// version offer recreates and refills every document. The logout path
-    /// tears the engine down anyway; anywhere else, stop it first.
+    /// tears the engine down anyway; anywhere else, stop it first, and only
+    /// for as long as it stays stopped: the peer still holds the documents,
+    /// so they return when replication resumes. This clears the device, it
+    /// does not delete content.
     pub fn wipe_all(&self) -> Result<(), ProtocolError> {
         self.protocol.data_wipe_all()
     }

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -6989,7 +6989,8 @@ impl DataStore {
     ///
     /// An application that uses this must call [`DataStore::wipe_all`] on
     /// logout. `wipePersistedState` clears the account directory of the
-    /// *default* provider, which a custom backend is not inside.
+    /// *default* provider, which a custom backend is not inside. Stop the
+    /// engine before wiping: [`DataStore::wipe_all`] says why.
     pub fn with_storage(
         protocol: Arc<OfflineProtocol>,
         storage: Box<dyn ProtocolStateStorageProvider>,
@@ -7180,6 +7181,12 @@ impl DataStore {
     }
 
     /// Deletes every record the data layer owns.
+    ///
+    /// Only durable once replication has stopped. There are no deletion
+    /// tombstones, so a peer cannot tell a wiped space from one this device
+    /// has never seen, and on a running engine with live sessions its next
+    /// version offer recreates and refills every document. The logout path
+    /// tears the engine down anyway; anywhere else, stop it first.
     pub fn wipe_all(&self) -> Result<(), ProtocolError> {
         self.protocol.data_wipe_all()
     }

--- a/crates/offline-protocol-uniffi/src/offline_protocol.udl
+++ b/crates/offline-protocol-uniffi/src/offline_protocol.udl
@@ -1963,7 +1963,9 @@ interface DataStore {
     // Only durable once replication has stopped. There are no deletion
     // tombstones, so a peer cannot tell a wiped space from one this device
     // has never seen, and on a running engine with live sessions its next
-    // version offer recreates and refills every document.
+    // version offer recreates and refills every document. Stopping covers it
+    // only while it stays stopped: the peer still holds them, so they return
+    // when replication resumes. This clears the device, not the content.
     [Throws=ProtocolError]
     void wipe_all();
 };

--- a/crates/offline-protocol-uniffi/src/offline_protocol.udl
+++ b/crates/offline-protocol-uniffi/src/offline_protocol.udl
@@ -1959,6 +1959,11 @@ interface DataStore {
 
     // Delete every record the data layer owns. The logout path for an
     // application that configured its own backend.
+    //
+    // Only durable once replication has stopped. There are no deletion
+    // tombstones, so a peer cannot tell a wiped space from one this device
+    // has never seen, and on a running engine with live sessions its next
+    // version offer recreates and refills every document.
     [Throws=ProtocolError]
     void wipe_all();
 };

--- a/crates/offline-protocol/src/protocol/data.rs
+++ b/crates/offline-protocol/src/protocol/data.rs
@@ -1313,7 +1313,10 @@ impl OfflineProtocol {
     /// version offer names them and they are recreated and refilled from the
     /// peer's copy, and an offer of our own naming nothing reads as a replica
     /// that has never seen the space. On the logout path the engine is being
-    /// torn down anyway. Anywhere else, stop it first.
+    /// torn down anyway. Anywhere else, stop it first, and only for as long
+    /// as it stays stopped: the peer still holds the documents, so they return
+    /// when replication resumes with it. The call clears this device, it does
+    /// not delete content.
     pub fn data_wipe_all(&mut self) -> Result<()> {
         let Some(storage) = self.data_storage() else {
             return Ok(());

--- a/crates/offline-protocol/src/protocol/data.rs
+++ b/crates/offline-protocol/src/protocol/data.rs
@@ -710,6 +710,11 @@ impl OfflineProtocol {
     /// than left in memory: an unflushed remote change would be lost to a
     /// restart, and the sender has already been told (by the acknowledgement
     /// the frame rides on) that it arrived.
+    ///
+    /// `Err` means the change is not durable. A document held over its cap
+    /// still answers `Applied`, because the cap refuses growth *after* the
+    /// change is on disk; the caller cannot tell the two apart from an error
+    /// alone, and one of them is a change it must not report as refused.
     pub(crate) fn data_apply_remote(
         &mut self,
         space: &str,
@@ -751,7 +756,28 @@ impl OfflineProtocol {
         if outcome == RemoteImport::Applied {
             // Remote work is not this replica's to push onward, so the flush
             // is told where the change came from.
-            self.flush_doc_from(storage.as_ref(), space, doc, Some(space))?;
+            //
+            // `DocTooLarge` is not an import failure and is not reported as
+            // one. It is raised after the delta record was written and the
+            // push decided, so the imported change is already durable; what
+            // failed is the size verdict that follows, and what it refuses is
+            // further *growth*. Propagating it would say the change was
+            // refused when it applied, skip the space record below, and cost
+            // the caller the one signal that a local edit may have been
+            // folded into this import and suppressed with it, because that
+            // compensation is gated on hearing `Applied`. A document over its
+            // cap is exactly where that matters: the pending edit it still
+            // accepts is a deletion, which is the route back under.
+            match self.flush_doc_from(storage.as_ref(), space, doc, Some(space)) {
+                Ok(()) => {}
+                Err(Error::DocTooLarge { .. }) => {
+                    debug!(
+                        space,
+                        doc, "Applied a remote change into a document that is over its cap"
+                    );
+                }
+                Err(err) => return Err(err),
+            }
             self.persist_space(storage.as_ref(), space)?;
         }
         Ok(outcome)
@@ -1252,8 +1278,22 @@ impl OfflineProtocol {
         };
         let keys: Vec<(String, String)> = self.data.docs.keys().cloned().collect();
         for (space, doc) in keys {
-            if let Err(err) = self.flush_doc(storage.as_ref(), &space, &doc) {
-                warn!(space, doc, error = %err, "Failed to flush document");
+            match self.flush_doc(storage.as_ref(), &space, &doc) {
+                Ok(()) => {}
+                // Not a failed flush, and not reported as one: the record was
+                // written and only the size verdict after it refused further
+                // growth. On a shutdown path the distinction is the whole
+                // question an operator is asking, which is whether anything
+                // was lost.
+                Err(Error::DocTooLarge { .. }) => {
+                    debug!(
+                        space,
+                        doc, "Flushed a document that is over its cap on shutdown"
+                    );
+                }
+                Err(err) => {
+                    warn!(space, doc, error = %err, "Failed to flush document");
+                }
             }
         }
         Ok(())

--- a/crates/offline-protocol/src/protocol/data.rs
+++ b/crates/offline-protocol/src/protocol/data.rs
@@ -1265,6 +1265,15 @@ impl OfflineProtocol {
     /// backend. `wipePersistedState` clears the account directory of the
     /// *default* provider, which a custom backend is not inside, so without
     /// this call those documents would outlive the account that made them.
+    ///
+    /// **Only durable once replication has stopped.** There are no deletion
+    /// tombstones in this release, so nothing distinguishes a space this
+    /// device wiped from one it has never seen. Called while the engine is
+    /// running with live sessions, every document comes back: the peer's next
+    /// version offer names them and they are recreated and refilled from the
+    /// peer's copy, and an offer of our own naming nothing reads as a replica
+    /// that has never seen the space. On the logout path the engine is being
+    /// torn down anyway. Anywhere else, stop it first.
     pub fn data_wipe_all(&mut self) -> Result<()> {
         let Some(storage) = self.data_storage() else {
             return Ok(());

--- a/crates/offline-protocol/src/protocol/data_sync.rs
+++ b/crates/offline-protocol/src/protocol/data_sync.rs
@@ -48,7 +48,11 @@
 //! first, which pushes them. That is work this device already owed the peer
 //! and the frame merely reached it, so it cannot recur: what it sends is
 //! what was pending before the frame arrived, and flushing is what stops it
-//! being pending.
+//! being pending. When that flush fails and the import then applies, the
+//! edit may have been folded into the imported change and suppressed with
+//! it, so a version offer is sent instead of the delta. That one is not an
+//! answer either, and it cannot recur for the same reason: it costs a
+//! storage failure that recovered inside a single frame.
 //!
 //! # Remote bytes are not our bytes
 //!
@@ -71,7 +75,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::{debug, warn};
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::protocol::prefixes::internal_prefixes;
 use crate::protocol::types::{storage_keys, DATA_SYNC_V1};
 use crate::protocol::OfflineProtocol;
@@ -793,8 +797,38 @@ impl OfflineProtocol {
         // Ahead of the marker below rather than inside its window, so the
         // window stays the length of one import. A crash during this flush
         // would otherwise quarantine a blob the engine never saw.
-        if let Err(err) = self.data_flush(space, doc) {
-            warn!(space, doc, error = %err, "Could not flush local edits before applying a remote change");
+        //
+        // The two errors say opposite things about what is still pending, so
+        // they are told apart. `DocTooLarge` is raised after the delta record
+        // was written, pushed and announced, and only the size verdict that
+        // follows it failed: nothing is left in the pending set and there is
+        // nothing to compensate for. Any other error may have left the commit
+        // un-exported, because the delta-write failure rewinds it back into
+        // the pending set. The import's own flush would then fold that edit
+        // into the imported change and suppress the pair toward the one peer
+        // it was owed to, which is exactly the loss this pre-flush exists to
+        // prevent.
+        let mut preflush_left_edits_pending = false;
+        match self.data_flush(space, doc) {
+            Ok(()) => {}
+            Err(Error::DocTooLarge { .. }) => {
+                debug!(
+                    space,
+                    doc,
+                    "Local edits were flushed and pushed before applying a remote change; the \
+                     document is over its cap and refuses further growth"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    space,
+                    doc,
+                    error = %err,
+                    "Could not flush local edits before applying a remote change; they may \
+                     still be pending"
+                );
+                preflush_left_edits_pending = true;
+            }
         }
 
         // Written *before* the engine is called. That ordering is the whole
@@ -808,6 +842,9 @@ impl OfflineProtocol {
 
         record.in_flight = None;
         self.persist_sync_record(space, &record);
+
+        // Read before the match below consumes the outcome.
+        let applied = matches!(outcome, Ok(RemoteImport::Applied));
 
         match outcome {
             Ok(RemoteImport::Applied) => {
@@ -884,6 +921,29 @@ impl OfflineProtocol {
                 }
             },
         }
+
+        // A pre-flush that failed followed by an import that applied is the
+        // one combination where a local edit can have been folded into the
+        // imported change and then suppressed toward the peer it was owed
+        // to. Nothing on the wire carries it and no trigger is left to
+        // notice, so the gap is announced and the peer asks for what it is
+        // missing. The alternative, sending the fold on with the suppression
+        // lifted, would hand the peer its own change back.
+        //
+        // Gated on `Applied` for the reason that also makes it terminate.
+        // The fold needs the import's own flush to have succeeded, and a
+        // storage failure that is still failing fails that one too, which
+        // makes the import answer `Err`. So every nudge costs a fresh
+        // transient failure that recovered inside one frame, and the offers
+        // cannot sustain each other.
+        //
+        // `origin` is `None`, not the space: what may be stranded here is
+        // this device's own edit, so naming the space would suppress the
+        // announcement toward the only peer that could act on it.
+        if preflush_left_edits_pending && applied {
+            self.nudge_data_sync(space, None, "preflush_failure");
+        }
+
         Ok(())
     }
 

--- a/crates/offline-protocol/src/protocol/data_sync.rs
+++ b/crates/offline-protocol/src/protocol/data_sync.rs
@@ -935,7 +935,22 @@ impl OfflineProtocol {
         // storage failure that is still failing fails that one too, which
         // makes the import answer `Err`. So every nudge costs a fresh
         // transient failure that recovered inside one frame, and the offers
-        // cannot sustain each other.
+        // cannot sustain each other. `Applied` and not "anything but `Err`"
+        // for the same reason: the outcomes that did not apply left the edit
+        // pending, where the next pre-flush still owes it to the peer.
+        //
+        // This is why a document over its cap must answer `Applied` rather
+        // than `DocTooLarge`, and does: its flush wrote the fold and then
+        // refused further growth, so the edit is stranded exactly as here,
+        // on the documents whose only pending edit is the deletion that
+        // brings them back under.
+        //
+        // One residual is left uncompensated on purpose. A `persist_space`
+        // failure after a flush that succeeded also strands a fold, and is
+        // indistinguishable here from a flush that failed. Offering on every
+        // `Err` would cover it and break the argument above: a store that
+        // keeps failing would then emit an offer per frame, and those do
+        // sustain each other. The narrower gap is the better trade.
         //
         // `origin` is `None`, not the space: what may be stranded here is
         // this device's own edit, so naming the space would suppress the

--- a/crates/offline-protocol/src/protocol/tests/data_sync.rs
+++ b/crates/offline-protocol/src/protocol/tests/data_sync.rs
@@ -590,6 +590,42 @@ fn a_local_edit_stranded_by_a_failed_pre_flush_is_announced_to_the_peer() {
     );
 }
 
+/// Push a document past `MAX_DOC_BYTES` and leave it there.
+///
+/// Two values that are together over the cap, rather than many small ones
+/// that add up to it. The cap is measured over the compacted export, which
+/// includes the delta history a flush has not folded away yet, so a document
+/// nudged over the line by its history drops back under as soon as compaction
+/// runs and the next flush answers `Ok`. Content this size cannot be
+/// compacted back under the cap, which is what makes `DocTooLarge` the answer
+/// every later flush gives.
+///
+/// The bytes are incompressible on purpose: the compacted encoding
+/// compresses, so a megabyte of one repeated byte measures as almost nothing.
+fn grow_past_cap(node: &mut Node, space: &str, doc: &str) {
+    let filler = |seed: u32| -> Vec<u8> {
+        let mut state = 0x9e37_79b9u32.wrapping_mul(seed.wrapping_add(1));
+        (0..600 * 1024)
+            .map(|_| {
+                state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                (state >> 24) as u8
+            })
+            .collect()
+    };
+    node.protocol
+        .data_map_set(space, doc, "m", "half", DataValue::bytes(filler(1)))
+        .expect("set");
+    node.protocol.data_flush(space, doc).expect("flush");
+    node.protocol
+        .data_map_set(space, doc, "m", "other_half", DataValue::bytes(filler(2)))
+        .expect("set");
+    let breach = node.protocol.data_flush(space, doc);
+    assert!(
+        matches!(breach, Err(crate::error::Error::DocTooLarge { .. })),
+        "the document answered {breach:?} rather than reaching its cap"
+    );
+}
+
 #[test]
 fn a_document_over_its_cap_still_accepts_a_remote_change() {
     let (mut alice, mut bob) = pair();
@@ -608,56 +644,7 @@ fn a_document_over_its_cap_still_accepts_a_remote_change() {
     // costs no frames and Bob's copy stays small. What is under test is what
     // Alice does with an arriving change, not how a megabyte crosses a link.
     alice.protocol.peer_data_sync.remove(&bob.address);
-
-    // Two values that are together over the cap, rather than many small ones
-    // that add up to it. The cap is measured over the compacted export, which
-    // includes the delta history a flush has not folded away yet, so a
-    // document nudged over the line by its history drops back under as soon
-    // as compaction runs and the next flush answers `Ok`. Content this size
-    // cannot be compacted back under the cap, which is what makes the error
-    // this test is named for the answer every flush gives.
-    //
-    // Incompressible: the compacted encoding compresses, so a megabyte of
-    // one repeated byte measures as almost nothing.
-    let filler = |seed: u32| -> Vec<u8> {
-        let mut state = 0x9e37_79b9u32.wrapping_mul(seed.wrapping_add(1));
-        (0..600 * 1024)
-            .map(|_| {
-                state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
-                (state >> 24) as u8
-            })
-            .collect()
-    };
-    alice
-        .protocol
-        .data_map_set(
-            &alice_space,
-            "notes",
-            "m",
-            "half",
-            DataValue::bytes(filler(1)),
-        )
-        .expect("set");
-    alice
-        .protocol
-        .data_flush(&alice_space, "notes")
-        .expect("flush");
-    alice
-        .protocol
-        .data_map_set(
-            &alice_space,
-            "notes",
-            "m",
-            "other_half",
-            DataValue::bytes(filler(2)),
-        )
-        .expect("set");
-    let breach = alice.protocol.data_flush(&alice_space, "notes");
-    assert!(
-        matches!(breach, Err(crate::error::Error::DocTooLarge { .. })),
-        "the document answered {breach:?} rather than reaching its cap"
-    );
-
+    grow_past_cap(&mut alice, &alice_space, "notes");
     alice.protocol.peer_data_sync.insert(bob.address.clone());
     alice.transport.clear_sent_messages();
 
@@ -717,6 +704,114 @@ fn a_document_over_its_cap_still_accepts_a_remote_change() {
         !pushed.is_empty(),
         "the pending deletion was committed but never sent, so `DocTooLarge` \
          does mean the flush was lost"
+    );
+}
+
+#[test]
+fn a_local_edit_stranded_over_the_cap_is_announced_to_the_peer() {
+    let armed = Arc::new(AtomicBool::new(false));
+    let fired = Arc::new(AtomicBool::new(false));
+    let alice = Node::with_state_storage("alice", |state| {
+        Arc::new(FailOneDeltaWrite {
+            inner: TestProtocolStateStorage { storage: state },
+            armed: armed.clone(),
+            fired: fired.clone(),
+        })
+    });
+    let (mut alice, mut bob) = pair_of(alice, Node::new("bob"));
+    let alice_space = Node::space_for(&bob);
+    let bob_space = Node::space_for(&alice);
+
+    write(&mut alice, &alice_space, "notes", "shared", "0");
+    settle(&mut alice, &mut bob);
+    assert_eq!(
+        read(&mut bob, &bob_space, "notes", "shared"),
+        Some(DataValue::text("0")),
+        "precondition: both replicas have to hold the document"
+    );
+
+    alice.protocol.peer_data_sync.remove(&bob.address);
+    grow_past_cap(&mut alice, &alice_space, "notes");
+    alice.protocol.peer_data_sync.insert(bob.address.clone());
+
+    // The seed rather than one of the fillers, for the reason the sibling
+    // test gives: dropping a filler brings the document back under the cap,
+    // the flush inside the import then answers `Ok`, and the arm under test
+    // is never reached.
+    alice
+        .protocol
+        .data_map_delete(&alice_space, "notes", "m", "shared")
+        .expect("deletions must keep working past the cap");
+    assert!(
+        alice
+            .protocol
+            .data_doc_size(&alice_space, "notes")
+            .expect("size")
+            > crate::MAX_DOC_BYTES as u64,
+        "precondition: the document has to still be over its cap with the \
+         deletion pending"
+    );
+    alice.transport.clear_sent_messages();
+
+    // Both halves of the loss at once, which is the case neither sibling
+    // test covers. The pre-flush cannot write its delta record, so the
+    // deletion is rewound into the pending set. The import then folds it
+    // into the imported change and suppresses the pair toward the only peer
+    // it was owed to, and the flush that did so answers `DocTooLarge`,
+    // because the document is over its cap either way. That error is raised
+    // after the fold is durable, so reading it as a failed import would
+    // withhold the announcement on exactly the documents whose one pending
+    // edit is the deletion that brings them back under.
+    write(&mut bob, &bob_space, "notes", "from_bob", "B");
+    armed.store(true, Ordering::SeqCst);
+    pump(&mut bob, &mut alice);
+
+    assert!(
+        fired.load(Ordering::SeqCst),
+        "precondition: the pre-flush has to have failed, or this proves nothing \
+         about what happens when it does"
+    );
+    assert_eq!(
+        read(&mut alice, &alice_space, "notes", "from_bob"),
+        Some(DataValue::text("B")),
+        "a document over its cap refused a remote change instead of stepping \
+         over the flush error"
+    );
+    assert_eq!(
+        alice
+            .protocol
+            .data_map_get(&alice_space, "notes", "m", "shared")
+            .expect("get"),
+        None,
+        "precondition: the fold has to have happened, or there is nothing \
+         stranded to announce"
+    );
+
+    // The announcement itself. Nothing else on this path sends: the fold's
+    // own push is suppressed as an echo, which is what strands it, so a
+    // non-acknowledgement frame here is the offer or nothing.
+    let announced: Vec<_> = alice
+        .transport
+        .sent_messages()
+        .into_iter()
+        .filter(|message| !message.metadata.contains_key(ACK_FOR_KEY))
+        .collect();
+    assert!(
+        !announced.is_empty(),
+        "the deletion folded into the import was stranded with no offer, so \
+         nothing is left to tell the peer to ask"
+    );
+
+    // The offer draws catch-up and the catch-up ladder runs out: every rung
+    // is over the frame budget for a document this size, and "nothing" is a
+    // rung. So the exchange still ends. What the peer does with the answer
+    // is the media path's job, not this one's; what is under test is that it
+    // gets to ask at all.
+    let rounds = settle(&mut alice, &mut bob);
+    assert_eq!(
+        rounds.last(),
+        Some(&0),
+        "the compensating offer started an exchange that does not end: {rounds:?}"
     );
 }
 

--- a/crates/offline-protocol/src/protocol/tests/data_sync.rs
+++ b/crates/offline-protocol/src/protocol/tests/data_sync.rs
@@ -8,6 +8,7 @@
 //! have to build, and a test that shortcuts any of it would be testing
 //! something else.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
@@ -35,6 +36,20 @@ struct Node {
 
 impl Node {
     fn new(label: &str) -> Self {
+        Node::with_state_storage(label, |state| {
+            Arc::new(TestProtocolStateStorage { storage: state })
+        })
+    }
+
+    /// [`Self::new`] with the state store wrapped.
+    ///
+    /// `wrap` is handed the same in-memory store the node keeps, so a test
+    /// can watch or fail individual records and still read the ones it did
+    /// not interfere with.
+    fn with_state_storage(
+        label: &str,
+        wrap: impl FnOnce(Arc<InMemoryStorage>) -> Arc<dyn ProtocolStateStorage>,
+    ) -> Self {
         let mut config = create_test_config_for_user(label);
         config.encryption.enabled = true;
         config.data.enabled = true;
@@ -43,12 +58,7 @@ impl Node {
         let secure = crate::test_identity::seeded_storage(label);
         let state = Arc::new(InMemoryStorage::new());
         protocol
-            .initialize_mls(
-                secure.clone(),
-                Arc::new(TestProtocolStateStorage {
-                    storage: state.clone(),
-                }),
-            )
+            .initialize_mls(secure.clone(), wrap(state.clone()))
             .expect("initialize_mls");
 
         let mock = MockTransport::new(TransportType::BLE);
@@ -131,9 +141,12 @@ impl Node {
 /// Two replicas with a real MLS session and the sync capability recorded on
 /// both sides, as a key-package exchange would leave them.
 fn pair() -> (Node, Node) {
-    let mut alice = Node::new("alice");
-    let mut bob = Node::new("bob");
+    pair_of(Node::new("alice"), Node::new("bob"))
+}
 
+/// [`pair`] over nodes a test has already built, for one that needs a
+/// particular store underneath a replica.
+fn pair_of(mut alice: Node, mut bob: Node) -> (Node, Node) {
     // A genuine 1:1 group: Alice imports Bob's key package, creates the
     // session, and Bob joins the Welcome it produced. Both managers now hold
     // the same group, which is what makes the frames below real ciphertext
@@ -475,6 +488,235 @@ fn a_local_edit_pending_when_a_remote_change_arrives_still_reaches_the_peer() {
         read(&mut alice, &alice_space, "notes", "from_bob"),
         Some(DataValue::text("B")),
         "draining the local edit cost the import it was making room for"
+    );
+}
+
+/// Storage that fails one `DATA_DELTA_LOG` write and then behaves, the way a
+/// backend that is briefly unavailable does.
+///
+/// One write rather than all of them on purpose: a store that never recovers
+/// fails the import's own flush too, and the fold this arms for needs that
+/// second flush to succeed.
+struct FailOneDeltaWrite {
+    inner: TestProtocolStateStorage,
+    armed: Arc<AtomicBool>,
+    fired: Arc<AtomicBool>,
+}
+
+impl ProtocolStateStorage for FailOneDeltaWrite {
+    fn store(&self, key_type: &str, key_id: &str, data: &[u8]) -> ProtocolStateResult<()> {
+        if key_type == storage_keys::DATA_DELTA_LOG && self.armed.swap(false, Ordering::SeqCst) {
+            self.fired.store(true, Ordering::SeqCst);
+            return Err(ProtocolStateError::StoreFailed(
+                "the backend is briefly unavailable".to_string(),
+            ));
+        }
+        self.inner.store(key_type, key_id, data)
+    }
+
+    fn load(&self, key_type: &str, key_id: &str) -> ProtocolStateResult<Option<Vec<u8>>> {
+        self.inner.load(key_type, key_id)
+    }
+
+    fn delete(&self, key_type: &str, key_id: &str) -> ProtocolStateResult<()> {
+        self.inner.delete(key_type, key_id)
+    }
+
+    fn list_keys(&self, key_type: &str) -> ProtocolStateResult<Vec<String>> {
+        self.inner.list_keys(key_type)
+    }
+}
+
+#[test]
+fn a_local_edit_stranded_by_a_failed_pre_flush_is_announced_to_the_peer() {
+    let armed = Arc::new(AtomicBool::new(false));
+    let fired = Arc::new(AtomicBool::new(false));
+    let alice = Node::with_state_storage("alice", |state| {
+        Arc::new(FailOneDeltaWrite {
+            inner: TestProtocolStateStorage { storage: state },
+            armed: armed.clone(),
+            fired: fired.clone(),
+        })
+    });
+    let (mut alice, mut bob) = pair_of(alice, Node::new("bob"));
+    let alice_space = Node::space_for(&bob);
+    let bob_space = Node::space_for(&alice);
+
+    write(&mut alice, &alice_space, "notes", "seed", "0");
+    settle(&mut alice, &mut bob);
+    assert_eq!(
+        read(&mut bob, &bob_space, "notes", "seed"),
+        Some(DataValue::text("0")),
+        "precondition: both replicas have to hold the document"
+    );
+
+    // Pending, as an application leaves work between flushes.
+    alice
+        .protocol
+        .data_map_set(
+            &alice_space,
+            "notes",
+            "m",
+            "from_alice",
+            DataValue::text("A"),
+        )
+        .expect("set");
+
+    // The pre-flush that drains it cannot write its delta record, so the
+    // commit is rewound and the edit goes back into the pending set. The
+    // import that follows flushes with the origin set, which folds the edit
+    // into the imported change and suppresses the pair toward the only peer
+    // it was owed to: the exact loss the pre-flush exists to prevent,
+    // reopened by a store that failed once.
+    armed.store(true, Ordering::SeqCst);
+    write(&mut bob, &bob_space, "notes", "from_bob", "B");
+    settle(&mut alice, &mut bob);
+
+    assert!(
+        fired.load(Ordering::SeqCst),
+        "precondition: the pre-flush has to have failed, or this proves nothing \
+         about what happens when it does"
+    );
+    assert_eq!(
+        read(&mut alice, &alice_space, "notes", "from_bob"),
+        Some(DataValue::text("B")),
+        "a failed pre-flush cost the import it was making room for"
+    );
+    assert_eq!(
+        read(&mut bob, &bob_space, "notes", "from_alice"),
+        Some(DataValue::text("A")),
+        "the edit stranded by the failed pre-flush was never announced, and \
+         nothing is left to notice it"
+    );
+}
+
+#[test]
+fn a_document_over_its_cap_still_accepts_a_remote_change() {
+    let (mut alice, mut bob) = pair();
+    let alice_space = Node::space_for(&bob);
+    let bob_space = Node::space_for(&alice);
+
+    write(&mut alice, &alice_space, "notes", "shared", "0");
+    settle(&mut alice, &mut bob);
+    assert_eq!(
+        read(&mut bob, &bob_space, "notes", "shared"),
+        Some(DataValue::text("0")),
+        "precondition: both replicas have to hold the document"
+    );
+
+    // Grown past the cap while the peer was not replicating, so the growth
+    // costs no frames and Bob's copy stays small. What is under test is what
+    // Alice does with an arriving change, not how a megabyte crosses a link.
+    alice.protocol.peer_data_sync.remove(&bob.address);
+
+    // Two values that are together over the cap, rather than many small ones
+    // that add up to it. The cap is measured over the compacted export, which
+    // includes the delta history a flush has not folded away yet, so a
+    // document nudged over the line by its history drops back under as soon
+    // as compaction runs and the next flush answers `Ok`. Content this size
+    // cannot be compacted back under the cap, which is what makes the error
+    // this test is named for the answer every flush gives.
+    //
+    // Incompressible: the compacted encoding compresses, so a megabyte of
+    // one repeated byte measures as almost nothing.
+    let filler = |seed: u32| -> Vec<u8> {
+        let mut state = 0x9e37_79b9u32.wrapping_mul(seed.wrapping_add(1));
+        (0..600 * 1024)
+            .map(|_| {
+                state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                (state >> 24) as u8
+            })
+            .collect()
+    };
+    alice
+        .protocol
+        .data_map_set(
+            &alice_space,
+            "notes",
+            "m",
+            "half",
+            DataValue::bytes(filler(1)),
+        )
+        .expect("set");
+    alice
+        .protocol
+        .data_flush(&alice_space, "notes")
+        .expect("flush");
+    alice
+        .protocol
+        .data_map_set(
+            &alice_space,
+            "notes",
+            "m",
+            "other_half",
+            DataValue::bytes(filler(2)),
+        )
+        .expect("set");
+    let breach = alice.protocol.data_flush(&alice_space, "notes");
+    assert!(
+        matches!(breach, Err(crate::error::Error::DocTooLarge { .. })),
+        "the document answered {breach:?} rather than reaching its cap"
+    );
+
+    alice.protocol.peer_data_sync.insert(bob.address.clone());
+    alice.transport.clear_sent_messages();
+
+    // Deletion is the only edit a document past its cap still accepts, and
+    // it is the route back under. Left pending, so the pre-flush has
+    // something to do when Bob's change arrives.
+    //
+    // The seed rather than one of the fillers: dropping 8 KiB from a
+    // document that has just crossed the cap brings it back under, and then
+    // the pre-flush answers `Ok` and this test proves nothing about the
+    // error it is named for.
+    alice
+        .protocol
+        .data_map_delete(&alice_space, "notes", "m", "shared")
+        .expect("deletions must keep working past the cap");
+    assert!(
+        alice
+            .protocol
+            .data_doc_size(&alice_space, "notes")
+            .expect("size")
+            > crate::MAX_DOC_BYTES as u64,
+        "precondition: the document has to still be over its cap with the \
+         deletion pending, or the pre-flush answers `Ok` and the arm under \
+         test is never reached"
+    );
+
+    // `DocTooLarge` is what the pre-flush answers here, and it is the one
+    // error that must not stop the import: the remote change may be the
+    // deletion that brings the document back under, so refusing it would
+    // close the only door out.
+    write(&mut bob, &bob_space, "notes", "from_bob", "B");
+    pump(&mut bob, &mut alice);
+
+    assert_eq!(
+        read(&mut alice, &alice_space, "notes", "from_bob"),
+        Some(DataValue::text("B")),
+        "a document over its cap refused a remote change instead of stepping over the flush error"
+    );
+    assert_eq!(
+        alice
+            .protocol
+            .data_map_get(&alice_space, "notes", "m", "shared")
+            .expect("get"),
+        None,
+        "the pre-flush did not commit the pending deletion"
+    );
+    // The claim the log makes on this path is that the flush and the push
+    // both happened and only the size verdict that follows them failed. The
+    // push is the half no local read can see.
+    let pushed: Vec<_> = alice
+        .transport
+        .sent_messages()
+        .into_iter()
+        .filter(|message| !message.metadata.contains_key(ACK_FOR_KEY))
+        .collect();
+    assert!(
+        !pushed.is_empty(),
+        "the pending deletion was committed but never sent, so `DocTooLarge` \
+         does mean the flush was lost"
     );
 }
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1548,7 +1548,9 @@ document again, so it is recreated and refilled from their copy. In a space
 named after a peer, treat deletion as local cleanup that replication may undo,
 not as a way to remove content: to retire content from both sides, empty the
 document (deletions inside a document replicate like any other change); to stop
-a space replicating at all, use a space name that is not a peer address.
+a space replicating at all, use a space name that is not a peer address. The
+same is true of `wipeAll()` on a running engine, for the same missing
+tombstone: see the storage section below.
 
 ### Turning it on
 
@@ -1585,6 +1587,18 @@ logout as well, or documents outlive the account that created them. `wipeAll()`
 throws if the backend refused any delete, and that error is the only signal
 that records survived the wipe: treat it as a failed logout rather than
 logging it, because nothing inside the application will show the difference.
+
+**A wipe is only durable once replication has stopped.** It is the same
+missing tombstone described above: nothing distinguishes a space this device
+wiped from one it has never seen. Called while the engine is still running
+with live sessions, every document comes back, from both directions. The
+peer's next version offer names the documents and they are recreated and
+refilled from the peer's copy, and an offer of our own naming nothing reads to
+the peer as a replica that has never seen the space, which it answers with all
+of it. There is no error and no event; the documents simply return. On the
+logout path this does not bite, because the engine is being torn down anyway.
+Anywhere else, stop it before wiping, and read `wipeAll()` as clearing this
+device rather than as deleting content.
 
 Verify any custom backend with `runStorageConformance(provider)`: an empty
 `failures` array is the definition of supported. Reference adapters live in

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1095,7 +1095,9 @@ deletion tombstones, so a peer cannot tell a wiped space from one this device
 has never seen, and on a running engine with live sessions its next version
 offer recreates and refills every document, with no error and no event. On the
 logout path the engine is being torn down anyway; anywhere else, stop it
-first.
+first, and only for as long as it stays stopped: the peer still holds the
+documents, so they return when replication resumes. Read `wipeAll()` as
+clearing this device rather than as deleting content.
 
 ## UniFFI Bindings
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1040,7 +1040,7 @@ await store.flush('space-1', 'profile');
 | `flush(space, doc)` | `void` | Persist pending edits |
 | `flushAll()` | `void` | |
 | `docSize(space, doc)` | `number` | Compacted size in bytes |
-| `wipeAll()` | `void` | Delete every data-layer record |
+| `wipeAll()` | `void` | Delete every data-layer record. Only durable once replication has stopped |
 
 A space id is the MLS scope the space rides on: a peer address or a group id.
 Space, document and collection names accept `A-Z a-z 0-9 . _ -` up to 128
@@ -1086,9 +1086,16 @@ choice: no rebuild and no build flag, and sealing sits above the seam, so a
 custom backend is handed sealed bytes and never sees document content.
 
 Verify a custom backend with `runStorageConformance(provider)`, and call
-`wipeAll()` on logout — `wipePersistedState()` clears the default provider's
+`wipeAll()` on logout: `wipePersistedState()` clears the default provider's
 account directory, which a custom backend is not inside. See
 [storage adapter references](../examples/storage-adapters/README.md).
+
+`wipeAll()` is only durable once replication has stopped. There are no
+deletion tombstones, so a peer cannot tell a wiped space from one this device
+has never seen, and on a running engine with live sessions its next version
+offer recreates and refills every document, with no error and no event. On the
+logout path the engine is being torn down anyway; anywhere else, stop it
+first.
 
 ## UniFFI Bindings
 

--- a/docs/bridges/README.md
+++ b/docs/bridges/README.md
@@ -267,7 +267,10 @@ The call is only durable once replication has stopped. There are no deletion
 tombstones, so a peer cannot tell a wiped space from one this device has never
 seen, and on a running engine with live sessions its next version offer
 recreates and refills every document. Logout tears the engine down anyway;
-a wipe used for anything else has to stop it first.
+a wipe used for anything else has to stop it first, and only for as long as it
+stays stopped: the peer still holds the documents, so they return when
+replication resumes. The call clears this device, it does not delete
+content.
 
 Reference adapters live in `examples/storage-adapters/`, one per binding,
 each with the conformance suite wired into its own test harness.

--- a/docs/bridges/README.md
+++ b/docs/bridges/README.md
@@ -263,6 +263,12 @@ directory, so an application that configures one **must** call
 `DataStore.wipeAll()` on logout. Without it, documents outlive the account
 that created them: a privacy failure with no symptom inside the app.
 
+The call is only durable once replication has stopped. There are no deletion
+tombstones, so a peer cannot tell a wiped space from one this device has never
+seen, and on a running engine with live sessions its next version offer
+recreates and refills every document. Logout tears the engine down anyway;
+a wipe used for anything else has to stop it first.
+
 Reference adapters live in `examples/storage-adapters/`, one per binding,
 each with the conformance suite wired into its own test harness.
 

--- a/docs/bridges/python.md
+++ b/docs/bridges/python.md
@@ -91,7 +91,9 @@ A worked reference lives in
 Python currently ships **no** `wipePersistedState` equivalent (the mobile
 bindings do). An application that needs logout has to clear its own storage
 root, and if it pointed documents at a separate backend, call
-`DataStore.wipe_all()` too.
+`DataStore.wipe_all()` too. Stop the protocol first: there are no deletion
+tombstones, so a wipe on a running engine with live sessions is undone by the
+peer's next version offer, which recreates and refills every document.
 
 ## Testing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -704,7 +704,9 @@ Two obligations come with a custom backend:
   `DataStore.wipeAll()` as well or documents outlive the account. Stop the
   engine first: there are no deletion tombstones, so a wipe on a running
   engine with live sessions is undone by the peer's next version offer, which
-  recreates and refills every document with no error and no event.
+  recreates and refills every document with no error and no event. Stopping
+  covers it only while it stays stopped, because the peer still holds the
+  documents: the call clears this device, it does not delete content.
 
 **Limits.** A document is capped at 1 MiB compacted, with a
 `data_doc_size_warning` event at 768 KiB. Passing the cap raises `DocTooLarge`;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -701,7 +701,10 @@ Two obligations come with a custom backend:
   [storage adapter references](../examples/storage-adapters/README.md).
 - Wipe it on logout. `wipePersistedState()` clears the **default** provider's
   account directory, which a custom backend is not inside, so call
-  `DataStore.wipeAll()` as well or documents outlive the account.
+  `DataStore.wipeAll()` as well or documents outlive the account. Stop the
+  engine first: there are no deletion tombstones, so a wipe on a running
+  engine with live sessions is undone by the peer's next version offer, which
+  recreates and refills every document with no error and no event.
 
 **Limits.** A document is capped at 1 MiB compacted, with a
 `data_doc_size_warning` event at 768 KiB. Passing the cap raises `DocTooLarge`;

--- a/docs/react-native-integration.md
+++ b/docs/react-native-integration.md
@@ -576,7 +576,7 @@ await store.flush('space-1', 'profile');
 | **flush** | `flush(spaceId, docId): Promise<void>` | Persists pending edits. |
 | **flushAll** | `flushAll(): Promise<void>` | Persists every open document. |
 | **docSize** | `docSize(spaceId, docId): Promise<number>` | Compacted size in bytes. |
-| **wipeAll** | `wipeAll(): Promise<void>` | Deletes every data-layer record. Needed on logout only when documents were pointed at an app-supplied backend, which `wipePersistedState` cannot reach. |
+| **wipeAll** | `wipeAll(): Promise<void>` | Deletes every data-layer record. Needed on logout only when documents were pointed at an app-supplied backend, which `wipePersistedState` cannot reach. Only durable once replication has stopped: with the engine running and sessions live, the peer's next version offer recreates and refills every document. |
 
 Edits batch before they reach storage: call `flush()` when the app must know a
 change is durable. The `data_changed` event fires **after** the change is

--- a/docs/spec/control-messages.md
+++ b/docs/spec/control-messages.md
@@ -236,6 +236,13 @@ arrives for a document it holds unflushed edits to, and this does not break
 the property: those changes were owed to the peer before the frame arrived, so
 flushing them is not an answer and cannot recur.
 
+A receiver MAY also emit one version offer when that flush failed and the
+frame's change then applied. The failure can leave the local edit pending, in
+which case the import folds it into the imported change and suppresses the
+pair as an echo, so the offer is what tells the peer to ask. It cannot recur
+either: it costs a storage failure that recovered inside one frame, since a
+failure still in force fails the import too and no offer is sent.
+
 The one chain longer than a single hop is that targeted offer: it draws
 catch-up and nothing further. It terminates because it names only documents
 the peer has itself just offered, so the peer creates nothing from it and has

--- a/examples/storage-adapters/README.md
+++ b/examples/storage-adapters/README.md
@@ -61,4 +61,9 @@ provider. A custom backend is not inside it, so an application that
 configures one must call `DataStore.wipeAll()` on logout. Skipping it leaves
 documents behind after the account that made them is gone.
 
+Stop the protocol before wiping. There are no deletion tombstones, so a peer
+cannot tell a wiped space from one this device has never seen, and on a
+running engine with live sessions its next version offer recreates and refills
+every document.
+
 See [C11 in the bridge contracts](../../docs/bridges/README.md#c11-a-storage-adapter-is-a-supported-extension-point-and-is-verified).

--- a/examples/storage-adapters/kotlin/SqliteProtocolStateStorage.kt
+++ b/examples/storage-adapters/kotlin/SqliteProtocolStateStorage.kt
@@ -28,7 +28,9 @@ import uniffi.offline_protocol.ProtocolStateStorageProvider
  *
  * Logout: an application that points documents here MUST call
  * `DataStore.wipeAll()` on logout. `wipePersistedState` clears the default
- * provider's directory, which this database is not inside.
+ * provider's directory, which this database is not inside. Stop the protocol
+ * first: with the engine running and sessions live, the peer's next version
+ * offer recreates and refills every document it wiped.
  */
 class SqliteProtocolStateStorage(
     context: Context,

--- a/examples/storage-adapters/python/sqlite_state_storage.py
+++ b/examples/storage-adapters/python/sqlite_state_storage.py
@@ -21,7 +21,9 @@ is empty. Green is the definition of "this backend is supported".
 
 Logout: an application that points documents here **must** call
 ``DataStore.wipe_all()`` on logout. ``wipePersistedState`` clears the
-default provider's directory, which this database is not inside.
+default provider's directory, which this database is not inside. Stop the
+protocol first: with the engine running and sessions live, the peer's next
+version offer recreates and refills every document it wiped.
 """
 
 from __future__ import annotations

--- a/examples/storage-adapters/swift/SqliteProtocolStateStorage.swift
+++ b/examples/storage-adapters/swift/SqliteProtocolStateStorage.swift
@@ -22,7 +22,9 @@ import SQLite3
 ///
 /// Logout: an application that points documents here MUST call
 /// `DataStore.wipeAll()` on logout. `wipePersistedState` clears the default
-/// provider's directory, which this database is not inside.
+/// provider's directory, which this database is not inside. Stop the protocol
+/// first: with the engine running and sessions live, the peer's next version
+/// offer recreates and refills every document it wiped.
 final class SqliteProtocolStateStorage: ProtocolStateStorageProvider {
 
     private var db: OpaquePointer?


### PR DESCRIPTION
Closes the two non-blocking residuals filed at review pass 5 of #382.

## #385: a transient pre-flush failure can refold a local edit, and the warn text is wrong for `DocTooLarge`

`4a71422e` drains local edits before applying a remote change, so they leave on their own delta instead of being folded into the imported change and suppressed as an echo toward the one peer they were owed to. That pre-flush was reported and stepped over for **every** error alike, but the two errors say opposite things about what is still pending.

- **`DocTooLarge`**: the delta record was written, pushed and announced, and only the size verdict that follows failed. Nothing is pending. The old message told an operator the opposite, on the one document they are most likely to be reading about.
- **Anything else**: the commit may be un-exported. The delta-write failure at `data.rs:1094` rewinds it back into the pending set, and `data_apply_remote`'s internal flush (`origin = Some(space)`) then performs exactly the fold the pre-flush exists to prevent. A storage write that fails once and succeeds a moment later reproduces the original bug for one window, with no compensating announcement.

The two are now told apart, both messages corrected, and a failed pre-flush followed by an import that **applied** offers versions so the peer asks for what it is missing.

**Why the `Applied` gate is also the termination argument:** the fold needs the import's own flush to have succeeded. A storage failure still in force fails that one too, which makes the import answer `Err` and sends no offer. So every offer costs a fresh transient failure that recovered inside a single frame, and the offers cannot sustain each other. `origin` is `None` rather than the space, because what may be stranded is this device's own edit and naming the space would suppress the announcement toward the only peer that could act on it.

Documented as a MAY in the spec's frame table and the module doc's "Every leg ends", alongside the existing pre-flush `delta` exemption.

### Tests

Both negative-controlled, and the first version of the second one was **vacuous** until the mutation caught it.

- `a_local_edit_stranded_by_a_failed_pre_flush_is_announced_to_the_peer` fails one `DATA_DELTA_LOG` write and then behaves. One write rather than all of them: a store that never recovers fails the import's flush too, and there is no fold to compensate for.
- `a_document_over_its_cap_still_accepts_a_remote_change` covers the other arm, where refusing the import would close the only door back under the cap. It asserts the push as well as the commit, because the push is the half of the corrected message no local read can see.

Two staging notes worth keeping: the cap is measured over an export that **includes un-folded delta history**, so a document nudged over the line by its history drops back under as soon as compaction runs and the next flush answers `Ok`. The content itself has to exceed the cap. And a deletion large enough to matter brings the document back under before the flush under test runs, so the pending edit has to be the small seed.

Removing the pre-flush entirely fails all three pre-flush tests, each with its own message; each new test fails only for its own mutation.

## #384: `wipeAll()` on a running engine is undone by the peer's next sync offer

Option 1 from the issue, which is owed regardless. `wipeAll()` does its job correctly and every document comes back if the engine is still running with live sessions: no tombstones means nothing distinguishes a wiped space from one this device has never seen, and both directions refill. There is no error and no event.

Every mention framed the call as the logout path, where the engine is being torn down anyway, and none said what happens anywhere else. The caveat now sits next to the `deleteDoc` one it generalises, and is restated at all 13 sites: API reference, upgrade guide, configuration guide, React Native and Python bridge docs, bridge contracts, storage adapter references, the three reference adapters, the TypeScript surface, the UDL comment, and the method's own docs on both the core and FFI side. Three of those (the reference adapters, the TypeScript JSDoc, the UDL comment) were not in the issue's list and came out of the repo-wide grep.

**Option 2 (self-enforcing) considered and not taken.** `wipeAll()` is the logout path, and an error returned during teardown ordering is its own hazard, as the issue says. A runtime warning is worse than it sounds: nothing clears the sync capability at `stop()`, so it would fire on the documented happy path too and train operators to ignore it. Tombstones (option 3) are out of scope and would need a new `v`.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `npx tsc --noEmit`, and the full `cargo test --workspace`: **2,363 passed, 0 failed** (tallied from the log, not a piped exit code).

The UDL change is comment-only, so it produces no binding drift. Proved rather than assumed: `./scripts/generate-bindings.sh` regenerated Swift, Kotlin and Python, and the UDL is the only modified file.

Fixes #384
Fixes #385