### PR TITLE
docs(protocol): give the data layer the guide half of its documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,47 @@ archived by series under [docs/changelog/](docs/changelog/); see the
 
 ### Documentation
 
+- **Replicated documents have a guide, a state machine and examples that run.**
+  The reference half was complete and the guide half was not: an application
+  author could read every frame on the wire and still have nowhere to learn
+  when a document is the right shape for their state.
+  [docs/data.md](./docs/data.md) is that document, and it answers the questions
+  the API reference cannot: message or document, what happens when two people
+  edit one key, what each size limit does when it is reached, and what this
+  version deliberately does not do.
+  [The replication state machine](./docs/state-machines/data-replication.md)
+  joins the other five with the local document states, the anti-entropy
+  exchange and its triggers, the catch-up ladder, and the six ways an
+  attachment fetch can end. Two programs make the behaviour executable rather
+  than described: `cargo run -p offline-protocol --example replicated_notes`
+  opens a store, edits all four collection types and reopens the same records
+  after the engine is rebuilt, and
+  `cargo run -p offline-protocol-data --example offline_merge` shows what two
+  people editing one document offline actually get back.
+
+- **The React Native guide no longer asks for a flag that is already on, and
+  now lists the whole surface.** It still told applications to set
+  `data: { enabled: true }`, the fifth restatement of a default that changed
+  before it ever shipped. Its `DataStore` table was also missing every
+  attachment method, the `DataValue` union it referred readers to, and its
+  event-type list named none of the six `data_*` events, so an app author
+  reading the platform guide could not tell they existed.
+
+- **The native platform guides cover the data layer.** Both document group
+  messaging with worked code and mentioned replicated documents nowhere, which
+  left Swift and Kotlin readers with no path into the API their binding
+  already exposes. Each now has a Replicated Documents section: the store,
+  values as JSON, the durability rule, the bring-your-own-backend constructor
+  with the logout obligation it carries, and the two events an application
+  must handle.
+
+- **The hand-written pieces and the routing table say so.** The TypeScript
+  bridge contract records that the `DataValue` union is maintained by hand and
+  names the Rust guard that pins it, because the one time it drifted both
+  `cargo test` and `tsc` stayed green. CLAUDE.md's "read this first" table now
+  routes a change in this area to the spec chapter, the state machine and the
+  two ADRs, and the docs index calls the ADR set nineteen rather than fifteen.
+
 - **`DataStore.wipeAll()` says that it is only durable once replication has
   stopped.** There are no deletion tombstones, so nothing distinguishes a
   space this device wiped from one it has never seen: called on a running

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ that are versioned, reviewable, and readable by people who are not an agent.
 | Anything security-relevant | [docs/security/threat-model.md](docs/security/threat-model.md) |
 | Acknowledgement, retry, session, group or transport behaviour | [docs/state-machines/](docs/state-machines/README.md) |
 | A decision that looks odd or over-engineered | [docs/adr/](docs/adr/README.md) |
+| Replicated documents: the store, sync frames, attachments | [docs/spec/data-sync.md](docs/spec/data-sync.md), [the replication state machine](docs/state-machines/data-replication.md), ADR [0018](docs/adr/0018-data-layer-engine-and-storage-seams.md) and [0019](docs/adr/0019-remote-document-imports-are-contained-not-trusted.md) |
 | Any binding: Swift, Kotlin, Python, TypeScript | [docs/bridges/](docs/bridges/README.md) |
 
 The ADR index is the fastest route to "why is this like this". If you are about

--- a/crates/offline-protocol-data/examples/offline_merge.rs
+++ b/crates/offline-protocol-data/examples/offline_merge.rs
@@ -1,0 +1,89 @@
+//! What happens when two people edit the same document while apart.
+//!
+//! Run it with:
+//!
+//! ```text
+//! cargo run --package offline-protocol-data --example offline_merge
+//! ```
+//!
+//! Two replicas start from one shared state, lose contact, both keep editing,
+//! and then exchange what each committed while away. The point of the example
+//! is the last line: after the exchange both replicas hold the same state, and
+//! neither of them ran a conflict resolver an application had to write.
+//!
+//! This is the engine seam rather than the application API. An application
+//! calls `data_map_set` and friends on `OfflineProtocol` and never sees a
+//! delta, because the protocol carries them; see
+//! `cargo run --package offline-protocol --example replicated_notes` for that
+//! side. What this example is for is the question the other one cannot answer:
+//! which edit wins, and what an application should therefore put in one key.
+
+use offline_protocol_data::{DataDoc, DataValue};
+
+fn text(value: &str) -> DataValue {
+    DataValue::Text {
+        value: value.to_string(),
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // One shared starting point: Ada writes, and Bo receives that change.
+    let mut ada = DataDoc::new();
+    ada.map_set("meta", "title", text("Coast road"))?;
+    ada.list_push("packing", text("water"))?;
+    let shared = ada.commit()?.expect("a change to share");
+
+    let mut bo = DataDoc::new();
+    bo.import(&shared.bytes)?;
+
+    println!("both start at: {}", bo.export_json()?);
+
+    // The link goes away here. Neither side can see the other's edits, and
+    // neither side blocks on that.
+    ada.map_set("meta", "title", text("Coast road, Friday"))?;
+    ada.list_push("packing", text("map"))?;
+    ada.text_insert("notes", 0, "leave at six")?;
+    ada.counter_increment("edits", 1.0)?;
+    let from_ada = ada.commit()?.expect("Ada's offline work");
+
+    bo.map_set("meta", "title", text("Coast road, Saturday"))?;
+    bo.list_push("packing", text("torch"))?;
+    bo.text_insert("notes", 0, "bring the tent, ")?;
+    bo.counter_increment("edits", 1.0)?;
+    let from_bo = bo.commit()?.expect("Bo's offline work");
+
+    println!("apart, Ada has: {}", ada.export_json()?);
+    println!("apart, Bo has:  {}", bo.export_json()?);
+
+    // The link comes back. Each side imports what the other committed. Order
+    // does not matter and neither does arriving twice: importing the same
+    // bytes again is a no-op, which is why at-least-once delivery is enough.
+    ada.import(&from_bo.bytes)?;
+    bo.import(&from_ada.bytes)?;
+    bo.import(&from_ada.bytes)?;
+
+    let ada_state = ada.export_json()?;
+    let bo_state = bo.export_json()?;
+
+    println!("together, Ada: {ada_state}");
+    println!("together, Bo:  {bo_state}");
+    println!("identical:     {}", ada_state == bo_state);
+
+    // Read that state against the four collection types:
+    //
+    // - `meta.title` is a map key two people wrote. One value wins, both
+    //   replicas pick the same one, and neither ends up holding half of each.
+    //   That is the reason to put independently editable fields in separate
+    //   keys rather than in one JSON blob.
+    // - `packing` kept every insertion. A list loses nothing to a concurrent
+    //   push.
+    // - `notes` merged at character level, so both sentences survive.
+    // - `edits` is 2. Two offline increments of 1 add up rather than
+    //   overwriting each other, which is what makes a counter a counter and
+    //   not an integer in a map.
+    println!("packing:       {} entries", ada.list_len("packing")?);
+    println!("notes:         {:?}", ada.text_value("notes")?);
+    println!("edits:         {}", ada.counter_value("edits")?);
+
+    Ok(())
+}

--- a/crates/offline-protocol/Cargo.toml
+++ b/crates/offline-protocol/Cargo.toml
@@ -69,3 +69,10 @@ openmls_basic_credential = { workspace = true }
 openmls_traits = { workspace = true }
 
 [lib]
+
+# The example drives the document API, which the `data` feature gates. Declared
+# so that a `--no-default-features` build skips it instead of failing to
+# compile a target that cannot exist in that configuration.
+[[example]]
+name = "replicated_notes"
+required-features = ["data"]

--- a/crates/offline-protocol/examples/replicated_notes.rs
+++ b/crates/offline-protocol/examples/replicated_notes.rs
@@ -1,0 +1,174 @@
+//! Replicated documents on one device: open a store, edit, persist, reopen.
+//!
+//! Run it with:
+//!
+//! ```text
+//! cargo run --package offline-protocol --example replicated_notes
+//! ```
+//!
+//! What it shows, in order: that a document needs no storage setup, that the
+//! four collection types behave the way an application expects, that a flush
+//! is what makes a change durable, and that the same records reopen into the
+//! same document after the engine is rebuilt.
+//!
+//! What it deliberately does not show is replication, which needs a second
+//! device, a confirmed MLS session, and a transport. The merge semantics that
+//! makes replication safe is a separate example that needs none of those:
+//! `cargo run --package offline-protocol-data --example offline_merge`.
+//!
+//! The backend below is an in-memory `ProtocolStateStorage`, written out in
+//! full because it is also the shape of the bring-your-own-storage seam: an
+//! application swaps SQLite, files, or its own encrypted store in at exactly
+//! this point, and sealing sits above it, so what `store` receives here is
+//! already ciphertext.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use offline_protocol::{
+    DataValue, OfflineProtocol, ProtocolConfig, ProtocolStateResult, ProtocolStateStorage,
+};
+use offline_protocol_mls::storage::InMemoryStorage;
+
+/// A protocol-state backend that keeps records in a map.
+///
+/// Four methods over `(key_type, key_id, bytes)`. The rules a real adapter
+/// has to honour are the ones the conformance suite checks: bytes are stored
+/// verbatim, a second write to one key replaces the first, and a key that was
+/// never written loads as `None` rather than as an error.
+#[derive(Default)]
+struct MemoryStateStorage {
+    records: Mutex<HashMap<(String, String), Vec<u8>>>,
+}
+
+impl ProtocolStateStorage for MemoryStateStorage {
+    fn store(&self, key_type: &str, key_id: &str, data: &[u8]) -> ProtocolStateResult<()> {
+        let mut records = self.records.lock().expect("storage mutex");
+        records.insert((key_type.to_string(), key_id.to_string()), data.to_vec());
+        Ok(())
+    }
+
+    fn load(&self, key_type: &str, key_id: &str) -> ProtocolStateResult<Option<Vec<u8>>> {
+        let records = self.records.lock().expect("storage mutex");
+        Ok(records
+            .get(&(key_type.to_string(), key_id.to_string()))
+            .cloned())
+    }
+
+    fn delete(&self, key_type: &str, key_id: &str) -> ProtocolStateResult<()> {
+        let mut records = self.records.lock().expect("storage mutex");
+        records.remove(&(key_type.to_string(), key_id.to_string()));
+        Ok(())
+    }
+
+    fn list_keys(&self, key_type: &str) -> ProtocolStateResult<Vec<String>> {
+        let records = self.records.lock().expect("storage mutex");
+        Ok(records
+            .keys()
+            .filter(|(stored_type, _)| stored_type == key_type)
+            .map(|(_, key_id)| key_id.clone())
+            .collect())
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Both stores outlive the engine below, which is what makes the reopen at
+    // the end a reopen rather than a fresh start. The secure store matters as
+    // much as the record store: documents are sealed with a key that lives in
+    // it, so dropping only that half looks exactly like data loss.
+    let secure = Arc::new(InMemoryStorage::default());
+    let records = Arc::new(MemoryStateStorage::default());
+
+    // `data.enabled` defaults to true, so nothing here switches the layer on.
+    let config = ProtocolConfig::builder("com.example.notes", "default").build()?;
+    let mut protocol = OfflineProtocol::new(config)?;
+
+    // Documents are sealed at rest and the record key is minted here, so this
+    // call is the prerequisite for every method below.
+    protocol.initialize_mls(secure.clone(), records.clone())?;
+
+    // A space is an MLS scope: a peer's address for a 1:1 space, or the group
+    // id for a group. Nothing replicates in this example, so the name only
+    // has to be a valid one.
+    let space = "demo-space";
+
+    protocol.data_create_doc(space, "trip")?;
+
+    // A map: last writer wins per key, and different keys never conflict.
+    protocol.data_map_set(
+        space,
+        "trip",
+        "meta",
+        "title",
+        DataValue::Text {
+            value: "Coast road".to_string(),
+        },
+    )?;
+
+    // A list: concurrent insertions both survive, in a deterministic order.
+    for item in ["water", "map", "torch"] {
+        protocol.data_list_push(
+            space,
+            "trip",
+            "packing",
+            DataValue::Text {
+                value: item.to_string(),
+            },
+        )?;
+    }
+
+    // Text: character-level merge, so two people typing in one paragraph keep
+    // both sets of words. Positions are character offsets, not byte offsets.
+    protocol.data_text_insert(space, "trip", "notes", 0, "Meet at the bridge")?;
+
+    // A counter: increments add up rather than overwriting each other.
+    protocol.data_counter_increment(space, "trip", "opened", 1.0)?;
+
+    // Edits batch before they reach storage. This is the call that makes them
+    // durable, and `data_changed` fires after the same point, never before.
+    protocol.data_flush(space, "trip")?;
+
+    println!("spaces:    {:?}", protocol.data_list_spaces()?);
+    println!("documents: {:?}", protocol.data_list_docs(space)?);
+    println!(
+        "compacted: {} bytes",
+        protocol.data_doc_size(space, "trip")?
+    );
+    println!(
+        "history:   {} bytes",
+        protocol.data_export_raw(space, "trip")?.len()
+    );
+    println!("json:      {}", protocol.data_doc_json(space, "trip")?);
+
+    // Both halves of the escape hatch are above: `data_doc_json` is the plain
+    // JSON of the current state, `data_export_raw` the engine-native history.
+    // An application can always take its data and leave.
+
+    // Reopen: a new engine over the same two stores. The records were sealed
+    // by the first one and are read back by the second, which is the property
+    // an application depends on across a restart.
+    drop(protocol);
+    let config = ProtocolConfig::builder("com.example.notes", "default").build()?;
+    let mut reopened = OfflineProtocol::new(config)?;
+    reopened.initialize_mls(secure, records)?;
+
+    println!("after reopen");
+    println!(
+        "  title:   {:?}",
+        reopened.data_map_get(space, "trip", "meta", "title")?
+    );
+    println!(
+        "  packing: {}",
+        reopened.data_list_len(space, "trip", "packing")?
+    );
+    println!(
+        "  notes:   {:?}",
+        reopened.data_text_value(space, "trip", "notes")?
+    );
+    println!(
+        "  opened:  {}",
+        reopened.data_counter_value(space, "trip", "opened")?
+    );
+
+    Ok(())
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ before changing behaviour, not before using the SDK.
 | [DORS Configuration](dors-configuration.md) | Tuning DORS for different use cases with parameter reference |
 | [Message Delivery](message-delivery.md) | Delivery lifecycle, retry/ACK system, flush triggers, and client-side persistence |
 | [Mesh Networking](mesh.md) | Peer discovery, connection management, message delivery, and routing |
+| [Replicated Documents](data.md) | Offline-first shared state: spaces, collections, how edits merge, attachments, storage |
 | [MLS Encryption](mls-integration.md) | End-to-end encryption with auto-encryption and manual MLS APIs |
 | [Service Discovery](service-discovery.md) | Decentralized service registration, discovery, and request/response |
 | [Telemetry](telemetry.md) | Wire up a telemetry sink for metrics, routing decisions, and MLS lifecycle |
@@ -68,18 +69,19 @@ implementation written against these documents should interoperate.
 
 | Document | Governs |
 |----------|---------|
-| [Overview](state-machines/README.md) | The invariant that spans all five |
+| [Overview](state-machines/README.md) | The invariant that spans all six |
 | [Delivery and acknowledgements](state-machines/delivery-and-acks.md) | What happens to an inbound frame, and when a receiver acknowledges |
 | [Outbox and retries](state-machines/outbox-and-retries.md) | An outbound message from send to terminal state |
 | [Session lifecycle](state-machines/session-lifecycle.md) | 1:1 MLS establishment, confirmation, desync, and heal |
 | [Group message lifecycle](state-machines/group-message-lifecycle.md) | A group message through fan-out, buffering, and drain |
 | [Transport lifecycle](state-machines/transport-lifecycle.md) | Transport availability, scoring, switching, escalation |
+| [Document replication](state-machines/data-replication.md) | A document from edit to durable record, a space from offer to convergence, an attachment fetch |
 
 ## Decisions
 
 | Document | Scope |
 |----------|-------|
-| [ADR index](adr/README.md) | Fifteen decisions that are expensive to reverse or easy to undo by accident |
+| [ADR index](adr/README.md) | Nineteen decisions that are expensive to reverse or easy to undo by accident |
 
 If something in the codebase looks redundant or over-engineered, check here
 before simplifying it.
@@ -111,6 +113,10 @@ in here fails **silently** when violated.
 | [React Native Example App](../examples/react-native-app/README.md) | Complete messaging app demonstrating all SDK features |
 | [Example App Setup](../examples/react-native-app/SETUP.md) | First-time setup for the example app |
 | [Example App Integration Guide](../examples/react-native-app/INTEGRATION_GUIDE.md) | Step-by-step project integration walkthrough |
+| [Mesh Wiki](../examples/mesh-wiki/README.md) | Mesh services: a device answering queries over BLE with no internet |
+| [Storage adapters](../examples/storage-adapters/README.md) | SQLite `ProtocolStateStorage` implementations for Swift, Kotlin and Python |
+| `cargo run -p offline-protocol --example replicated_notes` | Replicated documents: open a store, edit, persist, reopen |
+| `cargo run -p offline-protocol-data --example offline_merge` | What two people editing the same document offline actually get back |
 
 ## Contributing
 

--- a/docs/android-integration.md
+++ b/docs/android-integration.md
@@ -302,6 +302,67 @@ override fun onEvent(eventJson: String) {
 - The last admin cannot be demoted, removed, or leave (prevents orphaned groups)
 - If the last admin disconnects unexpectedly, a deterministic election promotes the next admin
 
+## Replicated Documents
+
+Shared state any member of a space can edit while disconnected, merging
+deterministically when the replicas meet again. The model, how concurrent edits
+resolve, and the limits are in the [Replicated Documents guide](data.md); this
+section is the Kotlin shape of it.
+
+`DataStore` wraps a live protocol instance. It needs `initializeMls` to have
+run, because documents are sealed at rest with the record key that call mints.
+`data.enabled` defaults to `true`, so nothing switches the layer on.
+
+```kotlin
+val store = DataStore(protocol)
+
+// A space is an MLS scope: a peer's address for a 1:1 space, a group id for a
+// group. Values cross as JSON: {"kind":"text","value":"..."}.
+val space = peerAddress
+
+store.createDoc(space, "trip")
+store.mapSet(space, "trip", "meta", "title", """{"kind":"text","value":"Coast road"}""")
+store.textInsert(space, "trip", "notes", 0u, "Meet at the bridge")
+store.counterIncrement(space, "trip", "opened", 1.0)
+
+// Edits batch. This is what makes them durable.
+store.flush(space, "trip")
+
+val json = store.docJson(space, "trip")
+```
+
+Every call above blocks while it reaches storage, so keep them off the main
+looper like every other protocol call
+([K2](bridges/kotlin.md#k2-nothing-blocking-on-the-main-looper)).
+
+To put documents in a store of your own rather than the one protocol state
+already uses, construct it with a provider instead. Sealing sits above that
+seam, so the adapter is handed sealed bytes and never sees document content,
+and an app that does this owes `wipeAll()` on logout because
+`wipePersistedState` cannot reach a backend it does not know about:
+
+```kotlin
+val store = DataStore.withStorage(protocol, myBackend)
+```
+
+A reference implementation and the conformance suite that gates one are in
+[`examples/storage-adapters/kotlin/`](../examples/storage-adapters/README.md).
+
+Six events arrive through the same `EventCallback` as everything else. Handle
+`data_changed` to re-render (it fires after the change is durable), and
+`data_attachment_requested` if your app writes attachment references: the SDK
+never kept the blob bytes, so only your app can answer, and a request nobody
+answers leaves the asking side showing a spinner forever.
+
+```kotlin
+"data_changed" ->
+    reload(obj.optString("space_id"), obj.optString("doc_id"))
+"data_attachment_requested" ->
+    // Answer with provideAttachment(...), or declineAttachment(...) if the
+    // bytes are gone. Both are real answers; silence is not.
+    respondToAttachment(obj)
+```
+
 ## Peer Identity
 
 There is no trust pin to manage. A peer's address **is** the hash of their

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1000,7 +1000,9 @@ pub struct FileProgress {
 
 Offline-first state any member of a space can edit while disconnected, merging
 deterministically when replicas meet again. Messaging is synced events; this is
-synced state.
+synced state. For the model behind these calls, how concurrent edits resolve,
+and what this version deliberately does not do, see the
+[Replicated Documents guide](data.md).
 
 Requires `initializeMls` to have run — documents are sealed at rest with the
 same per-install record key as every other protocol category, and that key is

--- a/docs/bridges/typescript.md
+++ b/docs/bridges/typescript.md
@@ -121,6 +121,34 @@ that collision was resolved by renaming the victim to
 fixing the pattern. Anchor it as `/lib/` before adding any nested `lib/`
 directory, or expect the same silent disappearance.
 
+## T9. The `DataValue` union is hand-written, and a Rust guard is what keeps it honest
+
+Document values cross the boundary as JSON rather than as a UDL type, which is
+what stops a new value kind from reshaping every binding. The cost lands here:
+no generator writes the reader, so `export type DataValue` in `src/index.ts` is
+maintained by hand, and so are the two strings that tell a caller what a kind
+may be.
+
+This has already happened once. `attachment` was added to the Rust enum, the
+UDL and all three generated bindings, and missed the TypeScript union. Both
+`cargo test` and `tsc --noEmit` stayed green, because a missing member of a
+union is legal TypeScript. The damage is on the read side and it is quiet:
+`mapGet` returns `{ kind: 'attachment', ... }` at runtime while the declared
+type says that cannot happen, so every exhaustive `switch` an application wrote
+is wrong and the compiler certified it.
+
+The pin is `react_native_types_cover_every_data_value_kind` in
+`crates/offline-protocol-uniffi/src/lib.rs`. It parses the Rust `DataValue`
+enum and asserts every kind appears in this union, in the UDL comment beside
+`map_set`, and in the runtime hint a caller gets for a malformed value. A kind
+added in Rust therefore fails a Rust test, which is the only place that can see
+all four at once ([C5](README.md#c5-hand-mirrored-constants-must-be-pinned-in-every-language)).
+
+Two consequences for anyone editing this file: keep the union one contiguous
+block ending in a blank line, because that is how the guard finds it, and do
+not "simplify" it to `Record<string, unknown>`. The union is the only thing
+telling an application that `attachment` is a shape it has to handle.
+
 ## Testing
 
 ```bash

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,299 @@
+# Replicated Documents
+
+The protocol's second application class. Messaging is synced events; this is
+synced state: a document any member of a space can edit while disconnected,
+merging deterministically when the replicas meet again.
+
+This guide is for application authors deciding whether to build on it and how
+to model their state. The wire contract is
+[Document replication](spec/data-sync.md), the method-by-method surface is the
+[API reference](api-reference.md#replicated-documents), and the runtime
+behaviour is [Document replication](state-machines/data-replication.md) in the
+state machines.
+
+## When this is the right tool
+
+Both classes ride one carrier, one encryption, and one set of transports. The
+question is what the state is, not how it travels.
+
+| Use a message | Use a document |
+|---------------|----------------|
+| A thing that happened at a time, in an order people can see | A thing that is currently true, whatever order the edits arrived in |
+| The receiver should be told once | Every member should be able to read it later, including one who joins after the edit |
+| The app keeps its own history | The app wants the current value and would otherwise rebuild it from a log |
+| One sender, many readers | Many editors, no coordinator |
+
+Chat, invitations, receipts and typing indicators are messages. A shared
+checklist, a group's settings, a collaboratively edited note, a per-member
+profile, a synced counter: those are documents, and building them out of
+messages means writing merge rules by hand for every field.
+
+Note that a document is not a database in the query sense. There is no query
+language, no index, and no partial replication in this version: a space
+replicates whole. Model state a member is entitled to hold in full, and keep
+anything else in messages or in your own storage.
+
+## The model
+
+**A space is an MLS scope.** A 1:1 session or a group *is* the space, and the
+roster that already exists is the membership. There is no second membership
+system to keep in step, which is the failure this shape prevents: two rosters
+that disagree about who is in the room.
+
+- A 1:1 space is named by the peer's address, so the two replicas name the
+  same space differently, each by the other's address. Pass the peer address
+  as `spaceId`.
+- A group space is named by the group id (`group:<uuid>`), so both replicas
+  name it identically. Pass the group id as `spaceId`.
+
+Inside a space are **documents**, inside a document are named
+**collections**, and a collection is one of four types:
+
+| Collection | Concurrent edits resolve as |
+|------------|-----------------------------|
+| `map` | Last writer wins per key. Different keys never conflict |
+| `list` | Both insertions survive, in a deterministic order |
+| `text` | Character-level merge, so two people typing in one paragraph both keep their words |
+| `counter` | Increments add up. Two devices adding 1 offline produce 2, not 1 |
+
+A map value is one of `null`, `bool`, `int`, `float`, `text`, `bytes`, or
+`attachment`.
+
+**A collection is identified by its name and its type together**, so one name
+used with two types is two collections. Both hold their data, both replicate,
+and both read back through their own accessors, but `docJson()` shows only one
+of them. Nothing reports the overlap, so treat a collection name as belonging
+to one type for the life of the document: `textInsert(..., 'notes', ...)` and
+`mapSet(..., 'notes', ...)` do not disagree with each other, they simply do not
+meet.
+
+**Values are replaced, never merged.** A map value or a list entry is one
+whole value. If two members write different values to one key, one of them
+wins and neither replica ends up holding half of each. Structured data goes in
+as a JSON string and merges whole, which is the trade this version makes: put
+the fields that should merge independently in separate keys, not in one blob.
+
+Names are bounded because they become record keys. A document or collection
+name is 1 to 128 bytes of `A-Z a-z 0-9 . _ -`; a map key is 1 to 256 bytes and
+otherwise unrestricted. A name outside that raises `InvalidArgument` at the
+call that used it.
+
+## Opening a store
+
+Two prerequisites, and neither is storage configuration:
+
+- `initializeMls` must have run. Documents are sealed at rest with the same
+  per-install record key as every other protocol-state category, and that key
+  is minted there. Before it, every method answers `DataStorageUnavailable`.
+- `data.enabled` must be on. It defaults to `true`, so there is nothing to
+  set; setting it to `false` makes every method answer `DataDisabled` and
+  stops the capability being advertised to peers.
+
+```typescript
+import { DataStore } from '@offline-protocol/mesh-sdk';
+
+const store = new DataStore();
+
+await store.mapSet(peerAddress, 'shopping', 'items', 'milk', {
+  kind: 'text',
+  value: '2 litres',
+});
+await store.textInsert(peerAddress, 'notes', 'body', 0, 'Meet at the bridge');
+await store.counterIncrement(peerAddress, 'stats', 'opened', 1);
+
+await store.flush(peerAddress, 'shopping');
+```
+
+Native platforms construct the store over a live protocol instance:
+[iOS](ios-integration.md#replicated-documents) and
+[Android](android-integration.md#replicated-documents). In Rust the same
+operations are methods on `OfflineProtocol` (`data_map_set`, `data_flush`, and
+so on).
+
+Two runnable programs are worth more than either listing. The first opens a
+store, writes to all four collection types, and reopens the same records after
+the engine is rebuilt; the second is the one that answers "what happens if we
+both edit this":
+
+```bash
+cargo run --package offline-protocol --example replicated_notes
+cargo run --package offline-protocol-data --example offline_merge
+```
+
+## Durability
+
+Edits batch before they reach storage, so a burst of keystrokes is not a burst
+of records.
+
+Call `flush()` when the app must know a change survived a crash. The SDK also
+flushes every open document when the protocol instance is dropped, and a
+`data_changed` event fires **after** the change is durable, never before: a UI
+that re-renders on that event is rendering state that survives a restart.
+
+Persisted changes are folded into the document periodically, so history does
+not grow without bound. Compaction runs when the delta log passes four times
+the compacted document (with a 64 KiB floor) or after 1024 commits.
+
+It switches off entirely for a document whose records did not all apply: a
+change that arrived ahead of the predecessor it builds on is parked and
+invisible until that predecessor turns up, and folding the log then would
+write a snapshot without it and delete the records holding it. A growing log
+is the cheaper failure. Compaction returns for that document when it is next
+opened over a complete log.
+
+## Replication
+
+Replication is anti-entropy, not a stream. Each side offers the version of
+every document it holds for that peer, the other answers with what is missing
+and its own versions, and the exchange stops. Nothing persists about how far a
+peer got: state that has to be reconciled after a crash is state that can be
+wrong.
+
+An exchange is triggered by:
+
+- a local change becoming durable, which is pushed to the space immediately,
+- an MLS session being confirmed with a peer,
+- that peer being rediscovered on any transport,
+- start-up, for 1:1 spaces,
+- joining a group, or a member being added to one.
+
+Offers to one peer are rate limited to one per 30 seconds. That window delays
+only the reconciliation sweep: a local change does not wait for it.
+
+Two things follow from at-least-once, unordered delivery being enough here.
+The first is that nothing needs ordering or exactly-once semantics; duplicates
+and reordering are absorbed by the merge. The second is that **a peer who was
+away misses nothing**: the next exchange sends whatever they lack, however
+long they were gone, as long as both replicas still hold the history in
+between.
+
+### In a group
+
+A group space replicates over the group send path, so one encryption serves
+the whole roster. Three consequences an application can see:
+
+- **Every member must be on a build that speaks group replication.** One
+  member that is not means no member is sent a group replication frame, because
+  the ciphertext reaches everyone and that member would surface it as text.
+  A single old device therefore stops group document sync for the whole room
+  until it updates.
+- **A change received from a group is not pushed back into it.** Anti-entropy
+  still closes real gaps, and re-broadcasting would turn one edit into N²
+  frames.
+- **Attachment bytes do not move inside a group** in this version. References
+  replicate like any other value; fetching the blob from a group member is
+  refused, because the transfer needs a confirmed pairwise session and two
+  group members need not have one.
+
+## Size, and what happens at each limit
+
+A document is bounded by one sealed protocol-state record. The limits below
+exist because of that, and each one is reported rather than silent.
+
+| Limit | Value | What happens |
+|-------|-------|--------------|
+| Document, compacted | 1 MiB | `DocTooLarge` at the call that breached it. The breaching change is still durable, deletions still apply, and the document accepts edits again once it is back under the cap |
+| Warning | 768 KiB | `data_doc_size_warning`, while there is still room to act |
+| One sync frame | 32 KiB of document bytes | The document is carried over the media path instead |
+| Whole document over the media path | 4 MiB, the record ceiling | A document past it is refused at the start of the transfer, because the receiver could not persist it even if every byte arrived |
+| Nowhere left to go | | `data_doc_unsyncable`, which is worth handling: the replicas will not converge, both sides keep accepting edits, and nothing else about that state looks like a problem |
+| Documents a peer may name in one space | 1024 | Bounds abuse rather than product use. Documents this application creates are not counted against it |
+
+Keep documents small on purpose. A shared list per conversation converges in
+one frame; a single document holding every list a person owns eventually does
+not fit in one, and the rungs below that are slower every time.
+
+## Attachments
+
+A document can name a blob it does not contain: a SHA-256, a size, and enough
+to display the thing. The bytes never enter the document and never enter
+protocol state, because a document is bounded by one sealed record and a layer
+that inlined blobs could not carry the blobs people actually send.
+
+**Your app owns the bytes.** The SDK never kept a copy, so when a peer asks
+for one you are asked, through `data_attachment_requested`. Answer with
+`provideAttachment` or refuse with `declineAttachment`, and answer either way:
+a reference outlives the bytes it names, so a peer holding a reference and no
+blob is ordinary, and without a refusal the asking side cannot tell that from a
+slow radio and shows somebody a spinner forever.
+
+The full surface, with worked code, is in the
+[API reference](api-reference.md#attachments).
+
+## Storage
+
+Documents live wherever protocol state already does, so a new application gets
+a working store with no storage setup at all: every binding ships a default
+provider.
+
+Putting them somewhere else is one line at construction rather than a rebuild,
+a cargo feature, or a change to any data API. In Rust it is a config field:
+
+```rust
+let config = ProtocolConfig::builder("my-app", "default")
+    .data_storage(Arc::new(MyBackend::open("documents.db")?))
+    .build()?;
+```
+
+and on the bindings it is a second constructor:
+`DataStore.withStorage(protocol:storage:)` on Swift,
+`DataStore.withStorage(protocol, storage)` on Kotlin,
+`DataStore.with_storage(protocol, storage)` on Python. The React Native
+JavaScript surface has no equivalent: an app there gets the default provider
+its native bridge already ships, and reaches this seam from native code if it
+needs to.
+
+Sealing sits above that seam. An adapter is handed sealed bytes and never sees
+document content, so a custom backend cannot weaken the at-rest posture even by
+accident. Verify one with `runStorageConformance(provider)` before shipping it:
+an adapter that returns success from every method can still lose overwrites or
+merge categories, and the suite is what catches that. Reference adapters for
+Swift, Kotlin and Python live in
+[`examples/storage-adapters/`](../examples/storage-adapters/README.md).
+
+One obligation comes with a custom backend: call `wipeAll()` on logout.
+`wipePersistedState()` clears the account directory of the *default* provider,
+which a custom backend is not inside, so documents would otherwise outlive the
+account that made them.
+
+## Events to handle
+
+| Event | Handle it because |
+|-------|-------------------|
+| `data_changed` | The change is durable. Re-render here |
+| `data_doc_size_warning` | The cap is a cliff otherwise, met for the first time as a failed write |
+| `data_attachment_requested` | Only your app has the bytes. Answer or decline |
+| `data_attachment_received` | The bytes arrived and matched the hash that asked for them. Store them where you keep files |
+| `data_attachment_unavailable` | The fetch ended without bytes: `declined`, `timeout`, `evicted`, `hash_mismatch`, `peer_gone`, or a transfer failure. Stop the spinner |
+| `data_doc_unsyncable` | Two replicas that will not converge, and nothing else reports it |
+
+## What this version does not do
+
+Each of these is a decision rather than an omission, and the reasoning is in
+the [design record](spec/data-sync.md) or the ADRs.
+
+- **No deletion tombstones.** `deleteDoc` removes the document here, and the
+  peer's next offer recreates and refills it, because a peer cannot tell a
+  deleted document from one this device has never seen. To remove content from
+  both replicas, empty the document: deletions *inside* a document replicate
+  like any other change. The same applies to `wipeAll()`, which is durable only
+  once replication has stopped.
+- **No query language and no partial replication.** A space replicates whole.
+- **No hosted component.** Relays and gateways carry sync frames as opaque MLS
+  ciphertext they cannot read, and nothing in this layer requires a server.
+- **No blob carriage in groups**, as above.
+- **No garbage collection for blobs.** The SDK does not know which references
+  still exist across every space, so deciding when your stored bytes are
+  unreferenced is your app's job.
+
+## Where to read next
+
+| Question | Document |
+|----------|----------|
+| What exactly is on the wire | [Document replication](spec/data-sync.md) |
+| What the runtime does, state by state | [Document replication state machine](state-machines/data-replication.md) |
+| Every method and event | [API reference](api-reference.md#replicated-documents) |
+| Why an engine and a backend seam | [ADR 0018](adr/0018-data-layer-engine-and-storage-seams.md) |
+| Why remote imports are contained | [ADR 0019](adr/0019-remote-document-imports-are-contained-not-trusted.md) |
+| What a hostile space member can do | [Threat model, R11](security/threat-model.md) |
+| Writing a storage backend | [Bridge contract C11](bridges/README.md#c11-a-storage-adapter-is-a-supported-extension-point-and-is-verified) |

--- a/docs/ios-integration.md
+++ b/docs/ios-integration.md
@@ -337,6 +337,71 @@ func onEvent(eventJson: String) {
 - The last admin cannot be demoted, removed, or leave (prevents orphaned groups)
 - If the last admin disconnects unexpectedly, a deterministic election promotes the next admin
 
+## Replicated Documents
+
+Shared state any member of a space can edit while disconnected, merging
+deterministically when the replicas meet again. The model, how concurrent edits
+resolve, and the limits are in the [Replicated Documents guide](data.md); this
+section is the Swift shape of it.
+
+`DataStore` wraps a live protocol instance. It needs `initializeMls` to have
+run, because documents are sealed at rest with the record key that call mints.
+`data.enabled` defaults to `true`, so nothing switches the layer on.
+
+```swift
+let store = try DataStore(protocol: offlineProtocol)
+
+// A space is an MLS scope: a peer's address for a 1:1 space, a group id for a
+// group. Values cross as JSON: {"kind":"text","value":"..."}.
+let space = peerAddress
+
+try store.createDoc(spaceId: space, docId: "trip")
+try store.mapSet(
+    spaceId: space, docId: "trip", collection: "meta", key: "title",
+    valueJson: #"{"kind":"text","value":"Coast road"}"#
+)
+try store.textInsert(
+    spaceId: space, docId: "trip", collection: "notes",
+    position: 0, text: "Meet at the bridge"
+)
+try store.counterIncrement(
+    spaceId: space, docId: "trip", collection: "opened", amount: 1
+)
+
+// Edits batch. This is what makes them durable.
+try store.flush(spaceId: space, docId: "trip")
+
+let json = try store.docJson(spaceId: space, docId: "trip")
+```
+
+To put documents in a store of your own rather than the one protocol state
+already uses, construct it with a provider instead. Sealing sits above that
+seam, so the adapter is handed sealed bytes and never sees document content,
+and an app that does this owes `wipeAll()` on logout because
+`wipePersistedState` cannot reach a backend it does not know about:
+
+```swift
+let store = try DataStore.withStorage(protocol: offlineProtocol, storage: myBackend)
+```
+
+A reference implementation and the conformance suite that gates one are in
+[`examples/storage-adapters/swift/`](../examples/storage-adapters/README.md).
+
+Six events arrive through the same `EventCallback` as everything else. Handle
+`data_changed` to re-render (it fires after the change is durable), and
+`data_attachment_requested` if your app writes attachment references: the SDK
+never kept the blob bytes, so only your app can answer, and a request nobody
+answers leaves the asking side showing a spinner forever.
+
+```swift
+case "data_changed":
+    reload(space: obj["space_id"] as? String, doc: obj["doc_id"] as? String)
+case "data_attachment_requested":
+    // Answer with provideAttachment(...), or declineAttachment(...) if the
+    // bytes are gone. Both are real answers; silence is not.
+    break
+```
+
 ## Peer Identity
 
 There is no trust pin to manage. A peer's address **is** the hash of their

--- a/docs/react-native-integration.md
+++ b/docs/react-native-integration.md
@@ -371,7 +371,7 @@ All methods are on the `OfflineProtocol` class. Types and events are exported fr
 | **once** | `once(eventType, listener): this` | Registers a one-time listener. |
 | **removeAllListeners** | `removeAllListeners(eventType?: EventType \| 'all'): this` | Removes listeners for a type or all. |
 
-**Event types**: `message_sent`, `message_received`, `message_delivered`, `message_failed`, `transport_switched`, `relay_promoted`, `relay_demoted`, `neighbor_discovered`, `neighbor_lost`, `network_metrics`, `file_progress`, `file_received`, `diagnostic`, `secure_session_established`, `secure_session_failed`, `connection_request_received`, `connection_request_undeliverable`, `connection_accepted`, `connection_rejected`, `connection_request_cancelled`, `group_created`, `group_message_received`, `group_member_added`, `group_member_removed`, `group_unauthorized_membership_change`, `group_message_sent`, `group_message_partial_failure`, `group_message_delivery_report`, `group_epoch_fork_detected`, `group_epoch_fork_resolved`, `group_role_changed`, `service_discovered`, `service_request_received`, `service_response_received`, `presence_updated`, `typing_indicator_received`, `read_receipt_received`, `message_relayed`, `message_deferred`.
+**Event types**: `message_sent`, `message_received`, `message_delivered`, `message_failed`, `transport_switched`, `relay_promoted`, `relay_demoted`, `neighbor_discovered`, `neighbor_lost`, `network_metrics`, `file_progress`, `file_received`, `diagnostic`, `secure_session_established`, `secure_session_failed`, `connection_request_received`, `connection_request_undeliverable`, `connection_accepted`, `connection_rejected`, `connection_request_cancelled`, `group_created`, `group_message_received`, `group_member_added`, `group_member_removed`, `group_unauthorized_membership_change`, `group_message_sent`, `group_message_partial_failure`, `group_message_delivery_report`, `group_epoch_fork_detected`, `group_epoch_fork_resolved`, `group_role_changed`, `service_discovered`, `service_request_received`, `service_response_received`, `presence_updated`, `typing_indicator_received`, `read_receipt_received`, `message_relayed`, `message_deferred`, `data_changed`, `data_doc_size_warning`, `data_attachment_requested`, `data_attachment_received`, `data_attachment_unavailable`, `data_doc_unsyncable`.
 
 **Identity**: `neighbor_discovered.peer_id` is the peer's canonical address — the `off1…` value that peer derived from its own identity key, on every transport — and is what you pass as `recipient` to `sendMessage` / `sendConnectionRequest`. Your own is `localAddress()`; no app chooses its address, so a peer claiming one can be checked by re-deriving it from the key it presents.
 
@@ -541,7 +541,14 @@ Parse the raw event and check the server frame's `type` before consuming extensi
 
 Offline-first state any member of a space can edit while disconnected, merging
 deterministically when replicas meet again. Requires
-`initializeMlsWithSecureStorage()` and `data: { enabled: true }` in the config.
+`initializeMlsWithSecureStorage()` to have run, because documents are sealed at
+rest with the key it mints. `data.enabled` defaults to `true`, so there is no
+flag to set; setting it to `false` makes every method below throw
+`DataDisabled`.
+
+`spaceId` is an MLS scope: a peer's address for a 1:1 space, or a group id for
+a group. See the [Replicated Documents guide](data.md) for the model, how
+concurrent edits resolve, and what this version deliberately does not do.
 
 ```typescript
 import { DataStore } from '@offline-protocol/mesh-sdk';
@@ -577,12 +584,41 @@ await store.flush('space-1', 'profile');
 | **flushAll** | `flushAll(): Promise<void>` | Persists every open document. |
 | **docSize** | `docSize(spaceId, docId): Promise<number>` | Compacted size in bytes. |
 | **wipeAll** | `wipeAll(): Promise<void>` | Deletes every data-layer record. Needed on logout only when documents were pointed at an app-supplied backend, which `wipePersistedState` cannot reach. Only durable once replication has stopped: with the engine running and sessions live, the peer's next version offer recreates and refills every document. |
+| **attachmentHash** | `attachmentHash(bytesBase64: string): Promise<string>` | The address of some bytes, in the spelling a reference uses. Compute it here rather than anywhere else: two spellings of one hash are two addresses. |
+| **fetchAttachment** | `fetchAttachment(spaceId, hash): Promise<void>` | Asks the peer for a blob. The answer arrives as an event, never inline. Rejects for a group space, and for a peer that cannot carry blobs. |
+| **provideAttachment** | `provideAttachment(spaceId, peerId, hash, bytesBase64): Promise<void>` | Answers a peer's request. Rejects if the bytes do not hash to `hash`. |
+| **declineAttachment** | `declineAttachment(spaceId, peerId, hash): Promise<void>` | Tells a peer the bytes are gone. Rejects for a peer that cannot carry blobs. |
+
+A `DataValue` is one of:
+
+```typescript
+type DataValue =
+  | { kind: 'null' }
+  | { kind: 'bool'; value: boolean }
+  | { kind: 'int'; value: number }
+  | { kind: 'float'; value: number }
+  | { kind: 'text'; value: string }
+  | { kind: 'bytes'; value: number[] }
+  | { kind: 'attachment'; hash: string; size: number; name?: string; mime?: string };
+```
 
 Edits batch before they reach storage: call `flush()` when the app must know a
 change is durable. The `data_changed` event fires **after** the change is
 durable. A document is capped at 1 MiB compacted, with `data_doc_size_warning`
 at 768 KiB; passing the cap raises `DocTooLarge`, and deletions keep working so
 the document can be brought back under it.
+
+**Attachments.** A document can name a blob it does not hold: write an
+`attachment` value with `attachmentHash`, and the bytes travel the media path
+rather than entering the document. Your app owns those bytes, so a peer's
+request arrives as `data_attachment_requested` and only you can answer it.
+Answer every one, with `provideAttachment` or `declineAttachment`: without a
+refusal the asking side cannot tell a peer that lost the file from one on a
+slow radio, and shows somebody a spinner forever. Fetched bytes arrive whole,
+base64, in `data_attachment_received`, and a fetch that ends without them
+arrives as `data_attachment_unavailable`. Blob carriage is 1:1 in this release;
+references replicate in a group but the bytes do not. Worked code is in the
+[API reference](api-reference.md#attachments).
 
 ### 11.12 MLS (End-to-End Encryption)
 

--- a/docs/state-machines/README.md
+++ b/docs/state-machines/README.md
@@ -1,6 +1,6 @@
 # State machines
 
-Five state machines govern the protocol's runtime behaviour. Each is documented
+Six state machines govern the protocol's runtime behaviour. Each is documented
 with its states, its transitions, the invariants that hold across them, and the
 failure modes that the current shape exists to prevent.
 
@@ -11,6 +11,7 @@ failure modes that the current shape exists to prevent.
 | [Session lifecycle](session-lifecycle.md) | 1:1 MLS session establishment, confirmation, desync, and heal |
 | [Group message lifecycle](group-message-lifecycle.md) | A group message from send through fan-out, buffering, and drain |
 | [Transport lifecycle](transport-lifecycle.md) | Transport availability, scoring, switching, and escalation |
+| [Document replication](data-replication.md) | A document from edit to durable record, a space from offer to convergence, an attachment fetch to one of six ends |
 
 ## How to read these
 
@@ -22,7 +23,7 @@ Several of these shapes look over-engineered until you know which bug they close
 and the surrounding prose is there so a future change does not undo one by
 accident.
 
-## The one invariant that spans all five
+## The one invariant that spans all six
 
 **Custody of an undelivered message stays with the sender until a receiver
 positively confirms it.**
@@ -35,3 +36,7 @@ sender keep custody, not to acknowledge and hope.
 The corollary matters to application teams: because acknowledgements are
 withheld on recoverable failures and re-sent on recovery, **a missing
 acknowledgement is not proof of non-delivery.**
+
+Document replication inherits it rather than restating it: a sync frame is an
+ordinary message on the same ladder, which is why that layer needed no delivery
+machinery of its own.

--- a/docs/state-machines/data-replication.md
+++ b/docs/state-machines/data-replication.md
@@ -1,0 +1,204 @@
+# Document replication
+
+A replicated document from a local edit to a durable record, a space from a
+version offer to convergence, and an attachment fetch from the question to one
+of six ends.
+
+The wire contract these states implement is
+[Document replication](../spec/data-sync.md). The application-facing view is
+[Replicated Documents](../data.md).
+
+## Invariants
+
+**D1. The space is derived, never declared.** No frame names its space. A
+receiver takes it from the authenticated wire sender, or from the group whose
+key opened the ciphertext. A peer that cannot name a space cannot reach a
+document shared with somebody else, and there is no authorization table to get
+wrong.
+
+**D2. Every leg ends.** An inbound frame produces at most one kind of answer,
+and no answer restarts an exchange. The failure this prevents has no symptom on
+either device except traffic that never stops.
+
+**D3. Every data-layer outcome is terminal.** A corrupt blob, an unknown
+version, a refused import or a switched-off layer is acknowledged and dropped,
+never deferred. Deferral means "this same ciphertext will succeed once the
+session is ready" and nothing else, so using it for anything else spends the
+sender's whole retry budget on a frame that can never be accepted.
+
+**D4. Bytes that came off a network are judged before the engine sees them.**
+Everywhere else in this layer the argument for handing bytes to the engine is
+that they came out of a sealed record whose AEAD tag vouched for them. MLS says
+who sent a blob and nothing about its shape. See
+[ADR 0019](../adr/0019-remote-document-imports-are-contained-not-trusted.md).
+
+**D5. Nothing persists about how far a peer got.** The version exchange answers
+that question on demand. State that has to be reconciled after a crash is state
+that can be wrong.
+
+## A document, locally
+
+```mermaid
+stateDiagram-v2
+    [*] --> Absent
+    Absent --> Open: create, or first write
+    Open --> Dirty: edit
+    Dirty --> Persisted: flush writes a delta record
+    Persisted --> Dirty: edit
+    Persisted --> Compacted: log passes a threshold
+    Compacted --> Dirty: edit
+
+    Dirty --> OverCap: compacted size passes 1 MiB
+    OverCap --> Persisted: deletions bring it back under
+
+    Open --> HistoryIncomplete: a record parks or will not read
+    HistoryIncomplete --> Open: an open sees a complete log again
+```
+
+**Edits batch; a flush is what makes them durable.** Flushes happen on an
+explicit `flush()` or `flushAll()`, and when the protocol instance is dropped,
+because the debounce window between an edit and its record is otherwise a
+window in which work is lost. `data_changed` fires *after* the record is
+durable, so a UI that re-renders on it renders state that survives a restart.
+
+**The cap refuses growth, not the document.** A document is measured
+compacted. Past 768 KiB it emits `data_doc_size_warning`, so the cap arrives
+while there is still room to act rather than as a failed write. Past 1 MiB the
+call raises `DocTooLarge`, the change that breached it is still durable, and
+deletions keep applying so the document can be brought back under and resume.
+
+**Compaction folds the log into the document** when the delta log passes four
+times the compacted size (with a 64 KiB floor) or after 1024 commits.
+
+**`HistoryIncomplete` switches compaction off for that document.** It is
+entered when a delta record parks behind a predecessor that never arrived, or
+when a record will not read. Both mean the in-memory document is missing
+changes the records still describe, so folding would write a snapshot without
+them and then delete the records holding them. A growing log is the cheaper
+failure.
+
+## An exchange, between two replicas
+
+Anti-entropy, not a stream. Each side offers what it holds, the other answers
+with what is missing, and the exchange stops.
+
+```mermaid
+sequenceDiagram
+    participant A as Replica A
+    participant B as Replica B
+    A->>B: offer (reply false): every document and version
+    B->>A: catch-up for each stale document
+    B->>A: offer (reply true)
+    A->>B: catch-up for each stale document
+    A->>B: targeted offer (reply true, partial true) for documents this created
+    B->>A: catch-up for those
+```
+
+The last leg is the only chain longer than one hop, and it terminates because
+it names only documents the peer has just offered: the peer creates nothing
+from it and has nothing to ask for in turn. An offer marked `reply` is never
+answered with another offer, which is the rule that keeps D2 true.
+
+Triggers, each of which names its cause in the logs:
+
+| Trigger | Cause | Scope |
+|---------|-------|-------|
+| A local change becoming durable | pushed immediately | The space it belongs to |
+| MLS session confirmed | the confirming event | That peer |
+| Peer rediscovered on any transport | `peer_rediscovered` | That peer, and groups shared with them |
+| Start-up | `start` | 1:1 spaces only |
+| Group joined, or a member added | `group_joined`, `member_added` | That member |
+
+Offers to one peer are suppressed for 30 seconds after the last one. The
+window delays only the reconciliation sweep: a local change does not wait for
+it, and the next trigger repeats the sweep anyway. Start-up deliberately does
+not sweep group spaces, because that would mean an offer per member per group
+at every launch to recover something a local commit already pushed.
+
+## The catch-up ladder
+
+Each rung is tried when the one above it cannot carry the gap, and each answer
+is terminal.
+
+| Rung | Carries | Bound | What happens when it does not fit |
+|------|---------|-------|-----------------------------------|
+| `delta` | The changes since the peer's version | 32 KiB per frame | The receiver asks for a snapshot when the changes need history it compacted away |
+| `snap` | The compacted document | 32 KiB per frame | Falls to the media path |
+| Whole document over the media path | The document as one transfer | 4 MiB, the record ceiling, gated on capability entry 3, 1:1 only | `data_doc_unsyncable` |
+
+A delta that arrives ahead of its predecessor parks, and the receiver answers
+with one targeted offer for that document. A snapshot answers nothing in every
+outcome, including refusal, which is what lets the rungs below it ask freely.
+
+The end of the ladder is reported rather than logged. `data_doc_unsyncable`
+means two replicas that will not converge while both keep accepting edits, and
+nothing else about that state looks like a problem.
+
+## An attachment fetch
+
+The fetching side. Every path out of `Outstanding` reports, because a
+reference that cannot be opened and never says so is the spinner the whole
+frame family exists to kill.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Outstanding: fetchAttachment
+    Outstanding --> Outstanding: a chunk arrives, refreshing the clock
+    Outstanding --> Received: bytes hash to what was asked for
+    Outstanding --> Unavailable: blob_gone (declined)
+    Outstanding --> Unavailable: 15 minutes of silence (timeout)
+    Outstanding --> Unavailable: displaced by newer fetches (evicted)
+    Outstanding --> Unavailable: bytes did not hash (hash_mismatch)
+    Outstanding --> Unavailable: peer blocked, forgotten, or capability gone (peer_gone)
+    Received --> [*]
+    Unavailable --> [*]
+```
+
+**The timeout is measured from the last sign of life, not from the question.**
+The record of the request is what admits the bytes at the end, so a request
+that expires mid-carriage discards a blob that fully arrived, and the retry it
+invites takes just as long and dies at the same point. Arriving chunks refresh
+the entry. Expired entries are swept on the protocol's periodic tick, so a
+device that never fetches again still reports.
+
+At most 64 fetches are outstanding at once; the 65th evicts the oldest, which
+reports `evicted` rather than going quiet. A fetch toward a peer that never
+advertised blob carriage is refused synchronously at the call: no event
+follows, because nothing left the device.
+
+The holding side answers `data_attachment_requested`, and the SDK cannot
+answer for it: blob bytes never entered protocol state, so only the
+application has them.
+
+| Bound | Value | What it stops |
+|-------|-------|---------------|
+| Per-hash window | 30 seconds | A peer re-asking for one blob it has already been answered about |
+| Per-peer budget | 32 live windows | A peer asking for a different hash every time, each costing a map entry and an app callback |
+| Global windows | 256, oldest evicted | The bound that still holds when a peer's budget resets |
+
+`provideAttachment` verifies that the bytes hash to the requested address
+before anything is sent, so a mistake is reported to the application that made
+it while it still has the file in hand.
+
+## Quarantine
+
+A blob about to be imported is recorded on disk first. If the process does not
+survive applying it, the next run finds that record and refuses the blob
+permanently rather than dying again on every retry. At most 32 digests per
+space, oldest out first: every entry is a change this device has decided never
+to apply, so a long list is a liability rather than a safety net.
+
+## In a group
+
+The frames and the ladder are identical. Three rules are not:
+
+- **Offers and answers are addressed to one member**, because anti-entropy
+  between two members is a conversation between two devices. Only a local
+  commit goes to the whole roster.
+- **An addressed frame still advances every member's ratchet**, so a sender
+  bounds how many it encrypts without giving the roster one and promotes the
+  next frame to a roster-wide delivery. See
+  [the group message lifecycle](group-message-lifecycle.md#addressed-frames-still-advance-everyones-ratchet).
+- **A change received from a group is never pushed back into it.** The
+  ciphertext already reached every member; re-broadcasting turns one edit into
+  N² frames.


### PR DESCRIPTION
## Why

The data layer's reference material is complete: a 549-line wire chapter, two ADRs, a threat-model entry, a full API-reference section, and crate rustdoc. Its **guide** material did not exist. An application author could read every frame on the wire and still have nowhere to learn whether their state is a message or a document, and the two native platform guides mentioned replicated documents nowhere at all.

This closes the seven gaps found in that audit.

## What is here

**New: [`docs/data.md`](docs/data.md)** (299 lines). When a document is the right tool versus a message, the model (spaces, documents, collections, values), how each collection type resolves concurrent edits, durability and compaction, what happens at each size limit, attachments, the storage swap and its logout obligation, the six events to handle, and what this version deliberately does not do. Linked from the Features table, and from the API reference.

**New: [`docs/state-machines/data-replication.md`](docs/state-machines/data-replication.md)** (204 lines). The sixth state machine: five invariants, the local document states (including the parked/`HistoryIncomplete` case that switches compaction off), the anti-entropy exchange with its five triggers and the 30-second offer window, the catch-up ladder, the six ends of an attachment fetch with the bounds on both sides, and the quarantine.

**New: two examples that run.**

```bash
cargo run -p offline-protocol --example replicated_notes   # store, edit, persist, reopen
cargo run -p offline-protocol-data --example offline_merge # two replicas, partitioned, converged
```

`replicated_notes` writes its in-memory `ProtocolStateStorage` out in full, so it doubles as the shape of the bring-your-own-backend seam, and it reuses **both** stores across the reopen (dropping only the secure half looks exactly like data loss). It is declared with `required-features = ["data"]` so `--no-default-features` skips it rather than failing to compile a target that cannot exist there.

**Fixed: the React Native guide.** It still required `data: { enabled: true }`, the fifth restatement of a default that changed before it ever shipped, and the one `cc9af4c9`'s sweep missed while declaring the API reference "the last one". Its `DataStore` table had none of the F5 attachment methods, the `DataValue` union it referred readers to was never defined, and its event-type list named none of the six `data_*` events.

**Fixed: the native guides.** iOS and Android each gain a Replicated Documents section with Swift/Kotlin code, the `withStorage` constructor and the `wipeAll()` obligation it carries, and the two events an application must handle.

**Fixed: the small stale bits.** The docs index called the ADR set fifteen decisions (it holds nineteen) and had no route to the data layer. CLAUDE.md's routing table now sends a change in this area to the spec chapter, the state machine and the two ADRs. `docs/bridges/typescript.md` gains T9: the `DataValue` union is hand-maintained, and the Rust guard that pins it is named, because the one time it drifted both `cargo test` and `tsc` stayed green.

## One correction the writing produced

The guide's first draft said a collection's type is fixed by the call that first writes to it. Probing the engine says otherwise: **a collection is identified by name *and* type**, so `text_insert("notes", ...)` and `map_set("notes", ...)` create two independent containers. Both hold data, both replicate, both read back through their own accessors, and `docJson()` shows only one of them. Nothing reports the overlap. Documented as it behaves; worth a look at whether the store should refuse the second type instead, which would be a code change rather than a doc one.

## Verification

- `cargo fmt --all -- --check` clean.
- Both examples compile and run; `cargo build --workspace --examples` green; `cargo build -p offline-protocol --no-default-features --examples` correctly matches no targets.
- `cargo clippy -p offline-protocol-data --example offline_merge -- -D warnings` clean. The `offline-protocol` example cannot be linted locally because `--all-targets` pulls the transport crate's test-utils mock, which fails `unwrap_used` on main today; CI's clippy jobs do not build examples, and its `cargo test --workspace` does.
- `cargo test -p offline-protocol-data`: 66 passed.
- Link and anchor check over all 82 markdown files: every link in the changed and new files resolves. The 13 pre-existing failures are all `docs/UPGRADING.md` self-anchors, untouched here.
- No em dashes introduced (the ones the scanner reports in the three platform guides are pre-existing lines).

No behaviour changes. The only non-documentation edits are the two example files and the `[[example]]` stanza that gates one of them.