### PR TITLE
feat(protocol): replicate documents in group spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,48 @@ archived by series under [docs/changelog/](docs/changelog/); see the
 
 ### Added
 
+- **Documents replicate in groups, encrypted once for the whole roster.** A
+  space named after a group id replicates with that group: the roster is the
+  replica set, membership is the existing MLS roster, and there is no second
+  membership system to disagree with it. A change is encrypted once and fanned
+  out per member on the same ladder a group message takes, so a group of ten
+  costs one encryption rather than ten.
+
+  Everything the 1:1 layer established carries over unchanged, because it is
+  the same code: the same frame family, the same version exchange, the same
+  catch-up ladder, and the same import containment. What is new is that a
+  space now has more than one other replica in it, which the three rules below
+  exist to handle.
+
+  **A change received from the group is never pushed back into it.** One group
+  ciphertext already reached every member; re-broadcasting would turn a single
+  edit into N² frames and get worse as the group grows.
+
+  **Version offers and their answers are addressed to one member.** Reconciling
+  with a peer is a conversation between two devices even inside a group, so
+  every other member is spared traffic about a question they did not ask. Only
+  a local commit goes to the roster.
+
+  **A member that cannot intercept these frames closes the gate for
+  everyone.** This is negotiated as a second `data_versions` entry rather than
+  a version bump, and the distinction matters: an install shipping the 1:1
+  layer replicates 1:1 perfectly well and has no group interception at all, so
+  a group replication frame would surface to its user as literal text. One
+  ciphertext serves the roster, so one such member means nobody is sent one.
+  Because members of a group never exchange key packages with each other, an
+  inviter attests the capability on the Add commit and in the Welcome, the way
+  it already attests rich-payload support; a later direct exchange always
+  overrides an attestation.
+
+  A group space reconciles when a member is invited, when this device joins,
+  and whenever a member is rediscovered. There is no cold-start sweep: a local
+  commit is already pushed when it happens and the per-member outbox carries it
+  across a restart.
+
+  Replication frames are never sent over the relay broadcast path, which exists
+  to produce a per-recipient delivery report about an application-facing
+  message; a replication frame has no such identity to report on.
+
 - **Documents replicate between peers, over the delivery ladder that was
   already there.** Two devices with a secure session converge on the documents
   they share: changes made offline on both sides merge on reconnect, and a
@@ -63,10 +105,9 @@ archived by series under [docs/changelog/](docs/changelog/); see the
 
   A document too large to catch up inside one frame is reported rather than
   sent; carrying one over the media transfer path is not yet implemented.
-  Group spaces are not yet replicated — this release is 1:1 only. Deletion has
-  no tombstone yet, so deleting a document from a space named after a peer is
-  local cleanup that their next offer undoes; empty the document to retire its
-  contents on both sides.
+  Deletion has no tombstone yet, so deleting a document from a replicated
+  space is local cleanup that the next offer undoes; empty the document to
+  retire its contents on both sides.
 
   **One known gap.** Replicas that stay in contact converge. Replicas
   separated by a partition that outlives a compaction may not: compaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   to produce a per-recipient delivery report about an application-facing
   message; a replication frame has no such identity to report on.
 
+  Because a group has one sender ratchet per epoch, an addressed frame still
+  advances the generation every *other* member has to reach, and MLS refuses a
+  generation too far ahead of the last one a receiver saw. A sender therefore
+  sends one frame to the whole roster after enough addressed ones, which keeps
+  every member's ratchet within reach; ordinary group chat does the same job,
+  so this only ever fires in a group that is purely replicating documents.
+  Without it a group could quietly stop delivering a talkative member's
+  messages, chat included, until a commit rotated the epoch.
+
 - **Documents replicate between peers, over the delivery ladder that was
   already there.** Two devices with a secure session converge on the documents
   they share: changes made offline on both sides merge on reconnect, and a

--- a/crates/offline-protocol-data/src/lib.rs
+++ b/crates/offline-protocol-data/src/lib.rs
@@ -90,6 +90,52 @@ pub fn validate_name(name: &str) -> DataResult<()> {
     Ok(())
 }
 
+/// Check a space name.
+///
+/// Looser than [`validate_name`] by exactly one character, the colon, and
+/// the reason is that a space is named after the MLS scope it replicates
+/// in. A 1:1 space is named by a peer address; a group space is named by
+/// the group id, which is minted as `group:<uuid>`. Refusing the colon
+/// would mean either giving group spaces a second, translated name — one
+/// more mapping to keep consistent and to get wrong — or refusing group
+/// replication outright.
+///
+/// The colon is safe here in a way it would not be in a document name.
+/// Record keys are composed as `{space}/{doc}` and `{space}/{doc}/{seq}`
+/// and are parsed by stripping the space prefix and splitting the
+/// remainder on `/`, so only the separator itself can make a key parse
+/// back into different parts than it was built from, and that stays
+/// forbidden.
+///
+/// Document names deliberately keep the narrow charset: a peer names those
+/// on the wire, and this one is never wire-supplied. A 1:1 space is derived
+/// from the authenticated sender of the frame and a group space from the
+/// group whose key decrypted it, so a peer cannot choose either.
+pub fn validate_space_name(name: &str) -> DataResult<()> {
+    if name.is_empty() {
+        return Err(DataError::InvalidName {
+            name: name.to_string(),
+            reason: "must not be empty",
+        });
+    }
+    if name.len() > MAX_NAME_LEN {
+        return Err(DataError::InvalidName {
+            name: name.to_string(),
+            reason: "longer than MAX_NAME_LEN",
+        });
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-' | b':'))
+    {
+        return Err(DataError::InvalidName {
+            name: name.to_string(),
+            reason: "may only contain A-Z a-z 0-9 . _ - :",
+        });
+    }
+    Ok(())
+}
+
 /// Check a map key.
 ///
 /// Keys are looser than names because they never enter a record key: they

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -32,6 +32,45 @@ pub(super) const GROUP_MESSAGE_DEDUP_TTL_SECS: u64 = 300;
 pub(super) const MAX_GROUP_MESSAGE_DEDUP_ENTRIES: usize = 10_000;
 /// Maximum allowed base64-encoded payload size for incoming group messages (1 MB).
 pub(crate) const MAX_BASE64_PAYLOAD_SIZE: usize = 1_048_576;
+/// How many application messages this device may encrypt under a group key
+/// without delivering one to the whole roster, before the next frame is
+/// promoted to roster-wide.
+///
+/// A group has one sender ratchet per epoch, so *every* encryption advances
+/// the generation every member must reach to decrypt anything later from
+/// this device. A frame delivered to one member advances it for all of them
+/// and is observed by one, and OpenMLS refuses a generation more than
+/// [`SENDER_RATCHET_MAXIMUM_FORWARD_DISTANCE`] (1000) ahead of the highest
+/// a receiver has seen. Past that gap the absent member cannot decrypt this
+/// device's next frame, and cannot decrypt the one after that either,
+/// because nothing advanced their ratchet: the group silently stops
+/// receiving this device's messages, chat included, until a commit rotates
+/// the epoch. A stable group produces no commits.
+///
+/// Directed replication answers are the first traffic in this SDK that
+/// advances the ratchet without every member seeing it, and they are
+/// produced by rediscovery rather than by anything the user does, so
+/// unbounded they cross 1000 on their own. Promoting one frame per budget
+/// to the whole roster puts a decryptable rung in every member's outbox and
+/// bounds the gap at the budget, restoring the property group messaging
+/// always had: generations advance roughly with roster-wide traffic.
+///
+/// 256 leaves room for three consecutive promoted frames to be lost outright
+/// and the fourth still to decrypt. It does not rescue a member absent long
+/// enough for the outbox to expire every rung (7 days); that case predates
+/// group replication and is bounded by the epoch, not by this.
+///
+/// [`SENDER_RATCHET_MAXIMUM_FORWARD_DISTANCE`]: offline_protocol_mls::group::SENDER_RATCHET_MAXIMUM_FORWARD_DISTANCE
+pub(crate) const MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS: u32 = 256;
+
+/// The budget is only meaningful below the distance it is protecting, and
+/// the two live in different crates. Stated to the compiler so raising the
+/// budget past the limit fails the build rather than shipping a bound that
+/// no longer bounds anything.
+const _: () = assert!(
+    MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS
+        < offline_protocol_mls::group::SENDER_RATCHET_MAXIMUM_FORWARD_DISTANCE
+);
 /// How long an outstanding relay group registration waits for its
 /// `__GROUP_CREATED__` answer before the correlation entry is expired. The
 /// relay answers within a round trip, so this is generous slack; what it
@@ -287,6 +326,21 @@ pub(crate) struct GroupMeshState {
     /// Deduplication cache for group messages received via multiple paths.
     /// Key: message ID, Value: when first seen.
     pub(crate) message_dedup: HashMap<String, Instant>,
+
+    /// Per group, how many application messages this device has encrypted
+    /// under the group key since it last sent one to the whole roster.
+    ///
+    /// The sender ratchet is per epoch and shared by every recipient, so a
+    /// frame addressed to one member still advances the generation the
+    /// others must reach. This counts how far that has run ahead of what
+    /// the roster has been given a chance to observe;
+    /// [`MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS`] documents what happens
+    /// when it is allowed to run to 1000.
+    ///
+    /// Bounded exactly like [`Self::members`], keyed the same way and
+    /// pruned on the same teardown paths. A stale entry would be harmless
+    /// anyway: it can only buy one early roster-wide frame after a re-join.
+    pub(crate) roster_invisible_generations: HashMap<String, u32>,
 
     /// Buffer for out-of-order MLS commits that failed to decrypt.
     /// Maps group_id -> deque of pending commits awaiting retry.
@@ -1777,6 +1831,9 @@ impl OfflineProtocol {
                         let _ = mls_guard.leave_group(&gid);
                     }
                     self.group_mesh.members.remove(&payload.group_id);
+                    self.group_mesh
+                        .roster_invisible_generations
+                        .remove(&payload.group_id);
                     let was_synced = self.group_mesh.relay_synced.remove(&payload.group_id);
                     let was_pending = self
                         .group_mesh
@@ -3642,6 +3699,9 @@ impl OfflineProtocol {
         // after we leave, and a stale one retried after a rapid re-invite
         // would expire with retry_count > 0 and falsely flag an epoch fork.
         self.group_mesh.members.remove(group_id);
+        self.group_mesh
+            .roster_invisible_generations
+            .remove(group_id);
         let was_synced = self.group_mesh.relay_synced.remove(group_id);
         let was_pending = self
             .group_mesh
@@ -3995,6 +4055,13 @@ impl OfflineProtocol {
             let gid = offline_protocol_mls::GroupId::new(group_id)?;
             mls_guard.encrypt_for_group(&gid, plaintext.as_bytes())?
         };
+        // Every member is given this one, by relay broadcast or per-member
+        // fan-out, so it is the rung that closes whatever gap the directed
+        // replication frames opened. Ordinary group chat is therefore what
+        // normally keeps the budget clear, and the promotion in
+        // `send_group_internal_frame` is what covers a group that is only
+        // replicating documents.
+        self.note_group_generation(group_id, true);
 
         let ciphertext_b64 = base64_encode(&encrypted.ciphertext);
         let epoch = encrypted.epoch;
@@ -5012,9 +5079,24 @@ impl OfflineProtocol {
         target: Option<&str>,
         plaintext: &str,
     ) -> Result<()> {
+        // A directed frame advances the group's sender ratchet for every
+        // member while only one of them observes it, so the addressing that
+        // keeps this traffic cheap is also what opens a decryption gap in
+        // the members it skips. Once the budget is spent the next frame goes
+        // to the whole roster instead, buying every member a rung they can
+        // still decrypt. See [`MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS`].
+        //
+        // Whatever the frame happens to be is safe to hand the roster: a
+        // delta or snapshot is an idempotent import the no-echo rule stops
+        // there, and a reply-offer names documents a current replica answers
+        // with nothing. The one that is merely wasteful is a snapshot
+        // request, which every member then answers instead of one; it is
+        // bounded by the blob cap and happens at most once per budget, which
+        // is cheaper than threading the body kind down here to avoid it.
+        let roster_wide = target.is_none() || self.group_generation_budget_spent(group_id);
         let members = match target {
-            Some(member) => vec![member.to_string()],
-            None => self.group_roster(group_id)?,
+            Some(member) if !roster_wide => vec![member.to_string()],
+            _ => self.group_roster(group_id)?,
         };
         if members.iter().all(|m| m == &self.local_id) {
             return Ok(());
@@ -5025,6 +5107,16 @@ impl OfflineProtocol {
             let gid = offline_protocol_mls::GroupId::new(group_id)?;
             mls_guard.encrypt_for_group(&gid, plaintext.as_bytes())?
         };
+        // Past the encryption, which is where the generation is actually
+        // spent: an error above consumed nothing.
+        self.note_group_generation(group_id, roster_wide);
+        if roster_wide && target.is_some() {
+            debug!(
+                group_id = %group_id,
+                "Promoting a directed replication frame to the whole roster to keep \
+                 every member's sender ratchet within reach"
+            );
+        }
         let ciphertext_b64 = base64_encode(&encrypted.ciphertext);
 
         let (_ids, _ok, failed) = self.fanout_group_frames_per_member(
@@ -5050,6 +5142,38 @@ impl OfflineProtocol {
             );
         }
         Ok(())
+    }
+
+    /// Whether this device has encrypted
+    /// [`MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS`] frames for `group_id`
+    /// without handing the whole roster one to observe.
+    fn group_generation_budget_spent(&self, group_id: &str) -> bool {
+        self.group_mesh
+            .roster_invisible_generations
+            .get(group_id)
+            .is_some_and(|spent| *spent >= MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS)
+    }
+
+    /// Records one group encryption against the ratchet-gap budget.
+    ///
+    /// Reset on a roster-wide send rather than on confirmed delivery,
+    /// deliberately: an unreachable member's copy is parked in the outbox
+    /// and arrives in order behind the others, so it is a rung they will
+    /// climb rather than one they missed. Waiting for delivery would mean a
+    /// single member who is merely offline pins every later frame to the
+    /// whole roster, which spends uplink on all of them to fix nothing.
+    fn note_group_generation(&mut self, group_id: &str, roster_wide: bool) {
+        if roster_wide {
+            self.group_mesh
+                .roster_invisible_generations
+                .remove(group_id);
+        } else {
+            *self
+                .group_mesh
+                .roster_invisible_generations
+                .entry(group_id.to_string())
+                .or_insert(0) += 1;
+        }
     }
 
     /// The roster of a group this device is a member of, cache first.

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -5078,8 +5078,21 @@ impl OfflineProtocol {
     /// a sealed record, or a frame that has just been decrypted. Both are
     /// dominated by work an order of magnitude larger than a group-state
     /// read.
+    ///
+    /// The `session:` namespace is refused before either lookup. MLS holds a
+    /// group per 1:1 session, and unlike [`Self::list_groups`], the
+    /// group-info read underneath answers for one — so a space named after a
+    /// session slot would otherwise be classified as a group space, and
+    /// `refresh_group_members` would then file that slot in
+    /// `group_mesh.members`, which leave, auto-promotion and the shared-group
+    /// sweep all read as the set of real groups. A space name is never
+    /// wire-supplied, so this is a local-caller footgun rather than a reachable
+    /// attack, and it costs one prefix test to make structurally impossible.
     #[cfg_attr(not(feature = "data"), allow(dead_code))]
     pub(crate) fn group_space_roster(&mut self, space: &str) -> Option<Vec<String>> {
+        if Self::is_session_group_id(space) {
+            return None;
+        }
         if let Some(members) = self.group_mesh.members.get(space) {
             return Some(members.clone());
         }

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -3344,7 +3344,15 @@ impl OfflineProtocol {
             .filter(|m| m.as_str() != invitee_user_id)
             .filter_map(|m| {
                 if *m == self_id {
-                    (!self.advertised_data_versions().is_empty())
+                    // Attest the entry itself, not merely that some data
+                    // version is advertised. The two coincide today because
+                    // one switch produces both, but claiming DATA_GROUP_V1
+                    // for a build that does not intercept group frames is
+                    // the single error that puts `__DATA_V1__` in front of a
+                    // user as text, and a self-attestation is the one place
+                    // the claim cannot be corrected by a direct exchange.
+                    self.advertised_data_versions()
+                        .contains(&DATA_GROUP_V1)
                         .then(|| (m.clone(), vec![DATA_GROUP_V1]))
                 } else {
                     self.attestable_data_versions(m).map(|v| (m.clone(), v))

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -60,6 +60,12 @@ pub(crate) const MAX_BASE64_PAYLOAD_SIZE: usize = 1_048_576;
 /// enough for the outbox to expire every rung (7 days); that case predates
 /// group replication and is bounded by the epoch, not by this.
 ///
+/// The budget bounds one epoch in one process, which is the only span the
+/// count can speak for: a commit restarts every member's ratchet, and a
+/// relaunch inherits a generation this device cannot read back. Both edges
+/// are handled where the count is stored rather than here, by
+/// [`GroupMeshState::roster_invisible_generations`].
+///
 /// [`SENDER_RATCHET_MAXIMUM_FORWARD_DISTANCE`]: offline_protocol_mls::group::SENDER_RATCHET_MAXIMUM_FORWARD_DISTANCE
 pub(crate) const MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS: u32 = 256;
 
@@ -312,6 +318,26 @@ fn claim_report_window<K: Eq + std::hash::Hash + Clone>(
     true
 }
 
+/// How far this device's group sender ratchet has run ahead of what the
+/// roster has been given a chance to observe, within one epoch.
+///
+/// Epoch-scoped because the thing it stands for is: a commit rotates the
+/// epoch and every member starts the new one at generation zero, so a count
+/// carried across a rotation describes a gap that no longer exists. Keyed by
+/// epoch rather than cleared at each rotation site so that a rotation this
+/// device has not yet noticed cannot leave the count describing the wrong
+/// epoch, and so a new rotation site cannot be added without one.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RosterRatchetGap {
+    /// The group epoch [`Self::invisible`] counts within.
+    pub(crate) epoch: u64,
+    /// Frames encrypted for the group in that epoch that were delivered to
+    /// fewer than all of its members. Zero means the roster has observed
+    /// this device at this epoch, which is what makes an entry with a count
+    /// of zero different from no entry at all.
+    pub(crate) invisible: u32,
+}
+
 /// Bundled state for group messaging.
 ///
 /// Groups together the cached member lists, dedup table, pending commit
@@ -327,8 +353,8 @@ pub(crate) struct GroupMeshState {
     /// Key: message ID, Value: when first seen.
     pub(crate) message_dedup: HashMap<String, Instant>,
 
-    /// Per group, how many application messages this device has encrypted
-    /// under the group key since it last sent one to the whole roster.
+    /// Per group, how far this device's sender ratchet has run ahead of the
+    /// roster, and in which epoch.
     ///
     /// The sender ratchet is per epoch and shared by every recipient, so a
     /// frame addressed to one member still advances the generation the
@@ -337,10 +363,19 @@ pub(crate) struct GroupMeshState {
     /// [`MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS`] documents what happens
     /// when it is allowed to run to 1000.
     ///
+    /// **A missing entry means "unknown", not "zero".** The MLS sender
+    /// ratchet is persisted with the group state and this map is not, so a
+    /// relaunch inherits a generation it cannot see: counting from zero
+    /// there would let a device that restarts often accumulate the gap
+    /// across sessions and strand a member without the budget ever
+    /// tripping. An absent entry therefore reads as spent, so the first
+    /// directed frame per group per process is promoted and re-bases every
+    /// member's reachable window. That costs one roster-wide frame per
+    /// group per launch and is what makes the bound hold across restarts.
+    ///
     /// Bounded exactly like [`Self::members`], keyed the same way and
-    /// pruned on the same teardown paths. A stale entry would be harmless
-    /// anyway: it can only buy one early roster-wide frame after a re-join.
-    pub(crate) roster_invisible_generations: HashMap<String, u32>,
+    /// pruned on the same teardown paths.
+    pub(crate) roster_invisible_generations: HashMap<String, RosterRatchetGap>,
 
     /// Buffer for out-of-order MLS commits that failed to decrypt.
     /// Maps group_id -> deque of pending commits awaiting retry.
@@ -4069,7 +4104,7 @@ impl OfflineProtocol {
         // normally keeps the budget clear, and the promotion in
         // `send_group_internal_frame` is what covers a group that is only
         // replicating documents.
-        self.note_group_generation(group_id, true);
+        self.note_group_generation(group_id, encrypted.epoch, true);
 
         let ciphertext_b64 = base64_encode(&encrypted.ciphertext);
         let epoch = encrypted.epoch;
@@ -5087,6 +5122,63 @@ impl OfflineProtocol {
         target: Option<&str>,
         plaintext: &str,
     ) -> Result<()> {
+        // Read either way, because both the promotion gate below and the
+        // roster-wide delivery list need it, and a directed send has
+        // already paid for it upstream.
+        let members = self.group_roster(group_id)?;
+        if members.iter().all(|m| m == &self.local_id) {
+            return Ok(());
+        }
+        // A promotion is a roster-wide delivery, so it answers to the
+        // all-members gate that every roster-wide delivery answers to: a
+        // member that does not intercept these frames renders one as
+        // literal `__DATA_V1__` text. A directed frame needs no such check
+        // (the member it answers asked for it, which is proof enough), but
+        // handing that same frame to the whole roster is exactly the send
+        // the gate exists to refuse. Consulted here rather than upstream
+        // because this is the only place a directed frame can become a
+        // roster-wide one.
+        let gate_open = self.group_data_sync_active(&members);
+
+        // Only a directed frame can be promoted, so only it needs the epoch
+        // before the encryption; a roster-wide one takes the epoch it was
+        // encrypted under. Read ahead of the encryption because the answer
+        // below can be "do not encrypt at all", and encrypting is the one
+        // step that cannot be taken back: it advances the ratchet for every
+        // member whether or not the frame is ever delivered.
+        let budget_spent = match target {
+            Some(_) => {
+                let epoch = self.group_epoch(group_id)?;
+                self.group_generation_budget_spent(group_id, epoch)
+            }
+            None => false,
+        };
+        if budget_spent && !gate_open {
+            // The gap is at the bound and the only frame that could close
+            // it is one this roster may not be sent. Encrypting anyway
+            // would spend another generation that no member except the
+            // target can ever observe, and past the forward-distance limit
+            // that costs them this device's group *chat*, not just its
+            // documents. Convergence with the member that asked is the
+            // cheaper thing to lose: replication here is already stalled
+            // group-wide on the member holding the gate shut, who is being
+            // probed, and either an ordinary group message or the gate
+            // opening releases this.
+            debug!(
+                group_id = %group_id,
+                "Withholding a directed replication frame: its ratchet budget is \
+                 spent and the group's replication gate is held closed, so the \
+                 promotion that would close the gap may not be sent"
+            );
+            return Ok(());
+        }
+
+        let encrypted = {
+            let mls_guard = self.read_mls_guard()?;
+            let gid = offline_protocol_mls::GroupId::new(group_id)?;
+            mls_guard.encrypt_for_group(&gid, plaintext.as_bytes())?
+        };
+
         // A directed frame advances the group's sender ratchet for every
         // member while only one of them observes it, so the addressing that
         // keeps this traffic cheap is also what opens a decryption gap in
@@ -5101,24 +5193,17 @@ impl OfflineProtocol {
         // request, which every member then answers instead of one; it is
         // bounded by the blob cap and happens at most once per budget, which
         // is cheaper than threading the body kind down here to avoid it.
-        let roster_wide = target.is_none() || self.group_generation_budget_spent(group_id);
-        let members = match target {
-            Some(member) if !roster_wide => vec![member.to_string()],
-            _ => self.group_roster(group_id)?,
-        };
-        if members.iter().all(|m| m == &self.local_id) {
-            return Ok(());
-        }
-
-        let encrypted = {
-            let mls_guard = self.read_mls_guard()?;
-            let gid = offline_protocol_mls::GroupId::new(group_id)?;
-            mls_guard.encrypt_for_group(&gid, plaintext.as_bytes())?
-        };
+        //
+        // The gate was cleared above, so a spent budget here is a promotion.
+        let promoted = budget_spent;
+        let roster_wide = target.is_none() || promoted;
+        // Counted against the epoch the frame was actually encrypted under
+        // rather than the one read above: a rotation between the two would
+        // otherwise file the count under an epoch no frame belongs to.
         // Past the encryption, which is where the generation is actually
         // spent: an error above consumed nothing.
-        self.note_group_generation(group_id, roster_wide);
-        if roster_wide && target.is_some() {
+        self.note_group_generation(group_id, encrypted.epoch, roster_wide);
+        if promoted {
             debug!(
                 group_id = %group_id,
                 "Promoting a directed replication frame to the whole roster to keep \
@@ -5126,10 +5211,14 @@ impl OfflineProtocol {
             );
         }
         let ciphertext_b64 = base64_encode(&encrypted.ciphertext);
+        let recipients = match target {
+            Some(member) if !roster_wide => vec![member.to_string()],
+            _ => members,
+        };
 
         let (_ids, _ok, failed) = self.fanout_group_frames_per_member(
             group_id,
-            &members,
+            &recipients,
             None,
             &ciphertext_b64,
             encrypted.epoch,
@@ -5153,16 +5242,37 @@ impl OfflineProtocol {
     }
 
     /// Whether this device has encrypted
-    /// [`MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS`] frames for `group_id`
-    /// without handing the whole roster one to observe.
-    fn group_generation_budget_spent(&self, group_id: &str) -> bool {
-        self.group_mesh
-            .roster_invisible_generations
-            .get(group_id)
-            .is_some_and(|spent| *spent >= MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS)
+    /// [`MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS`] frames for `group_id` at
+    /// `epoch` without handing the whole roster one to observe.
+    ///
+    /// Three answers, and the two that are not a comparison carry the
+    /// mechanism:
+    ///
+    /// - **No entry: spent.** This process has never given the roster a
+    ///   frame in this group, and the generation it inherited from earlier
+    ///   sessions is not readable from here. See
+    ///   [`GroupMeshState::roster_invisible_generations`].
+    /// - **An entry for another epoch: not spent.** A rotation this device
+    ///   recorded either side of is a ratchet every member restarted at
+    ///   zero, so whatever gap the old epoch held is gone. Promoting there
+    ///   would spend a roster-wide frame to close nothing.
+    fn group_generation_budget_spent(&self, group_id: &str, epoch: u64) -> bool {
+        match self.group_mesh.roster_invisible_generations.get(group_id) {
+            Some(gap) if gap.epoch == epoch => {
+                gap.invisible >= MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS
+            }
+            Some(_) => false,
+            None => true,
+        }
     }
 
-    /// Records one group encryption against the ratchet-gap budget.
+    /// Records one group encryption at `epoch` against the ratchet-gap
+    /// budget.
+    ///
+    /// A roster-wide send stores a count of zero rather than removing the
+    /// entry: absence is how a process that has never given this roster a
+    /// frame is told apart from one that just did, and removing here would
+    /// make every send after a roster-wide one promote.
     ///
     /// Reset on a roster-wide send rather than on confirmed delivery,
     /// deliberately: an unreachable member's copy is parked in the outbox
@@ -5170,18 +5280,45 @@ impl OfflineProtocol {
     /// climb rather than one they missed. Waiting for delivery would mean a
     /// single member who is merely offline pins every later frame to the
     /// whole roster, which spends uplink on all of them to fix nothing.
-    fn note_group_generation(&mut self, group_id: &str, roster_wide: bool) {
-        if roster_wide {
-            self.group_mesh
-                .roster_invisible_generations
-                .remove(group_id);
-        } else {
-            *self
-                .group_mesh
-                .roster_invisible_generations
-                .entry(group_id.to_string())
-                .or_insert(0) += 1;
+    fn note_group_generation(&mut self, group_id: &str, epoch: u64, roster_wide: bool) {
+        let entry = self
+            .group_mesh
+            .roster_invisible_generations
+            .entry(group_id.to_string())
+            .or_insert(RosterRatchetGap {
+                epoch,
+                invisible: 0,
+            });
+        if entry.epoch != epoch {
+            // The epoch moved under us: the old count described a ratchet
+            // every member has since restarted.
+            *entry = RosterRatchetGap {
+                epoch,
+                invisible: 0,
+            };
         }
+        if roster_wide {
+            entry.invisible = 0;
+        } else {
+            entry.invisible = entry.invisible.saturating_add(1);
+        }
+    }
+
+    /// The epoch a group is currently on.
+    ///
+    /// Deliberately not cached: the ratchet-gap budget is only meaningful
+    /// against the epoch the next encryption will actually use, and a stale
+    /// epoch here reads a count filed under a ratchet every member has since
+    /// restarted. Paid only on the directed-send path, and dominated by the
+    /// group encryption it precedes.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn group_epoch(&self, group_id: &str) -> Result<u64> {
+        let mls_guard = self.read_mls_guard()?;
+        let gid = offline_protocol_mls::GroupId::new(group_id)?;
+        let info = mls_guard
+            .get_group_info(&gid)?
+            .ok_or_else(|| Error::GroupNotFound(group_id.to_string()))?;
+        Ok(info.epoch)
     }
 
     /// The roster of a group this device is a member of, cache first.

--- a/crates/offline-protocol/src/group_mesh.rs
+++ b/crates/offline-protocol/src/group_mesh.rs
@@ -11,7 +11,8 @@
 
 use crate::protocol::{
     base64_decode, base64_encode, internal_prefixes, GroupMemberRemovedPayload,
-    InternalMessageResult, OfflineProtocol, RichPayloadV1, RichSendExtras, RICH_PAYLOAD_V1,
+    InternalMessageResult, OfflineProtocol, RichPayloadV1, RichSendExtras, DATA_GROUP_V1,
+    RICH_PAYLOAD_V1,
 };
 use crate::{Error, Event, Result};
 use chrono::{DateTime, Utc};
@@ -561,6 +562,20 @@ pub(crate) struct GroupMlsWelcomePayload {
     /// overrides its attested entry.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub(crate) member_rich: HashMap<String, Vec<u8>>,
+    /// Group-replication versions the inviter attests per existing member,
+    /// the [`DATA_GROUP_V1`] sibling of [`Self::member_rich`] and additive
+    /// in the same way (absent from old SDKs, absence means "no
+    /// information").
+    ///
+    /// Without it a joiner replicates documents only with members it has
+    /// separately exchanged key packages with, which on a group it was
+    /// invited into is typically just the inviter. Identical recipient-side
+    /// trust bounds: entries outside the joined MLS roster are ignored, and
+    /// a later direct key-package exchange overrides an attested entry.
+    ///
+    /// [`DATA_GROUP_V1`]: crate::protocol::types::DATA_GROUP_V1
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub(crate) member_data: HashMap<String, Vec<u8>>,
     /// The group creator the inviter has on record (additive; absent from
     /// old SDKs and from inviters whose own metadata never learned it).
     ///
@@ -622,6 +637,15 @@ pub(crate) struct GroupMlsCommitPayload {
     /// later direct key-package exchange overrides it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) affected_member_rich: Option<Vec<u8>>,
+    /// Group-replication versions the inviter attests for the added member,
+    /// the [`DATA_GROUP_V1`] sibling of [`Self::affected_member_rich`],
+    /// with the same trust bounds: honored only for the member the MLS
+    /// state delta actually added, only from an admin sender, and
+    /// overridden by a later direct key-package exchange.
+    ///
+    /// [`DATA_GROUP_V1`]: crate::protocol::types::DATA_GROUP_V1
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) affected_member_data: Option<Vec<u8>>,
 }
 
 /// Payload for group leave notifications sent via mesh.
@@ -1135,6 +1159,17 @@ impl OfflineProtocol {
                 // message dedups against this one, and emit it as the
                 // app-facing id so every member sees the same id for this
                 // logical message regardless of arrival path.
+                // Replication rides the group ciphertext, so it surfaces
+                // here, in the one place a group plaintext is known to be
+                // authentic and attributed. Consumed rather than emitted:
+                // an app that received this as a message would render the
+                // frame as text.
+                #[cfg(feature = "data")]
+                if let Some(body) = text.strip_prefix(internal_prefixes::DATA_V1) {
+                    let body = body.to_string();
+                    self.handle_group_data_sync_frame(&payload.group_id, sender, &body);
+                    return InternalMessageResult::Consumed;
+                }
                 let msg_id = logical_key.unwrap_or_else(|| message.id.as_str().to_string());
                 if msg_id != message.id.as_str() {
                     self.group_mesh
@@ -1483,6 +1518,14 @@ impl OfflineProtocol {
                     self.record_attested_rich(user_id, versions);
                 }
             }
+            // Same bound, same reason, for group replication: without these
+            // this device would edit documents in its new group and send
+            // them to nobody but the inviter.
+            for (user_id, versions) in &payload.member_data {
+                if members.contains(user_id) {
+                    self.record_attested_data(user_id, versions);
+                }
+            }
 
             self.group_mesh.members.insert(group_id.clone(), members);
 
@@ -1544,6 +1587,13 @@ impl OfflineProtocol {
                     "Failed to send fresh key package to inviter after Welcome (will retry on discovery)"
                 );
             }
+
+            // Ask the inviter for the group's documents. An empty offer
+            // is the request: a space this device has never seen lists no
+            // documents, and a peer reading a complete offer that omits
+            // theirs answers with the whole of each one.
+            #[cfg(feature = "data")]
+            self.kick_group_data_sync(&group_id, sender, "group_joined");
 
             self.emit_event(Event::group_member_added(
                 group_id.clone(),
@@ -1991,6 +2041,16 @@ impl OfflineProtocol {
             {
                 if member == affected && metadata_sender_is_admin {
                     self.record_attested_rich(member, versions);
+                }
+            }
+            // The group-replication half, on the same gate: without it the
+            // newcomer is invisible to this member's document sync, and the
+            // whole group's replication gate stays closed on their account.
+            if let (Some(versions), Some(affected)) =
+                (&payload.affected_member_data, &payload.affected_member)
+            {
+                if member == affected && metadata_sender_is_admin {
+                    self.record_attested_data(member, versions);
                 }
             }
             self.emit_event(Event::group_member_added(
@@ -2617,6 +2677,24 @@ impl OfflineProtocol {
                             );
                             continue;
                         };
+                        // Same interception on the drain, and the ACK is
+                        // still owed: a frame buffered until group state
+                        // caught up was deferred, so the sender is still
+                        // retransmitting it until this ACK lands.
+                        #[cfg(feature = "data")]
+                        if let Some(body) = text.strip_prefix(internal_prefixes::DATA_V1) {
+                            let body = body.to_string();
+                            let ack_sender = entry.sender.clone();
+                            let ack_message_id = entry.message_id.clone();
+                            delivered_here.insert(ack_message_id.clone());
+                            self.handle_group_data_sync_frame(group_id, &entry.sender, &body);
+                            self.ack_drained_group_message(
+                                &ack_sender,
+                                &ack_message_id,
+                                entry.received_via,
+                            );
+                            continue;
+                        }
                         info!(
                             group_id = %group_id,
                             msg_id = %entry.message_id,
@@ -3198,6 +3276,25 @@ impl OfflineProtocol {
             })
             .collect();
 
+        // The same two directions again for group replication. Documents
+        // are worse than rich extras to get wrong here: extras degrade to
+        // text the recipient still reads, whereas a member outside the
+        // attestation web simply never receives anyone's edits and has no
+        // way to notice.
+        let invitee_data = self.attestable_data_versions(invitee_user_id);
+        let member_data: HashMap<String, Vec<u8>> = members
+            .iter()
+            .filter(|m| m.as_str() != invitee_user_id)
+            .filter_map(|m| {
+                if *m == self_id {
+                    (!self.advertised_data_versions().is_empty())
+                        .then(|| (m.clone(), vec![DATA_GROUP_V1]))
+                } else {
+                    self.attestable_data_versions(m).map(|v| (m.clone(), v))
+                }
+            })
+            .collect();
+
         // Send Welcome to invitee
         let welcome_payload = GroupMlsWelcomePayload {
             group_id: group_id.to_string(),
@@ -3206,6 +3303,7 @@ impl OfflineProtocol {
             member_list: members.clone(),
             member_roles,
             member_rich,
+            member_data,
             // Carries our creator of record so the joiner's `check_is_admin`
             // has a fallback when the role snapshot above is incomplete.
             // Absent when we never learned it ourselves (joined via an older
@@ -3230,6 +3328,7 @@ impl OfflineProtocol {
             affected_member: Some(invitee_user_id.to_string()),
             role: Some(GroupRole::Member),
             affected_member_rich: invitee_rich,
+            affected_member_data: invitee_data,
         };
         let commit_content = format!(
             "{}{}",
@@ -3271,6 +3370,14 @@ impl OfflineProtocol {
 
         // Sync membership update to relay
         let _ = self.try_relay_register_group(group_id, None, &members);
+
+        // Hand the newcomer what this device holds in the group's space.
+        // Their own offer (sent when the Welcome lands) covers the same
+        // ground from the other side; both exist because either frame can
+        // be the one that is lost, and a redundant offer costs one frame
+        // that a current replica answers with nothing.
+        #[cfg(feature = "data")]
+        self.kick_group_data_sync(group_id, invitee_user_id, "member_added");
 
         info!(group_id = %group_id, invitee = %invitee_user_id, "Invited member to group");
         Ok(())
@@ -3360,6 +3467,7 @@ impl OfflineProtocol {
             affected_member: Some(member_id.to_string()),
             role: None,
             affected_member_rich: None,
+            affected_member_data: None,
         };
         let commit_content = format!(
             "{}{}",
@@ -4864,6 +4972,123 @@ impl OfflineProtocol {
         Ok((message_ids, succeeded_members, failed_members))
     }
 
+    /// Encrypts one internally-consumed plaintext for a group and delivers
+    /// it, either to the whole roster or to a single member.
+    ///
+    /// The carrier the data layer replicates over. Everything about it is
+    /// the group message path minus the parts that make a message a
+    /// message: no app-facing `GroupMessageSent` event, no logical id, no
+    /// rich extras, no reply threading. What it keeps is the part that
+    /// matters — one MLS encryption for the whole roster, and the ordinary
+    /// per-member ladder (outbox, retry, dedup, park) underneath.
+    ///
+    /// `target` is `None` for a change every member needs and `Some(member)`
+    /// for the answer to one member's question. A directed frame is still
+    /// encrypted under the group key: two members of a group need not have
+    /// a 1:1 session with each other, and making replication wait for one
+    /// would make it depend on a handshake that may never happen. The cost
+    /// is that the roster could read a directed frame if it were delivered
+    /// to them, which is not a confidentiality question — every member is
+    /// entitled to the contents — but a traffic one, and it is why the
+    /// answer legs are addressed rather than broadcast.
+    ///
+    /// Deliberately without `stage_outbox_reseal`, unlike the 1:1 sync
+    /// sender. Re-sealing stages *plaintext* to be re-encrypted for a
+    /// recipient, and this ciphertext belongs to a group epoch rather than
+    /// to a pairwise session; a staged reseal here would re-seal a group
+    /// frame as a 1:1 payload, which is worse than the retry it would
+    /// rescue. Group messaging makes the same trade for the same reason.
+    ///
+    /// Relay broadcast is deliberately not taken even for the roster-wide
+    /// case. The broadcast path arms a delivery-report correlation that
+    /// re-sends per member and emits app-facing group events; a replication
+    /// frame has no app-facing identity to report on, and the report would
+    /// name message ids the app never saw. Per-member fan-out is the
+    /// always-correct path and the one a mesh-only group takes anyway.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn send_group_internal_frame(
+        &mut self,
+        group_id: &str,
+        target: Option<&str>,
+        plaintext: &str,
+    ) -> Result<()> {
+        let members = match target {
+            Some(member) => vec![member.to_string()],
+            None => self.group_roster(group_id)?,
+        };
+        if members.iter().all(|m| m == &self.local_id) {
+            return Ok(());
+        }
+
+        let encrypted = {
+            let mls_guard = self.read_mls_guard()?;
+            let gid = offline_protocol_mls::GroupId::new(group_id)?;
+            mls_guard.encrypt_for_group(&gid, plaintext.as_bytes())?
+        };
+        let ciphertext_b64 = base64_encode(&encrypted.ciphertext);
+
+        let (_ids, _ok, failed) = self.fanout_group_frames_per_member(
+            group_id,
+            &members,
+            None,
+            &ciphertext_b64,
+            encrypted.epoch,
+            None,
+            None,
+            MessagePriority::Low,
+        )?;
+        if !failed.is_empty() {
+            // Not an error: a member that could not be reached now has the
+            // frame in their outbox entry's place in the ladder, and the
+            // version exchange on their next reconnect closes any gap the
+            // ladder does not. Logged because a persistent failure here is
+            // a group that quietly stops converging.
+            debug!(
+                group_id = %group_id,
+                failed = failed.len(),
+                "Some members could not be handed a replication frame"
+            );
+        }
+        Ok(())
+    }
+
+    /// The roster of a group this device is a member of, cache first.
+    ///
+    /// The cache is authoritative when populated and empty after a restart,
+    /// so a miss is not an answer: MLS is consulted and the cache filled,
+    /// which is the same fallback [`Self::send_group_message_inner`] makes
+    /// for the same reason.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn group_roster(&mut self, group_id: &str) -> Result<Vec<String>> {
+        if let Some(members) = self.group_mesh.members.get(group_id) {
+            return Ok(members.clone());
+        }
+        self.refresh_group_members(group_id)
+    }
+
+    /// The roster of `space`, when `space` names a group this device is in.
+    ///
+    /// The question every replication decision starts from: is this space a
+    /// group, a peer, or neither. Answered structurally rather than by
+    /// parsing the name, so a space is a group space exactly when MLS says
+    /// this device holds that group.
+    ///
+    /// The MLS lookup behind a cache miss is not free, and it is affordable
+    /// because of where this is called from: a flush that has just written
+    /// a sealed record, or a frame that has just been decrypted. Both are
+    /// dominated by work an order of magnitude larger than a group-state
+    /// read.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn group_space_roster(&mut self, space: &str) -> Option<Vec<String>> {
+        if let Some(members) = self.group_mesh.members.get(space) {
+            return Some(members.clone());
+        }
+        if offline_protocol_mls::GroupId::new(space).is_err() {
+            return None;
+        }
+        self.refresh_group_members(space).ok()
+    }
+
     /// Replaces the set of capability tokens advertised by the connected
     /// relay.
     ///
@@ -5161,6 +5386,7 @@ impl OfflineProtocol {
                         affected_member: None,
                         role: None,
                         affected_member_rich: None,
+                        affected_member_data: None,
                     };
                     let commit_content = match serde_json::to_string(&commit_payload) {
                         Ok(json) => format!("{}{}", internal_prefixes::GROUP_MLS_COMMIT, json),
@@ -5755,6 +5981,17 @@ impl OfflineProtocol {
         match self.decrypt_group_application(group_id, ciphertext_bytes, sender) {
             GroupDecryptOutcome::Plaintext(pt) => match String::from_utf8(pt) {
                 Ok(text) => {
+                    // The third and last arm a decrypted group plaintext can
+                    // reach. Missing one of them is the failure class this
+                    // repository has already paid for once: a hardening fix
+                    // that landed on a single inbound path while its sibling
+                    // stayed broken.
+                    #[cfg(feature = "data")]
+                    if let Some(body) = text.strip_prefix(internal_prefixes::DATA_V1) {
+                        let body = body.to_string();
+                        self.handle_group_data_sync_frame(group_id, sender, &body);
+                        return;
+                    }
                     let (content, media_metadata, content_type, forward_info_event) =
                         Self::restore_group_rich(text, forward_info, sender);
                     self.emit_event(Event::group_message_received(

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -1,5 +1,6 @@
 use super::group_mesh::*;
 use crate::protocol::tests::{create_test_config, create_test_config_for_user};
+use crate::protocol::DATA_GROUP_V1;
 use crate::protocol::{base64_decode, base64_encode, internal_prefixes, InternalMessageResult};
 use crate::test_identity::{id, session_slot};
 use crate::{Event, OfflineProtocol};
@@ -11947,8 +11948,8 @@ fn group_send_rejects_internal_prefix_content() {
 /// Returns (alice, bob, carol, group_id) with the invite already performed
 /// and alice's outbox holding the Welcome (to carol) + Commit (to bob).
 fn setup_three_party_invite(
-    bob_rich_known: bool,
-    carol_rich_known: bool,
+    bob_known: bool,
+    carol_known: bool,
 ) -> (OfflineProtocol, OfflineProtocol, OfflineProtocol, String) {
     let storage_a = Arc::new(crate::mls::InMemoryStorage::default());
     let storage_b = Arc::new(crate::mls::InMemoryStorage::new());
@@ -11981,11 +11982,16 @@ fn setup_three_party_invite(
             local_expires_at_ms: now_ms + 600_000,
         },
     );
-    if bob_rich_known {
-        crate::protocol::tests::feed_key_package_with_rich(
+    if bob_known {
+        // Both families from one key package, because that is what a real
+        // exchange carries: rich extras and document replication are
+        // separate fields of the same payload, and Alice attests each of
+        // them to the group from the same knowledge.
+        crate::protocol::tests::feed_key_package_with_capabilities(
             &mut alice,
             &id("bob"),
             vec![crate::protocol::RICH_PAYLOAD_V1],
+            vec![crate::protocol::DATA_SYNC_V1, DATA_GROUP_V1],
         );
         // The synthetic capability advertisement clobbered the pending key
         // package with junk bytes; restore the real one for the invite.
@@ -12025,11 +12031,12 @@ fn setup_three_party_invite(
         let carol_mls = carol.mls_manager_for_testing().read().unwrap();
         carol_mls.generate_key_package().unwrap()
     };
-    if carol_rich_known {
-        crate::protocol::tests::feed_key_package_with_rich(
+    if carol_known {
+        crate::protocol::tests::feed_key_package_with_capabilities(
             &mut alice,
             &id("carol"),
             vec![crate::protocol::RICH_PAYLOAD_V1],
+            vec![crate::protocol::DATA_SYNC_V1, DATA_GROUP_V1],
         );
     }
     alice.pending_key_packages.insert(
@@ -12262,6 +12269,234 @@ fn non_admin_commit_attestation_is_ignored() {
 
     assert!(
         !bob.group_rich_seal_active(&members),
+        "an attestation from a non-admin sender must be ignored"
+    );
+}
+
+// ----------------------------------------------------------------------------
+// The same four seams for group replication.
+//
+// `member_data` / `affected_member_data` are the `DATA_GROUP_V1` siblings of
+// the rich attestation above, and they are load-bearing in a way the rich
+// half is not: rich extras degrade to text the recipient still reads, whereas
+// a member outside the attestation web receives nobody's document edits and
+// has no way to notice. Because the group gate is all-members, one such
+// member closes replication for the whole group.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn invite_attests_group_replication_on_commit_and_welcome() {
+    let (alice, _bob, _carol, _group_id) = setup_three_party_invite(true, true);
+
+    let commit = alice
+        .outbox_messages()
+        .find(|m| {
+            m.recipient.as_str() == &id("bob")
+                && m.content.starts_with(internal_prefixes::GROUP_MLS_COMMIT)
+        })
+        .expect("commit to bob must be queued");
+    let commit_payload: GroupMlsCommitPayload = serde_json::from_str(
+        commit
+            .content
+            .strip_prefix(internal_prefixes::GROUP_MLS_COMMIT)
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        commit_payload.affected_member_data,
+        Some(vec![DATA_GROUP_V1]),
+        "the commit must tell the existing members what the newcomer \
+         supports, or the group's gate stays closed on her account"
+    );
+
+    let welcome = alice
+        .outbox_messages()
+        .find(|m| {
+            m.recipient.as_str() == &id("carol")
+                && m.content.starts_with(internal_prefixes::GROUP_MLS_WELCOME)
+        })
+        .expect("welcome to carol must be queued");
+    let welcome_payload: GroupMlsWelcomePayload = serde_json::from_str(
+        welcome
+            .content
+            .strip_prefix(internal_prefixes::GROUP_MLS_WELCOME)
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        welcome_payload.member_data.get(&id("alice")),
+        Some(&vec![DATA_GROUP_V1]),
+        "the welcome must self-attest the inviter"
+    );
+    assert_eq!(
+        welcome_payload.member_data.get(&id("bob")),
+        Some(&vec![DATA_GROUP_V1]),
+        "Carol will never exchange key packages with Bob, so this map is the \
+         only way she learns he replicates"
+    );
+    assert!(
+        !welcome_payload.member_data.contains_key(&id("carol")),
+        "the joiner needs no entry about itself"
+    );
+}
+
+#[test]
+fn invite_omits_group_replication_attestation_for_unknown_members() {
+    // Absence of knowledge must propagate as absence here too. Claiming
+    // support for a member the inviter never heard from is the one error
+    // that puts `__DATA_V1__` frames in front of an install that renders
+    // them as chat text.
+    let (alice, _bob, _carol, _group_id) = setup_three_party_invite(false, false);
+
+    let commit = alice
+        .outbox_messages()
+        .find(|m| {
+            m.recipient.as_str() == &id("bob")
+                && m.content.starts_with(internal_prefixes::GROUP_MLS_COMMIT)
+        })
+        .expect("commit to bob must be queued");
+    let commit_payload: GroupMlsCommitPayload = serde_json::from_str(
+        commit
+            .content
+            .strip_prefix(internal_prefixes::GROUP_MLS_COMMIT)
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(commit_payload.affected_member_data, None);
+
+    let welcome = alice
+        .outbox_messages()
+        .find(|m| {
+            m.recipient.as_str() == &id("carol")
+                && m.content.starts_with(internal_prefixes::GROUP_MLS_WELCOME)
+        })
+        .expect("welcome to carol must be queued");
+    let welcome_payload: GroupMlsWelcomePayload = serde_json::from_str(
+        welcome
+            .content
+            .strip_prefix(internal_prefixes::GROUP_MLS_WELCOME)
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        welcome_payload.member_data.get(&id("alice")),
+        Some(&vec![DATA_GROUP_V1]),
+        "the inviter still self-attests from what it actually advertises"
+    );
+    assert!(!welcome_payload.member_data.contains_key(&id("bob")));
+}
+
+#[test]
+fn commit_attestation_opens_the_group_replication_gate() {
+    // Bob (an existing member) never exchanges key packages with carol. Until
+    // the commit lands she is a member of unknown capability, and because one
+    // group ciphertext reaches the whole roster, that one unknown holds Bob's
+    // gate shut for every document in the group.
+    let (alice, mut bob, _carol, _group_id) = setup_three_party_invite(true, true);
+    let members = vec![id("alice"), id("bob"), id("carol")];
+    assert!(
+        !bob.group_data_sync_active(&members),
+        "precondition: carol is unknown to bob until the commit arrives"
+    );
+
+    let commit = alice
+        .outbox_messages()
+        .find(|m| {
+            m.recipient.as_str() == &id("bob")
+                && m.content.starts_with(internal_prefixes::GROUP_MLS_COMMIT)
+        })
+        .expect("commit to bob must be queued")
+        .clone();
+    bob.process_internal_message(&make_message(&id("alice"), &id("bob"), &commit.content));
+
+    assert!(
+        bob.group_data_sync_active(&members),
+        "the admin's attested commit must teach bob that the newcomer \
+         replicates, or the group quietly stops converging for everyone"
+    );
+}
+
+#[test]
+fn welcome_group_replication_attestation_is_bounded_to_the_roster() {
+    let (alice, _bob, mut carol, group_id) = setup_three_party_invite(true, true);
+
+    let welcome = alice
+        .outbox_messages()
+        .find(|m| {
+            m.recipient.as_str() == &id("carol")
+                && m.content.starts_with(internal_prefixes::GROUP_MLS_WELCOME)
+        })
+        .expect("welcome to carol must be queued")
+        .clone();
+
+    // An inviter can put any name in this map. Only the MLS roster the
+    // joiner actually joined bounds who an attestation may be recorded for.
+    let mut payload: GroupMlsWelcomePayload = serde_json::from_str(
+        welcome
+            .content
+            .strip_prefix(internal_prefixes::GROUP_MLS_WELCOME)
+            .unwrap(),
+    )
+    .unwrap();
+    payload
+        .member_data
+        .insert(id("mallory"), vec![DATA_GROUP_V1]);
+    let tampered = format!(
+        "{}{}",
+        internal_prefixes::GROUP_MLS_WELCOME,
+        serde_json::to_string(&payload).unwrap()
+    );
+    carol.process_internal_message(&make_message(&id("alice"), &id("carol"), &tampered));
+    assert!(
+        carol.group_mesh.members.contains_key(&group_id),
+        "carol must have joined via the Welcome"
+    );
+
+    assert!(
+        carol.group_data_sync_active(&vec![id("alice"), id("bob"), id("carol")]),
+        "the welcome attestation must let the joiner replicate with members \
+         it never directly exchanged with"
+    );
+    assert!(
+        !carol.group_data_sync_active(&vec![id("carol"), id("mallory")]),
+        "a non-roster map entry must not be recorded"
+    );
+}
+
+#[test]
+fn non_admin_commit_group_replication_attestation_is_ignored() {
+    // Same trust bound as the role and the rich attestation: honored only
+    // from an admin sender, because adds are admin-only and a non-admin
+    // sender means the metadata is forged by construction.
+    let (alice, mut bob, _carol, group_id) = setup_three_party_invite(true, true);
+    let members = vec![id("alice"), id("bob"), id("carol")];
+
+    // Demote alice and promote bob in bob's own metadata, for the reason the
+    // rich sibling above spells out: demoting alice alone would leave her
+    // resolving as admin through the group-creator fallback.
+    {
+        let bob_mls = bob.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&group_id).unwrap();
+        bob_mls
+            .set_member_role(&gid, &id("alice"), GroupRole::Member)
+            .unwrap();
+        bob_mls
+            .set_member_role(&gid, &id("bob"), GroupRole::Admin)
+            .unwrap();
+    }
+
+    let commit = alice
+        .outbox_messages()
+        .find(|m| {
+            m.recipient.as_str() == &id("bob")
+                && m.content.starts_with(internal_prefixes::GROUP_MLS_COMMIT)
+        })
+        .expect("commit to bob must be queued")
+        .clone();
+    bob.process_internal_message(&make_message(&id("alice"), &id("bob"), &commit.content));
+
+    assert!(
+        !bob.group_data_sync_active(&members),
         "an attestation from a non-admin sender must be ignored"
     );
 }

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -153,6 +153,7 @@ fn test_group_welcome_cannot_squat_session_slot() {
     // 1:1 session slot.
     let squat = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        member_data: HashMap::new(),
         created_by: None,
         group_id: session_slot("alice", "bob"),
         group_name: None,
@@ -397,6 +398,7 @@ fn test_group_mls_process_commit_empty_ciphertext_no_event() {
     // MLS processing will fail, so no membership event should be emitted.
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::Add,
         ciphertext: String::new(),
@@ -533,6 +535,7 @@ fn test_group_mls_payload_serialization_roundtrip() {
 
     let welcome_payload = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        member_data: HashMap::new(),
         created_by: None,
         group_id: "group:def".to_string(),
         group_name: Some("Test Group".to_string()),
@@ -548,6 +551,7 @@ fn test_group_mls_payload_serialization_roundtrip() {
 
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: "group:ghi".to_string(),
         commit_type: GroupCommitType::Add,
         ciphertext: "Y29tbWl0".to_string(),
@@ -726,6 +730,7 @@ fn test_group_mls_commit_with_spoofed_sender_rejected_not_buffered() {
 
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::KeyUpdate,
         ciphertext: base64_encode(&commit.ciphertext),
@@ -825,6 +830,7 @@ fn test_group_mls_commit_unknown_group() {
     // Simulate receiving a commit for a group we don't belong to
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: "group:nonexistent".to_string(),
         commit_type: GroupCommitType::Add,
         ciphertext: base64_encode(b"fake-commit-data"),
@@ -1143,6 +1149,7 @@ fn test_group_mls_welcome_bad_data_no_panic() {
     // Send a Welcome with invalid base64 welcome_data
     let welcome_payload = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        member_data: HashMap::new(),
         created_by: None,
         group_id: "group:bad-welcome".to_string(),
         group_name: Some("Bad Group".to_string()),
@@ -1178,6 +1185,7 @@ fn test_group_mls_welcome_valid_base64_bad_mls_no_panic() {
     // Send a Welcome with valid base64 but garbage MLS data
     let welcome_payload = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        member_data: HashMap::new(),
         created_by: None,
         group_id: "group:garbage-mls".to_string(),
         group_name: Some("Garbage MLS".to_string()),
@@ -1244,6 +1252,7 @@ fn test_group_mls_commit_oversized_ciphertext_rejected() {
     let oversized = "A".repeat(MAX_BASE64_PAYLOAD_SIZE + 1);
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: "group:oversized".to_string(),
         commit_type: GroupCommitType::Add,
         ciphertext: oversized,
@@ -1445,6 +1454,7 @@ fn test_group_mls_commit_failure_buffers_for_retry() {
         message_id: "test-mid-1".to_string(),
         data: serde_json::to_string(&GroupMlsCommitPayload {
             affected_member_rich: None,
+            affected_member_data: None,
             group_id: group_id.clone(),
             commit_type: GroupCommitType::Add,
             ciphertext: base64_encode(b"commit-data"),
@@ -1491,6 +1501,7 @@ fn test_group_mls_pending_commit_buffer_cap() {
     for i in 0..(MAX_PENDING_COMMITS_PER_GROUP + 4) {
         let data = serde_json::to_string(&GroupMlsCommitPayload {
             affected_member_rich: None,
+            affected_member_data: None,
             group_id: group_id.clone(),
             commit_type: GroupCommitType::Add,
             ciphertext: base64_encode(format!("commit-{}", i).as_bytes()),
@@ -1565,6 +1576,7 @@ fn test_group_mls_commit_empty_ciphertext_not_buffered() {
     // Empty ciphertext — this is a malformed commit, not an ordering issue
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::Remove,
         ciphertext: String::new(),
@@ -1782,6 +1794,7 @@ fn test_group_mls_drain_pending_commits_no_double_buffering() {
     // Manually insert pending commits with garbage ciphertext.
     let bad_commit = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: real_group_id.clone(),
         commit_type: GroupCommitType::Add,
         ciphertext: base64_encode(b"not-a-real-mls-commit"),
@@ -1837,6 +1850,7 @@ fn test_group_mls_drain_pending_commits_expired_entries_dropped() {
     // Insert an expired pending commit
     let bad_commit = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::Add,
         ciphertext: base64_encode(b"stale-commit"),
@@ -1879,6 +1893,7 @@ fn test_group_mls_handle_commit_permanent_failure_not_buffered() {
     // Simulate receiving a commit with valid base64 but garbage MLS bytes.
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::Add,
         ciphertext: base64_encode(b"fake-but-decodable-commit"),
@@ -1916,6 +1931,7 @@ fn test_group_mls_commit_rejected_not_buffered() {
     // Empty ciphertext — should be rejected, not buffered
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: "group:reject-test".to_string(),
         commit_type: GroupCommitType::Add,
         ciphertext: String::new(),
@@ -2388,6 +2404,7 @@ fn test_group_mls_commit_group_not_found_is_buffered_for_welcome_race() {
     // bounded by the per-group/global caps and the TTL sweep.
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: "group:does-not-exist".to_string(),
         commit_type: GroupCommitType::Add,
         ciphertext: base64_encode(b"some-commit-data"),
@@ -2426,6 +2443,7 @@ fn test_group_mls_commit_bad_deserialization_is_rejected_not_retriable() {
     // Valid base64 but garbage MLS bytes
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::Add,
         ciphertext: base64_encode(b"this-is-not-mls"),
@@ -2671,6 +2689,7 @@ fn test_group_mls_pending_commit_drain_cascades() {
         message_id: "test-mid-7".to_string(),
         data: serde_json::to_string(&GroupMlsCommitPayload {
             affected_member_rich: None,
+            affected_member_data: None,
             group_id: group_id.clone(),
             commit_type: GroupCommitType::Add,
             ciphertext: base64_encode(b"commit-1"),
@@ -2687,6 +2706,7 @@ fn test_group_mls_pending_commit_drain_cascades() {
         message_id: "test-mid-8".to_string(),
         data: serde_json::to_string(&GroupMlsCommitPayload {
             affected_member_rich: None,
+            affected_member_data: None,
             group_id: group_id.clone(),
             commit_type: GroupCommitType::Add,
             ciphertext: base64_encode(b"commit-2"),
@@ -5569,6 +5589,7 @@ fn test_epoch_fork_cleared_on_successful_commit() {
     // Build a protocol-layer commit message from bob to alice
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::KeyUpdate,
         ciphertext: base64_encode(&bob_commit.ciphertext),
@@ -5844,6 +5865,7 @@ fn test_key_update_commit_type_serialization() {
     // Verify KeyUpdate serializes/deserializes correctly
     let payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: "test-group".to_string(),
         commit_type: GroupCommitType::KeyUpdate,
         ciphertext: "abc".to_string(),
@@ -6553,6 +6575,7 @@ fn test_non_key_update_commit_does_not_clear_fork_state() {
     // succeed in process_commit_core, but the commit_type is Add.
     let add_commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::Add,
         ciphertext: base64_encode(&bob_update.ciphertext),
@@ -6595,6 +6618,7 @@ fn test_key_update_commit_clears_fork_state() {
 
     let ku_commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::KeyUpdate,
         ciphertext: base64_encode(&bob_update.ciphertext),
@@ -7811,6 +7835,7 @@ fn test_welcome_payload_carries_roles() {
 
     let payload = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        member_data: HashMap::new(),
         created_by: None,
         group_id: "group:test".to_string(),
         group_name: Some("Test".to_string()),
@@ -7828,6 +7853,7 @@ fn test_welcome_payload_carries_roles() {
 fn test_commit_payload_carries_role() {
     let payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: "group:test".to_string(),
         commit_type: GroupCommitType::Add,
         ciphertext: "abc".to_string(),
@@ -7842,6 +7868,7 @@ fn test_commit_payload_carries_role() {
     // None role should be omitted from JSON
     let payload_no_role = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: "group:test".to_string(),
         commit_type: GroupCommitType::Remove,
         ciphertext: "abc".to_string(),
@@ -8526,6 +8553,7 @@ fn test_self_removal_commit_from_admin_emits_event_and_cleans_up() {
     // the self-removal fallback path.
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::Remove,
         ciphertext: base64_encode(b"undecryptable-commit-ciphertext"),
@@ -8576,6 +8604,7 @@ fn test_self_removal_commit_from_non_admin_is_rejected() {
     // Eve (non-admin) sends a forged commit claiming to remove &id("user123")
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::Remove,
         ciphertext: base64_encode(b"garbage-ciphertext"),
@@ -13827,6 +13856,7 @@ fn test_group_invite_with_an_unprovable_member_is_declined_and_reported() {
 
     let payload = GroupMlsWelcomePayload {
         member_rich: HashMap::new(),
+        member_data: HashMap::new(),
         created_by: None,
         group_id: group_info.group_id.to_string(),
         group_name: Some("mallory-group".to_string()),
@@ -13919,6 +13949,7 @@ fn test_forged_leaf_commit_is_rejected_permanently_and_not_buffered() {
 
     let commit_payload = GroupMlsCommitPayload {
         affected_member_rich: None,
+        affected_member_data: None,
         group_id: group_id.clone(),
         commit_type: GroupCommitType::Add,
         ciphertext: base64_encode(&commit_bytes),
@@ -14056,6 +14087,7 @@ fn test_repeated_unprovable_invites_from_one_sender_are_rate_limited() {
         };
         let payload = GroupMlsWelcomePayload {
             member_rich: HashMap::new(),
+            member_data: HashMap::new(),
             created_by: None,
             group_id: group_info.group_id.to_string(),
             group_name: Some("mallory-group".to_string()),

--- a/crates/offline-protocol/src/group_mesh_tests.rs
+++ b/crates/offline-protocol/src/group_mesh_tests.rs
@@ -12464,6 +12464,43 @@ fn welcome_group_replication_attestation_is_bounded_to_the_roster() {
 }
 
 #[test]
+fn the_inviter_self_attests_exactly_what_it_advertises() {
+    // The inviter's own entry is the one attestation nothing can correct
+    // later: every other member's is overridden the moment their key package
+    // arrives, but nobody ever sends us ours. So it has to state the group
+    // entry itself rather than "some data version is on" — the two coincide
+    // today because one switch produces both, and this pins them together so
+    // a later split cannot quietly promise group interception this build
+    // does not do. Promising it wrongly is the one error that puts literal
+    // `__DATA_V1__` text in front of a user.
+    let (alice, _bob, _carol, _group_id) = setup_three_party_invite(true, true);
+    let advertises_group = alice.advertised_data_versions().contains(&DATA_GROUP_V1);
+
+    let welcome = alice
+        .outbox_messages()
+        .find(|m| {
+            m.recipient.as_str() == &id("carol")
+                && m.content.starts_with(internal_prefixes::GROUP_MLS_WELCOME)
+        })
+        .expect("welcome to carol must be queued");
+    let welcome_payload: GroupMlsWelcomePayload = serde_json::from_str(
+        welcome
+            .content
+            .strip_prefix(internal_prefixes::GROUP_MLS_WELCOME)
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        welcome_payload.member_data.contains_key(&id("alice")),
+        advertises_group,
+        "the inviter's self-attestation and its own advertisement have to be \
+         the same claim; a build that attests what it does not advertise is \
+         telling the group to send it frames it will render as chat text"
+    );
+}
+
+#[test]
 fn non_admin_commit_group_replication_attestation_is_ignored() {
     // Same trust bound as the role and the rich attestation: honored only
     // from an admin sender, because adds are admin-only and a non-admin

--- a/crates/offline-protocol/src/protocol/data.rs
+++ b/crates/offline-protocol/src/protocol/data.rs
@@ -170,7 +170,7 @@ impl OfflineProtocol {
     }
 
     fn validate_ids(space: &str, doc: &str) -> Result<()> {
-        offline_protocol_data::validate_name(space).map_err(map_data_error)?;
+        offline_protocol_data::validate_space_name(space).map_err(map_data_error)?;
         offline_protocol_data::validate_name(doc).map_err(map_data_error)?;
         Ok(())
     }
@@ -657,7 +657,7 @@ impl OfflineProtocol {
     /// document to find out would defeat both callers, whose whole question
     /// is whether opening one is allowed.
     fn space_docs(&mut self, space: &str) -> Option<&BTreeSet<String>> {
-        if offline_protocol_data::validate_name(space).is_err() {
+        if offline_protocol_data::validate_space_name(space).is_err() {
             return None;
         }
         let storage = self.data_storage_for_sync()?;
@@ -832,7 +832,7 @@ impl OfflineProtocol {
 
     /// The documents in a space.
     pub fn data_list_docs(&mut self, space: &str) -> Result<Vec<String>> {
-        offline_protocol_data::validate_name(space).map_err(map_data_error)?;
+        offline_protocol_data::validate_space_name(space).map_err(map_data_error)?;
         let storage = self.require_data_storage()?;
         self.load_space(storage.as_ref(), space)?;
         Ok(self

--- a/crates/offline-protocol/src/protocol/data_sync.rs
+++ b/crates/offline-protocol/src/protocol/data_sync.rs
@@ -173,6 +173,40 @@ enum SyncBody {
     NeedSnapshot { doc: String },
 }
 
+/// Where a sync frame goes and what it is sealed under.
+///
+/// The one thing F4 added to this module. 1:1 replication could treat the
+/// space, the peer, and the reply address as a single value because they
+/// genuinely were one; a group space is one scope with many members, so the
+/// space no longer names the recipient and the two have to be carried
+/// separately.
+#[derive(Debug, Clone)]
+pub(crate) enum SyncChannel {
+    /// A 1:1 space, sealed to the peer the space is named after.
+    Peer,
+    /// A group space, sealed once for the whole roster.
+    ///
+    /// Used only for changes every member needs: a local commit. Group MLS
+    /// produces one ciphertext for everyone, which is what makes group
+    /// replication cheap, and it is also why this must never be used for an
+    /// answer to one member's question — the other members would each
+    /// receive, decrypt, and import a blob they already had.
+    GroupBroadcast,
+    /// A group space, sealed for the roster but delivered to one member.
+    ///
+    /// The reply leg. Anti-entropy between two members of a group is still
+    /// a conversation between two devices: an offer is answered by the
+    /// member that received it and by nobody else. Every other member is
+    /// spared the traffic, and the terminating 1.5-round-trip exchange the
+    /// 1:1 path relies on keeps working unchanged.
+    ///
+    /// Sealed under the group key rather than the pair's 1:1 session on
+    /// purpose: two members of a group need not have a 1:1 session at all,
+    /// and requiring one would make replication depend on a handshake that
+    /// may never happen.
+    GroupDirected(String),
+}
+
 /// Which frame a blob arrived in.
 ///
 /// Carried into the import so a rung of the catch-up ladder knows whether
@@ -213,6 +247,17 @@ pub(crate) fn blob_digest(blob: &[u8]) -> String {
     hex_encode(&hasher.finalize()[..16])
 }
 
+/// The rate-limit key for offers toward one member of one group.
+///
+/// A group space and a 1:1 space share one window map, so the two key
+/// spaces must not overlap: a bare peer address is the 1:1 key, and this
+/// one is deliberately built with a character no validated peer id, group
+/// id or address can contain, so no composed key can ever collide with a
+/// peer's own.
+fn group_offer_key(member: &str, group_id: &str) -> String {
+    format!("{member}\x01{group_id}")
+}
+
 fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
@@ -229,12 +274,82 @@ impl OfflineProtocol {
         if !self.data_sync_active(peer) {
             return;
         }
-        if let Some(last) = self.last_data_sync_offer.get(peer) {
-            if Instant::now().duration_since(*last) < DATA_SYNC_OFFER_INTERVAL {
-                return;
-            }
+        if !self.data_sync_offer_due(peer) {
+            return;
         }
         self.offer_versions(peer, cause);
+    }
+
+    /// Offer our versions of every document in `group_id` to one member.
+    ///
+    /// The group counterpart of [`Self::kick_data_sync`], and addressed for
+    /// the same reason its answers are: a member coming back into range is
+    /// a conversation with that member. Broadcasting the offer to the whole
+    /// roster would have every other member answer a question nobody asked
+    /// them.
+    ///
+    /// Rate-limited per (member, group) rather than per member, so a peer
+    /// shared across several groups reconciles all of them rather than
+    /// whichever one its rediscovery happened to reach first.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn kick_group_data_sync(&mut self, group_id: &str, member: &str, cause: &str) {
+        let members = match self.group_roster(group_id) {
+            Ok(members) => members,
+            Err(_) => return,
+        };
+        if !self.group_data_sync_active(&members) {
+            return;
+        }
+        let key = group_offer_key(member, group_id);
+        if !self.data_sync_offer_due(&key) {
+            return;
+        }
+        self.offer_versions_over(
+            group_id,
+            &SyncChannel::GroupDirected(member.to_string()),
+            cause,
+        );
+    }
+
+    /// Whether the reconciliation sweep keyed by `key` is outside its
+    /// suppression window, stamping it when it is.
+    ///
+    /// Stamped here rather than after the send for the reason
+    /// [`Self::offer_versions_over`] gives: a read that fails will still
+    /// fail a moment later, and retrying it at discovery speed is the
+    /// traffic the window exists to prevent.
+    fn data_sync_offer_due(&mut self, key: &str) -> bool {
+        if let Some(last) = self.last_data_sync_offer.get(key) {
+            if Instant::now().duration_since(*last) < DATA_SYNC_OFFER_INTERVAL {
+                return false;
+            }
+        }
+        self.last_data_sync_offer
+            .insert(key.to_string(), Instant::now());
+        true
+    }
+
+    /// Offer versions of every group space this device shares with `peer`.
+    ///
+    /// Wired to the same rediscovery seam as [`Self::kick_data_sync`], and
+    /// needed because a group space has no 1:1 trigger to ride: two members
+    /// may never establish a session with each other, so without this the
+    /// only thing that ever reconciles them is a fresh local commit.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn kick_shared_group_data_sync(&mut self, peer: &str, cause: &str) {
+        if !self.config.data.enabled {
+            return;
+        }
+        let shared: Vec<String> = self
+            .group_mesh
+            .members
+            .iter()
+            .filter(|(_, members)| members.iter().any(|m| m == peer))
+            .map(|(group_id, _)| group_id.clone())
+            .collect();
+        for group_id in shared {
+            self.kick_group_data_sync(&group_id, peer, cause);
+        }
     }
 
     /// Offer our versions because a change happened that no frame carried,
@@ -249,21 +364,85 @@ impl OfflineProtocol {
     /// until somebody asks, both sides hold documents they believe agree;
     /// on a link that never drops there is no next trigger to ask.
     pub(crate) fn nudge_data_sync(&mut self, space: &str, origin: Option<&str>, cause: &str) {
-        if origin == Some(space) || !self.data_sync_active(space) {
-            return;
+        match self.space_channel(space, origin) {
+            Some(SyncChannel::Peer) => self.offer_versions(space, cause),
+            // The roster-wide leg, and the one place a group offer is not
+            // addressed to one member. What went unsent was a change every
+            // member needs, and there is no single member to ask: each of
+            // them answers with what they are missing, and a member that is
+            // already current answers with nothing.
+            Some(channel @ SyncChannel::GroupBroadcast) => {
+                self.offer_versions_over(space, &channel, cause)
+            }
+            Some(SyncChannel::GroupDirected(_)) | None => {}
         }
-        self.offer_versions(space, cause);
+    }
+
+    /// How a space replicates, or `None` when it does not.
+    ///
+    /// The single place the three kinds of space are told apart. A space is
+    /// a group space when MLS says this device holds a group by that name,
+    /// a 1:1 space when the name is a peer that advertised replication, and
+    /// local-only otherwise — and "local-only" is the honest answer for a
+    /// space whose peer never advertised, whose group is gone, or whose
+    /// members are not all group-capable.
+    ///
+    /// `origin`, when set, names the peer a change was just applied from,
+    /// and suppresses announcing that change back to them.
+    fn space_channel(&mut self, space: &str, origin: Option<&str>) -> Option<SyncChannel> {
+        if let Some(members) = self.group_space_roster(space) {
+            // A change that arrived over the group reached every member at
+            // once, because that is what one group ciphertext does. Pushing
+            // it on would have every member push every change to every
+            // other member: N times the frames for nothing, and worse as
+            // the group grows. Anti-entropy still closes real gaps.
+            if origin.is_some() {
+                return None;
+            }
+            if self.group_data_sync_active(&members) {
+                return Some(SyncChannel::GroupBroadcast);
+            }
+            // The gate is closed, and for a group the usual reason is not
+            // that somebody opted out but that we have never heard from
+            // them: members added by a third party exchange no key packages
+            // with us, and an inviter running an SDK from before
+            // attestation forwards none. Sending them ours makes their
+            // automatic reply teach us what they support. Guarded by
+            // `key_package_sent_to`, so a group that stays closed does not
+            // re-probe on every commit.
+            let unknown = self.group_data_unknown_members(&members);
+            if !unknown.is_empty() {
+                debug!(
+                    space,
+                    unknown = unknown.len(),
+                    "Group replication is held closed by members of unknown capability; probing"
+                );
+                self.backfill_group_rich_capabilities(&unknown);
+            }
+            return None;
+        }
+        if origin == Some(space) || !self.data_sync_active(space) {
+            return None;
+        }
+        Some(SyncChannel::Peer)
     }
 
     /// Send our version of every document in a space to the peer that names
     /// it, and start the window that suppresses the next sweep.
     fn offer_versions(&mut self, peer: &str, cause: &str) {
-        // Stamped before the read rather than after the send. A version read
-        // that fails will still fail a millisecond from now, and retrying it
-        // at discovery speed is the traffic the window exists to prevent.
+        // Stamped even on the unlimited path so an offer sent right now
+        // still suppresses the next sweep: the sweep would re-send what
+        // this frame already carried.
         self.last_data_sync_offer
             .insert(peer.to_string(), Instant::now());
+        self.offer_versions_over(peer, &SyncChannel::Peer, cause);
+    }
 
+    /// [`Self::offer_versions`] over an explicit channel, which is what a
+    /// group space needs: the offer is addressed to one member, not
+    /// broadcast to the roster.
+    fn offer_versions_over(&mut self, space: &str, channel: &SyncChannel, cause: &str) {
+        let peer = space;
         let docs = match self.data_sync_versions(peer) {
             Ok(docs) => docs,
             Err(err) => {
@@ -276,8 +455,8 @@ impl OfflineProtocol {
                 return;
             }
         };
-        debug!(peer = %peer, cause, docs = docs.len(), "Offering document versions");
-        self.send_version_frames(peer, docs, false, false);
+        debug!(space = %peer, cause, docs = docs.len(), "Offering document versions");
+        self.send_version_frames(peer, channel, docs, false, false);
     }
 
     /// Send one version frame per batch of documents.
@@ -289,7 +468,8 @@ impl OfflineProtocol {
     /// about one document with the whole space.
     fn send_version_frames(
         &mut self,
-        peer: &str,
+        space: &str,
+        channel: &SyncChannel,
         docs: BTreeMap<String, String>,
         reply: bool,
         force_partial: bool,
@@ -316,7 +496,8 @@ impl OfflineProtocol {
         let partial = force_partial || batches.len() > 1;
         for batch in batches {
             self.send_sync_frame(
-                peer,
+                space,
+                channel,
                 &SyncBody::Versions {
                     reply,
                     partial,
@@ -333,7 +514,7 @@ impl OfflineProtocol {
     /// suppressing the counter-offer, so a request cannot start a chain of
     /// its own; `partial` keeps the peer from reading one name as the
     /// complete list and answering with every other document in the space.
-    fn request_doc_catch_up(&mut self, space: &str, doc: &str) {
+    fn request_doc_catch_up(&mut self, space: &str, channel: &SyncChannel, doc: &str) {
         let version = match self.data_doc_version(space, doc) {
             Ok(version) => version,
             Err(err) => {
@@ -341,9 +522,9 @@ impl OfflineProtocol {
                 return;
             }
         };
-        let peer = space.to_string();
         self.send_version_frames(
-            &peer,
+            space,
+            channel,
             BTreeMap::from([(doc.to_string(), version)]),
             true,
             true,
@@ -352,15 +533,22 @@ impl OfflineProtocol {
 
     /// Seal one frame and put it on the ladder.
     ///
-    /// Deliberately the strict encryptor: a sync frame never initiates
-    /// session establishment. Documents converge when the peers next talk,
-    /// and provoking a handshake for an offer nobody asked for would make
-    /// every reconnect noisier than the messaging it rides on.
-    fn send_sync_frame(&mut self, peer: &str, body: &SyncBody) {
+    /// The channel decides what "seal" means: a 1:1 space seals to its
+    /// peer, a group space seals once under the group key. Everything
+    /// above this function is written in terms of a space and a channel and
+    /// does not know which of the two it is driving, which is what keeps
+    /// one implementation of the exchange, the catch-up ladder and the
+    /// import containment serving both.
+    fn send_sync_frame(&mut self, space: &str, channel: &SyncChannel, body: &SyncBody) {
         let plaintext = match serde_json::to_string(body) {
             Ok(json) => format!(
                 "{}{{\"v\":{},{}",
                 internal_prefixes::DATA_V1,
+                // The frame schema is the 1:1 version in both cases. The
+                // group entry advertises that a peer *intercepts* these
+                // frames inside a group ciphertext; it does not describe a
+                // second frame shape, and minting one would mean two
+                // parsers for identical bodies.
                 DATA_SYNC_V1,
                 // The body serializes as an object; splice the version in as
                 // its first field rather than nesting, so a future version
@@ -368,11 +556,34 @@ impl OfflineProtocol {
                 &json[1..]
             ),
             Err(err) => {
-                warn!(peer = %peer, error = %err, "Failed to encode sync frame");
+                warn!(space, error = %err, "Failed to encode sync frame");
                 return;
             }
         };
 
+        match channel {
+            SyncChannel::Peer => self.send_sync_frame_to_peer(space, plaintext),
+            SyncChannel::GroupBroadcast => {
+                if let Err(err) = self.send_group_internal_frame(space, None, &plaintext) {
+                    debug!(space, error = %err, "Group replication frame not sent");
+                }
+            }
+            SyncChannel::GroupDirected(member) => {
+                let member = member.clone();
+                if let Err(err) = self.send_group_internal_frame(space, Some(&member), &plaintext) {
+                    debug!(space, error = %err, "Directed replication frame not sent");
+                }
+            }
+        }
+    }
+
+    /// The 1:1 leg: seal to the peer the space is named after.
+    ///
+    /// Deliberately the strict encryptor: a sync frame never initiates
+    /// session establishment. Documents converge when the peers next talk,
+    /// and provoking a handshake for an offer nobody asked for would make
+    /// every reconnect noisier than the messaging it rides on.
+    fn send_sync_frame_to_peer(&mut self, peer: &str, plaintext: String) {
         let encrypted = match self.encrypt_content_for_recipient_strict(peer, &plaintext) {
             Ok(content) => content,
             Err(err) => {
@@ -444,9 +655,9 @@ impl OfflineProtocol {
         blob: &[u8],
         origin: Option<&str>,
     ) {
-        if origin == Some(space) || !self.data_sync_active(space) {
+        let Some(channel) = self.space_channel(space, origin) else {
             return;
-        }
+        };
         if blob.len() > MAX_SYNC_BLOB_BYTES {
             // Too big to inline, so the catch-up ladder has to fetch it: it
             // can answer with a compacted snapshot instead of raw history.
@@ -463,9 +674,9 @@ impl OfflineProtocol {
             self.nudge_data_sync(space, origin, "oversized_delta");
             return;
         }
-        let peer = space.to_string();
         self.send_sync_frame(
-            &peer,
+            space,
+            &channel,
             &SyncBody::Delta {
                 doc: doc.to_string(),
                 blob: BASE64.encode(blob),
@@ -483,6 +694,46 @@ impl OfflineProtocol {
     /// corrupt blob or a disabled layer would spend the sender's whole retry
     /// budget on a frame that cannot ever be accepted.
     pub(crate) fn handle_data_sync_frame(&mut self, sender: &str, body: &str) {
+        // The space is the sender. Never a field on the frame: a peer that
+        // could name the space could write into a document it replicates
+        // with somebody else.
+        self.handle_data_sync_frame_over(sender, &SyncChannel::Peer, sender, body);
+    }
+
+    /// A `__DATA_V1__` frame that arrived inside a *group* ciphertext.
+    ///
+    /// The space is the group, and the same structural argument holds as
+    /// for 1:1: the group is not named by the frame, it is the group whose
+    /// key opened the ciphertext. A member of one group cannot reach
+    /// another group's documents without being a member of that group too,
+    /// and the decrypt already proved membership and authenticated the
+    /// sender.
+    ///
+    /// Answers go back to `sender` alone rather than to the roster. Every
+    /// other member either has what was asked for or will ask for it
+    /// themselves.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn handle_group_data_sync_frame(
+        &mut self,
+        group_id: &str,
+        sender: &str,
+        body: &str,
+    ) {
+        self.handle_data_sync_frame_over(
+            group_id,
+            &SyncChannel::GroupDirected(sender.to_string()),
+            sender,
+            body,
+        );
+    }
+
+    fn handle_data_sync_frame_over(
+        &mut self,
+        space: &str,
+        channel: &SyncChannel,
+        sender: &str,
+        body: &str,
+    ) {
         if !self.config.data.enabled {
             // Parsing is never capability-gated, but applying is: the layer
             // is off, so the frame is dropped. Nothing is lost permanently —
@@ -517,23 +768,20 @@ impl OfflineProtocol {
             }
         };
 
-        // The space is the sender. Never a field on the frame: a peer that
-        // could name the space could write into a document it replicates
-        // with somebody else.
-        let space = sender.to_string();
+        let space = space.to_string();
         let outcome = match frame {
             SyncBody::Versions {
                 reply,
                 partial,
                 docs,
-            } => self.answer_version_offer(&space, reply, partial, docs),
+            } => self.answer_version_offer(&space, channel, reply, partial, docs),
             SyncBody::Delta { doc, blob } => {
-                self.accept_remote_blob(&space, &doc, &blob, BlobKind::Delta)
+                self.accept_remote_blob(&space, channel, &doc, &blob, BlobKind::Delta)
             }
             SyncBody::Snapshot { doc, blob } => {
-                self.accept_remote_blob(&space, &doc, &blob, BlobKind::Snapshot)
+                self.accept_remote_blob(&space, channel, &doc, &blob, BlobKind::Snapshot)
             }
-            SyncBody::NeedSnapshot { doc } => self.answer_snapshot_request(&space, &doc),
+            SyncBody::NeedSnapshot { doc } => self.answer_snapshot_request(&space, channel, &doc),
         };
         if let Err(err) = outcome {
             warn!(peer = %sender, error = %err, "Sync frame could not be handled");
@@ -544,6 +792,7 @@ impl OfflineProtocol {
     fn answer_version_offer(
         &mut self,
         space: &str,
+        channel: &SyncChannel,
         reply: bool,
         partial: bool,
         theirs: BTreeMap<String, String>,
@@ -597,7 +846,7 @@ impl OfflineProtocol {
                 // may be in a frame that has not arrived, or in no frame at
                 // all because the offer was about a single document.
                 if !partial {
-                    self.offer_catch_up(space, doc, None);
+                    self.offer_catch_up(space, channel, doc, None);
                 }
                 continue;
             };
@@ -605,7 +854,9 @@ impl OfflineProtocol {
                 continue;
             }
             match BASE64.decode(theirs_encoded) {
-                Ok(token) => self.offer_catch_up(space, doc, Some(VersionToken::from_bytes(token))),
+                Ok(token) => {
+                    self.offer_catch_up(space, channel, doc, Some(VersionToken::from_bytes(token)))
+                }
                 Err(err) => {
                     warn!(space, doc, error = %err, "Undecodable version token in a sync frame");
                 }
@@ -622,11 +873,10 @@ impl OfflineProtocol {
         // created from it empty for as long as the link stays up, because
         // the peer has said everything it had to say and nothing else here
         // ever asks.
-        let peer = space.to_string();
         if !reply {
-            self.send_version_frames(&peer, ours, true, false);
+            self.send_version_frames(space, channel, ours, true, false);
         } else {
-            self.send_version_frames(&peer, created, true, true);
+            self.send_version_frames(space, channel, created, true, true);
         }
         Ok(())
     }
@@ -638,14 +888,20 @@ impl OfflineProtocol {
     /// reported rather than retried: a document too large for every inline
     /// form needs the media path, which the attachment stage brings, and a
     /// silent stall would be indistinguishable from a peer with no changes.
-    fn offer_catch_up(&mut self, space: &str, doc: &str, theirs: Option<VersionToken>) {
+    fn offer_catch_up(
+        &mut self,
+        space: &str,
+        channel: &SyncChannel,
+        doc: &str,
+        theirs: Option<VersionToken>,
+    ) {
         if let Some(token) = theirs {
             match self.data_catch_up(space, doc, &token) {
                 Ok(CatchUp::UpToDate) => return,
                 Ok(CatchUp::Updates(bytes)) if bytes.len() <= MAX_SYNC_BLOB_BYTES => {
-                    let peer = space.to_string();
                     self.send_sync_frame(
-                        &peer,
+                        space,
+                        channel,
                         &SyncBody::Delta {
                             doc: doc.to_string(),
                             blob: BASE64.encode(bytes),
@@ -663,7 +919,7 @@ impl OfflineProtocol {
             }
         }
 
-        self.send_snapshot(space, doc);
+        self.send_snapshot(space, channel, doc);
     }
 
     /// Send a whole document, the top rung and the answer to every refusal
@@ -671,12 +927,12 @@ impl OfflineProtocol {
     ///
     /// Terminal by construction: a snapshot provokes no answer of its own,
     /// which is what lets the refusals underneath it ask for one freely.
-    fn send_snapshot(&mut self, space: &str, doc: &str) {
+    fn send_snapshot(&mut self, space: &str, channel: &SyncChannel, doc: &str) {
         match self.data_export_snapshot(space, doc) {
             Ok(bytes) if bytes.len() <= MAX_SYNC_BLOB_BYTES => {
-                let peer = space.to_string();
                 self.send_sync_frame(
-                    &peer,
+                    space,
+                    channel,
                     &SyncBody::Snapshot {
                         doc: doc.to_string(),
                         blob: BASE64.encode(bytes),
@@ -702,7 +958,12 @@ impl OfflineProtocol {
     /// Only a document already held is served. A request naming an unknown
     /// one would otherwise create it, which is a way to spend this device's
     /// storage that does not even require a blob.
-    fn answer_snapshot_request(&mut self, space: &str, doc: &str) -> Result<()> {
+    fn answer_snapshot_request(
+        &mut self,
+        space: &str,
+        channel: &SyncChannel,
+        doc: &str,
+    ) -> Result<()> {
         if offline_protocol_data::validate_name(doc).is_err() {
             warn!(space, doc, "Snapshot request names an invalid document");
             return Ok(());
@@ -712,7 +973,7 @@ impl OfflineProtocol {
             return Ok(());
         }
         debug!(space, doc, "Serving a snapshot the peer asked for");
-        self.send_snapshot(space, doc);
+        self.send_snapshot(space, channel, doc);
         Ok(())
     }
 
@@ -720,6 +981,7 @@ impl OfflineProtocol {
     fn accept_remote_blob(
         &mut self,
         space: &str,
+        channel: &SyncChannel,
         doc: &str,
         encoded: &str,
         kind: BlobKind,
@@ -861,7 +1123,7 @@ impl OfflineProtocol {
                 // something.
                 BlobKind::Delta => {
                     debug!(space, doc, "Remote change parked; asking for the gap");
-                    self.request_doc_catch_up(space, doc);
+                    self.request_doc_catch_up(space, channel, doc);
                 }
                 // A snapshot is the top of the ladder. Asking again returns
                 // the same bytes, so this is reported and left, rather than
@@ -882,9 +1144,9 @@ impl OfflineProtocol {
                 // exchange neither side can end. Name what would work.
                 BlobKind::Delta => {
                     debug!(space, doc, "Remote change needs a snapshot; asking for one");
-                    let peer = space.to_string();
                     self.send_sync_frame(
-                        &peer,
+                        space,
+                        channel,
                         &SyncBody::NeedSnapshot {
                             doc: doc.to_string(),
                         },

--- a/crates/offline-protocol/src/protocol/data_sync.rs
+++ b/crates/offline-protocol/src/protocol/data_sync.rs
@@ -335,11 +335,19 @@ impl OfflineProtocol {
     /// needed because a group space has no 1:1 trigger to ride: two members
     /// may never establish a session with each other, so without this the
     /// only thing that ever reconciles them is a fresh local commit.
+    ///
+    /// Which groups this device is in comes from MLS, not from the roster
+    /// cache alone. The cache is filled on demand and is empty after a
+    /// restart, so reading only it would make this sweep silently do nothing
+    /// on a cold process, which is the launch where it matters most: two
+    /// members that drifted apart and are not editing have no other trigger
+    /// left.
     #[cfg_attr(not(feature = "data"), allow(dead_code))]
     pub(crate) fn kick_shared_group_data_sync(&mut self, peer: &str, cause: &str) {
         if !self.config.data.enabled {
             return;
         }
+        self.enumerate_group_spaces_once();
         let shared: Vec<String> = self
             .group_mesh
             .members
@@ -349,6 +357,35 @@ impl OfflineProtocol {
             .collect();
         for group_id in shared {
             self.kick_group_data_sync(&group_id, peer, cause);
+        }
+    }
+
+    /// Fill the roster cache from MLS once per session, so
+    /// [`Self::kick_shared_group_data_sync`] can see a group that nothing has
+    /// touched yet.
+    ///
+    /// Costs one key listing, plus a group-state read for each group not
+    /// already cached — the same read the next send to that group would have
+    /// paid. Marked done even when a group read fails: the failure is per
+    /// group and retrying the whole enumeration on every discovery is the
+    /// traffic the offer window exists to prevent. An MLS that is not ready
+    /// yet is not a failure of this kind and leaves the flag alone, so the
+    /// next discovery tries again.
+    fn enumerate_group_spaces_once(&mut self) {
+        if self.group_spaces_enumerated {
+            return;
+        }
+        let Ok(groups) = self.list_groups() else {
+            return;
+        };
+        self.group_spaces_enumerated = true;
+        for group_id in groups {
+            if self.group_mesh.members.contains_key(&group_id) {
+                continue;
+            }
+            if let Err(err) = self.refresh_group_members(&group_id) {
+                debug!(group_id = %group_id, error = %err, "Group roster unreadable while enumerating group spaces");
+            }
         }
     }
 

--- a/crates/offline-protocol/src/protocol/data_sync.rs
+++ b/crates/offline-protocol/src/protocol/data_sync.rs
@@ -302,6 +302,13 @@ impl OfflineProtocol {
             Err(_) => return,
         };
         if !self.group_data_sync_active(&members) {
+            // Rediscovery is the one trigger a group space has that does
+            // not require somebody to be editing, so it is also the only
+            // moment a device that never writes anything will notice the
+            // gate is shut. Probing only from the local-commit path would
+            // leave a member that merely reads waiting for someone else to
+            // do it.
+            self.probe_group_data_capabilities(group_id, &members);
             return;
         }
         let key = group_offer_key(member, group_id);
@@ -313,6 +320,32 @@ impl OfflineProtocol {
             &SyncChannel::GroupDirected(member.to_string()),
             cause,
         );
+    }
+
+    /// Ask the members holding a group's replication gate closed what they
+    /// support.
+    ///
+    /// For a group the usual reason the gate is shut is not that somebody
+    /// opted out but that we have never heard from them: members added by a
+    /// third party exchange no key packages with us, and an inviter running
+    /// an SDK from before attestation forwards none. Sending them ours
+    /// makes their automatic reply teach us what they support.
+    ///
+    /// The probe itself is capability-agnostic and guarded by
+    /// `key_package_sent_to`, so a group that stays closed does not re-probe
+    /// on every commit or every rediscovery.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    fn probe_group_data_capabilities(&mut self, space: &str, members: &[String]) {
+        let unknown = self.group_data_unknown_members(members);
+        if unknown.is_empty() {
+            return;
+        }
+        debug!(
+            space,
+            unknown = unknown.len(),
+            "Group replication is held closed by members of unknown capability; probing"
+        );
+        self.backfill_group_rich_capabilities(&unknown);
     }
 
     /// Drop every offer window belonging to `peer`: the 1:1 one, and the
@@ -467,23 +500,7 @@ impl OfflineProtocol {
             if self.group_data_sync_active(&members) {
                 return Some(SyncChannel::GroupBroadcast);
             }
-            // The gate is closed, and for a group the usual reason is not
-            // that somebody opted out but that we have never heard from
-            // them: members added by a third party exchange no key packages
-            // with us, and an inviter running an SDK from before
-            // attestation forwards none. Sending them ours makes their
-            // automatic reply teach us what they support. Guarded by
-            // `key_package_sent_to`, so a group that stays closed does not
-            // re-probe on every commit.
-            let unknown = self.group_data_unknown_members(&members);
-            if !unknown.is_empty() {
-                debug!(
-                    space,
-                    unknown = unknown.len(),
-                    "Group replication is held closed by members of unknown capability; probing"
-                );
-                self.backfill_group_rich_capabilities(&unknown);
-            }
+            self.probe_group_data_capabilities(space, &members);
             return None;
         }
         if origin == Some(space) || !self.data_sync_active(space) {

--- a/crates/offline-protocol/src/protocol/data_sync.rs
+++ b/crates/offline-protocol/src/protocol/data_sync.rs
@@ -255,8 +255,12 @@ pub(crate) fn blob_digest(blob: &[u8]) -> String {
 /// id or address can contain, so no composed key can ever collide with a
 /// peer's own.
 fn group_offer_key(member: &str, group_id: &str) -> String {
-    format!("{member}\x01{group_id}")
+    format!("{member}{GROUP_OFFER_KEY_SEP}{group_id}")
 }
+
+/// The separator [`group_offer_key`] composes with, named so the split that
+/// takes a key back apart cannot drift from the format that built it.
+const GROUP_OFFER_KEY_SEP: char = '\x01';
 
 fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
@@ -309,6 +313,30 @@ impl OfflineProtocol {
             &SyncChannel::GroupDirected(member.to_string()),
             cause,
         );
+    }
+
+    /// Drop every offer window belonging to `peer`: the 1:1 one, and the
+    /// group one for each group shared with them.
+    ///
+    /// The group windows are keyed by (member, group), so removing the bare
+    /// peer key leaves them all behind, and each of them suppresses the
+    /// first group offer to that peer for a further window once the
+    /// capability is relearned. That is the same silent non-sync
+    /// [`Self::forget_data_sync_peer`] exists to prevent, one space at a
+    /// time.
+    ///
+    /// Windows left by a group this device *left* are deliberately not
+    /// swept here: they name a scope that no longer replicates at all, and
+    /// on a re-join the worst they can cost is one suppressed offer that
+    /// the next discovery re-sends.
+    #[cfg(feature = "data")]
+    pub(crate) fn forget_data_sync_offer_windows(&mut self, peer: &str) {
+        self.last_data_sync_offer.retain(|key, _| {
+            key != peer
+                && !key
+                    .split_once(GROUP_OFFER_KEY_SEP)
+                    .is_some_and(|(member, _)| member == peer)
+        });
     }
 
     /// Whether the reconciliation sweep keyed by `key` is outside its

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -6,8 +6,8 @@ use super::{
     GroupMemberAddedPayload, GroupMemberRemovedPayload, GroupMessageReceivedPayload,
     InternalMessageResult, KeyPackagePayload, OfflineProtocol, PeerCapabilities, PresencePayload,
     ReadReceiptPayload, ReceivedKeyPackage, TypingIndicatorPayload, UserGroupsPayload,
-    DATA_SYNC_V1, MAX_KEY_PACKAGE_LIFETIME_MS, MAX_KEY_PACKAGE_SENT_TO, MAX_PENDING_KEY_PACKAGES,
-    MAX_READ_RECEIPT_IDS, MLS_ENVELOPE_COMPACT_V1, RICH_PAYLOAD_V1,
+    DATA_GROUP_V1, DATA_SYNC_V1, MAX_KEY_PACKAGE_LIFETIME_MS, MAX_KEY_PACKAGE_SENT_TO,
+    MAX_PENDING_KEY_PACKAGES, MAX_READ_RECEIPT_IDS, MLS_ENVELOPE_COMPACT_V1, RICH_PAYLOAD_V1,
 };
 use crate::events::{DecryptionFailureCode, Event, SecurityWarningCode};
 use crate::mls_observability::{DecryptionFailureKind, MlsErrorCategory, MlsOperationContext};
@@ -126,6 +126,31 @@ impl OfflineProtocol {
             } else {
                 self.forget_data_sync_peer(sender);
             }
+
+            // The group entry is recorded independently of the 1:1 one,
+            // because a peer can honestly advertise the first without the
+            // second: an install from before group spaces replicates 1:1
+            // perfectly well and would render a group sync frame to its
+            // user as literal `__DATA_V1__` text. Collapsing the two into
+            // one flag is exactly how that frame gets sent.
+            if self.config.data.enabled && payload.data_versions.contains(&DATA_GROUP_V1) {
+                if !self.peer_data_group.contains(sender)
+                    && self.peer_data_group.len() >= MAX_KEY_PACKAGE_SENT_TO
+                {
+                    self.peer_data_group.clear();
+                }
+                self.peer_data_group.insert(sender.to_string());
+            } else {
+                self.peer_data_group.remove(sender);
+            }
+
+            // Direct knowledge is authoritative for the group capability
+            // too: a key package from the peer itself evicts whatever an
+            // inviter attested about them, in either direction. The durable
+            // side happens below — `from_advertised` never carries an
+            // attested field, so persisting the fresh advertisement drops
+            // it from the record as well.
+            self.peer_data_group_attested.remove(sender);
 
             // A direct key package is authoritative for this peer: drop any
             // inviter-attested rich entry (the durable side happens below —

--- a/crates/offline-protocol/src/protocol/message_dispatch.rs
+++ b/crates/offline-protocol/src/protocol/message_dispatch.rs
@@ -1791,6 +1791,9 @@ impl OfflineProtocol {
                         }
                     }
                     self.group_mesh.members.remove(&payload.group_id);
+                    self.group_mesh
+                        .roster_invisible_generations
+                        .remove(&payload.group_id);
                     let was_synced = self.group_mesh.relay_synced.remove(&payload.group_id);
                     // The outstanding-registration correlation goes too, as
                     // in every other membership-teardown path: a pending

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -1731,7 +1731,7 @@ impl OfflineProtocol {
         self.peer_data_group.remove(peer);
         self.peer_data_group_attested.remove(peer);
         #[cfg(feature = "data")]
-        self.last_data_sync_offer.remove(peer);
+        self.forget_data_sync_offer_windows(peer);
     }
 
     /// [`Self::forget_data_sync_peer`] for every peer at once.

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -429,6 +429,26 @@ pub struct OfflineProtocol {
     #[cfg(feature = "data")]
     pub(crate) last_data_sync_offer: HashMap<String, Instant>,
 
+    /// Whether the MLS group list has been read into `group_mesh.members`
+    /// once this session, so the shared-group rediscovery sweep can see the
+    /// groups this device is in.
+    ///
+    /// That cache is filled on demand by group traffic and is empty after a
+    /// restart, so a sweep that only read it would find nothing on exactly
+    /// the launch where two members have drifted apart and neither is
+    /// editing. Enumerating is one key listing plus, per group not already
+    /// cached, the group-state read the next group send would have paid
+    /// anyway.
+    ///
+    /// One shot rather than per sweep because the cache stays complete once
+    /// filled: creating a group inserts, a Welcome inserts, and leaving
+    /// removes. Deliberately not a cold-start sweep, which was rejected for
+    /// putting an offer per member per group on the mesh at every launch;
+    /// this is per peer, only when that peer is actually in front of us, and
+    /// still behind the offer window.
+    #[cfg(feature = "data")]
+    pub(crate) group_spaces_enumerated: bool,
+
     /// Lamport logical clock for causal message ordering.
     /// Ticked on send, merged on receive.
     lamport_clock: LamportClock,
@@ -842,6 +862,8 @@ impl OfflineProtocol {
             data: data::DataLayer::default(),
             #[cfg(feature = "data")]
             last_data_sync_offer: HashMap::new(),
+            #[cfg(feature = "data")]
+            group_spaces_enumerated: false,
             lamport_clock: LamportClock::new(),
             confirmation_retry_due_at: HashMap::new(),
             confirmation_probe_due_at: HashMap::new(),
@@ -1151,6 +1173,13 @@ impl OfflineProtocol {
         }
 
         self.mls_manager = Some(manager);
+        // A re-init can swap the identity, and with it which groups exist, so
+        // the one-shot group enumeration has to run again. Past the last
+        // `return Err` above, so a failed init leaves the flag alone.
+        #[cfg(feature = "data")]
+        {
+            self.group_spaces_enumerated = false;
+        }
         self.emit_mls_initialized();
 
         // Announced only here, past the last `return Err` — a restore failure
@@ -2417,7 +2446,7 @@ impl OfflineProtocol {
         Ok(plaintext)
     }
 
-    fn is_session_group_id(group_id: &str) -> bool {
+    pub(crate) fn is_session_group_id(group_id: &str) -> bool {
         group_id.starts_with("session:")
     }
 

--- a/crates/offline-protocol/src/protocol/mod.rs
+++ b/crates/offline-protocol/src/protocol/mod.rs
@@ -326,6 +326,33 @@ pub struct OfflineProtocol {
     /// on `initialize_mls`, bounded like `key_package_sent_to`.
     peer_rich_attested: std::collections::HashSet<String>,
 
+    /// Peers whose key package advertised *group* document replication
+    /// ([`DATA_GROUP_V1`] in `data_versions`), so a group they share with
+    /// this device may carry `__DATA_V1__` frames.
+    ///
+    /// Separate from `peer_data_sync` because the two entries mean
+    /// different things and a peer can advertise the first without the
+    /// second: an install predating group spaces replicates 1:1 perfectly
+    /// well and would render a group sync frame as chat text. Same
+    /// lifecycle as every capability set: learned from key-package
+    /// exchange, persisted, restored on `initialize_mls`, bounded like
+    /// `key_package_sent_to`.
+    ///
+    /// [`DATA_GROUP_V1`]: crate::protocol::types::DATA_GROUP_V1
+    peer_data_group: std::collections::HashSet<String>,
+
+    /// Peers whose *group* replication support we learned indirectly, from
+    /// an inviter's attestation on the Add commit or Welcome.
+    ///
+    /// The group analogue of `peer_rich_attested`, and load-bearing for the
+    /// same structural reason: members of a group never exchange key
+    /// packages with each other, so without attestation a group would
+    /// replicate only among whichever members happened to have met
+    /// directly. Direct knowledge stays authoritative — a key package from
+    /// the peer evicts its attested entry. Consulted only by
+    /// `group_data_sync_active`, never by 1:1 sync.
+    peer_data_group_attested: std::collections::HashSet<String>,
+
     /// Peers already flagged with a `PlaintextSend` security warning, so the
     /// explicit-opt-out plaintext path warns once per peer instead of once
     /// per message.
@@ -800,6 +827,8 @@ impl OfflineProtocol {
             peer_compact_envelope: std::collections::HashSet::new(),
             peer_rich_payload: std::collections::HashSet::new(),
             peer_data_sync: std::collections::HashSet::new(),
+            peer_data_group: std::collections::HashSet::new(),
+            peer_data_group_attested: std::collections::HashSet::new(),
             peer_rich_attested: std::collections::HashSet::new(),
             plaintext_send_warned: std::collections::HashSet::new(),
             plaintext_receive_warned: std::collections::HashSet::new(),
@@ -974,6 +1003,8 @@ impl OfflineProtocol {
         let previous_peer_rich_payload = self.peer_rich_payload.clone();
         let previous_peer_data_sync = self.peer_data_sync.clone();
         let previous_peer_rich_attested = self.peer_rich_attested.clone();
+        let previous_peer_data_group = self.peer_data_group.clone();
+        let previous_peer_data_group_attested = self.peer_data_group_attested.clone();
 
         let previous_local_id = std::mem::replace(&mut self.local_id, local_id.clone());
         let previous_identity_established = self.identity_established;
@@ -1114,6 +1145,8 @@ impl OfflineProtocol {
             self.peer_rich_payload = previous_peer_rich_payload;
             self.peer_data_sync = previous_peer_data_sync;
             self.peer_rich_attested = previous_peer_rich_attested;
+            self.peer_data_group = previous_peer_data_group;
+            self.peer_data_group_attested = previous_peer_data_group_attested;
             return Err(err);
         }
 
@@ -1512,6 +1545,14 @@ impl OfflineProtocol {
             // document written without ever being explicitly created leaves
             // records but no index entry, and those are precisely the
             // documents no peer has seen yet.
+            // Group spaces appear in this list and are deliberately not
+            // swept: `kick_data_sync` answers only for a space named after
+            // a peer, so a group space falls through it. A cold-start sweep
+            // for groups would mean an offer per member per group at every
+            // launch, and what it would recover is narrow — a local commit
+            // is already pushed to the roster when it happens, and the
+            // per-member outbox carries it across a restart. Rediscovery
+            // and joins reconcile the rest.
             for space in self.data_list_spaces().unwrap_or_default() {
                 self.kick_data_sync(&space, "start");
             }
@@ -1658,6 +1699,8 @@ impl OfflineProtocol {
     /// it is relearned, which is a document that silently does not sync.
     pub(crate) fn forget_data_sync_peer(&mut self, peer: &str) {
         self.peer_data_sync.remove(peer);
+        self.peer_data_group.remove(peer);
+        self.peer_data_group_attested.remove(peer);
         #[cfg(feature = "data")]
         self.last_data_sync_offer.remove(peer);
     }
@@ -1665,6 +1708,8 @@ impl OfflineProtocol {
     /// [`Self::forget_data_sync_peer`] for every peer at once.
     pub(crate) fn forget_every_data_sync_peer(&mut self) {
         self.peer_data_sync.clear();
+        self.peer_data_group.clear();
+        self.peer_data_group_attested.clear();
         #[cfg(feature = "data")]
         self.last_data_sync_offer.clear();
     }
@@ -1737,6 +1782,14 @@ impl OfflineProtocol {
         // the partition this discovery just ended.
         #[cfg(feature = "data")]
         self.kick_data_sync(peer_id, "peer_rediscovered");
+
+        // The same reconciliation for every group space shared with this
+        // peer. A group space cannot ride the 1:1 trigger above: two
+        // members of a group need not have a session with each other at
+        // all, so for them this discovery is the only moment anything knows
+        // they are both reachable.
+        #[cfg(feature = "data")]
+        self.kick_shared_group_data_sync(peer_id, "peer_rediscovered");
 
         // Only send key package if encryption is enabled and auto key exchange is on
         if !self.config.encryption.enabled || !self.config.encryption.auto_key_exchange {

--- a/crates/offline-protocol/src/protocol/send.rs
+++ b/crates/offline-protocol/src/protocol/send.rs
@@ -958,7 +958,7 @@ impl OfflineProtocol {
         #[cfg(feature = "data")]
         {
             if self.config.data.enabled {
-                return vec![super::types::DATA_SYNC_V1];
+                return vec![super::types::DATA_SYNC_V1, super::types::DATA_GROUP_V1];
             }
         }
         Vec::new()
@@ -1058,6 +1058,100 @@ impl OfflineProtocol {
     pub(crate) fn attestable_rich_versions(&self, peer_id: &str) -> Option<Vec<u8>> {
         (self.peer_rich_payload.contains(peer_id) || self.peer_rich_attested.contains(peer_id))
             .then(|| vec![RICH_PAYLOAD_V1])
+    }
+
+    /// Whether documents may replicate into a group: the layer is enabled
+    /// here and every non-self member is known to intercept group sync
+    /// frames — either self-advertised in a directly received key package
+    /// (`peer_data_group`) or attested by a group inviter on the Add commit
+    /// / Welcome (`peer_data_group_attested`).
+    ///
+    /// All-members rather than per-member, and that is not a convenience.
+    /// Group MLS encryption produces one ciphertext for everyone, so a
+    /// frame sent for the capable members is also delivered to the rest;
+    /// one member that cannot intercept it renders it to its user as
+    /// literal `__DATA_V1__` text. The gate is therefore closed by a single
+    /// unknown member, which is the same conservatism
+    /// [`Self::group_rich_seal_active`] applies to sealed rich bodies, for
+    /// the same reason and with a worse symptom if skipped.
+    ///
+    /// Blocking is deliberately not consulted here. A blocked *peer* is a
+    /// 1:1 relationship; a group send is one ciphertext to a roster, and
+    /// dropping the whole group's replication because one member is blocked
+    /// would be a surprising amount of collateral. The 1:1 gate keeps its
+    /// block check because there the recipient and the relationship are the
+    /// same thing.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn group_data_sync_active(&self, members: &[String]) -> bool {
+        #[cfg(feature = "data")]
+        {
+            self.config.data.enabled
+                && members
+                    .iter()
+                    .filter(|m| m.as_str() != self.local_id)
+                    .all(|m| {
+                        self.peer_data_group.contains(m.as_str())
+                            || self.peer_data_group_attested.contains(m.as_str())
+                    })
+        }
+        #[cfg(not(feature = "data"))]
+        {
+            let _ = members;
+            false
+        }
+    }
+
+    /// Group members (non-self) not known to intercept group sync frames.
+    ///
+    /// These are the members holding [`Self::group_data_sync_active`]
+    /// closed. Handed to [`Self::backfill_group_rich_capabilities`], whose
+    /// probe is capability-agnostic: it sends our key package so the peer's
+    /// reply teaches us everything they advertise at once.
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn group_data_unknown_members(&self, members: &[String]) -> Vec<String> {
+        #[cfg(feature = "data")]
+        {
+            members
+                .iter()
+                .filter(|m| {
+                    m.as_str() != self.local_id
+                        && !self.peer_data_group.contains(m.as_str())
+                        && !self.peer_data_group_attested.contains(m.as_str())
+                })
+                .cloned()
+                .collect()
+        }
+        #[cfg(not(feature = "data"))]
+        {
+            let _ = members;
+            Vec::new()
+        }
+    }
+
+    /// The sync versions we can attest for a peer when inviting it into (or
+    /// welcoming it to) a group.
+    ///
+    /// [`DATA_GROUP_V1`] when the peer is known group-capable, directly or
+    /// itself attested — attestation chains transitively, which is how
+    /// knowledge reaches members several adds removed from any direct
+    /// exchange. `None` when unknown, and `None` is deliberately not a
+    /// downgrade signal: absence of knowledge must never evict what another
+    /// member learned first-hand.
+    ///
+    /// [`DATA_GROUP_V1`]: crate::protocol::types::DATA_GROUP_V1
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn attestable_data_versions(&self, peer_id: &str) -> Option<Vec<u8>> {
+        #[cfg(feature = "data")]
+        {
+            (self.peer_data_group.contains(peer_id)
+                || self.peer_data_group_attested.contains(peer_id))
+            .then(|| vec![super::types::DATA_GROUP_V1])
+        }
+        #[cfg(not(feature = "data"))]
+        {
+            let _ = peer_id;
+            None
+        }
     }
 
     /// Best-effort capability backfill for group members whose rich support

--- a/crates/offline-protocol/src/protocol/storage.rs
+++ b/crates/offline-protocol/src/protocol/storage.rs
@@ -4,7 +4,7 @@ use super::state_crypto::{StateRecordCipher, SEALED_RECORD_OVERHEAD, STATE_RECOR
 use super::{
     lifetime_expired, storage_keys, MediaTransferDescriptor, OfflineProtocol, OutboxEntry,
     PeerCapabilities, PendingMessage, PendingMessageRecord, ReceivedKeyPackage, SessionState,
-    WelcomeDeliveryState, WelcomeLifecycleRecord, DATA_SYNC_V1, MAX_BLOCKED_USERS,
+    WelcomeDeliveryState, WelcomeLifecycleRecord, DATA_GROUP_V1, DATA_SYNC_V1, MAX_BLOCKED_USERS,
     MAX_KEY_PACKAGE_SENT_TO, MAX_MIGRATED_PENDING_WRITES_PER_LAUNCH, MAX_PENDING_KEY_PACKAGES,
     MAX_PENDING_MESSAGES_GLOBAL, MAX_PENDING_MESSAGES_PER_PEER, MAX_PENDING_MESSAGE_BYTES_GLOBAL,
     MAX_PENDING_MESSAGE_BYTES_PER_PEER, MAX_PERSISTED_CAPABILITY_VERSIONS,
@@ -2859,6 +2859,57 @@ impl OfflineProtocol {
         self.persist_peer_capabilities(peer_id, &caps);
     }
 
+    /// Records an inviter-attested *group replication* capability, the
+    /// [`DATA_GROUP_V1`] sibling of [`Self::record_attested_rich`].
+    ///
+    /// Every rule there applies here for the same reasons: skip self, skip
+    /// peers already known directly, gate the in-memory set on our own kill
+    /// switch, bound it like `key_package_sent_to`, and never write an
+    /// attested-only record over a capability record that could not be read
+    /// this session.
+    ///
+    /// What differs is only what is at stake. Without this, a group
+    /// replicates among whichever members happen to have exchanged key
+    /// packages directly and quietly does not replicate with the rest —
+    /// members of a group never exchange key packages with each other, so
+    /// on a group nobody built out of existing 1:1 contacts that subset can
+    /// easily be empty.
+    ///
+    /// [`DATA_GROUP_V1`]: crate::protocol::types::DATA_GROUP_V1
+    #[cfg_attr(not(feature = "data"), allow(dead_code))]
+    pub(crate) fn record_attested_data(&mut self, peer_id: &str, versions: &[u8]) {
+        if peer_id == self.local_id || !versions.contains(&DATA_GROUP_V1) {
+            return;
+        }
+        // Direct self-advertisement already covers this peer; an attested
+        // duplicate would only go stale.
+        if self.peer_data_group.contains(peer_id) {
+            return;
+        }
+        if self.config.data.enabled {
+            if !self.peer_data_group_attested.contains(peer_id)
+                && self.peer_data_group_attested.len() >= MAX_KEY_PACKAGE_SENT_TO
+            {
+                self.peer_data_group_attested.clear();
+            }
+            self.peer_data_group_attested.insert(peer_id.to_string());
+        }
+        let Ok(existing) = self.load_peer_capabilities(peer_id) else {
+            warn!(
+                peer_id = %peer_id,
+                "Peer capability record unreadable this session; not persisting the attested capability"
+            );
+            return;
+        };
+        let mut caps = existing.unwrap_or_default();
+        caps.attested_data_versions = versions
+            .iter()
+            .copied()
+            .take(MAX_PERSISTED_CAPABILITY_VERSIONS)
+            .collect();
+        self.persist_peer_capabilities(peer_id, &caps);
+    }
+
     /// Repopulates the in-memory capability sets (`peer_compact_envelope`,
     /// `peer_rich_payload`) from the durable per-peer records, so a send
     /// right after relaunch — before any live key-package exchange — keeps
@@ -2983,6 +3034,15 @@ impl OfflineProtocol {
             // problem.
             if self.config.data.enabled && caps.data_versions.contains(&DATA_SYNC_V1) {
                 self.peer_data_sync.insert(peer_id.clone());
+            }
+            // The group half of the same failure, and a quieter one: a group
+            // space that stops replicating after a restart looks to every
+            // member like a group where nobody happens to be editing.
+            if self.config.data.enabled && caps.data_versions.contains(&DATA_GROUP_V1) {
+                self.peer_data_group.insert(peer_id.clone());
+            }
+            if self.config.data.enabled && caps.attested_data_versions.contains(&DATA_GROUP_V1) {
+                self.peer_data_group_attested.insert(peer_id.clone());
             }
             // Not gated on the sealing kill switch: this is a destination
             // address, and the transport decides whether to seal at all. A

--- a/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
+++ b/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
@@ -737,3 +737,68 @@ fn the_group_capability_is_advertised_and_recorded() {
          will ever send it one"
     );
 }
+
+#[test]
+fn the_shared_group_sweep_finds_a_group_on_a_cold_roster_cache() {
+    // Rediscovery is the only trigger a group space has for closing a gap
+    // that no live frame carried, and the launch it matters on is the one
+    // where nothing has touched the group yet. The roster cache is filled on
+    // demand, so a sweep that read only it would find nothing here and the
+    // two replicas would sit apart until somebody happened to edit.
+    let (mut alice, mut bob, mut carol, group) = trio();
+    write(&mut alice, &group, "notes", "title", "hello");
+    settle(&mut alice, &mut bob, &mut carol);
+    alice.transport.clear_sent_messages();
+
+    // What a relaunch leaves behind: MLS still holds the group, and nothing
+    // has refilled the caches that live only in memory.
+    alice.protocol.group_mesh.members.clear();
+    alice.protocol.last_data_sync_offer.clear();
+    alice.protocol.group_spaces_enumerated = false;
+
+    alice
+        .protocol
+        .kick_shared_group_data_sync(&bob.address, "peer_rediscovered");
+
+    assert!(
+        data_frames_sent(&alice, &mut bob, &group) > 0,
+        "a rediscovered member of a group this device is in has to be \
+         offered its documents, and which groups those are comes from MLS, \
+         not from a cache that a restart emptied"
+    );
+}
+
+#[test]
+fn a_space_named_after_a_one_to_one_session_slot_is_not_a_group_space() {
+    // MLS stores every 1:1 session as a group, and the group-info read that
+    // classifies a space answers for one. Left unguarded, a space named
+    // after a session slot is treated as a group space and then filed in
+    // `group_mesh.members` — the cache that leaving a group, admin
+    // auto-promotion and the shared-group sweep all read as the set of real
+    // groups. A space name is never wire-supplied, so this is a local
+    // footgun rather than a reachable attack, and it costs one prefix test.
+    let alice = Member::new("alice");
+    crate::protocol::tests::create_local_session_with(&alice.protocol, "bob");
+    let slot = crate::test_identity::session_slot("alice", "bob");
+
+    // Non-vacuity: without this the assertions below would pass on a name
+    // MLS simply does not know, which is the wrong reason.
+    {
+        let mls = alice.protocol.mls_manager_for_testing().read().unwrap();
+        let gid = offline_protocol_mls::GroupId::new(&slot).unwrap();
+        assert!(
+            mls.has_group(&gid).unwrap(),
+            "precondition: MLS really does hold a group at the session slot"
+        );
+    }
+
+    let mut alice = alice;
+    assert!(
+        alice.protocol.group_space_roster(&slot).is_none(),
+        "a session slot must never classify as a group space"
+    );
+    assert!(
+        !alice.protocol.group_mesh.members.contains_key(&slot),
+        "and classifying it must not have filed it in the roster cache"
+    );
+}

--- a/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
+++ b/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use offline_protocol_data::DataValue;
 use offline_protocol_transport::{MockTransport, Transport, TransportType};
 
-use crate::group_mesh::MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS;
+use crate::group_mesh::{RosterRatchetGap, MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS};
 use crate::mls::InMemoryStorage;
 use crate::protocol::prefixes::internal_prefixes;
 use crate::protocol::tests::{create_test_config_for_user, id};
@@ -855,13 +855,42 @@ fn directed_frames_do_not_strand_the_member_they_skip() {
     );
 }
 
+/// The gap this device believes it has opened in `group`.
+fn ratchet_gap(member: &Member, group: &str) -> Option<RosterRatchetGap> {
+    member
+        .protocol
+        .group_mesh
+        .roster_invisible_generations
+        .get(group)
+        .copied()
+}
+
+/// Declare the budget spent at the epoch the group is actually on, which is
+/// what 256 directed frames would have done, without sending them.
+fn spend_the_budget(member: &mut Member, group: &str) {
+    let epoch = ratchet_gap(member, group)
+        .expect("the group has to have been sent something before its budget can be spent")
+        .epoch;
+    member
+        .protocol
+        .group_mesh
+        .roster_invisible_generations
+        .insert(
+            group.to_string(),
+            RosterRatchetGap {
+                epoch,
+                invisible: MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS,
+            },
+        );
+}
+
 #[test]
 fn a_roster_wide_frame_clears_the_ratchet_gap_budget() {
     // The budget is spent by frames the roster does not see and cleared by
     // one it does. Group chat is the common clearer, so a talkative group
     // never promotes anything; a group that only replicates documents is
     // the one that relies on the promotion.
-    let (mut alice, mut bob, _carol, group) = trio();
+    let (mut alice, bob, _carol, group) = trio();
 
     for _ in 0..10 {
         alice.protocol.last_data_sync_offer.clear();
@@ -870,14 +899,12 @@ fn a_roster_wide_frame_clears_the_ratchet_gap_budget() {
             .kick_group_data_sync(&group, &bob.address, "rediscovered");
     }
     assert_eq!(
-        alice
-            .protocol
-            .group_mesh
-            .roster_invisible_generations
-            .get(&group)
-            .copied(),
-        Some(10),
-        "each directed frame has to be counted, or the budget never trips"
+        ratchet_gap(&alice, &group).map(|gap| gap.invisible),
+        Some(9),
+        "each directed frame has to be counted, or the budget never trips. \
+         Nine and not ten because the first frame of the process is promoted \
+         on its own account: this device cannot see the generation it \
+         inherited from earlier sessions"
     );
 
     alice
@@ -886,16 +913,183 @@ fn a_roster_wide_frame_clears_the_ratchet_gap_budget() {
         .expect("send a group message");
 
     assert_eq!(
-        alice
-            .protocol
-            .group_mesh
-            .roster_invisible_generations
-            .get(&group)
-            .copied(),
-        None,
+        ratchet_gap(&alice, &group).map(|gap| gap.invisible),
+        Some(0),
         "a message every member is handed puts the whole roster back within \
          reach, so the gap it closed must not keep counting against the next \
          promotion"
+    );
+    assert!(
+        ratchet_gap(&alice, &group).is_some(),
+        "and the entry has to stay: an absent one means \"this process has \
+         never given the roster a frame\", which would promote every frame \
+         from here on"
+    );
+}
+
+#[test]
+fn the_first_directed_frame_of_a_process_is_promoted() {
+    // The MLS sender ratchet is persisted with the group state and this
+    // counter is not, so a relaunch inherits a generation it cannot read.
+    // Counting from zero there would let a device that restarts often
+    // accumulate the gap across sessions and strand a member without the
+    // budget ever tripping: four quiet launches of 250 directed frames each
+    // cross 1000 with the counter never leaving 250.
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    // Give the group a history so the offer below has something to carry,
+    // then take the process back to what a relaunch leaves: the MLS state
+    // (and its generation) intact, this map empty.
+    write(&mut alice, &group, "notes", "title", "hello");
+    settle(&mut alice, &mut bob, &mut carol);
+    alice
+        .protocol
+        .group_mesh
+        .roster_invisible_generations
+        .clear();
+    alice.transport.clear_sent_messages();
+
+    alice.protocol.last_data_sync_offer.clear();
+    alice
+        .protocol
+        .kick_group_data_sync(&group, &bob.address, "rediscovered");
+
+    assert!(
+        data_frames_sent(&alice, &mut carol, &group) > 0,
+        "the first directed frame after a relaunch has to reach the whole \
+         roster: it is the only rung this process can be sure every member \
+         can still decrypt"
+    );
+    assert_eq!(
+        ratchet_gap(&alice, &group).map(|gap| gap.invisible),
+        Some(0),
+        "and having promoted it, the count starts from a gap of nothing"
+    );
+}
+
+#[test]
+fn an_epoch_rotation_rebases_the_ratchet_gap() {
+    // The gap is a property of one epoch: a commit rotates the group and
+    // every member restarts the ratchet at zero, so a count carried across
+    // the rotation describes a gap that no longer exists. Keyed by epoch
+    // rather than cleared at each rotation site, because a rotation site
+    // added later cannot forget to call something it never knew about.
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    write(&mut alice, &group, "notes", "title", "hello");
+    settle(&mut alice, &mut bob, &mut carol);
+    let epoch = ratchet_gap(&alice, &group)
+        .expect("the write recorded an epoch")
+        .epoch;
+
+    // A spent budget belonging to an epoch the group has since left.
+    alice
+        .protocol
+        .group_mesh
+        .roster_invisible_generations
+        .insert(
+            group.clone(),
+            RosterRatchetGap {
+                epoch: epoch.saturating_sub(1),
+                invisible: MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS,
+            },
+        );
+    alice.transport.clear_sent_messages();
+
+    alice.protocol.last_data_sync_offer.clear();
+    alice
+        .protocol
+        .kick_group_data_sync(&group, &bob.address, "rediscovered");
+
+    assert_eq!(
+        data_frames_sent(&alice, &mut carol, &group),
+        0,
+        "a gap recorded in an epoch the group has left must not spend a \
+         roster-wide frame to close a ratchet every member already restarted"
+    );
+    let gap = ratchet_gap(&alice, &group).expect("the directed frame was counted");
+    assert_eq!(
+        gap.epoch, epoch,
+        "the count has to move to the epoch it now describes"
+    );
+    assert_eq!(
+        gap.invisible, 1,
+        "and start from that epoch's first invisible frame"
+    );
+}
+
+#[test]
+fn a_promotion_never_crosses_a_closed_replication_gate() {
+    // A directed frame needs no capability check: the member it answers
+    // asked for it. A promotion is a roster-wide delivery, and handing that
+    // same frame to a member who does not intercept `__DATA_V1__` shows it
+    // to their user as literal text, which is the send the all-members gate
+    // exists to refuse. Reachable through knowledge asymmetry: Alice can be
+    // answering Bob perfectly legitimately at the moment she learns Carol is
+    // on a build that cannot read these.
+    //
+    // With the promotion unavailable the frame is withheld rather than sent
+    // addressed, because every directed encryption spends a generation only
+    // its target observes. Past the forward-distance limit that costs the
+    // others this device's group *chat*, so continuing would trade a
+    // permanent messaging failure for a document convergence that is
+    // already stalled group-wide.
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    write(&mut alice, &group, "notes", "title", "hello");
+    settle(&mut alice, &mut bob, &mut carol);
+    spend_the_budget(&mut alice, &group);
+    let spent = ratchet_gap(&alice, &group).expect("the budget was just spent");
+    alice.protocol.peer_data_group.remove(&carol.address);
+    alice.transport.clear_sent_messages();
+
+    // Bob asks. Alice would answer him directly, and the spent budget is
+    // what would otherwise promote that answer to the whole roster.
+    bob.protocol.last_data_sync_offer.clear();
+    bob.protocol
+        .kick_group_data_sync(&group, &alice.address, "rediscovered");
+    {
+        let (a, c) = (&mut alice, &mut carol);
+        pump(&mut bob, &mut [a, c]);
+    }
+
+    assert_eq!(
+        data_frames_sent(&alice, &mut carol, &group),
+        0,
+        "the ratchet budget promoted a replication frame into a roster whose \
+         gate is closed; Carol renders it to her user as literal __DATA_V1__ \
+         text, which is the whole reason the gate exists"
+    );
+    assert_eq!(
+        data_frames_sent(&alice, &mut bob, &group),
+        0,
+        "with the promotion unavailable the answer has to be withheld, not \
+         sent addressed: another generation only Bob observes is one more \
+         step toward Carol losing this device's chat as well"
+    );
+    assert_eq!(
+        ratchet_gap(&alice, &group).map(|gap| gap.invisible),
+        Some(spent.invisible),
+        "a withheld frame must not be counted, or the refusal spends the \
+         very budget it exists to stop spending"
+    );
+
+    // The positive control, and the reason this test is about the gate
+    // rather than about nothing ever happening: the same question, with
+    // Carol known capable again, is answered by the promotion.
+    alice.protocol.peer_data_group.insert(carol.address.clone());
+    alice.transport.clear_sent_messages();
+    bob.protocol.last_data_sync_offer.clear();
+    bob.protocol
+        .kick_group_data_sync(&group, &alice.address, "rediscovered");
+    {
+        let (a, c) = (&mut alice, &mut carol);
+        pump(&mut bob, &mut [a, c]);
+    }
+    assert!(
+        data_frames_sent(&alice, &mut carol, &group) > 0,
+        "once every member can read one, the spent budget has to promote the \
+         answer to the whole roster: that is the rung Carol climbs"
     );
 }
 
@@ -906,7 +1100,7 @@ fn forgetting_a_peer_drops_its_group_offer_windows_too() {
     // key leaves one behind per shared group, and each of those suppresses
     // the first offer to that peer after the capability is relearned —
     // which is a document that silently does not sync, one space at a time.
-    let (mut alice, mut bob, _carol, group) = trio();
+    let (mut alice, bob, _carol, group) = trio();
 
     alice
         .protocol

--- a/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
+++ b/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
@@ -1094,6 +1094,29 @@ fn a_promotion_never_crosses_a_closed_replication_gate() {
 }
 
 #[test]
+fn a_closed_gate_probes_the_member_holding_it_shut() {
+    // Rediscovery is the only trigger a group space has that does not
+    // require somebody to be editing, so on a device that only reads it is
+    // the only moment anything notices the gate is shut. Probing from the
+    // local-commit path alone would leave that device waiting for another
+    // member to do it.
+    let (mut alice, bob, _carol, group) = trio();
+    alice.protocol.peer_data_group.remove(&bob.address);
+    alice.protocol.key_package_sent_to.clear();
+
+    alice
+        .protocol
+        .kick_group_data_sync(&group, &bob.address, "rediscovered");
+
+    assert!(
+        alice.protocol.key_package_sent_to.contains(&bob.address),
+        "a member of unknown capability has to be asked what it supports; \
+         our key package is the question, and its automatic reply is the \
+         answer"
+    );
+}
+
+#[test]
 fn forgetting_a_peer_drops_its_group_offer_windows_too() {
     // The offer window and the capability are two halves of one fact. A
     // group window is keyed by (member, group), so dropping the bare peer

--- a/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
+++ b/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
@@ -898,3 +898,38 @@ fn a_roster_wide_frame_clears_the_ratchet_gap_budget() {
          promotion"
     );
 }
+
+#[test]
+fn forgetting_a_peer_drops_its_group_offer_windows_too() {
+    // The offer window and the capability are two halves of one fact. A
+    // group window is keyed by (member, group), so dropping the bare peer
+    // key leaves one behind per shared group, and each of those suppresses
+    // the first offer to that peer after the capability is relearned —
+    // which is a document that silently does not sync, one space at a time.
+    let (mut alice, mut bob, _carol, group) = trio();
+
+    alice
+        .protocol
+        .kick_group_data_sync(&group, &bob.address, "rediscovered");
+    alice.protocol.kick_data_sync(&bob.address, "rediscovered");
+    assert!(
+        alice
+            .protocol
+            .last_data_sync_offer
+            .keys()
+            .any(|k| k.contains(&group)),
+        "precondition: the group offer has to have stamped a window"
+    );
+
+    alice.protocol.forget_data_sync_peer(&bob.address);
+
+    assert!(
+        !alice
+            .protocol
+            .last_data_sync_offer
+            .keys()
+            .any(|k| k.starts_with(bob.address.as_str())),
+        "every window belonging to the forgotten peer has to go, the group \
+         ones included"
+    );
+}

--- a/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
+++ b/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
@@ -1,0 +1,739 @@
+//! Replication across a group space, over the real group send and receive
+//! paths.
+//!
+//! The sibling of `data_sync.rs`, and the same standard applies: every frame
+//! here is encrypted for a real MLS group, carried by a transport, and
+//! dispatched by the group message handler. What is new in this file is that
+//! a space now has more than one other replica in it, so the questions are
+//! different — one ciphertext has to serve the roster, an answer has to
+//! reach one member rather than all of them, and a member that cannot
+//! intercept these frames must never be sent one.
+
+use std::sync::{Arc, Mutex};
+
+use offline_protocol_data::DataValue;
+use offline_protocol_transport::{MockTransport, Transport, TransportType};
+
+use crate::mls::InMemoryStorage;
+use crate::protocol::prefixes::internal_prefixes;
+use crate::protocol::tests::{create_test_config_for_user, id};
+use crate::protocol::types::{DATA_GROUP_V1, DATA_SYNC_V1};
+use crate::protocol::{OfflineProtocol, TestProtocolStateStorage};
+
+/// One member of the group, with the transport its frames go through.
+struct Member {
+    protocol: OfflineProtocol,
+    transport: MockTransport,
+    address: String,
+    events: Arc<Mutex<Vec<crate::Event>>>,
+}
+
+impl Member {
+    fn new(label: &str) -> Self {
+        let mut config = create_test_config_for_user(label);
+        config.encryption.enabled = true;
+        config.data.enabled = true;
+
+        let mut protocol = OfflineProtocol::new(config).expect("protocol");
+        let secure = crate::test_identity::seeded_storage(label);
+        let state = Arc::new(InMemoryStorage::new());
+        protocol
+            .initialize_mls(
+                secure,
+                Arc::new(TestProtocolStateStorage { storage: state }),
+            )
+            .expect("initialize_mls");
+
+        let mock = MockTransport::new(TransportType::BLE);
+        mock.start().expect("transport start");
+        let transport = mock.clone();
+        protocol
+            .transport_manager_mut()
+            .add_transport(TransportType::BLE, Box::new(mock));
+
+        let events: Arc<Mutex<Vec<crate::Event>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = events.clone();
+        protocol.on_event(move |event| sink.lock().unwrap().push(event));
+        protocol.start().expect("start");
+
+        Self {
+            protocol,
+            transport,
+            address: id(label),
+            events,
+        }
+    }
+
+    /// Whether the application was handed a group message.
+    ///
+    /// The thing a missed interception looks like: the frame decrypts, and
+    /// because nothing recognised it the group handler emits it as a chat
+    /// message whose body is literal `__DATA_V1__` JSON.
+    fn saw_group_message(&self) -> bool {
+        self.events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|event| matches!(event, crate::Event::GroupMessageReceived { .. }))
+    }
+}
+
+/// A real three-member MLS group, with every member known group-capable.
+///
+/// Built through the MLS manager rather than through `invite_to_group` so
+/// the fixture is the group itself and not the invite path: the triggers
+/// that ride an invite have their own tests, and a fixture that depended on
+/// them could not tell a broken trigger from a broken group.
+fn trio() -> (Member, Member, Member, String) {
+    let mut alice = Member::new("alice");
+    let mut bob = Member::new("bob");
+    let mut carol = Member::new("carol");
+
+    let group_id = {
+        let info = alice.protocol.create_group("notes").expect("create");
+        info.group_id.as_str().to_string()
+    };
+    let gid = offline_protocol_mls::GroupId::new(&group_id).unwrap();
+
+    // Bob first, then Carol. Adding Carol advances the group epoch, and Bob
+    // has to merge that commit or Alice's later ciphertext is one epoch
+    // ahead of him — which is a real condition the protocol handles by
+    // buffering, and which would make this fixture silently test the
+    // buffering path instead of replication.
+    add_member(&alice, &bob, &gid, &[]);
+    add_member(&alice, &carol, &gid, &[&bob]);
+
+    // Every member has to agree on the roster, and Bob has to learn Carol
+    // (and vice versa) the way a real join does: from the group state, not
+    // from this fixture's knowledge of it.
+    alice.protocol.refresh_group_members(&group_id).unwrap();
+    let roster = vec![
+        alice.address.clone(),
+        bob.address.clone(),
+        carol.address.clone(),
+    ];
+    for member in [&mut bob, &mut carol] {
+        member
+            .protocol
+            .group_mesh
+            .members
+            .insert(group_id.clone(), roster.clone());
+    }
+
+    // What an inviter's attestation leaves behind on each member. The
+    // attestation plumbing that produces it has its own tests; these are
+    // about what happens once every member is known capable.
+    let (a, b, c) = (
+        alice.address.clone(),
+        bob.address.clone(),
+        carol.address.clone(),
+    );
+    for (member, others) in [
+        (&mut alice, [&b, &c]),
+        (&mut bob, [&a, &c]),
+        (&mut carol, [&a, &b]),
+    ] {
+        for other in others {
+            member.protocol.peer_data_group.insert(other.clone());
+        }
+    }
+
+    (alice, bob, carol, group_id)
+}
+
+/// Add `joiner` to the group, merging the resulting commit into every
+/// member that is already in it.
+///
+/// `existing` are the members other than the adder, who merges its own
+/// commit as part of producing it.
+fn add_member(
+    adder: &Member,
+    joiner: &Member,
+    gid: &offline_protocol_mls::GroupId,
+    existing: &[&Member],
+) {
+    let kp = {
+        let mls = joiner.protocol.mls_manager_for_testing().read().unwrap();
+        mls.generate_key_package().unwrap()
+    };
+    let (welcome, commit) = {
+        let mls = adder.protocol.mls_manager_for_testing().read().unwrap();
+        mls.add_group_member(gid, &joiner.address, &kp.key_package_data)
+            .unwrap()
+    };
+    {
+        let mls = joiner.protocol.mls_manager_for_testing().read().unwrap();
+        mls.join_group(&welcome).unwrap();
+    }
+    for member in existing {
+        let mls = member.protocol.mls_manager_for_testing().read().unwrap();
+        let encrypted = offline_protocol_mls::EncryptedMessage {
+            group_id: gid.clone(),
+            message_type: offline_protocol_mls::MlsMessageType::Commit,
+            epoch: commit.epoch,
+            ciphertext: commit.ciphertext.clone(),
+            sender_id: adder.address.clone(),
+            timestamp_ms: 0,
+        };
+        // A commit returns `Ok(None)`: MLS consumed it and advanced the
+        // epoch rather than producing application data.
+        mls.decrypt_from_group(&encrypted, &adder.address)
+            .expect("merge the add commit");
+    }
+}
+
+/// Carry everything `from` sent to whichever of `to` it was addressed to.
+fn pump(from: &mut Member, to: &mut [&mut Member]) -> usize {
+    let messages = from.transport.sent_messages();
+    from.transport.clear_sent_messages();
+    let mut moved = 0;
+    for message in messages {
+        for peer in to.iter_mut() {
+            if message.recipient.as_str() == peer.address {
+                peer.transport.queue_message(message.clone());
+                moved += 1;
+            }
+        }
+    }
+    for peer in to.iter_mut() {
+        while peer.protocol.receive_message().is_some() {}
+    }
+    moved
+}
+
+/// Run the group to quiescence, returning the frames carried each round.
+fn settle(alice: &mut Member, bob: &mut Member, carol: &mut Member) -> Vec<usize> {
+    let mut rounds = Vec::new();
+    for _ in 0..8 {
+        let mut carried = 0;
+        // Split borrows: each pump needs the sender mutably and the others
+        // mutably, which cannot overlap.
+        carried += {
+            let (b, c) = (&mut *bob, &mut *carol);
+            pump(alice, &mut [b, c])
+        };
+        carried += {
+            let (a, c) = (&mut *alice, &mut *carol);
+            pump(bob, &mut [a, c])
+        };
+        carried += {
+            let (a, b) = (&mut *alice, &mut *bob);
+            pump(carol, &mut [a, b])
+        };
+        rounds.push(carried);
+        if carried == 0 {
+            break;
+        }
+    }
+    rounds
+}
+
+fn write(member: &mut Member, space: &str, doc: &str, key: &str, value: &str) {
+    member
+        .protocol
+        .data_map_set(space, doc, "m", key, DataValue::text(value))
+        .expect("set");
+    member.protocol.data_flush(space, doc).expect("flush");
+}
+
+fn read(member: &mut Member, space: &str, doc: &str, key: &str) -> Option<DataValue> {
+    member
+        .protocol
+        .data_map_get(space, doc, "m", key)
+        .expect("get")
+}
+
+/// How many of the frames a member sent are replication frames.
+///
+/// Counted by decrypting them as the recipient would, because a group frame
+/// is opaque on the wire: `__GRP_MLS_MSG__` is all an observer sees whether
+/// it carries a chat message or a document change.
+fn data_frames_sent(from: &Member, to: &mut Member, group_id: &str) -> usize {
+    from.transport
+        .sent_messages()
+        .iter()
+        .filter(|message| message.recipient.as_str() == to.address)
+        .filter(|message| {
+            let Some(payload) = message
+                .content
+                .strip_prefix(internal_prefixes::GROUP_MLS_MSG)
+            else {
+                return false;
+            };
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) else {
+                return false;
+            };
+            let Some(ciphertext) = value.get("ciphertext").and_then(|c| c.as_str()) else {
+                return false;
+            };
+            let Ok(bytes) = crate::protocol::base64_decode(ciphertext) else {
+                return false;
+            };
+            let mls = to.protocol.mls_manager_for_testing().read().unwrap();
+            let gid = offline_protocol_mls::GroupId::new(group_id).unwrap();
+            let encrypted = offline_protocol_mls::EncryptedMessage {
+                group_id: gid,
+                message_type: offline_protocol_mls::MlsMessageType::Application,
+                epoch: 0,
+                ciphertext: bytes,
+                sender_id: from.address.clone(),
+                timestamp_ms: 0,
+            };
+            matches!(
+                mls.decrypt_from_group(&encrypted, &from.address),
+                Ok(Some(plaintext))
+                    if String::from_utf8_lossy(&plaintext)
+                        .starts_with(internal_prefixes::DATA_V1)
+            )
+        })
+        .count()
+}
+
+#[test]
+fn a_change_written_in_a_group_reaches_every_member() {
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    write(&mut alice, &group, "notes", "title", "hello");
+    settle(&mut alice, &mut bob, &mut carol);
+
+    for (label, member) in [("bob", &mut bob), ("carol", &mut carol)] {
+        assert_eq!(
+            read(member, &group, "notes", "title"),
+            Some(DataValue::text("hello")),
+            "{label} never received the change"
+        );
+    }
+}
+
+#[test]
+fn a_group_change_is_encrypted_once_for_the_whole_roster() {
+    // The headline property of a group space, and the reason it is not N
+    // 1:1 spaces: one MLS encryption serves everyone. A regression here
+    // would not fail any convergence test — every member would still
+    // receive the change — so it is asserted directly.
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    write(&mut alice, &group, "notes", "title", "hello");
+
+    let to_bob = data_frames_sent(&alice, &mut bob, &group);
+    let to_carol = data_frames_sent(&alice, &mut carol, &group);
+    assert_eq!(
+        (to_bob, to_carol),
+        (1, 1),
+        "one commit must produce exactly one frame per member"
+    );
+
+    let ciphertexts: Vec<String> = alice
+        .transport
+        .sent_messages()
+        .iter()
+        .filter_map(|m| {
+            let payload = m.content.strip_prefix(internal_prefixes::GROUP_MLS_MSG)?;
+            let value: serde_json::Value = serde_json::from_str(payload).ok()?;
+            Some(value.get("ciphertext")?.as_str()?.to_string())
+        })
+        .collect();
+    assert_eq!(ciphertexts.len(), 2, "one copy addressed to each member");
+    assert_eq!(
+        ciphertexts[0], ciphertexts[1],
+        "both members must be handed the SAME ciphertext: encrypting per \
+         member would make a group of N cost N encryptions and N times the \
+         key material, which is the whole reason a group space exists"
+    );
+}
+
+#[test]
+fn a_change_received_from_the_group_is_not_pushed_on() {
+    // Without this rule every member re-broadcasts every change to every
+    // other member: one edit becomes N^2 frames, and the group gets slower
+    // the more people are in it. The change already reached everyone —
+    // that is what one group ciphertext does.
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    write(&mut alice, &group, "notes", "title", "hello");
+
+    // Carry Alice's frame in, then look at what Bob does with it — before
+    // any further settling, because a settle would let the traffic this
+    // test is looking for be absorbed and disappear.
+    {
+        let (b, c) = (&mut bob, &mut carol);
+        pump(&mut alice, &mut [b, c]);
+    }
+    assert_eq!(
+        read(&mut bob, &group, "notes", "title"),
+        Some(DataValue::text("hello")),
+        "the change has to have arrived for its echo to be meaningful"
+    );
+
+    let echoed_to_carol = data_frames_sent(&bob, &mut carol, &group);
+    assert_eq!(
+        echoed_to_carol, 0,
+        "Bob re-broadcast a change he received from the group; Carol \
+         already had it from Alice's own frame"
+    );
+}
+
+#[test]
+fn a_member_that_cannot_intercept_group_frames_is_never_sent_one() {
+    // The compatibility trap `DATA_GROUP_V1` exists for. An install that
+    // speaks only the 1:1 version holds group sessions and has no group
+    // interception at all, so a replication frame sent into its group
+    // surfaces to its user as literal `__DATA_V1__` text. One ciphertext
+    // serves the roster, so one such member has to close the gate for
+    // everyone.
+    let (mut alice, mut bob, mut carol, group) = trio();
+    alice.protocol.peer_data_group.remove(&carol.address);
+
+    write(&mut alice, &group, "notes", "title", "hello");
+
+    assert_eq!(
+        data_frames_sent(&alice, &mut bob, &group),
+        0,
+        "the gate is all-members: a frame Bob can read is delivered to \
+         Carol too, and she would render it as text"
+    );
+
+    settle(&mut alice, &mut bob, &mut carol);
+    assert_eq!(
+        read(&mut bob, &group, "notes", "title"),
+        None,
+        "nothing may replicate while a member of unknown capability is in \
+         the roster"
+    );
+}
+
+#[test]
+fn the_group_capability_is_independent_of_the_one_to_one_one() {
+    // A peer from before group spaces advertises `[1]` and replicates 1:1
+    // perfectly well. Collapsing the two entries into one flag would either
+    // send that peer a group frame it renders as text, or stop replicating
+    // with it entirely.
+    let mut protocol = OfflineProtocol::new({
+        let mut config = create_test_config_for_user("alice");
+        config.encryption.enabled = true;
+        config.data.enabled = true;
+        config
+    })
+    .unwrap();
+    protocol
+        .initialize_mls_for_test(Arc::new(InMemoryStorage::new()))
+        .unwrap();
+
+    protocol.peer_data_sync.insert(id("legacy"));
+    assert!(
+        protocol.data_sync_active(&id("legacy")),
+        "1:1 replication must work with a peer that predates group spaces"
+    );
+    assert!(
+        !protocol.group_data_sync_active(&[id("alice"), id("legacy")]),
+        "the same peer must hold the group gate closed"
+    );
+
+    protocol.peer_data_group.insert(id("current"));
+    protocol.peer_data_sync.insert(id("current"));
+    assert!(protocol.group_data_sync_active(&[id("alice"), id("current")]));
+}
+
+#[test]
+fn a_group_space_is_named_by_its_group_id() {
+    // The group id carries a colon, which the document charset forbids and
+    // the space charset allows for exactly this reason. If a space could
+    // not be named by its scope, a group space would need a second
+    // translated name and something would have to keep the two consistent.
+    let (mut alice, _bob, _carol, group) = trio();
+    assert!(group.starts_with("group:"), "group ids carry a colon");
+
+    write(&mut alice, &group, "notes", "title", "hello");
+    assert_eq!(
+        read(&mut alice, &group, "notes", "title"),
+        Some(DataValue::text("hello"))
+    );
+    assert!(
+        alice.protocol.data_list_spaces().unwrap().contains(&group),
+        "the space has to be listed under the name it was written with"
+    );
+}
+
+#[test]
+fn a_joining_member_catches_up_on_documents_written_before_it_arrived() {
+    // The roster-change half of the item: a member that joins a group with
+    // history has to receive it, and the only thing that knows the history
+    // exists is the member holding it.
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    // Carol has not yet heard of this document.
+    write(&mut alice, &group, "notes", "title", "hello");
+    settle(&mut alice, &mut bob, &mut carol);
+
+    // A fresh member with no knowledge of the space at all, standing in for
+    // one that has just been welcomed.
+    let mut dave = Member::new("dave");
+    let gid = offline_protocol_mls::GroupId::new(&group).unwrap();
+    let kp = {
+        let mls = dave.protocol.mls_manager_for_testing().read().unwrap();
+        mls.generate_key_package().unwrap()
+    };
+    let (welcome, _commit) = {
+        let mls = alice.protocol.mls_manager_for_testing().read().unwrap();
+        mls.add_group_member(&gid, &dave.address, &kp.key_package_data)
+            .unwrap()
+    };
+    {
+        let mls = dave.protocol.mls_manager_for_testing().read().unwrap();
+        mls.join_group(&welcome).unwrap();
+    }
+    alice.protocol.refresh_group_members(&group).unwrap();
+    dave.protocol.group_mesh.members.insert(
+        group.clone(),
+        vec![
+            alice.address.clone(),
+            bob.address.clone(),
+            carol.address.clone(),
+            dave.address.clone(),
+        ],
+    );
+    for other in [&bob.address, &carol.address, &dave.address] {
+        alice.protocol.peer_data_group.insert(other.clone());
+    }
+    for other in [&alice.address, &bob.address, &carol.address] {
+        dave.protocol.peer_data_group.insert(other.clone());
+    }
+
+    // What the inviter does on a real invite: offer the newcomer what this
+    // device holds.
+    alice
+        .protocol
+        .kick_group_data_sync(&group, &dave.address, "member_added");
+
+    for _ in 0..6 {
+        let mut carried = 0;
+        carried += {
+            let (d, b) = (&mut dave, &mut bob);
+            pump(&mut alice, &mut [d, b])
+        };
+        carried += {
+            let (a, b) = (&mut alice, &mut bob);
+            pump(&mut dave, &mut [a, b])
+        };
+        if carried == 0 {
+            break;
+        }
+    }
+
+    assert_eq!(
+        read(&mut dave, &group, "notes", "title"),
+        Some(DataValue::text("hello")),
+        "a member that joined after the writing never received the document"
+    );
+}
+
+#[test]
+fn an_answer_goes_to_the_member_that_asked_and_to_nobody_else() {
+    // Anti-entropy between two members is still a conversation between two
+    // devices. Broadcasting the answer would have every other member
+    // decrypt and import a change they already had, and on a mesh that is
+    // the traffic the whole design is trying not to spend.
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    write(&mut alice, &group, "notes", "title", "hello");
+    settle(&mut alice, &mut bob, &mut carol);
+
+    // Bob asks Alice for her versions. Only Alice should answer, and only
+    // to Bob.
+    bob.protocol
+        .kick_group_data_sync(&group, &alice.address, "test_offer");
+    {
+        let (a, c) = (&mut alice, &mut carol);
+        pump(&mut bob, &mut [a, c])
+    };
+
+    assert_eq!(
+        data_frames_sent(&alice, &mut carol, &group),
+        0,
+        "Carol was sent an answer to a question Bob asked"
+    );
+}
+
+#[test]
+fn edits_made_apart_converge_across_the_group_and_the_exchange_terminates() {
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    // Give every replica the document, so all three can edit it while
+    // apart.
+    write(&mut alice, &group, "notes", "a", "1");
+    settle(&mut alice, &mut bob, &mut carol);
+
+    // Partitioned: each writes a different key and nothing moves.
+    write(&mut alice, &group, "notes", "from_alice", "x");
+    write(&mut bob, &group, "notes", "from_bob", "y");
+    write(&mut carol, &group, "notes", "from_carol", "z");
+    alice.transport.clear_sent_messages();
+    bob.transport.clear_sent_messages();
+    carol.transport.clear_sent_messages();
+
+    // Reconnect: one member sweeps the others.
+    alice
+        .protocol
+        .kick_group_data_sync(&group, &bob.address, "reconnect");
+    alice
+        .protocol
+        .kick_group_data_sync(&group, &carol.address, "reconnect");
+    bob.protocol
+        .kick_group_data_sync(&group, &carol.address, "reconnect");
+
+    let rounds = settle(&mut alice, &mut bob, &mut carol);
+
+    for (label, member) in [
+        ("alice", &mut alice),
+        ("bob", &mut bob),
+        ("carol", &mut carol),
+    ] {
+        for key in ["from_alice", "from_bob", "from_carol"] {
+            assert!(
+                read(member, &group, "notes", key).is_some(),
+                "{label} is missing {key} after reconnecting"
+            );
+        }
+    }
+
+    assert_eq!(
+        rounds.last(),
+        Some(&0),
+        "the exchange has to stop: replicas that answer each other's \
+         answers converge and then keep talking forever (rounds: {rounds:?})"
+    );
+}
+
+#[test]
+fn group_replication_stops_when_the_layer_is_switched_off() {
+    let (mut alice, mut bob, mut carol, group) = trio();
+    write(&mut alice, &group, "notes", "title", "hello");
+    settle(&mut alice, &mut bob, &mut carol);
+    alice.transport.clear_sent_messages();
+
+    alice.protocol.config.data.enabled = false;
+
+    // The switch refuses the edit itself, which is the layer's shipped
+    // behaviour and not what this test is about.
+    assert!(
+        alice
+            .protocol
+            .data_map_set(&group, "notes", "m", "title", DataValue::text("again"))
+            .is_err(),
+        "a switched-off layer refuses writes"
+    );
+
+    // What it is about: nothing goes out on the group path either. A sweep
+    // is the one thing that could still produce a frame without a local
+    // edit behind it.
+    alice
+        .protocol
+        .kick_group_data_sync(&group, &bob.address, "kill_switch");
+    assert_eq!(
+        data_frames_sent(&alice, &mut bob, &group),
+        0,
+        "the kill switch has to gate the group path too"
+    );
+}
+
+/// Encrypt one replication frame for the group, as a member would send it,
+/// and hand back the base64 ciphertext.
+///
+/// The two tests below need the frame without the transport that normally
+/// carries it, because they are about the two inbound paths a frame can
+/// take *other* than the live mesh one.
+fn group_data_frame(from: &mut Member, group: &str, doc: &str, key: &str, value: &str) -> String {
+    // Produce a real delta by writing, then reading back what the push sent.
+    write(from, group, doc, key, value);
+    let frame = from
+        .transport
+        .sent_messages()
+        .iter()
+        .find_map(|m| {
+            let payload = m.content.strip_prefix(internal_prefixes::GROUP_MLS_MSG)?;
+            let value: serde_json::Value = serde_json::from_str(payload).ok()?;
+            Some(value.get("ciphertext")?.as_str()?.to_string())
+        })
+        .expect("the write produced a group replication frame");
+    from.transport.clear_sent_messages();
+    frame
+}
+
+#[test]
+fn a_replication_frame_delivered_by_the_relay_is_intercepted() {
+    // The relay path is a second inbound route into the same group, and it
+    // does not go through the mesh handler at all. A frame arriving this
+    // way must be consumed as replication rather than surfaced as a
+    // message: this repository has already paid once for a hardening fix
+    // that landed on one inbound path while its sibling stayed broken.
+    let (mut alice, mut bob, _carol, group) = trio();
+    let ciphertext = group_data_frame(&mut alice, &group, "notes", "title", "hello");
+
+    bob.protocol.handle_relay_group_message_with_mls(
+        &group,
+        &alice.address,
+        &ciphertext,
+        "2026-08-20T00:00:00Z",
+        "relay-msg-1",
+        None,
+        None,
+    );
+
+    assert_eq!(
+        read(&mut bob, &group, "notes", "title"),
+        Some(DataValue::text("hello")),
+        "a replication frame delivered by the relay was not applied"
+    );
+    assert!(
+        !bob.saw_group_message(),
+        "the frame was surfaced to the application as a chat message"
+    );
+}
+
+#[test]
+fn a_replication_frame_buffered_before_the_group_was_ready_is_intercepted_on_drain() {
+    // The third inbound path: a frame that arrived before local group state
+    // could open it waits in the pending buffer and is re-judged on drain.
+    // Its ACK is still owed there — the sender is retransmitting until it
+    // lands — so the drain has to both apply the frame and settle it.
+    let (mut alice, mut bob, _carol, group) = trio();
+    let ciphertext = group_data_frame(&mut alice, &group, "notes", "title", "hello");
+
+    bob.protocol.buffer_pending_group_message(
+        &group,
+        crate::group_mesh::PendingGroupMessage {
+            sender: alice.address.clone(),
+            message_id: "buffered-1".to_string(),
+            logical_id: None,
+            ciphertext_b64: ciphertext,
+            timestamp: Some("2026-08-20T00:00:00Z".to_string()),
+            reply_to: None,
+            forward_info: None,
+            buffered_at: std::time::Instant::now(),
+            received_via: None,
+        },
+    );
+
+    bob.protocol.drain_pending_group_messages(&group);
+
+    assert_eq!(
+        read(&mut bob, &group, "notes", "title"),
+        Some(DataValue::text("hello")),
+        "a replication frame drained from the pending buffer was not applied"
+    );
+    assert!(
+        !bob.saw_group_message(),
+        "the drained frame was surfaced to the application as a chat message"
+    );
+}
+
+#[test]
+fn the_group_capability_is_advertised_and_recorded() {
+    let (alice, _bob, _carol, _group) = trio();
+    assert_eq!(
+        alice.protocol.advertised_data_versions(),
+        vec![DATA_SYNC_V1, DATA_GROUP_V1],
+        "a build that intercepts group frames has to say so, or no peer \
+         will ever send it one"
+    );
+}

--- a/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
+++ b/crates/offline-protocol/src/protocol/tests/data_sync_group.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, Mutex};
 use offline_protocol_data::DataValue;
 use offline_protocol_transport::{MockTransport, Transport, TransportType};
 
+use crate::group_mesh::MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS;
 use crate::mls::InMemoryStorage;
 use crate::protocol::prefixes::internal_prefixes;
 use crate::protocol::tests::{create_test_config_for_user, id};
@@ -800,5 +801,100 @@ fn a_space_named_after_a_one_to_one_session_slot_is_not_a_group_space() {
     assert!(
         !alice.protocol.group_mesh.members.contains_key(&slot),
         "and classifying it must not have filed it in the roster cache"
+    );
+}
+
+#[test]
+fn directed_frames_do_not_strand_the_member_they_skip() {
+    // A group has ONE sender ratchet per epoch. A frame addressed to one
+    // member still advances the generation every *other* member must reach,
+    // and OpenMLS refuses a generation more than 1000 ahead of the highest a
+    // receiver has seen. Directed replication answers are the first traffic
+    // in this SDK that advances the ratchet without every member observing
+    // it, and rediscovery produces them without the user doing anything, so
+    // left unbounded they cross 1000 on their own.
+    //
+    // What that costs is not the replication: it is every later frame from
+    // this sender, chat included, permanently undecryptable for the skipped
+    // member until a commit rotates the epoch — and a stable group produces
+    // no commits. The frame lands as `Retriable`, is buffered, and expires.
+    let (mut alice, mut bob, mut carol, group) = trio();
+
+    // Alice and Bob reconcile over and over while Carol is simply not
+    // around, which is the steady state of a rediscovery loop between two
+    // co-located members of a three-member group.
+    let hidden = MAX_ROSTER_INVISIBLE_GROUP_GENERATIONS as usize * 5;
+    for _ in 0..hidden {
+        // The production trigger, with only its rate limit stepped over.
+        alice.protocol.last_data_sync_offer.clear();
+        alice
+            .protocol
+            .kick_group_data_sync(&group, &bob.address, "rediscovered");
+    }
+    assert!(
+        hidden > 1000,
+        "the run has to exceed the forward-distance limit or this test \
+         passes for the wrong reason (hidden: {hidden})"
+    );
+
+    // Deliver everything, including the frames the budget promoted to the
+    // whole roster. Those are the rungs Carol climbs.
+    settle(&mut alice, &mut bob, &mut carol);
+
+    // Now something every member needs.
+    write(&mut alice, &group, "notes", "title", "hello");
+    settle(&mut alice, &mut bob, &mut carol);
+
+    assert_eq!(
+        read(&mut carol, &group, "notes", "title"),
+        Some(DataValue::text("hello")),
+        "Carol could not decrypt a frame addressed to the whole roster: the \
+         directed traffic she never saw ran the group's sender ratchet out of \
+         her reach, which costs her every later message from Alice and not \
+         just this one"
+    );
+}
+
+#[test]
+fn a_roster_wide_frame_clears_the_ratchet_gap_budget() {
+    // The budget is spent by frames the roster does not see and cleared by
+    // one it does. Group chat is the common clearer, so a talkative group
+    // never promotes anything; a group that only replicates documents is
+    // the one that relies on the promotion.
+    let (mut alice, mut bob, _carol, group) = trio();
+
+    for _ in 0..10 {
+        alice.protocol.last_data_sync_offer.clear();
+        alice
+            .protocol
+            .kick_group_data_sync(&group, &bob.address, "rediscovered");
+    }
+    assert_eq!(
+        alice
+            .protocol
+            .group_mesh
+            .roster_invisible_generations
+            .get(&group)
+            .copied(),
+        Some(10),
+        "each directed frame has to be counted, or the budget never trips"
+    );
+
+    alice
+        .protocol
+        .send_group_message(&group, "an ordinary message", None, None)
+        .expect("send a group message");
+
+    assert_eq!(
+        alice
+            .protocol
+            .group_mesh
+            .roster_invisible_generations
+            .get(&group)
+            .copied(),
+        None,
+        "a message every member is handed puts the whole roster back within \
+         reach, so the gap it closed must not keep counting against the next \
+         promotion"
     );
 }

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -2,6 +2,7 @@
 mod data_layer;
 #[cfg(feature = "data")]
 mod data_sync;
+mod data_sync_group;
 
 use super::*;
 use crate::constants::{ACK_FOR_KEY, ACK_HOP_COUNT_KEY, ACK_TRANSPORT_KEY};
@@ -2824,7 +2825,120 @@ fn data_sync_is_advertised_only_when_the_layer_is_on() {
     );
 
     let on = protocol_with_data_storage(Arc::new(InMemoryStorage::new()));
-    assert_eq!(on.advertised_data_versions(), vec![DATA_SYNC_V1]);
+    assert_eq!(
+        on.advertised_data_versions(),
+        vec![DATA_SYNC_V1, DATA_GROUP_V1],
+        "both entries, and the order is append-only: the group entry says \
+         this build intercepts sync frames arriving inside a group \
+         ciphertext, which a build advertising only the first does not. A \
+         peer reads them independently, so replacing rather than appending \
+         would silently stop 1:1 replication with every shipped install"
+    );
+}
+
+#[test]
+fn the_group_capability_survives_a_restart() {
+    // The group half of `data_sync_capability_survives_a_restart`, and a
+    // quieter failure than the 1:1 one: a group space that stops
+    // replicating after a relaunch looks to every member exactly like a
+    // group where nobody happens to be editing.
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = protocol_with_data_storage(storage.clone());
+    feed_key_package_with_data(
+        &mut protocol,
+        &id("peer"),
+        vec![DATA_SYNC_V1, DATA_GROUP_V1],
+    );
+    let members = vec![id("user123"), id("peer")];
+    assert!(protocol.group_data_sync_active(&members));
+
+    let restarted = protocol_with_data_storage(storage);
+    assert!(
+        restarted.peer_data_group.contains(&id("peer")),
+        "the group capability must survive a restart"
+    );
+    assert!(restarted.group_data_sync_active(&members));
+}
+
+#[test]
+fn a_peer_that_advertises_only_one_to_one_sync_holds_the_group_gate_closed() {
+    // The whole reason the group entry is separate. This peer replicates
+    // 1:1 correctly and would render a group replication frame to its user
+    // as literal `__DATA_V1__` text.
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = protocol_with_data_storage(storage.clone());
+    feed_key_package_with_data(&mut protocol, &id("peer"), vec![DATA_SYNC_V1]);
+
+    assert!(protocol.data_sync_active(&id("peer")));
+    assert!(!protocol.peer_data_group.contains(&id("peer")));
+    assert!(!protocol.group_data_sync_active(&[id("user123"), id("peer")]));
+
+    let restarted = protocol_with_data_storage(storage);
+    assert!(
+        restarted.data_sync_active(&id("peer")),
+        "1:1 replication has to survive the restart too"
+    );
+    assert!(!restarted.group_data_sync_active(&[id("user123"), id("peer")]));
+}
+
+#[test]
+fn attested_group_sync_opens_the_group_gate_only_and_persists() {
+    // Members of a group never exchange key packages with each other, so
+    // without attestation a group replicates only among whichever members
+    // happened to have met directly — a subset that can easily be empty.
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = protocol_with_data_storage(storage.clone());
+    let members = vec![id("user123"), id("peer")];
+    assert!(!protocol.group_data_sync_active(&members));
+
+    protocol.record_attested_data(&id("peer"), &[DATA_GROUP_V1]);
+    assert!(protocol.peer_data_group_attested.contains(&id("peer")));
+    assert!(protocol.group_data_sync_active(&members));
+    assert!(
+        !protocol.data_sync_active(&id("peer")),
+        "an attestation must never open 1:1 replication: that path always \
+         has direct knowledge, and a third party's claim is not it"
+    );
+
+    let restarted = protocol_with_data_storage(storage);
+    assert!(
+        restarted.peer_data_group_attested.contains(&id("peer")),
+        "an attested group capability must survive a restart"
+    );
+    assert!(restarted.group_data_sync_active(&members));
+}
+
+#[test]
+fn attested_group_sync_ignores_non_v2_and_self() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = protocol_with_data_storage(storage);
+    protocol.record_attested_data(&id("peer"), &[DATA_SYNC_V1]);
+    assert!(
+        !protocol.peer_data_group_attested.contains(&id("peer")),
+        "the 1:1 entry says nothing about group interception"
+    );
+    protocol.record_attested_data(&id("user123"), &[DATA_GROUP_V1]);
+    assert!(!protocol.peer_data_group_attested.contains(&id("user123")));
+}
+
+#[test]
+fn a_direct_key_package_overrides_an_attested_group_capability() {
+    // Direct knowledge is authoritative in both directions, memory and
+    // disk, exactly as it is for the rich attestation.
+    let storage = Arc::new(InMemoryStorage::new());
+    let mut protocol = protocol_with_data_storage(storage.clone());
+    let members = vec![id("user123"), id("peer")];
+
+    protocol.record_attested_data(&id("peer"), &[DATA_GROUP_V1]);
+    feed_key_package_with_data(&mut protocol, &id("peer"), Vec::new());
+    assert!(!protocol.peer_data_group_attested.contains(&id("peer")));
+    assert!(!protocol.group_data_sync_active(&members));
+
+    let restarted = protocol_with_data_storage(storage);
+    assert!(
+        !restarted.peer_data_group_attested.contains(&id("peer")),
+        "a direct downgrade must kill the durable attested record too"
+    );
 }
 
 #[test]
@@ -2886,6 +3000,7 @@ fn peer_capability_restore_prunes_overflow() {
     let storage = Arc::new(InMemoryStorage::new());
     let caps = PeerCapabilities {
         attested_rich_versions: Vec::new(),
+        attested_data_versions: Vec::new(),
         env_versions: Vec::new(),
         rich_versions: vec![RICH_PAYLOAD_V1],
         data_versions: Vec::new(),
@@ -3025,6 +3140,7 @@ fn peer_capability_restore_prefers_session_peers() {
     // forged leftovers.
     let caps = PeerCapabilities {
         attested_rich_versions: Vec::new(),
+        attested_data_versions: Vec::new(),
         env_versions: Vec::new(),
         rich_versions: vec![RICH_PAYLOAD_V1],
         data_versions: Vec::new(),

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -2114,6 +2114,19 @@ pub(crate) fn feed_key_package_with_rich(
     sender: &str,
     rich_versions: Vec<u8>,
 ) {
+    feed_key_package_with_capabilities(protocol, sender, rich_versions, Vec::new());
+}
+
+/// One key package advertising both capability families at once, which is
+/// what a real one does: `rich_versions` and `data_versions` are separate
+/// fields of the same payload, and a fixture that could only feed one of
+/// them makes a peer that supports both impossible to express.
+pub(crate) fn feed_key_package_with_capabilities(
+    protocol: &mut OfflineProtocol,
+    sender: &str,
+    rich_versions: Vec<u8>,
+    data_versions: Vec<u8>,
+) {
     let payload = KeyPackagePayload {
         user_id: sender.to_string(),
         key_package_data: vec![1, 2, 3, 4],
@@ -2123,7 +2136,7 @@ pub(crate) fn feed_key_package_with_rich(
         wire_versions: Vec::new(),
         env_versions: Vec::new(),
         rich_versions,
-        data_versions: Vec::new(),
+        data_versions,
         nostr_pubkey: None,
     };
     let content = format!(

--- a/crates/offline-protocol/src/protocol/tests/mod.rs
+++ b/crates/offline-protocol/src/protocol/tests/mod.rs
@@ -3033,7 +3033,7 @@ fn peer_capability_restore_prunes_overflow() {
 /// manager level (import + create), without needing the peer to process the
 /// Welcome — `has_session`/`list_sessions` are local.
 #[cfg(test)]
-fn create_local_session_with(protocol: &OfflineProtocol, peer_label: &str) {
+pub(crate) fn create_local_session_with(protocol: &OfflineProtocol, peer_label: &str) {
     let peer = id(peer_label);
     let peer = peer.as_str();
     let peer_mgr = crate::test_identity::manager_for(

--- a/crates/offline-protocol/src/protocol/types.rs
+++ b/crates/offline-protocol/src/protocol/types.rs
@@ -736,6 +736,21 @@ pub(crate) const MAX_RICH_EXTRAS_BYTES: usize = 32 * 1024;
 /// as an unreadable document rather than as a refused negotiation.
 pub(crate) const DATA_SYNC_V1: u8 = 1;
 
+/// Group-space replication, advertised in
+/// [`KeyPackagePayload::data_versions`] alongside [`DATA_SYNC_V1`]: the
+/// sender intercepts `__DATA_V1__` frames arriving inside a *group*
+/// ciphertext, not only inside a 1:1 one.
+///
+/// A separate entry rather than a bump, and the reason is a compatibility
+/// trap rather than tidiness. A build that speaks only [`DATA_SYNC_V1`]
+/// advertises it, holds group sessions, and has no group interception at
+/// all: every group path emits whatever decrypts as a chat message, so a
+/// group sync frame sent to one would surface to its user as literal
+/// `__DATA_V1__{...}` text. Gating group sends on this entry is what keeps
+/// that frame from ever being sent, and appending rather than replacing is
+/// what keeps 1:1 replication working with those same peers.
+pub(crate) const DATA_GROUP_V1: u8 = 2;
+
 /// Rich fields accepted by the `send_message_with` surface. Only ever
 /// delivered inside the sealed [`RichPayloadV1`] body — toward a recipient
 /// that did not advertise [`RICH_PAYLOAD_V1`] they are silently dropped,
@@ -1189,6 +1204,21 @@ pub(crate) struct PeerCapabilities {
     /// selection.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) attested_rich_versions: Vec<u8>,
+    /// Sync versions a *group inviter* attested for this peer, carried on
+    /// the group Add commit / Welcome exactly like
+    /// [`Self::attested_rich_versions`] and kept separate from the direct
+    /// `data_versions` above for the same reason: attestation is
+    /// third-party and may be stale, so a direct key-package exchange
+    /// overwrites the whole record and clears this field.
+    ///
+    /// Group members never exchange key packages with each other, so
+    /// without this a group would replicate only among the subset of
+    /// members that happen to have met directly, and the rest would sit
+    /// there editing documents nobody receives. Consulted only by the
+    /// group replication gate, never by 1:1 sync (which always has direct
+    /// knowledge: session establishment exchanges key packages).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attested_data_versions: Vec<u8>,
 
     /// The peer's Nostr public key, from [`KeyPackagePayload::nostr_pubkey`].
     ///
@@ -1252,6 +1282,7 @@ impl PeerCapabilities {
                 .take(MAX_PERSISTED_CAPABILITY_VERSIONS)
                 .collect(),
             attested_rich_versions: Vec::new(),
+            attested_data_versions: Vec::new(),
             nostr_pubkey: nostr_pubkey.and_then(normalize_nostr_pubkey),
         }
     }
@@ -1263,6 +1294,7 @@ impl PeerCapabilities {
             || !self.rich_versions.is_empty()
             || !self.data_versions.is_empty()
             || !self.attested_rich_versions.is_empty()
+            || !self.attested_data_versions.is_empty()
             || self.nostr_pubkey.is_some()
     }
 }
@@ -1719,10 +1751,13 @@ pub(crate) mod storage_keys {
 
     /// Key type for compacted replicated documents, one record per document.
     ///
-    /// Key ID is `{space}/{doc}`. Both halves are validated by
-    /// `offline_protocol_data::validate_name`, whose charset excludes the
-    /// separator, so the composed key always parses back into the two parts
-    /// it was built from.
+    /// Key ID is `{space}/{doc}`. The space is validated by
+    /// `offline_protocol_data::validate_space_name` and the document by
+    /// `validate_name`; neither charset includes the separator, so the
+    /// composed key always parses back into the two parts it was built
+    /// from. (The space charset additionally allows `:`, so a group space
+    /// can be named by its `group:<uuid>` id — inert here, since keys are
+    /// parsed by stripping the space prefix and splitting on `/`.)
     ///
     /// Post-split only: deliberately absent from
     /// [`ADOPTABLE_STATE_KEY_TYPES`], which has no pre-split data to inherit

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1511,12 +1511,13 @@ config section if present.
 
 ---
 
-## 16. Replicated documents are available, and replicate 1:1
+## 16. Replicated documents are available, 1:1 and in groups
 
 A new `DataStore` object ships on every binding: offline-first documents any
 member of a space can edit while disconnected, merging deterministically when
 replicas meet again. Messaging is synced events; this is synced state. Two
-peers with a secure session converge on the documents they share.
+peers with a secure session converge on the documents they share, and so does
+every member of a group.
 
 **Existing applications need no changes.** `data.enabled` defaults to `true`,
 but nothing is persisted until a document is written, nothing is sent until a
@@ -1527,13 +1528,31 @@ the rest of this section if you are not using it.
 
 ### What replicates, and with whom
 
-A space replicates with the peer whose address names it. Name a space after a
-peer's address and its documents converge with that peer; name it anything else
-and it stays on the device. Nothing else needs configuring, and there is no
-sharing call: the space name *is* the sharing decision.
+A space replicates with the scope its name refers to:
 
-Replication is 1:1 in this release. Group spaces are not yet replicated, and a
-document too large to catch up inside a single frame is reported rather than
+| Space name | Replicates with |
+|---|---|
+| A peer's address | That peer |
+| A group id (`groupId` from `createGroup`) | Every member of that group |
+| Anything else | Nobody; it stays on the device |
+
+Nothing else needs configuring, and there is no sharing call: the space name
+*is* the sharing decision.
+
+A group space uses the group's own roster, so adding or removing a member
+changes who replicates without any second membership list to maintain. A
+change is encrypted once for the whole group rather than once per member.
+
+**A group replicates only when every member is running a build that supports
+it.** Group replication is negotiated separately from 1:1, because an install
+shipping only the 1:1 layer would display a group replication frame to its
+user as raw text. A single member on such a build stops the group's documents
+replicating for everyone until they upgrade, and the SDK will keep probing
+them. 1:1 spaces are unaffected. There is no event for this today; if a
+group's documents are not converging, check that every member is on a current
+build.
+
+A document too large to catch up inside a single frame is reported rather than
 sent.
 
 Replicas that stay in contact converge. Two that are separated by a partition
@@ -1548,7 +1567,8 @@ document again, so it is recreated and refilled from their copy. In a space
 named after a peer, treat deletion as local cleanup that replication may undo,
 not as a way to remove content: to retire content from both sides, empty the
 document (deletions inside a document replicate like any other change); to stop
-a space replicating at all, use a space name that is not a peer address. The
+a space replicating at all, use a space name that is neither a peer address
+nor a group id. The
 same is true of `wipeAll()` on a running engine, for the same missing
 tombstone: see the storage section below.
 

--- a/docs/adr/0019-remote-document-imports-are-contained-not-trusted.md
+++ b/docs/adr/0019-remote-document-imports-are-contained-not-trusted.md
@@ -1,7 +1,8 @@
 # 0019. Remote document imports are contained, not trusted
 
 **Status:** Accepted
-**Shipped in:** unreleased (F3, 1:1 replication)
+**Shipped in:** unreleased (F3, 1:1 replication; extended to group spaces
+by F4)
 
 ## Context
 
@@ -45,15 +46,24 @@ partition-and-reconnect traffic, which is the entire point of this layer.
 Remote blobs are contained in layers, each of which stops something specific.
 None of them is "the peer is authenticated, so this is fine".
 
-### 1. MLS scopes the surface; the space is the sender
+### 1. MLS scopes the surface; the space is derived, never declared
 
 A blob reaches the import path only from an authenticated member of the space,
-and the space is derived from the wire sender rather than read off the frame.
-A peer therefore cannot name a space, which means they cannot reach a document
-shared with somebody else.
+and the space is derived rather than read off the frame. On a 1:1 session it
+is the wire sender. In a group it is the group whose key opened the
+ciphertext, so reaching a group's documents requires being able to encrypt
+under that group's key, which is membership.
 
-**Failure prevented:** cross-peer writes, and an authorization table that has
+A peer therefore cannot name a space in either scope, which means they cannot
+reach a document shared with somebody else.
+
+**Failure prevented:** cross-space writes, and an authorization table that has
 to be right for that to hold.
+
+**What group spaces change:** the number of members who can reach this path,
+and nothing else. Every layer below is per space rather than per sender, so a
+group is contained by the same machinery as a pair, and a blob refused because
+one member sent it stays refused when the next one does.
 
 ### 2. Frames are bounded before they are decoded
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1042,9 +1042,15 @@ await store.flush('space-1', 'profile');
 | `docSize(space, doc)` | `number` | Compacted size in bytes |
 | `wipeAll()` | `void` | Delete every data-layer record. Only durable once replication has stopped |
 
-A space id is the MLS scope the space rides on: a peer address or a group id.
-Space, document and collection names accept `A-Z a-z 0-9 . _ -` up to 128
-characters, because they are composed into storage record keys.
+A space id is the MLS scope the space rides on: a peer address (replicates
+1:1 with that peer), a group id from `createGroup` (replicates with every
+member of that group), or any other name (stays on the device).
+
+Document and collection names accept `A-Z a-z 0-9 . _ -` up to 128 characters,
+because they are composed into storage record keys. A space name additionally
+accepts `:`, so that a group id can name its own space; the separator itself
+is excluded from both, which is what keeps a composed key parsing back into
+the parts it was built from.
 
 ### DataValue
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -409,6 +409,19 @@ replicates with. Not silent, not remote-code-execution, and not available to
 anyone outside the space: it requires someone the user has already accepted
 into a shared document, and it is attributable to them.
 
+**Group spaces widen who this is, not what it does.** A 1:1 space has exactly
+one other member; a group space has as many as the roster, and every one of
+them can reach this path. The population is still people the user accepted
+into the group, and a frame is still attributable to the member whose leaf
+signed it, so the class does not change. What changes is that "someone the
+user accepted" now includes members somebody *else* added, which is a
+membership decision the group's admins make and the containment below does
+not depend on.
+
+The quarantine that bounds this is per space, so one crafted blob is refused
+for the whole group rather than per sender. A second member sending the same
+blob is refused by the same record.
+
 **Why it stands:** the defects are upstream and the engine is not ours to fix
 on our own schedule. Re-implementing its decoder to predict what it will accept
 would mean maintaining a second parser that has to agree with the first one

--- a/docs/spec/capability-negotiation.md
+++ b/docs/spec/capability-negotiation.md
@@ -10,7 +10,7 @@ Peers advertise what they can parse in the key package payload, the body of a
 | `wire_versions` | Hop-local | Which frame encodings we may emit to this peer | JSON only |
 | `env_versions` | End to end | Which `__MLS_ENC__` payload forms we may emit | Legacy JSON envelope only |
 | `rich_versions` | End to end | Whether we may seal a `__RICH_V1__` body, and the v2 media envelope | Plain text only, extras dropped |
-| `data_versions` | End to end | Whether we may send `__DATA_V1__` document sync frames, and which document encoding they carry | No replication with that peer |
+| `data_versions` | End to end | Whether we may send `__DATA_V1__` document sync frames, and which document encoding they carry. Entry 1 is 1:1 replication; entry 2 additionally means the peer intercepts these frames inside a *group* ciphertext | No replication with that peer |
 | `nostr_pubkey` | End to end | Which key metadata is sealed to on the Nostr path | Seal to the publicly computable key |
 
 The key package payload also carries `user_id`, the MLS key package itself, a
@@ -59,6 +59,20 @@ For `data_versions` the consequence is quieter than a downgrade and worse: both
 sides keep accepting edits to a document neither is replicating, so the symptom
 is not a dropped feature but two replicas that disagree, with nothing anywhere
 reporting a problem.
+
+`data_versions` entries are read independently and the list is append-only. A
+peer advertising `[1]` is not a peer advertising `[1, 2]` with something
+missing: it is an implementation that replicates 1:1 and would render a group
+replication frame as literal text. Treating the two as one flag either sends
+that peer a frame it cannot read or stops replicating with it altogether.
+
+Entry 2 has a second source, because members of a group never exchange key
+packages with each other: a group inviter MAY attest it for a member on the
+Add commit and in the Welcome, exactly as it attests `rich_versions`. An
+attestation opens the *group* gate only, never 1:1 replication, and any
+directly received key package from that peer overrides it in both
+directions. Absence of an attestation means "no information" and MUST NOT be
+read as a downgrade.
 
 `wire_versions` is **hop-local** and deliberately in-memory only. It describes
 what the next hop decodes, and it is re-exchanged on connect.

--- a/docs/spec/control-messages.md
+++ b/docs/spec/control-messages.md
@@ -220,6 +220,22 @@ offers, deltas answering them, and snapshots to the member that asked, so the
 1.5-round-trip termination rule below holds unchanged. Only a local commit is
 sent to the whole roster.
 
+With one exception, which a sender MUST implement: a group has a single
+sender ratchet per epoch, so an addressed frame advances the generation every
+*other* member has to reach, and a member that never observes one falls out
+of MLS's forward-distance window and stops decrypting that sender entirely.
+A sender MUST therefore bound how many frames it encrypts for a group without
+delivering one to the whole roster, and deliver the next one roster-wide when
+that bound is reached. A promoted frame is an ordinary roster-wide delivery
+and is subject to the all-members gate above like any other. Where the bound
+is reached and the gate is closed, a sender MUST withhold the frame rather
+than send it addressed: a roster-wide frame some member renders as text is
+the worse outcome, and spending further generations that only one member can
+observe strands the rest for messaging as well as replication. Receivers need no special
+handling, since every body is either idempotent or answerable with nothing.
+See [the group message lifecycle](../state-machines/group-message-lifecycle.md#addressed-frames-still-advance-everyones-ratchet)
+for the bound this implementation uses.
+
 Directed frames are still encrypted under the group key rather than a
 pairwise session: two members of a group need not have a 1:1 session with
 each other, and requiring one would make replication depend on a handshake

--- a/docs/spec/control-messages.md
+++ b/docs/spec/control-messages.md
@@ -148,10 +148,18 @@ request and response bodies are sent in cleartext. See
 
 ## Document sync frames
 
-`__DATA_V1__` frames replicate documents between two peers. They travel only
-inside the decrypted MLS plaintext, never as an outer wire prefix, and only
-toward a peer whose key package advertised `data_versions`
+`__DATA_V1__` frames replicate documents. They travel only inside the
+decrypted MLS plaintext, never as an outer wire prefix, and only toward peers
+whose key package advertised `data_versions`
 ([capability negotiation](capability-negotiation.md)).
+
+A frame rides one of two scopes, and the frame shape is identical in both:
+
+- **A 1:1 session**, sealed to the peer the space is named after.
+- **A group**, sealed once under the group key and carried by the group
+  message path. This requires `data_versions` entry 2 from *every* member,
+  not just the recipient, for the reason given under
+  [Group scope](#group-scope).
 
 ### Shape
 
@@ -175,10 +183,48 @@ new version here, and a peer that has not advertised it is not sent one.
 
 ### The space is never on the wire
 
-Neither the space nor the peer appears in any frame. A receiver derives the
-space from the authenticated wire sender, and a sender from the recipient. The
-two replicas therefore name the same space differently, each by the other's
-address, and a peer cannot reach a document shared with anybody else.
+Neither the space nor the peer appears in any frame. On a 1:1 session a
+receiver derives the space from the authenticated wire sender, and a sender
+from the recipient; the two replicas therefore name the same space
+differently, each by the other's address. In a group the space is the group
+whose key opened the ciphertext, so both replicas name it identically.
+
+In both cases the space is derived, never declared, and that is what bounds
+reach: a peer cannot name a space, so it cannot reach a document shared with
+anybody else. Reaching a group's documents requires being able to encrypt
+under that group's key, which is membership.
+
+### Group scope
+
+A group space replicates over the group send path: one MLS encryption serves
+the whole roster, and the frame is delivered per member on the ordinary
+ladder.
+
+Three rules make that safe and bounded.
+
+**Every member must advertise entry 2.** An implementation that advertises
+only entry 1 replicates 1:1 correctly and does not intercept `__DATA_V1__`
+inside a group ciphertext, so it would surface the frame to its user as
+literal text. Because one ciphertext reaches the whole roster, a single such
+member means no member may be sent a group replication frame. A sender MUST
+NOT send one unless every other member is known to speak entry 2.
+
+**A change received from a group MUST NOT be pushed back into it.** The group
+ciphertext already reached every member. Re-broadcasting turns one edit into
+N² frames and gets worse as the group grows; anti-entropy still closes real
+gaps.
+
+**Offers and answers are addressed to one member.** Anti-entropy between two
+members is a conversation between two devices. A sender MUST address version
+offers, deltas answering them, and snapshots to the member that asked, so the
+1.5-round-trip termination rule below holds unchanged. Only a local commit is
+sent to the whole roster.
+
+Directed frames are still encrypted under the group key rather than a
+pairwise session: two members of a group need not have a 1:1 session with
+each other, and requiring one would make replication depend on a handshake
+that may never happen. Every member is entitled to the contents, so
+addressing is a traffic decision, not a confidentiality one.
 
 ### The exchange
 

--- a/docs/state-machines/group-message-lifecycle.md
+++ b/docs/state-machines/group-message-lifecycle.md
@@ -239,6 +239,33 @@ Three rules that are easy to get wrong:
 The full reasoning for report-by-default and the fail-open enforcement rule is in
 [Group protocol](../spec/group-protocol.md#membership-authorization).
 
+## Replication frames take the same three paths
+
+A group space replicates over this exact machinery: a `__DATA_V1__` frame is
+encrypted for the group and fanned out per member like any group message. It
+therefore arrives by all three inbound paths above, and **all three intercept
+it** after the decrypt succeeds and before anything is emitted to the
+application. A path that missed the interception would surface the frame to
+the user as a chat message whose body is literal `__DATA_V1__` JSON.
+
+On the drain path the interception still owes the deferred ACK: a frame
+buffered until group state caught up was never acknowledged, so the sender is
+retransmitting until the drain settles it.
+
+What differs from a group message:
+
+| | Group message | Replication frame |
+|---|---|---|
+| Relay broadcast | Taken when the v3 gate holds | Never: a replication frame has no app-facing id for a delivery report to name |
+| Emitted to the app | `GroupMessageReceived` | Nothing; `DataChanged` fires from the store when a change lands |
+| Logical id | Used for cross-path dedup | None |
+| Gate | Roster | Roster, **and** every member advertising `data_versions` entry 2 |
+| Answers | n/a | Addressed to the one member that asked, not broadcast |
+
+A change arriving from the group is never pushed back into it: the group
+ciphertext already reached every member, so re-broadcasting would make one
+edit cost N² frames.
+
 ## Bounds
 
 | Bound | Value |
@@ -248,6 +275,7 @@ The full reasoning for report-by-default and the fail-open enforcement rule is i
 | Broadcast report timeout | 60 s |
 | Unauthorized-change report suppression | 300 s per (group, committer, enforced) |
 | Unproven-leaf report suppression | 300 s per (group, sender, site) |
+| Replication offer suppression | 30 s per (member, group) |
 
 The `enforced` component of the first key is load-bearing. Dropping it lets an
 earlier report-only event suppress the refusal alarm for the same committer,

--- a/docs/state-machines/group-message-lifecycle.md
+++ b/docs/state-machines/group-message-lifecycle.md
@@ -290,6 +290,36 @@ documents. It does not rescue a member absent long enough for the outbox to
 expire every rung, which predates group replication and is bounded by the
 epoch instead.
 
+The count is scoped to one epoch and one process, because those are the only
+spans it can speak for:
+
+- **A commit rebases it.** Every member restarts the ratchet at zero when the
+  epoch rotates, so a count carried across a rotation describes a gap that no
+  longer exists, and promoting on it would spend a roster-wide frame to close
+  nothing. The count is therefore stored against the epoch it was taken in
+  rather than cleared at each rotation site, so a rotation site added later
+  cannot forget to clear it.
+- **A relaunch does not reset the gap it is counting.** The sender ratchet is
+  persisted with the group state; this count is not. Reading a missing count
+  as zero would let a device that restarts often accumulate the true gap
+  across sessions and strand a member without the bound ever tripping. A
+  missing count therefore reads as *spent*: the first directed frame per
+  group per process goes to the whole roster, which re-bases every member's
+  reachable window at the cost of one frame per group per launch.
+
+**A promotion is still a roster-wide delivery, so it answers to the
+all-members gate.** A directed frame needs no capability check, because the
+member it answers asked for it; handing that same frame to the whole roster
+is exactly the send the gate refuses.
+
+When the bound is reached and the gate is closed, the frame is withheld
+rather than sent addressed. Every directed encryption spends a generation
+only its target observes, so continuing past the bound trades a document
+convergence that is already stalled group-wide (the closed gate stops local
+commits too) for the permanent loss of this device's group *chat* to every
+other member. Either an ordinary group message or the gate opening releases
+it, and the member holding the gate shut is being probed meanwhile.
+
 ## Bounds
 
 | Bound | Value |
@@ -300,7 +330,8 @@ epoch instead.
 | Unauthorized-change report suppression | 300 s per (group, committer, enforced) |
 | Unproven-leaf report suppression | 300 s per (group, sender, site) |
 | Replication offer suppression | 30 s per (member, group) |
-| Roster-invisible group generations | 256 per group, then the next frame goes to the whole roster |
+| Roster-invisible group generations | 256 per group per epoch, then the next frame goes to the whole roster (gate permitting) |
+| First directed frame per group per process | Always roster-wide: the inherited generation is unreadable |
 
 The `enforced` component of the first key is load-bearing. Dropping it lets an
 earlier report-only event suppress the refusal alarm for the same committer,

--- a/docs/state-machines/group-message-lifecycle.md
+++ b/docs/state-machines/group-message-lifecycle.md
@@ -266,6 +266,30 @@ A change arriving from the group is never pushed back into it: the group
 ciphertext already reached every member, so re-broadcasting would make one
 edit cost N² frames.
 
+### Addressed frames still advance everyone's ratchet
+
+A group has one sender ratchet per epoch, so a frame addressed to a single
+member advances the generation *every* member must reach to decrypt anything
+later from that sender. MLS refuses a generation more than 1000 ahead of the
+highest a receiver has seen, and a receiver that cannot decrypt does not
+advance, so once the gap opens it never closes on its own: the skipped member
+stops receiving that sender's frames entirely, chat included, until a commit
+rotates the epoch. A stable group produces no commits.
+
+Directed replication answers are the first traffic here that advances the
+ratchet without every member observing it, and rediscovery produces them
+without the user doing anything. A sender therefore counts the frames it has
+encrypted for a group without giving the whole roster one, and at the bound
+below sends the next frame to the roster instead. That costs the other
+members one redundant import, which the CRDT absorbs and the no-echo rule
+stops there, and it leaves each of them a rung they can still decrypt.
+
+Ordinary group chat clears this count, so a talking group never promotes
+anything; the promotion is what covers a group that only replicates
+documents. It does not rescue a member absent long enough for the outbox to
+expire every rung, which predates group replication and is bounded by the
+epoch instead.
+
 ## Bounds
 
 | Bound | Value |
@@ -276,6 +300,7 @@ edit cost N² frames.
 | Unauthorized-change report suppression | 300 s per (group, committer, enforced) |
 | Unproven-leaf report suppression | 300 s per (group, sender, site) |
 | Replication offer suppression | 30 s per (member, group) |
+| Roster-invisible group generations | 256 per group, then the next frame goes to the whole roster |
 
 The `enforced` component of the first key is load-bearing. Dropping it lets an
 earlier report-only event suppress the refusal alarm for the same committer,


### PR DESCRIPTION
Workstream **F4** (todo item 17): documents now replicate across MLS groups.
Design record: `.plans/data-layer-f4-implementation.md`. Follows F3 (#382,
residuals in #386), which shipped 1:1 replication.

## What this is

A space named after a group id replicates with that group: the roster is the
replica set, and a change is encrypted **once** for the whole roster rather
than once per member. The frames, the version exchange, the catch-up ladder
and the import quarantine all carried over from F3 untouched. Most of the
diff is teaching the exchange to tell apart three things F3 could treat as
one value: the space, the peer, and the reply address.

## The decision worth reviewing

**Group replication is a second `data_versions` entry, not a version bump.**

An install shipping only the 1:1 layer advertises `data_versions = [1]`, holds
group sessions perfectly happily, and has no group interception at all: every
group receive path emits whatever decrypts as a chat message. Send one a
replication frame and its user gets a wall of literal `__DATA_V1__` JSON in
the conversation.

So `DATA_GROUP_V1 = 2` is appended, read independently of entry 1, and the
gate is **all-members** rather than per-recipient, because one group ciphertext
reaches the whole roster. Members of a group never exchange key packages with
each other, so the inviter attests the capability on the Add commit and in the
Welcome, exactly as it already attests `rich_versions` (roster-bounded,
admin-bounded, evicted by any direct exchange).

## Two rules that keep the traffic bounded

- **A change received from the group is never pushed back into it.** The
  ciphertext already reached every member; re-broadcasting turns one edit into
  N^2 frames and gets worse as the group grows.
- **Offers and answers are addressed to the member that asked.** Reconciling
  with a peer is a conversation between two devices even inside a group, so
  F3's terminating 1.5-round-trip exchange keeps working. Only a local commit
  goes to the roster.

Directed frames are still sealed under the group key: two members need not
share a 1:1 session, and requiring one would make replication depend on a
handshake that may never happen.

## What the mutation testing found

Nine mechanisms were negative-controlled (mutate, watch the test fail with its
own message, restore). Seven passed first time. **Two did not, and both were
real gaps:** deleting the interception in the *relay* receive path, or in the
*buffered-drain* path, broke no test at all. Only the live mesh path was
covered.

That is the same class as #366, and it was invisible to a green suite. Both
now have tests driving the real entry points, and both assert two things: the
change applied, **and** no `GroupMessageReceived` reached the application. The
second assertion is the one that names the failure, because a missed
interception does not lose data. It shows it to the user as text.

## Smaller notes

- Group ids are `group:<uuid>`, and `validate_name` rejected `:`. Space names
  got their own validator that admits it; document and collection names keep
  the narrow charset, because a peer names those on the wire and this one is
  never wire-supplied. Verified first that all three shipped storage providers
  digest `(key_type, key_id)` into a hex filename. This also made an existing
  `api-reference.md` claim ("a space id is a peer address or a group id") true
  for the first time.
- **Subscriptions needed no new surface.** `DataChanged` already fires from
  `flush_doc` after the durable write for every apply, so that half of the item
  is tests and docs rather than code. No new API was invented for it.
- No relay broadcast for replication frames: that path arms a delivery-report
  correlation and emits app-facing events, and a replication frame has no
  app-facing identity to report on.
- No `stage_outbox_reseal` on the group path (unlike the 1:1 sender): reseal
  stages plaintext to re-encrypt *for a recipient*, but this ciphertext belongs
  to a group epoch, so it would re-seal a group frame as a 1:1 payload. Group
  messaging makes the same trade.
- No cold-start sweep for group spaces, deliberately, with the skip commented
  at the loop so it reads as a decision.

## Known gap

A group with **one member on an old build stops replicating for everyone**
until they upgrade. The SDK keeps probing them and `UPGRADING.md` §16 says to
check for it, but there is no event surfacing it. Recorded as open in the F4
record; an event is the honest fix if it turns up in practice.

## Contracts

Additive only. Welcome/commit JSON gains optional fields (no
`deny_unknown_fields`), the capability list is append-only, the frame body
schema is unchanged (`v:1`). **No UDL change, so no binding regeneration and
no bridge surface to re-pin.** 1:1 replication is behaviourally untouched and
its suite is green.

## Gates

`fmt`, `clippy --workspace -D warnings`, `clippy --package offline-protocol
--no-default-features` (the step the F3 record flags as missed-locally,
caught-by-CI), `RUSTDOCFLAGS="-D warnings" cargo doc`, and the full
`cargo test --workspace`: **2,382 passed, 0 failed.**

Docs updated: both spec files, ADR 0019, threat model R11, the group message
lifecycle state machine, `UPGRADING.md` §16, `api-reference.md`, and
`CHANGELOG.md` (including correcting the F3 entry's now-false "1:1 only"
claim).
