### PR TITLE
feat(core): a leaf node speaks MLS, and both halves are measured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,17 @@ jobs:
       - name: Build core standalone with default features
         run: cargo build --package offline-protocol-core --locked
 
+      # `embedded-footprint` has its own workspace, so the repo's Clippy job
+      # does not reach it. The leaf configurations are linted individually
+      # because each is a separate link with a different feature set.
+      - name: Clippy the footprint harness
+        working-directory: tools/embedded-footprint
+        run: |
+          for features in "" "leaf-min" "leaf" "leaf-full"; do
+            cargo clippy --release --locked --target thumbv8m.main-none-eabihf \
+              ${features:+--features "$features"} -- -D warnings
+          done
+
       # Report-only: the size is information, not a threshold. A number that
       # fails a build invites tuning the number.
       - name: Measure embedded footprint
@@ -229,11 +240,20 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci-mls-interop
           workspaces: tools/mls-interop
+
+      # The workspace Clippy and Format jobs stop at the SDK's workspace
+      # boundary, and this crate has its own. Without this step it is the only
+      # Rust in the repo that nothing lints.
+      - name: Clippy
+        working-directory: tools/mls-interop
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       # The other half of ADR 0021. `embedded-footprint` proves a leaf's MLS
       # stack fits; this proves it is talking to the phone rather than only to
@@ -241,8 +261,9 @@ jobs:
       # changes behaviour, which is the point: an interop claim is about two
       # specific versions.
       #
-      # Step 0 inside the harness is a negative control that requires the
-      # uncorrected mls-rs defaults to be REJECTED. If that starts passing,
+      # The step 0 lines are negative controls: each restores one mls-rs
+      # default and requires the phone to refuse the result, except 0.3, which
+      # pins a cap OpenMLS declares and never applies. If any of them flips,
       # read the harness README before touching anything.
       - name: Phone and leaf MLS stacks interoperate
         working-directory: tools/mls-interop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,32 @@ jobs:
       - name: Measure embedded footprint
         run: ./tools/embedded-footprint/measure.sh >> "$GITHUB_STEP_SUMMARY"
 
+  mls-interop:
+    name: MLS interop (phone <-> leaf)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-mls-interop
+          workspaces: tools/mls-interop
+
+      # The other half of ADR 0021. `embedded-footprint` proves a leaf's MLS
+      # stack fits; this proves it is talking to the phone rather than only to
+      # itself. Both library versions are pinned, so this fails when a bump
+      # changes behaviour, which is the point: an interop claim is about two
+      # specific versions.
+      #
+      # Step 0 inside the harness is a negative control that requires the
+      # uncorrected mls-rs defaults to be REJECTED. If that starts passing,
+      # read the harness README before touching anything.
+      - name: Phone and leaf MLS stacks interoperate
+        working-directory: tools/mls-interop
+        run: cargo run --release --locked
+
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/docs/adr/0020-core-compiles-without-std.md
+++ b/docs/adr/0020-core-compiles-without-std.md
@@ -76,8 +76,14 @@ with a number rather than an argument.
 This ADR covers the protocol layer only. It does not make MLS run on a leaf
 node, and it should not be read as promising that: OpenMLS is not a no_std
 crate, and MLS key-schedule and ratchet-tree state does not fit alongside a
-vendor radio stack in 256 KB. A leaf node's payload cryptography is a separate
-decision, still open.
+vendor radio stack in 256 KB.
+
+A leaf node's payload cryptography was settled separately, in
+[ADR 0021](0021-a-leaf-node-speaks-mls.md). The paragraph above holds for
+OpenMLS and for large groups, and turned out not to hold for the shape the
+problem has: a phone paired with one device is a two-member group whose ratchet
+tree is three nodes, and a second RFC 9420 implementation that does build
+without `std` fits the part. A leaf runs real MLS.
 
 ## What would undo this
 

--- a/docs/adr/0021-a-leaf-node-speaks-mls.md
+++ b/docs/adr/0021-a-leaf-node-speaks-mls.md
@@ -1,0 +1,199 @@
+# 0021. A leaf node speaks MLS, through a second implementation
+
+**Status:** Accepted
+
+## Context
+
+[ADR 0020](0020-core-compiles-without-std.md) made `offline-protocol-core`
+build for bare metal and measured it: about 95 KB of flash for the receiving
+half of the protocol. It closed by naming what it had not solved.
+
+> It does not make MLS run on a leaf node, and it should not be read as
+> promising that: OpenMLS is not a `no_std` crate, and MLS key-schedule and
+> ratchet-tree state does not fit alongside a vendor radio stack in 256 KB. A
+> leaf node's payload cryptography is a separate decision, still open.
+
+That leaves a device that can parse a frame, validate its addressing, and
+forward it, but cannot read one word of it. Every payload in this protocol is
+MLS ciphertext. A lock in that state is a relay, not an endpoint: the phone can
+send it "unlock" and it can neither open the message nor produce an answer
+anyone would believe.
+
+The obvious next move is to design something smaller than MLS for the device
+and teach the phone to speak both. That move costs more than it looks like it
+costs, and the cost is not on the device. The engine has exactly one sealing
+path today. A second one means a second envelope prefix in a registry where new
+prefixes are signature-gated by default, a second wire form for the data layer
+and group spaces and media to learn, a second trust story with its own
+provisioning adversary, and a threat model that has to state which guarantees
+apply to which peer. It also means picking what to give up, because the
+realistic candidates all give up something: a static-key HPKE seal has no
+forward secrecy and no replay defence, and Noise with a periodic rehandshake
+bounds post-compromise recovery by the rehandshake interval.
+
+## The measurement that changed the decision
+
+ADR 0020's premise is true about OpenMLS and about large groups. It is not true
+about the shape this problem actually has.
+
+A phone paired with one device is a **two-member group**. The ratchet tree is
+three nodes. Published state estimates for that shape are roughly 2 KB of
+logical state, single-digit kilobytes persisted. The frightening numbers
+attached to MLS state are all O(N) numbers, and N here is 2.
+
+And RFC 9420 exists in `no_std` Rust. `mls-rs` carries `no_std` as a
+CI-gated configuration, built for `thumbv6m-none-eabi`, which is a weaker part
+than the M33 this SDK targets. Its RustCrypto provider supports
+`CURVE25519_AES128`, which is
+`MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519`: the one ciphersuite this SDK
+pins, in one place, and never negotiates.
+
+So the question stopped being "what weaker thing does a leaf speak" and became
+"does the same thing fit". Two harnesses answer that, and both are in the tree
+because a decision resting on numbers should ship the thing that reproduces
+them.
+
+**It fits.** `tools/embedded-footprint` links a whole leaf image, protocol layer
+included:
+
+| Configuration | Flash | vs baseline |
+|---|--:|--:|
+| Application messages only, not shippable | 361.9 KiB | 360.8 KiB |
+| **Never-committing leaf, the candidate** | **391.3 KiB** | **390.2 KiB** |
+| `rfc_compliant`, X.509 included, upper bound | 403.8 KiB | 402.7 KiB |
+
+On a 1536 KB part that is about a quarter of flash for the candidate, against a
+budget that also has to hold a radio stack and an application. Roughly 111 KiB
+of it is P-384 and P-256 arithmetic that nothing here uses, linked because the
+provider keeps all four curves in one enum with no feature gating and filters
+suites at runtime. A curve-gated provider is worth about 28% of the image and is
+not needed to clear the bar.
+
+**And it interoperates.** `tools/mls-interop` runs OpenMLS 0.7.4 against
+mls-rs 0.56.0, both pinned, with this SDK's ciphersuite, this SDK's group
+configuration, and this SDK's credential shape: pair, join from a Welcome with
+no out-of-band tree, an application message each way, a commit from the phone,
+and a message after it. No published result covered that pair before this one.
+
+## Decision
+
+**A leaf node speaks MLS. The protocol does not change, and the phone does not
+learn a second way to seal anything.** The device runs a second RFC 9420
+implementation, sized for the part, and the frames on the wire are the frames
+that are there today.
+
+The device is a **never-committing member**. The phone creates the group, adds
+the device, and issues every commit; the device joins, opens what arrives,
+answers, and persists. Per-commit cost on the device is two elliptic-curve
+operations, tens of milliseconds on this class of part. Per-message cost is
+symmetric only.
+
+What this buys is not a smaller compromise. It is the absence of one. Forward
+secrecy, post-compromise security, replay defence, sender authentication, the
+three `derive(presented_key) == claimed_address` gates, and the unconditional
+leaf identity binding of [ADR 0010](0010-unconditional-leaf-identity-binding.md)
+all apply to a leaf exactly as they apply to a phone, because it is the same
+protocol and the same checks. For this device class that is not merely adequate:
+continuous ratcheting is something no shipped smart-home protocol provides.
+Z-Wave S2 distributes static network-lifetime keys and its own specification
+argues against ever rotating them; Matter and Aliro perform an ephemeral
+exchange at establishment and then run a non-forward-secret fast path for most
+sessions. No regulation requires better. The phrase "forward secrecy" does not
+appear in ETSI EN 303 645 at all.
+
+It also removes a problem rather than solving it. A device with no MLS has no
+way to advertise a capability, because capability advertisement in this protocol
+rides in a key package and nothing else, so every frame sent to such a device
+would fall to the JSON floor forever. A device that does MLS mints a signed key
+package like any other peer, and the whole negotiation layer applies unchanged.
+
+### Three things a leaf's key package must do differently
+
+These were found by running the two stacks against each other, not by reading
+either one's documentation, and each is a default that produces a key package
+the phone refuses.
+
+**The lifetime must be shortened.** mls-rs defaults to a year. OpenMLS refuses
+any leaf node whose total lifetime range exceeds one hour plus three months.
+
+**`not_before` must be backdated.** OpenMLS tests `not_before < now`, strictly,
+while mls-rs's client builder writes `not_before` as exactly the timestamp it is
+given. A package stamped with the current second is refused for being not yet
+valid. The backdate is also the margin that absorbs clock skew between the two
+devices.
+
+**The timestamp must be supplied, not read.** This is the one with consequences
+past the call site. A bare-metal leaf has no clock, and mls-rs stamps
+`not_before = 0` when it cannot read one, with a source comment saying the value
+exists so that tests can run. A device shipping that way emits a validity window
+in 1970 and is refused as expired. **A leaf therefore needs a time source at
+pairing**, from its radio stack, its commissioner, or the pairing exchange. Note
+what this is and is not: key package validity is a freshness bound, not an
+authentication mechanism, so a wrong clock costs availability rather than
+security. It still has to be designed rather than discovered on a bench.
+
+`tools/mls-interop` builds the uncorrected configuration and requires the phone
+to reject it. That negative control is the guard: each correction is a default
+someone will eventually tidy back, and a harness that only proves the corrected
+path works cannot tell them they broke it.
+
+### What must be true of the device that is not true of a phone
+
+**State must be durable before a frame is emitted.** A leaf that answers and
+then loses power before its ratchet state reaches flash comes back and reuses an
+AEAD nonce, which is a confidentiality failure, not a delivery hiccup. Ordering
+the persist before the emit is the requirement; the SDK's existing storage seam
+is the shape it takes.
+
+**Randomness is the integrator's problem.** `mls-rs` reaches `getrandom`, which
+has no bare-metal backend. The device wires that symbol to its vendor TRNG, and
+MLS key generation is exactly as strong as what it returns. The footprint
+harness registers a counter in that slot, which is sound for measuring an image
+that never executes and must never be copied into firmware.
+
+**Post-compromise security arrives on a cadence the phone sets.** Healing
+happens when a commit rotates the device's leaf. A never-committing device does
+not originate those, so the phone's existing session rekey path is what drives
+recovery, and its interval is what bounds the window. Letting a device originate
+Update proposals would make it self-healing and is deliberately not in this
+decision.
+
+**A QR code must not carry a key package.** An MLS init key is single-use and a
+sticker is not, so the second person to scan one gets a collision. Pairing keeps
+the shape it already has: the static artifact carries `{address, pubkey}`, and a
+fresh key package flows over the pairing radio.
+
+## Consequences
+
+A door lock can hold a real end-to-end encrypted conversation with a phone,
+under the same guarantees a phone gets, on about a quarter of an xG24's flash.
+
+The engine keeps one sealing path. Nothing in `send.rs`, the prefix registry,
+the data layer, group spaces, or the media envelope learns a new case, and the
+threat model does not fork into "peers like this" and "peers like that".
+
+The device class picks up obligations the SDK has not had to state before: a
+time source at pairing, durable state before emission, and an entropy source
+that is real. They are written down here because they are invisible in a passing
+build and expensive on a bench.
+
+Two risks are accepted with open eyes. mls-rs has not had a third-party security
+audit and its only `no_std` crypto provider is the one its own authors label
+experimental; this is a monitored dependency, not a settled one. And an interop
+result covers exactly the two versions it pinned, which is why both are pinned
+with `=` and why the harness is in the tree rather than in a commit message.
+
+This ADR does not decide the storage backend, the radio, the pairing user
+experience, or whether a device ever joins a group space rather than a pair.
+
+## What would undo this
+
+Adding a second sealing path to the engine. The moment a leaf speaks something
+other than `__MLS_ENC__`, every argument above is void: the negotiation layer
+stops applying, the threat model forks, and the reason this was affordable
+disappears. If a future device genuinely cannot run MLS, that is a new ADR that
+has to re-derive the cost on the phone side, not an extension of this one.
+
+Re-inheriting the leaf's crypto configuration from a default is the smaller
+version of the same thing. The three key package corrections above are load
+bearing, and `tools/mls-interop` step 0 is what says so out loud.

--- a/docs/adr/0021-a-leaf-node-speaks-mls.md
+++ b/docs/adr/0021-a-leaf-node-speaks-mls.md
@@ -58,7 +58,7 @@ included:
 
 | Configuration | Flash | vs baseline |
 |---|--:|--:|
-| Application messages only, not shippable | 361.9 KiB | 360.8 KiB |
+| Application messages only, not shippable | 361.7 KiB | 360.6 KiB |
 | **Never-committing leaf, the candidate** | **391.3 KiB** | **390.2 KiB** |
 | `rfc_compliant`, X.509 included, upper bound | 403.8 KiB | 402.7 KiB |
 
@@ -107,14 +107,11 @@ rides in a key package and nothing else, so every frame sent to such a device
 would fall to the JSON floor forever. A device that does MLS mints a signed key
 package like any other peer, and the whole negotiation layer applies unchanged.
 
-### Three things a leaf's key package must do differently
+### Two things a leaf's key package must do differently
 
 These were found by running the two stacks against each other, not by reading
 either one's documentation, and each is a default that produces a key package
 the phone refuses.
-
-**The lifetime must be shortened.** mls-rs defaults to a year. OpenMLS refuses
-any leaf node whose total lifetime range exceeds one hour plus three months.
 
 **`not_before` must be backdated.** OpenMLS tests `not_before < now`, strictly,
 while mls-rs's client builder writes `not_before` as exactly the timestamp it is
@@ -132,10 +129,41 @@ what this is and is not: key package validity is a freshness bound, not an
 authentication mechanism, so a wrong clock costs availability rather than
 security. It still has to be designed rather than discovered on a bench.
 
-`tools/mls-interop` builds the uncorrected configuration and requires the phone
-to reject it. That negative control is the guard: each correction is a default
-someone will eventually tidy back, and a harness that only proves the corrected
-path works cannot tell them they broke it.
+`tools/mls-interop` restores each default in turn and requires the phone to
+reject the result. Those negative controls are the guard: each correction is a
+default someone will eventually tidy back, and a harness that only proves the
+corrected path works cannot tell them they broke it.
+
+### A third default that is policy, not a correction
+
+An earlier draft of this ADR listed a third correction, that a leaf must shorten
+mls-rs's one-year key package lifetime because OpenMLS refuses any leaf node
+whose total lifetime range exceeds one hour plus three months. **OpenMLS 0.7.4
+does not do that.** It declares the bound
+(`MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS`) and the predicate that tests it
+(`Lifetime::has_acceptable_range`), and nothing in the crate calls the
+predicate. `KeyPackageIn::validate` checks only the `not_before < now <
+not_after` window, and names its failure `InvalidLifetime`, which is what made a
+year-long lifetime look like it was refused for its range when it was really
+refused for its `not_before`.
+
+The correction is kept as leaf-side policy, at 28 days: RFC 9420 asks an
+application to define a maximum total lifetime, and a shorter window bounds how
+long an unused init key stays usable. It is simply not something the phone makes
+a leaf do, and this ADR should not have said it was.
+
+Two things follow. The first is a harness rule: negative controls restore one
+default at a time, because a control that broke all three at once was refused
+for whichever reason OpenMLS checked first and could not tell a real requirement
+from an imagined one. That is how this was found, on the first run after the
+split. The second is a gap on the phone, recorded here and deliberately not
+fixed in this ADR's change: because no cap is applied,
+`MlsManager::import_key_package` admits a key package from any peer with an
+arbitrarily long lifetime, where RFC 9420 asks an implementation to reject it.
+It is a freshness bound rather than an authentication one, so it is not urgent,
+but it is ours to enforce and no library is doing it for us.
+`tools/mls-interop` step 0.3 pins the current behaviour and fails if OpenMLS
+starts applying its own cap.
 
 ### What must be true of the device that is not true of a phone
 
@@ -195,5 +223,6 @@ disappears. If a future device genuinely cannot run MLS, that is a new ADR that
 has to re-derive the cost on the phone side, not an extension of this one.
 
 Re-inheriting the leaf's crypto configuration from a default is the smaller
-version of the same thing. The three key package corrections above are load
-bearing, and `tools/mls-interop` step 0 is what says so out loud.
+version of the same thing. The key package corrections above are load bearing,
+and the `tools/mls-interop` step 0 lines are what say so out loud, one per
+default so that each can be believed on its own.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ silently undo it. Decisions that follow from the obvious default do not need one
 | [0018](0018-data-layer-engine-and-storage-seams.md) | The data layer has two seams: the engine and the backend | Accepted |
 | [0019](0019-remote-document-imports-are-contained-not-trusted.md) | Remote document imports are contained, not trusted | Accepted |
 | [0020](0020-core-compiles-without-std.md) | Core compiles without `std`, and `std` is a default-on feature | Accepted |
+| [0021](0021-a-leaf-node-speaks-mls.md) | A leaf node speaks MLS, through a second implementation | Accepted |
 
 ## Format
 

--- a/tools/embedded-footprint/Cargo.toml
+++ b/tools/embedded-footprint/Cargo.toml
@@ -15,6 +15,48 @@ description = "Measures what offline-protocol-core costs in flash and RAM on a C
 offline-protocol-core = { path = "../../crates/offline-protocol-core", default-features = false }
 cortex-m-rt = "0.7.5"
 
+# The MLS half, optional because the two original binaries measure the protocol
+# layer alone and must keep doing so without a heavier dependency tree in the
+# graph. Only the `leaf*` binaries pull these in.
+mls-rs = { version = "0.56", default-features = false, optional = true }
+mls-rs-crypto-rustcrypto = { version = "0.22", default-features = false, optional = true }
+# `rand_core::OsRng` reaches getrandom, which has no backend on bare metal. The
+# `custom` feature is what lets the binary register one; see `src/rng.rs`.
+getrandom = { version = "0.2", default-features = false, features = [
+    "custom",
+], optional = true }
+
+[features]
+# Shared by every leaf configuration below. Never selected on its own: each
+# variant adds the mls-rs feature set that names it.
+leaf-base = ["dep:mls-rs", "dep:mls-rs-crypto-rustcrypto", "dep:getrandom"]
+
+# What a never-committing leaf actually needs. Application messages are
+# `PrivateMessage`, so `private_message` is not optional; `out_of_order` and
+# `prior_epoch` are what let a node on a lossy radio still decrypt when frames
+# arrive late or straddle a commit, which is the normal case on this hardware,
+# not an edge one.
+leaf = [
+    "leaf-base",
+    "mls-rs/private_message",
+    "mls-rs/out_of_order",
+    "mls-rs/prior_epoch",
+    "mls-rs/by_ref_proposal",
+]
+
+# The floor: application messages and nothing else. Not a shippable
+# configuration, measured to show what the resilience features above cost.
+leaf-min = ["leaf-base", "mls-rs/private_message"]
+
+# The ceiling: everything RFC 9420 asks of a full implementation, X.509
+# credential support included. A leaf uses basic credentials, so this is an
+# upper bound for the report rather than a candidate.
+leaf-full = ["leaf-base", "mls-rs/rfc_compliant"]
+
+[[bin]]
+name = "leaf"
+required-features = ["leaf-base"]
+
 [profile.release]
 # `minisize`'s settings, because that is the profile a mobile or embedded
 # artifact ships under and the number is meant to be quotable.

--- a/tools/embedded-footprint/README.md
+++ b/tools/embedded-footprint/README.md
@@ -1,17 +1,18 @@
 # Embedded footprint harness
 
-Answers one question with a number: **what does `offline-protocol-core` cost
-on a Cortex-M33?**
+Answers two questions with numbers: **what does `offline-protocol-core` cost on
+a Cortex-M33, and what does a whole leaf node cost once MLS is added to it?**
 
 ```
 rustup target add thumbv8m.main-none-eabihf
 rustup component add llvm-tools-preview
-./measure.sh
+./measure.sh              # everything
+./measure.sh --core-only  # skip the MLS images
 ```
 
 ## What it measures
 
-Two firmware images are linked for `thumbv8m.main-none-eabihf` under the
+Firmware images are linked for `thumbv8m.main-none-eabihf` under the
 release profile (`opt-level = "z"`, LTO, `panic = "abort"`), which is the
 shape a shipping artifact has:
 
@@ -21,9 +22,17 @@ shape a shipping artifact has:
   JSON frame, re-encode it as binary wire v1, decode that, re-encode as JSON,
   parse an address and verify it is canonically spelled, and run the
   identifier policy.
+- `leaf` is the same plus MLS: mint a key package, join from a Welcome, open
+  what arrives, seal an answer, and persist. It is built three times, against
+  the smallest mls-rs feature set that works, the set a real leaf needs, and
+  the full `rfc_compliant` set, because the spread between them is the part
+  that is actually a choice.
 
 The reported figure is the **delta**, so it excludes the runtime cost that any
-firmware pays whether or not it speaks this protocol.
+firmware pays whether or not it speaks this protocol. The leaf images report two
+deltas: against `baseline` it is the whole image, which is what answers "does it
+fit"; against `protocol` it is what MLS costs on top of what was already
+measured.
 
 The workload is the receiving half on purpose. A constrained leaf node does not
 mint messages, it answers them, so it never calls the `std`-gated constructors.
@@ -44,7 +53,23 @@ include:
 It is also not the SDK engine. The engine is `std` and `tokio` bound and does
 not build for this target at all; a leaf node is not supposed to run it.
 
-Static RAM excludes the heap. Both binaries provision 16 KiB so it cancels in
+For the `leaf` images specifically, two more things are missing and neither is
+small. **Heap is the first.** MLS group state is allocated, not static, so
+`.bss` barely moves and the working-set figure is simply not in this
+measurement; it has to come from running the thing. **Interoperability is the
+second.** These images are linked and never executed, and the MLS calls are fed
+bytes that are not a real Welcome, so nothing here says the stack can talk to
+the phone. `tools/mls-interop` is what answers that, and it is the gate that
+matters more.
+
+About a third of the `leaf` image is dead weight that a better crypto provider
+would remove: `mls-rs-crypto-rustcrypto` holds all four curves in one
+`EcPrivateKey` enum with no feature gating, so P-384 and P-256 arithmetic link
+even when only ciphersuite 3 is enabled. That is roughly 111 KiB, measured by
+symbol attribution rather than estimated. Enabling a suite is a runtime filter
+in that provider, not a compile-time one.
+
+Static RAM excludes the heap. Every binary provisions 16 KiB so it cancels in
 the delta, and the allocator is a bump allocator that never frees, which is
 acceptable only because these images are linked and measured, never executed.
 A real node brings its own allocator (roughly one to two more kilobytes of
@@ -66,3 +91,9 @@ silently shrinks to almost nothing and the footprint looks like an improvement.
 The guard against that is `.text` collapsing toward the baseline: if the delta
 ever drops by an order of magnitude, the sample stopped parsing, it did not
 get cheaper.
+
+The `leaf` images have the same failure mode and a stricter guard, because they
+need one: their MLS inputs are *deliberately* not valid, so "it stopped parsing"
+is not a signal there at all. `measure.sh` counts `mls_rs` symbols in each image
+and fails the run below fifty. A footprint that quietly stopped containing the
+thing being measured is worse than no footprint, because it reads as progress.

--- a/tools/embedded-footprint/measure.sh
+++ b/tools/embedded-footprint/measure.sh
@@ -24,7 +24,15 @@ if [[ -z "${LLVM_SIZE}" ]]; then
     echo "llvm-size not found. Run: rustup component add llvm-tools-preview" >&2
     exit 1
 fi
+# Fatal for the same reason `llvm-size` is. This one is the only guard the leaf
+# images have against silently hollowing out, and a run that skipped it would
+# still print a table, which is the failure mode the guard exists to prevent.
+# Both binaries ship in `llvm-tools-preview`, so needing one is needing both.
 LLVM_NM=$(find "$(rustc --print sysroot)" -name llvm-nm -type f | head -1)
+if [[ -z "${LLVM_NM}" ]]; then
+    echo "llvm-nm not found. Run: rustup component add llvm-tools-preview" >&2
+    exit 1
+fi
 
 # `--locked` because the point of this harness is a number that does not move
 # for reasons unrelated to the code being measured.
@@ -86,13 +94,11 @@ for row in "${LEAF_ROWS[@]}"; do
     # linked (a workload that optimises away, a dependency that silently drops
     # out), the flash number falls toward `protocol` and reads as an
     # improvement. A symbol count cannot be fooled that way.
-    if [[ -n "${LLVM_NM}" ]]; then
-        symbols=$("${LLVM_NM}" "${OUT}/leaf" 2>/dev/null | grep -c "mls_rs" || true)
-        if (( symbols < 50 )); then
-            echo "FAIL: only ${symbols} mls-rs symbols in the ${feature} image." >&2
-            echo "The workload stopped linking MLS; the number below is not a footprint." >&2
-            exit 1
-        fi
+    symbols=$("${LLVM_NM}" "${OUT}/leaf" 2>/dev/null | grep -c "mls_rs" || true)
+    if (( symbols < 50 )); then
+        echo "FAIL: only ${symbols} mls-rs symbols in the ${feature} image." >&2
+        echo "The workload stopped linking MLS; the number below is not a footprint." >&2
+        exit 1
     fi
 
     awk -v f="${f}" -v bf="${base_flash}" -v pf="${prot_flash}" -v l="${label}" 'BEGIN {

--- a/tools/embedded-footprint/measure.sh
+++ b/tools/embedded-footprint/measure.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 #
-# Builds both binaries and reports what offline-protocol-core costs on a
-# Cortex-M33, as a delta against a baseline firmware that has the same runtime
-# and none of the protocol.
+# Reports what the protocol layer, and then a whole leaf node, cost on a
+# Cortex-M33, each as a delta against a baseline firmware that has the same
+# runtime and none of the protocol.
 #
 # Requires: rustup target add thumbv8m.main-none-eabihf
 #           rustup component add llvm-tools-preview
+#
+# Pass --core-only to skip the MLS images, which is the right thing to do when
+# the MLS dependency tree cannot be fetched.
 
 set -euo pipefail
 cd "$(dirname "$0")"
+
+CORE_ONLY=0
+[[ "${1:-}" == "--core-only" ]] && CORE_ONLY=1
 
 TARGET=thumbv8m.main-none-eabihf
 OUT="target/${TARGET}/release"
@@ -18,6 +24,7 @@ if [[ -z "${LLVM_SIZE}" ]]; then
     echo "llvm-size not found. Run: rustup component add llvm-tools-preview" >&2
     exit 1
 fi
+LLVM_NM=$(find "$(rustc --print sysroot)" -name llvm-nm -type f | head -1)
 
 # `--locked` because the point of this harness is a number that does not move
 # for reasons unrelated to the code being measured.
@@ -28,17 +35,17 @@ section() {  # section <binary> <section-name>
     "${LLVM_SIZE}" -A "$1" | awk -v s="$2" '$1 == s { print $2; found=1 } END { if (!found) print 0 }'
 }
 
-base_flash=$(( $(section "${OUT}/baseline" .text) + $(section "${OUT}/baseline" .rodata) ))
-prot_flash=$(( $(section "${OUT}/protocol" .text) + $(section "${OUT}/protocol" .rodata) ))
+flash() {  # flash <binary>
+    echo $(( $(section "$1" .text) + $(section "$1" .rodata) ))
+}
+
+base_flash=$(flash "${OUT}/baseline")
+prot_flash=$(flash "${OUT}/protocol")
 base_bss=$(section "${OUT}/baseline" .bss)
 prot_bss=$(section "${OUT}/protocol" .bss)
 
-flash_delta=$(( prot_flash - base_flash ))
-bss_delta=$(( prot_bss - base_bss ))
-
-# `bc` is not guaranteed on a CI runner; awk is.
-awk -v bf="${base_flash}" -v pf="${prot_flash}" -v fd="${flash_delta}" \
-    -v bd="${bss_delta}" -v tgt="${TARGET}" 'BEGIN {
+awk -v bf="${base_flash}" -v pf="${prot_flash}" -v fd="$(( prot_flash - base_flash ))" \
+    -v bd="$(( prot_bss - base_bss ))" -v tgt="${TARGET}" 'BEGIN {
   k = 1024
   printf "| Measurement | Bytes | KiB |\n"
   printf "|---|--:|--:|\n"
@@ -51,3 +58,62 @@ awk -v bf="${base_flash}" -v pf="${prot_flash}" -v fd="${flash_delta}" \
   printf "harness provisions 16 KiB in both binaries so it cancels here, and a\n"
   printf "real node sizes its own from its workload.\n"
 }'
+
+[[ "${CORE_ONLY}" == "1" ]] && exit 0
+
+# The leaf images. Each variant is a separate link, so they are built and
+# measured one at a time into the same output path.
+echo
+echo "### Leaf node: protocol layer plus MLS"
+echo
+printf "| Configuration | Flash | vs baseline | vs protocol only |\n"
+printf "|---|--:|--:|--:|\n"
+
+declare -a LEAF_ROWS=(
+    "leaf-min:application messages only (not shippable)"
+    "leaf:never-committing leaf (candidate)"
+    "leaf-full:rfc_compliant, X.509 included (upper bound)"
+)
+
+leaf_measured=0
+for row in "${LEAF_ROWS[@]}"; do
+    feature="${row%%:*}"
+    label="${row#*:}"
+    cargo build --release --locked --quiet --features "${feature}"
+    f=$(flash "${OUT}/leaf")
+
+    # The guard the sample-honesty problem needs. If MLS ever stops being
+    # linked (a workload that optimises away, a dependency that silently drops
+    # out), the flash number falls toward `protocol` and reads as an
+    # improvement. A symbol count cannot be fooled that way.
+    if [[ -n "${LLVM_NM}" ]]; then
+        symbols=$("${LLVM_NM}" "${OUT}/leaf" 2>/dev/null | grep -c "mls_rs" || true)
+        if (( symbols < 50 )); then
+            echo "FAIL: only ${symbols} mls-rs symbols in the ${feature} image." >&2
+            echo "The workload stopped linking MLS; the number below is not a footprint." >&2
+            exit 1
+        fi
+    fi
+
+    awk -v f="${f}" -v bf="${base_flash}" -v pf="${prot_flash}" -v l="${label}" 'BEGIN {
+      k = 1024
+      printf "| %s | %.1f KiB | %.1f KiB | %.1f KiB |\n", l, f/k, (f-bf)/k, (f-pf)/k
+    }'
+    leaf_measured=1
+done
+
+if (( leaf_measured )); then
+    cat <<'NOTE'
+
+The candidate row is the number that answers "does it fit": on a 1536 KiB xG24
+that is the whole leaf image, protocol layer included, against a part that also
+has to hold a radio stack and an application.
+
+Two things this does not measure. Heap is the first: MLS group state is
+allocated, not static, so `.bss` stays flat here and the working-set figure has
+to come from running the thing, not linking it. Interoperability is the second:
+these images are linked and never executed, and the MLS calls are fed bytes
+that are not a real Welcome, so this says nothing about whether the stack talks
+to the phone's OpenMLS. That question has its own harness.
+NOTE
+fi

--- a/tools/embedded-footprint/src/bin/baseline.rs
+++ b/tools/embedded-footprint/src/bin/baseline.rs
@@ -12,6 +12,9 @@
 
 #![no_std]
 #![no_main]
+// `#[entry] fn main() -> !` has to diverge and there is nothing to park on in a
+// program that is linked and never run.
+#![allow(clippy::empty_loop)]
 
 extern crate alloc;
 
@@ -23,6 +26,10 @@ use core::hint::black_box;
 use cortex_m_rt::entry;
 
 #[entry]
+// Not `vec![]`. The point of these two lines is a heap allocation the optimiser
+// cannot fold away, and this binary is the subtrahend for every number in the
+// report, so its shape is not free to change for tidiness.
+#[allow(clippy::vec_init_then_push)]
 fn main() -> ! {
     let mut v: Vec<u8> = Vec::new();
     v.push(black_box(1));

--- a/tools/embedded-footprint/src/bin/leaf.rs
+++ b/tools/embedded-footprint/src/bin/leaf.rs
@@ -8,9 +8,10 @@
 //!
 //! The workload is the **never-committing member** profile. The phone creates
 //! the group, adds the device, and issues every commit; the device mints a key
-//! package at pairing, joins from a Welcome, processes what arrives, answers,
-//! and persists. No `commit_builder` appears here, deliberately: leaving the
-//! commit path unlinked is part of why the number is what it is.
+//! package at pairing, joins from a Welcome, processes what arrives, seals an
+//! answer, persists, and only then emits. No `commit_builder` appears here,
+//! deliberately: leaving the commit path unlinked is part of why the number is
+//! what it is.
 //!
 //! Two deltas come out of this. Against `baseline` it is the whole leaf image,
 //! which answers "does it fit". Against `protocol` it is what MLS costs on top
@@ -29,6 +30,9 @@
 
 #![no_std]
 #![no_main]
+// `#[entry] fn main() -> !` has to diverge and there is nothing to park on in a
+// program that is linked and never run.
+#![allow(clippy::empty_loop)]
 
 extern crate alloc;
 
@@ -44,6 +48,7 @@ use offline_protocol_core::{validate_id_chars, Address, Message, UserId};
 
 use mls_rs::identity::basic::{BasicCredential, BasicIdentityProvider};
 use mls_rs::identity::SigningIdentity;
+use mls_rs::time::MlsTime;
 use mls_rs::{CipherSuite, CipherSuiteProvider, Client, CryptoProvider, MlsMessage};
 use mls_rs_crypto_rustcrypto::RustCryptoProvider;
 
@@ -66,6 +71,19 @@ const SAMPLE_ADDRESS: &str = "off1qyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyr4s29s";
 /// Stands in for a frame arriving off the radio. Not a valid MLS message; see
 /// the module note on why that does not affect what gets linked.
 const INBOUND: &[u8] = &[0u8; 128];
+
+/// When the device was paired, in seconds since the epoch.
+///
+/// This is a parameter of the workload rather than something read from a clock
+/// because a bare-metal leaf has no clock to read. Handed `None`, mls-rs stamps
+/// `not_before = 0`, which puts the key package's validity window in 1970 and
+/// gets it refused as expired by the phone (`tools/mls-interop` proves that
+/// refusal). Supplying the timestamp is therefore the shape the firmware has to
+/// have, and it is why ADR 0021 makes a time source at pairing an obligation on
+/// the device: on hardware this value comes from the radio stack, the
+/// commissioner, or the pairing exchange. The literal is `SAMPLE_JSON`'s
+/// timestamp in seconds, so this file quotes one clock and not two.
+const PAIRED_AT: u64 = 1_787_314_332;
 
 /// The protocol layer's own workload, identical to `protocol.rs`.
 fn protocol_workload() {
@@ -116,9 +134,16 @@ fn mls_workload() -> Option<()> {
     // Pairing: the device mints one key package for the phone to consume. This
     // is the artifact a QR code must never carry, because an MLS init key is
     // single-use and a sticker is not.
-    if let Ok(key_package) =
-        client.generate_key_package_message(Default::default(), Default::default(), None)
-    {
+    //
+    // The timestamp is supplied, not read. See `PAIRED_AT`: the `None` this
+    // call would otherwise take is the 1970 trap, and a workload that models
+    // the device's order of operations should not model the refused version of
+    // its first step.
+    if let Ok(key_package) = client.generate_key_package_message(
+        Default::default(),
+        Default::default(),
+        Some(MlsTime::from(PAIRED_AT)),
+    ) {
         if let Ok(bytes) = key_package.to_bytes() {
             black_box(&bytes);
         }
@@ -137,16 +162,21 @@ fn mls_workload() -> Option<()> {
         }
     }
 
-    if let Ok(answer) = group.encrypt_application_message(black_box(b"unlocked"), Vec::new()) {
-        if let Ok(bytes) = answer.to_bytes() {
-            black_box(&bytes);
-        }
-    }
+    let answer = group
+        .encrypt_application_message(black_box(b"unlocked"), Vec::new())
+        .ok()?;
 
     // A leaf that emits before its ratchet state is durable will reuse an AEAD
-    // nonce after a power cut. Ordering this call before the emit above is the
-    // whole point of writing it down.
+    // nonce after a power cut, which is a confidentiality failure and not a
+    // delivery hiccup. So the persist goes here, between sealing the answer and
+    // handing it to the radio, and the `black_box` below is the emit it has to
+    // come before. Writing the two in the other order would link the same code
+    // and teach the wrong thing to whoever uses this file as a skeleton.
     group.write_to_storage().ok()?;
+
+    if let Ok(bytes) = answer.to_bytes() {
+        black_box(&bytes);
+    }
 
     Some(())
 }

--- a/tools/embedded-footprint/src/bin/leaf.rs
+++ b/tools/embedded-footprint/src/bin/leaf.rs
@@ -1,0 +1,160 @@
+//! A leaf node's whole image: the protocol layer plus the MLS half.
+//!
+//! `protocol` measures what it costs to parse and validate a frame. This adds
+//! what it costs to *open* one, which ADR 0020 left open on the grounds that
+//! MLS does not fit on this class of part. That claim is true of OpenMLS and of
+//! large groups, and the pairing this measures is neither: a phone and one
+//! device are a two-member group, where the ratchet tree is three nodes.
+//!
+//! The workload is the **never-committing member** profile. The phone creates
+//! the group, adds the device, and issues every commit; the device mints a key
+//! package at pairing, joins from a Welcome, processes what arrives, answers,
+//! and persists. No `commit_builder` appears here, deliberately: leaving the
+//! commit path unlinked is part of why the number is what it is.
+//!
+//! Two deltas come out of this. Against `baseline` it is the whole leaf image,
+//! which answers "does it fit". Against `protocol` it is what MLS costs on top
+//! of the protocol layer already measured.
+//!
+//! # What this image is not
+//!
+//! It is linked and measured, never executed, exactly like the other two. The
+//! MLS calls below are fed `black_box`ed bytes that are not a real Welcome and
+//! not a real ciphertext, so at runtime each would return `Err`. That is sound
+//! for a code-size measurement, because the optimiser cannot prove the failure
+//! and links every path, and it is worthless as a functional test. Proving that
+//! this stack interoperates with the phone's OpenMLS is a separate exercise
+//! with a separate harness. The guard against the measurement silently hollowing
+//! out is the symbol count in `measure.sh`, not this file.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+// Links the allocator, the panic handler, and the getrandom backend.
+use embedded_footprint as _;
+
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::hint::black_box;
+use cortex_m_rt::entry;
+use offline_protocol_core::{validate_id_chars, Address, Message, UserId};
+
+use mls_rs::identity::basic::{BasicCredential, BasicIdentityProvider};
+use mls_rs::identity::SigningIdentity;
+use mls_rs::{CipherSuite, CipherSuiteProvider, Client, CryptoProvider, MlsMessage};
+use mls_rs_crypto_rustcrypto::RustCryptoProvider;
+
+/// The suite the SDK pins in exactly one place
+/// (`offline-protocol-mls/src/group.rs`). A leaf that negotiated anything else
+/// could not talk to a phone, so the provider below is built with this one
+/// enabled and the other three left out of the image.
+const CIPHERSUITE: CipherSuite = CipherSuite::CURVE25519_AES128;
+
+/// A real message, produced by the SDK on the host and pasted here. Both
+/// codecs round-trip it, which was checked before it was embedded.
+///
+/// Duplicated from `protocol.rs` rather than shared, so that adding this binary
+/// cannot move the number that binary already reports.
+const SAMPLE_JSON: &str = r#"{"id":"ea22cfba-7e3f-4820-9ba5-fe33dd9ef33e","sender":"off1qyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyr4s29s","recipient":"off1qy3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygqe5r2d","app_id":"test-app","priority":"medium","ttl":8,"hop_count":0,"timestamp":1787314332937,"lamport_clock":0,"content_type":"text","content":"hello","metadata":{},"requires_ack":true,"reply_to_msg":null}"#;
+
+/// The sender from `SAMPLE_JSON`, canonically spelled.
+const SAMPLE_ADDRESS: &str = "off1qyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyr4s29s";
+
+/// Stands in for a frame arriving off the radio. Not a valid MLS message; see
+/// the module note on why that does not affect what gets linked.
+const INBOUND: &[u8] = &[0u8; 128];
+
+/// The protocol layer's own workload, identical to `protocol.rs`.
+fn protocol_workload() {
+    if let Ok(message) = Message::from_json(black_box(SAMPLE_JSON)) {
+        if let Ok(wire) = message.to_wire_v1_bytes() {
+            if let Ok(decoded) = Message::from_wire_v1_bytes(black_box(&wire)) {
+                if let Ok(json) = decoded.to_json() {
+                    black_box(&json);
+                }
+                black_box(&decoded.content);
+            }
+            black_box(&wire);
+        }
+    }
+
+    if let Ok(address) = black_box(SAMPLE_ADDRESS).parse::<Address>() {
+        black_box(address.to_string() == SAMPLE_ADDRESS);
+        black_box(address.hash_bytes());
+    }
+
+    black_box(validate_id_chars(black_box("alice-123"), "User ID").is_ok());
+    black_box(UserId::new(black_box(SAMPLE_ADDRESS)).is_ok());
+}
+
+/// Everything the device does with MLS, in the order it does it.
+fn mls_workload() -> Option<()> {
+    // Only the pinned suite is enabled, so the other three curves never reach
+    // the image.
+    let crypto = RustCryptoProvider::with_enabled_cipher_suites(vec![CIPHERSUITE]);
+    let suite = crypto.cipher_suite_provider(CIPHERSUITE)?;
+
+    // The device's long-term signature key. On real hardware this is generated
+    // once at provisioning and lives in whatever key storage the part offers,
+    // not regenerated per boot as it is here.
+    let (secret, public) = suite.signature_key_generate().ok()?;
+
+    // The credential content is the device's own `off1` address, which is the
+    // shape the SDK already requires of every leaf credential.
+    let credential = BasicCredential::new(SAMPLE_ADDRESS.as_bytes().to_vec());
+    let signing_identity = SigningIdentity::new(credential.into_credential(), public);
+
+    let client: Client<_> = Client::builder()
+        .identity_provider(BasicIdentityProvider)
+        .crypto_provider(crypto)
+        .signing_identity(signing_identity, secret, CIPHERSUITE)
+        .build();
+
+    // Pairing: the device mints one key package for the phone to consume. This
+    // is the artifact a QR code must never carry, because an MLS init key is
+    // single-use and a sticker is not.
+    if let Ok(key_package) =
+        client.generate_key_package_message(Default::default(), Default::default(), None)
+    {
+        if let Ok(bytes) = key_package.to_bytes() {
+            black_box(&bytes);
+        }
+    }
+
+    // Joining: the phone commits the Add and hands back a Welcome.
+    let welcome = MlsMessage::from_bytes(black_box(INBOUND)).ok()?;
+    let (mut group, info) = client.join_group(None, &welcome, None).ok()?;
+    black_box(&info);
+
+    // Steady state: open what arrives (application messages, and the commits
+    // the phone issues), answer, and persist before the answer is emitted.
+    if let Ok(inbound) = MlsMessage::from_bytes(black_box(INBOUND)) {
+        if let Ok(received) = group.process_incoming_message(inbound) {
+            black_box(&received);
+        }
+    }
+
+    if let Ok(answer) = group.encrypt_application_message(black_box(b"unlocked"), Vec::new()) {
+        if let Ok(bytes) = answer.to_bytes() {
+            black_box(&bytes);
+        }
+    }
+
+    // A leaf that emits before its ratchet state is durable will reuse an AEAD
+    // nonce after a power cut. Ordering this call before the emit above is the
+    // whole point of writing it down.
+    group.write_to_storage().ok()?;
+
+    Some(())
+}
+
+#[entry]
+fn main() -> ! {
+    protocol_workload();
+    black_box(mls_workload());
+
+    loop {}
+}

--- a/tools/embedded-footprint/src/bin/protocol.rs
+++ b/tools/embedded-footprint/src/bin/protocol.rs
@@ -11,6 +11,9 @@
 
 #![no_std]
 #![no_main]
+// `#[entry] fn main() -> !` has to diverge and there is nothing to park on in a
+// program that is linked and never run.
+#![allow(clippy::empty_loop)]
 
 extern crate alloc;
 

--- a/tools/embedded-footprint/src/lib.rs
+++ b/tools/embedded-footprint/src/lib.rs
@@ -53,3 +53,28 @@ static ALLOCATOR: Bump = Bump;
 fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }
+
+/// Entropy, for linking only.
+///
+/// `rand_core::OsRng` reaches `getrandom`, which has no backend on a bare-metal
+/// target, so the link fails without one registered. This counter is **not**
+/// entropy and must never be copied into firmware: a real leaf node wires this
+/// symbol to its vendor TRNG, and MLS key generation is only as strong as what
+/// it returns. It is acceptable here for exactly one reason, which is the same
+/// reason the allocator above never frees: this image is linked and measured,
+/// never executed.
+#[cfg(feature = "leaf-base")]
+mod rng {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn fill(dest: &mut [u8]) -> Result<(), getrandom::Error> {
+        for byte in dest.iter_mut() {
+            *byte = COUNTER.fetch_add(1, Ordering::Relaxed) as u8;
+        }
+        Ok(())
+    }
+
+    getrandom::register_custom_getrandom!(fill);
+}

--- a/tools/mls-interop/Cargo.lock
+++ b/tools/mls-interop/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,23 +157,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-name = "cortex-m-rt"
-version = "0.7.6"
+name = "core-models"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c439b23bf18154d8a634543caf1ee73cceb723f2902f7ea243634159a00fd47"
+checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
 dependencies = [
- "cortex-m-rt-macros",
-]
-
-[[package]]
-name = "cortex-m-rt-macros"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a75f3e7f3f01d649668d68e02d0ef92c7041a9c97b8fe6bc354ddbf40822d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "hax-lib",
+ "pastey",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -186,13 +183,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -204,7 +226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -280,6 +302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug_tree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1ec383f2d844902d3c34e4253ba11ae48513cdaddc565cf1a6518db09a8e57"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,7 +375,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -372,21 +403,10 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1 0.7.3",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "embedded-footprint"
-version = "0.0.0"
-dependencies = [
- "cortex-m-rt",
- "getrandom",
- "mls-rs",
- "mls-rs-crypto-rustcrypto",
- "offline-protocol-core",
 ]
 
 [[package]]
@@ -407,7 +427,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -477,9 +497,12 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -509,6 +532,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,8 +572,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "hax-lib"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543f93241d32b3f00569201bfce9d7a93c92c6421b23c77864ac929dc947b9fc"
+dependencies = [
+ "hax-lib-macros",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "hax-lib-macros"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8755751e760b11021765bb04cb4a6c4e24742688d9f3aa14c2079638f537b0f"
+dependencies = [
+ "hax-lib-macros-types",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "hax-lib-macros-types"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f177c9ae8ea456e2f71ff3c1ea47bf4464f772a05133fcbba56cd5ba169035a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -534,6 +618,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hkdf"
@@ -551,6 +638,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hpke-rs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ad6a58eb3e0ee30be8bfc7a9770ae98adcfa1d9bc820a5847732ce84f70837"
+dependencies = [
+ "hpke-rs-crypto",
+ "hpke-rs-libcrux",
+ "hpke-rs-rust-crypto",
+ "libcrux-sha3",
+ "log",
+ "rand_core 0.9.5",
+ "serde",
+ "subtle",
+ "tls_codec",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-crypto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a73a99d9008010d73289f41335a3f6e14fb8c04eaf60e9111b450463b1bbc7f"
+dependencies = [
+ "rand_core 0.9.5",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-libcrux"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ce6b7e54aebe540faee869c67ee253bede44ea6cb67c6e72c7847d6c59f1df"
+dependencies = [
+ "hpke-rs-crypto",
+ "libcrux-aead",
+ "libcrux-ecdh",
+ "libcrux-hkdf",
+ "libcrux-kem",
+ "libcrux-traits",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-rust-crypto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b28be6cba9081c7feda2651d51c2a900029798e78b4c1e093e792f4571a870"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "hkdf",
+ "hpke-rs-crypto",
+ "k256",
+ "p256",
+ "p384",
+ "rand 0.8.7",
+ "rand_chacha 0.3.1",
+ "rand_core 0.10.1",
+ "rand_core 0.6.4",
+ "sha2",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -595,10 +751,242 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "elliptic-curve",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libcrux-aead"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13297ce29869a5c0edab0378837b0fc5f88bf99a843712d9201c3b1150b3b476"
+dependencies = [
+ "libcrux-aesgcm",
+ "libcrux-chacha20poly1305",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-aesgcm"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f2a019dab4097585a7d4f5b9deebe46cd1e628b16a5bc4cb0ce35e1da334e6"
+dependencies = [
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-chacha20poly1305"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc08d044676af21343b32b988411fa98dbb5cf65a03c9df478ced221bbdfdb1b"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-poly1305",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-curve25519"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1e5fd8476a6ed609d24ef42aee5ab6f99f7c65d054f92412da9f499e423299"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-ecdh"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65f73ce79337c762eb38bbac91e4c9b9e60cf318e8501b812750c640814d45e"
+dependencies = [
+ "libcrux-curve25519",
+ "libcrux-p256",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "libcrux-hacl-rs"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2637dc87d158e1f1b550fd9b226443e84153fded4de69028d897b534d16d22e6"
+dependencies = [
+ "libcrux-macros",
+]
+
+[[package]]
+name = "libcrux-hkdf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1a89ca0c89be3a268a921e47105fb7873badf7267f5e3ebf4ea46baedd73ef"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-hmac",
+ "libcrux-secrets",
+]
+
+[[package]]
+name = "libcrux-hmac"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7a242707d65960770bd7e14e4f18a92bdf0b967777dd404887db8d087a643b"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-sha2",
+]
+
+[[package]]
+name = "libcrux-intrinsics"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b5db005ff8001e026b73a6842ee81bbef8ec5ff0e1915a67ae65fd2a9fafa5"
+dependencies = [
+ "core-models",
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-kem"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12631592f491d22fd1a176d32b2c6edfb673998fd3987e9d95f8fa79ad2a737b"
+dependencies = [
+ "libcrux-curve25519",
+ "libcrux-ecdh",
+ "libcrux-ml-kem",
+ "libcrux-p256",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "libcrux-macros"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd6aa2dcd5be681662001b81d493f1569c6d49a32361f470b0c955465cd0338"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "libcrux-ml-kem"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14ab3e477de9df6ee1273a114018ff62c4996ca9220070c4e5cb1743f94a67d"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand 0.9.5",
+ "tls_codec",
+]
+
+[[package]]
+name = "libcrux-p256"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4778ba25cb08bb8a96bd100e19ed9aecf78337198fd176036e21042b2dd99bc"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-secrets",
+ "libcrux-sha2",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-platform"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9e21d7ed31a92ac539bd69a8c970b183ee883872d2d19ce27036e24cb8ecc4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libcrux-poly1305"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02491808ee5b9db8cb65fad64ae0be812db64beef179d945c00c7787dc7dfcf9"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+]
+
+[[package]]
+name = "libcrux-secrets"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce650f3041b44ba40d4263852347d007cd2cd9d1cc856a6f6c8b2e10c3fd40b"
+dependencies = [
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-sha2"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d253473f259fc74a280c43f29c464f7e374abdf28b4942234dc707f529d4b7"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-sha3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ae0b7d0e1cc4793a609fd0ff2ca3b3a3fabae523770c619a3d4bc86417b0d7"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-traits"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
+dependencies = [
+ "libcrux-secrets",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "maybe-async"
@@ -618,6 +1006,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mls-interop"
+version = "0.0.0"
+dependencies = [
+ "mls-rs",
+ "mls-rs-crypto-rustcrypto",
+ "offline-protocol-core",
+ "openmls",
+ "openmls_basic_credential",
+ "openmls_rust_crypto",
+ "openmls_traits",
+ "sha2",
+]
+
+[[package]]
 name = "mls-rs"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,8 +1027,10 @@ checksum = "4392c3b3ed7d835ca8f318f85ca65d3f0d3e879538d6e70679827a2f3af72029"
 dependencies = [
  "async-trait",
  "cfg-if",
+ "debug_tree",
  "futures",
- "getrandom",
+ "getrandom 0.2.17",
+ "hex",
  "itertools",
  "maybe-async",
  "mls-rs-codec",
@@ -634,9 +1038,11 @@ dependencies = [
  "mls-rs-identity-x509",
  "portable-atomic",
  "portable-atomic-util",
- "rand_core",
+ "rand_core 0.6.4",
+ "serde",
  "spin",
  "subtle",
+ "thiserror",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -649,6 +1055,7 @@ checksum = "45bd834f164dc06c1fed805540ae307a460b7ed7c2769a35a376f1de577a0dc1"
 dependencies = [
  "itertools",
  "mls-rs-codec-derive",
+ "thiserror",
  "wasm-bindgen",
 ]
 
@@ -674,6 +1081,8 @@ dependencies = [
  "hex",
  "maybe-async",
  "mls-rs-codec",
+ "serde",
+ "thiserror",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -689,6 +1098,7 @@ dependencies = [
  "maybe-async",
  "mls-rs-core",
  "mls-rs-crypto-traits",
+ "thiserror",
  "zeroize",
 ]
 
@@ -704,6 +1114,7 @@ dependencies = [
  "chacha20poly1305",
  "ed25519-dalek",
  "generic-array",
+ "getrandom 0.2.17",
  "hkdf",
  "hmac",
  "maybe-async",
@@ -712,9 +1123,10 @@ dependencies = [
  "mls-rs-crypto-traits",
  "p256",
  "p384",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1 0.8.1",
  "sha2",
+ "thiserror",
  "x25519-dalek",
  "zeroize",
 ]
@@ -740,7 +1152,36 @@ dependencies = [
  "async-trait",
  "maybe-async",
  "mls-rs-core",
+ "thiserror",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -753,6 +1194,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tracing",
  "unicode-normalization",
  "uuid",
 ]
@@ -768,6 +1210,84 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openmls"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6986942607b11b141468e415617fd74a56f790e8f8810fb5a77e7d173182b689"
+dependencies = [
+ "log",
+ "openmls_traits",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+ "tls_codec",
+ "zeroize",
+]
+
+[[package]]
+name = "openmls_basic_credential"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e6454b2b1b6749fc2f142d7f74eb387f7793be88187ed372e9f5f4cf10c34c"
+dependencies = [
+ "ed25519-dalek",
+ "openmls_traits",
+ "p256",
+ "rand 0.8.7",
+ "serde",
+ "tls_codec",
+]
+
+[[package]]
+name = "openmls_memory_storage"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7b071ea5573a97efaa72b7c53e81cebc644b62ef0fe992bad685cc0f7dd4ea"
+dependencies = [
+ "log",
+ "openmls_traits",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "openmls_rust_crypto"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e864b90d4b297b84a46ada993142a72392737248050100533ae063586c7f433f"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "ed25519-dalek",
+ "hkdf",
+ "hmac",
+ "hpke-rs",
+ "hpke-rs-crypto",
+ "hpke-rs-rust-crypto",
+ "openmls_memory_storage",
+ "openmls_traits",
+ "p256",
+ "rand 0.8.7",
+ "rand_chacha 0.3.1",
+ "serde",
+ "sha2",
+ "thiserror",
+ "tls_codec",
+]
+
+[[package]]
+name = "openmls_traits"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e21d8877bacdbc407060df29bf59b145bb886a8fa0099b87ae8067a34b902a13"
+dependencies = [
+ "serde",
+ "tls_codec",
+]
 
 [[package]]
 name = "p256"
@@ -792,6 +1312,12 @@ dependencies = [
  "primeorder",
  "sha2",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem-rfc7468"
@@ -872,12 +1398,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -899,12 +1456,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -973,6 +1638,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,7 +1698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1121,6 +1796,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "serde",
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,7 +1885,10 @@ version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
  "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1171,6 +1902,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1218,15 +1958,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/tools/mls-interop/Cargo.toml
+++ b/tools/mls-interop/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "mls-interop"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Proves the leaf's MLS stack interoperates with the phone's"
+
+# Its own workspace, for the same reason `embedded-footprint` has one: it links
+# two independent MLS implementations at once, and neither belongs in the SDK's
+# dependency graph.
+[workspace]
+
+[dependencies]
+# The phone's stack, pinned to exactly what the SDK resolves today. An interop
+# claim is about two specific versions, so neither of these floats.
+openmls = "=0.7.4"
+openmls_rust_crypto = "=0.4.4"
+openmls_basic_credential = "0.4"
+openmls_traits = "0.4"
+
+# The leaf's stack, in the configuration `embedded-footprint` measures, plus
+# `std` because this harness runs on the host.
+mls-rs = { version = "=0.56.0", default-features = false, features = [
+    "private_message",
+    "out_of_order",
+    "prior_epoch",
+    "by_ref_proposal",
+    "std",
+] }
+mls-rs-crypto-rustcrypto = "=0.22.1"
+
+# Address derivation, so the leaf's credential is checked against the real type
+# rather than a copy of the rule.
+offline-protocol-core = { path = "../../crates/offline-protocol-core" }
+sha2 = "0.10"
+
+[profile.release]
+debug = false

--- a/tools/mls-interop/Cargo.toml
+++ b/tools/mls-interop/Cargo.toml
@@ -29,8 +29,12 @@ mls-rs = { version = "=0.56.0", default-features = false, features = [
 ] }
 mls-rs-crypto-rustcrypto = "=0.22.1"
 
-# Address derivation, so the leaf's credential is checked against the real type
-# rather than a copy of the rule.
+# Address derivation, so the credential check runs against the real `Address`
+# type. The derivation rule itself, and the sender-ratchet constants in
+# `main.rs`, are copies of what `offline-protocol-mls` declares: nothing pins
+# the two together, so a change there leaves this harness green while it stops
+# testing the SDK's configuration. Closing that seam belongs with the stage that
+# gives the leaf a home in the workspace.
 offline-protocol-core = { path = "../../crates/offline-protocol-core" }
 sha2 = "0.10"
 

--- a/tools/mls-interop/README.md
+++ b/tools/mls-interop/README.md
@@ -1,0 +1,84 @@
+# MLS interop harness
+
+Answers one question with a pass or a failure: **does the leaf's MLS stack talk
+to the phone's?**
+
+```
+cargo run --release
+```
+
+## Why this exists
+
+`tools/embedded-footprint` measures whether a leaf node's stack *fits*. Fitting
+is not the interesting risk. A device that links 390 KiB of MLS and cannot
+decrypt a single frame the phone sends has passed the footprint gate and failed
+at the only thing that matters.
+
+The two stacks are different implementations by different authors: OpenMLS on
+the phone, mls-rs on the device. Both claim RFC 9420 conformance and both run
+the MLS working group's test vectors, which is evidence but not proof about
+*this* pairing, with *this* ciphersuite, carrying *this* SDK's credentials. No
+published result covers that pair. This harness is that result.
+
+## What it runs
+
+A never-committing member's whole life, in one process:
+
+| Step | Who | What |
+|---|---|---|
+| 0 | leaf | mls-rs defaults produce a key package the phone **refuses** |
+| 1-2 | leaf | derive an `off1` address, mint a key package with the corrections |
+| 3-4 | phone | parse it, validate it, check the SDK's leaf identity binding |
+| 5 | phone | create the group, commit the Add, merge |
+| 6 | leaf | join from the Welcome, with no out-of-band tree data |
+| 7-8 | both | application message each way |
+| 9 | leaf | process a commit the phone issued |
+| 10 | leaf | decrypt again in the new epoch |
+
+The phone is configured the way `crates/offline-protocol-mls/src/group.rs`
+configures it. Both library versions are pinned with `=`: an interop result is a
+claim about two specific versions and is worthless if either floats.
+
+## The three corrections, and step 0
+
+Getting a leaf's key package accepted took three changes, none of them
+signposted by either library. All are on the leaf side.
+
+1. **Shorten the key package lifetime.** mls-rs defaults to a year. OpenMLS
+   refuses any leaf node whose total lifetime range exceeds one hour plus three
+   months. The default is refused on arrival.
+2. **Backdate `not_before`.** OpenMLS tests `not_before < now`, strictly.
+   mls-rs's client builder writes `not_before` as exactly the timestamp it is
+   handed, without the backdating its own `Lifetime::seconds` helper applies, so
+   a package stamped with the current second is refused for being not yet valid.
+3. **Pass the timestamp in rather than letting the library read a clock.** This
+   is the one with consequences beyond this file. A bare-metal leaf has no
+   clock, and mls-rs stamps `not_before = 0` when it cannot read one, with a
+   source comment saying the value is there so tests can run. A device that
+   ships that way emits a key package whose validity window is in 1970 and is
+   refused as expired. **A leaf therefore needs a time source at pairing**, from
+   its radio stack, its commissioner, or the pairing exchange itself.
+
+There is also a framing difference, smaller and not a correction to either side:
+the SDK puts a bare `KeyPackage` on the wire while mls-rs's convenience API
+returns one wrapped in an `MLSMessage`. Both are legal. They have to agree.
+
+**Step 0 is a negative control and is the most important line in the output.**
+It builds a leaf with the uncorrected defaults and requires the phone to reject
+it. Every one of the three corrections is a default that someone will eventually
+tidy back, and a harness that only proves the corrected path works cannot tell
+them they broke it. If step 0 ever *passes*, one of the two libraries changed
+its lifetime rules, and whether these corrections are still load-bearing has to
+be re-derived rather than assumed.
+
+## What this does not prove
+
+It is one process on a host, so it tests the two libraries against each other
+and nothing else. It says nothing about the radio, the fragmentation path, flash
+persistence across a power cut, or timing on the part. It also does not exercise
+the SDK's envelope layer: it stops at the MLS boundary, and how a sealed frame
+is wrapped for the wire is `crates/offline-protocol/src/protocol/send.rs`'s
+business, tested separately.
+
+It is deliberately not a member of the SDK workspace. It links two independent
+MLS implementations at once, and neither belongs in the SDK's dependency graph.

--- a/tools/mls-interop/README.md
+++ b/tools/mls-interop/README.md
@@ -26,9 +26,10 @@ A never-committing member's whole life, in one process:
 
 | Step | Who | What |
 |---|---|---|
-| 0 | leaf | mls-rs defaults produce a key package the phone **refuses** |
+| 0.1-0.2 | leaf | each corrected default, restored, produces a key package the phone **refuses** |
+| 0.3 | leaf | a year-long lifetime is **accepted**, pinning a cap OpenMLS declares and never applies |
 | 1-2 | leaf | derive an `off1` address, mint a key package with the corrections |
-| 3-4 | phone | parse it, validate it, check the SDK's leaf identity binding |
+| 3-4 | phone | parse it, validate it, re-derive the address from the key package it received |
 | 5 | phone | create the group, commit the Add, merge |
 | 6 | leaf | join from the Welcome, with no out-of-band tree data |
 | 7-8 | both | application message each way |
@@ -39,19 +40,16 @@ The phone is configured the way `crates/offline-protocol-mls/src/group.rs`
 configures it. Both library versions are pinned with `=`: an interop result is a
 claim about two specific versions and is worthless if either floats.
 
-## The three corrections, and step 0
+## The corrections, and step 0
 
-Getting a leaf's key package accepted took three changes, none of them
-signposted by either library. All are on the leaf side.
+Getting a leaf's key package accepted took changes neither library signposts.
+Both are on the leaf side.
 
-1. **Shorten the key package lifetime.** mls-rs defaults to a year. OpenMLS
-   refuses any leaf node whose total lifetime range exceeds one hour plus three
-   months. The default is refused on arrival.
-2. **Backdate `not_before`.** OpenMLS tests `not_before < now`, strictly.
+1. **Backdate `not_before`.** OpenMLS tests `not_before < now`, strictly.
    mls-rs's client builder writes `not_before` as exactly the timestamp it is
    handed, without the backdating its own `Lifetime::seconds` helper applies, so
    a package stamped with the current second is refused for being not yet valid.
-3. **Pass the timestamp in rather than letting the library read a clock.** This
+2. **Pass the timestamp in rather than letting the library read a clock.** This
    is the one with consequences beyond this file. A bare-metal leaf has no
    clock, and mls-rs stamps `not_before = 0` when it cannot read one, with a
    source comment saying the value is there so tests can run. A device that
@@ -63,13 +61,40 @@ There is also a framing difference, smaller and not a correction to either side:
 the SDK puts a bare `KeyPackage` on the wire while mls-rs's convenience API
 returns one wrapped in an `MLSMessage`. Both are legal. They have to agree.
 
-**Step 0 is a negative control and is the most important line in the output.**
-It builds a leaf with the uncorrected defaults and requires the phone to reject
-it. Every one of the three corrections is a default that someone will eventually
-tidy back, and a harness that only proves the corrected path works cannot tell
-them they broke it. If step 0 ever *passes*, one of the two libraries changed
-its lifetime rules, and whether these corrections are still load-bearing has to
-be re-derived rather than assumed.
+**The step 0 lines are negative controls, and they are the most important lines
+in the output.** Each restores one default and requires the phone to refuse the
+result, one at a time rather than all at once. A correction is a default someone
+will eventually tidy back, and a harness that only proves the corrected path
+works cannot tell them they broke it. If 0.1 or 0.2 ever *passes*, one of the
+two libraries changed its validity rules and whether that correction is still
+load-bearing has to be re-derived rather than assumed.
+
+### The correction that wasn't, and what it found
+
+Splitting the control is what produced the most useful result in this harness.
+
+A third item used to be listed above: shorten the key package lifetime, because
+"OpenMLS refuses any leaf node whose total lifetime range exceeds one hour plus
+three months". **That is not true of OpenMLS 0.7.4.** The constant exists
+(`MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS`) and so does the predicate
+(`Lifetime::has_acceptable_range`), and nothing in the crate calls the
+predicate. `KeyPackageIn::validate` checks only `Lifetime::is_valid`, the
+`not_before < now < not_after` window, and reports failure as `InvalidLifetime`,
+which is the error name that made a year-long lifetime look like it was refused
+for its range when it was really refused for its `not_before`. A control that
+broke all three defaults at once could not tell those apart. One that breaks
+them individually says so on the first run.
+
+Step 0.3 pins the finding from both directions. The 28-day lifetime this harness
+uses stays, because RFC 9420 asks an application to define a maximum and it
+bounds how long an unused init key is usable, but it is **leaf-side policy, not
+an interop requirement**. If 0.3 ever starts failing, OpenMLS wired up its cap
+and that changed.
+
+It also says something about the phone rather than the leaf: because no cap is
+applied, the SDK admits a key package from any peer with an arbitrarily long
+lifetime, which RFC 9420 asks implementations to reject. That is a gap in
+`MlsManager::import_key_package`, recorded in ADR 0021 and not fixed from here.
 
 ## What this does not prove
 

--- a/tools/mls-interop/src/main.rs
+++ b/tools/mls-interop/src/main.rs
@@ -21,13 +21,21 @@
 //!
 //! # The part worth reading
 //!
-//! Getting this to pass took three corrections, all of them on the leaf's key
-//! package and none of them obvious. [`leaf_key_package`] documents each, and
-//! [`default_configuration_is_rejected`] runs the uncorrected version and
-//! requires it to *fail*. That negative control is the point: every correction
-//! is a default that someone will eventually "simplify" back, and without a
-//! test that fails when they do, the next person to hit these spends their time
-//! on a hardware bring-up bench instead of here.
+//! Getting this to pass took corrections to the leaf's key package that neither
+//! library signposts. [`leaf_key_package`] documents them, and
+//! [`corrections_are_load_bearing`] restores each default in turn and requires
+//! the phone to refuse the result. Those negative controls are the point: a
+//! correction is a default that someone will eventually "simplify" back, and
+//! without a test that fails when they do, the next person to hit these spends
+//! their time on a hardware bring-up bench instead of here.
+//!
+//! Restoring one default at a time rather than all at once is what makes them
+//! worth having, and it is also what corrected this file's own account of
+//! itself. Two of the three defaults originally listed here are genuinely
+//! refused by the phone. The third, a year-long key package lifetime, is not
+//! refused at all: see [`the_lifetime_cap_is_policy_not_enforcement`]. A control
+//! that broke all three at once could not tell the difference, because OpenMLS
+//! reports every one of these as `InvalidLifetime`.
 
 use openmls::prelude::tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize};
 use openmls::prelude::*;
@@ -57,10 +65,12 @@ const MAXIMUM_FORWARD_DISTANCE: u32 = 1000;
 
 /// How long a leaf's key package claims to be valid.
 ///
-/// mls-rs defaults to a year. OpenMLS refuses any leaf node whose total
-/// lifetime range exceeds one hour plus three months
-/// (`MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS`), so the default is refused on
-/// arrival. 28 days sits well inside the cap.
+/// mls-rs defaults to a year. 28 days is leaf-side policy rather than something
+/// the phone makes us do: it is what RFC 9420 asks an application to define, it
+/// sits inside the cap OpenMLS declares in
+/// `MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS`, and it bounds how long an unused init
+/// key stays usable. The phone does not enforce that cap today, which
+/// [`the_lifetime_cap_is_policy_not_enforcement`] pins and explains.
 const KEY_PACKAGE_LIFETIME: Duration = Duration::from_secs(28 * 24 * 3600);
 
 /// How far into the past a key package's validity window has to start.
@@ -71,6 +81,10 @@ const KEY_PACKAGE_LIFETIME: Duration = Duration::from_secs(28 * 24 * 3600);
 /// current second is refused for being not yet valid. This is also the margin
 /// that absorbs clock skew between the two devices.
 const NOT_BEFORE_BACKDATE: u64 = 3600;
+
+/// mls-rs's own default, kept as a named constant because
+/// [`corrections_are_load_bearing`] has to be able to restore it.
+const MLS_RS_DEFAULT_LIFETIME: Duration = Duration::from_secs(365 * 24 * 3600);
 
 /// The SDK's one derivation: an address is the truncated hash of the identity
 /// key, so a credential containing it carries its own proof.
@@ -119,11 +133,10 @@ fn leaf_client(lifetime: Duration) -> (Client<impl MlsConfig>, String) {
     (client, address)
 }
 
-/// The leaf's pairing artifact, with all three corrections applied.
+/// The leaf's pairing artifact, with the corrections applied.
 ///
-/// 1. **The lifetime is shortened.** See [`KEY_PACKAGE_LIFETIME`].
-/// 2. **`not_before` is backdated.** See [`NOT_BEFORE_BACKDATE`].
-/// 3. **The timestamp is passed in, not read.** A bare-metal leaf has no
+/// 1. **`not_before` is backdated.** See [`NOT_BEFORE_BACKDATE`].
+/// 2. **The timestamp is passed in, not read.** A bare-metal leaf has no
 ///    clock, and mls-rs stamps `not_before = 0` when it cannot read one, which
 ///    puts the validity window in 1970 and gets the package refused as expired.
 ///    Passing it explicitly here is not a test convenience: it is the shape the
@@ -131,14 +144,27 @@ fn leaf_client(lifetime: Duration) -> (Client<impl MlsConfig>, String) {
 ///    pairing**, from its radio stack, its commissioner, or the pairing frame
 ///    itself. That obligation is real and belongs in the ADR.
 ///
+/// The shortened lifetime is a third difference from mls-rs's defaults but not
+/// a correction, because the phone accepts the default: see
+/// [`KEY_PACKAGE_LIFETIME`].
+///
 /// The framing correction is separate and smaller: the SDK puts a bare
 /// `KeyPackage` on the wire, while mls-rs's convenience API returns one wrapped
 /// in an `MLSMessage`. Both are legal; they just have to agree.
-fn leaf_key_package(client: &Client<impl MlsConfig>, backdate: u64) -> Vec<u8> {
-    let paired_at = MlsTime::from(unix_now() - backdate);
-
+///
+/// `not_before` is a parameter rather than something computed here so that
+/// [`corrections_are_load_bearing`] can restore one default at a time. Note in
+/// particular that a clockless leaf is reproduced by passing 0, never by
+/// passing `None`: this harness runs on a host, so `None` would have mls-rs
+/// read a real clock and the 1970 window the device actually emits would never
+/// appear.
+fn leaf_key_package(client: &Client<impl MlsConfig>, not_before: u64) -> Vec<u8> {
     client
-        .generate_key_package_message(Default::default(), Default::default(), Some(paired_at))
+        .generate_key_package_message(
+            Default::default(),
+            Default::default(),
+            Some(MlsTime::from(not_before)),
+        )
         .expect("leaf generates a key package")
         .into_key_package()
         .expect("the message is a key package")
@@ -170,24 +196,98 @@ fn phone_admits(provider: &OpenMlsRustCrypto, bytes: &[u8]) -> Result<KeyPackage
         .map_err(|e| format!("{e:?}"))
 }
 
-/// The negative control.
+/// The negative controls: one per correction, each restoring a single default.
 ///
-/// mls-rs's defaults produce a key package the phone refuses. If this ever
-/// stops failing, one of the two libraries changed its mind and the
-/// corrections above may no longer be load-bearing, which is worth knowing
-/// deliberately rather than discovering by deleting them.
-fn default_configuration_is_rejected() {
-    let (client, _) = leaf_client(Duration::from_secs(365 * 24 * 3600));
-    let bytes = leaf_key_package(&client, 0);
+/// One at a time is the whole design. With several defaults wrong at once a
+/// package is refused for whichever reason OpenMLS happens to check first, and
+/// a control like that cannot say which correction is doing the work. Splitting
+/// them is what turned up that one of the three originally claimed here is not
+/// enforced by the phone at all: see
+/// [`the_lifetime_cap_is_policy_not_enforcement`].
+///
+/// If either case below is ACCEPTED, one of the two stacks changed its validity
+/// rules and whether that correction is still load-bearing has to be re-derived
+/// rather than discovered by someone deleting it.
+fn corrections_are_load_bearing() {
     let (provider, _, _) = phone();
+    let now = unix_now();
+
+    // Both cases are the same OpenMLS rule: `not_before < now`, tested strictly
+    // in `Lifetime::is_valid`. The first stamps `not_before` an hour into the
+    // future rather than at exactly `now`, which is what dropping the backdate
+    // literally produces. That is deliberate: `not_before == now` is refused
+    // only when the phone validates inside the same second the package was
+    // minted, so a control built on it would be a coin flip. An hour of skew
+    // exercises the same rule deterministically, and skew between two devices
+    // is the form this failure takes in the field anyway.
+    let cases: [(&str, &str, u64); 2] = [
+        (
+            "a leaf whose clock leads the phone's",
+            "NOT_BEFORE_BACKDATE",
+            now + NOT_BEFORE_BACKDATE,
+        ),
+        (
+            "a leaf with no clock at all, stamping 1970",
+            "the supplied pairing timestamp",
+            0,
+        ),
+    ];
+
+    for (index, (what, correction, not_before)) in cases.iter().enumerate() {
+        let (client, _) = leaf_client(KEY_PACKAGE_LIFETIME);
+        let bytes = leaf_key_package(&client, *not_before);
+
+        match phone_admits(&provider, &bytes) {
+            Err(e) => println!("  0.{} {what} is refused ({e})", index + 1),
+            Ok(_) => panic!(
+                "the phone ACCEPTED a key package from {what}.\n\
+                 OpenMLS or mls-rs changed its key package validity rules, so \
+                 {correction} may no longer be load-bearing. Re-derive that \
+                 before touching it."
+            ),
+        }
+    }
+}
+
+/// The third default, and the one that turned out not to be a correction.
+///
+/// RFC 9420 tells an application to define a maximum total lifetime for a leaf
+/// node and reject anything longer, and OpenMLS 0.7.4 ships both halves of
+/// that: the constant `MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS` (an hour plus
+/// three months) and the predicate `Lifetime::has_acceptable_range`. Nothing
+/// calls the predicate. `KeyPackageIn::validate` checks only
+/// `Lifetime::is_valid`, which is the `not_before < now < not_after` window,
+/// and returns `InvalidLifetime` when it fails, which is the error name that
+/// made a year-long lifetime look like it was being refused for its range when
+/// it was really being refused for its `not_before`.
+///
+/// So [`KEY_PACKAGE_LIFETIME`] is leaf-side policy, not something the phone
+/// enforces. Worth keeping, because it is what RFC 9420 asks and it bounds how
+/// long an unused init key stays usable, but it is not an interop correction
+/// and this harness must not imply that it is. Two consequences, both pinned
+/// here rather than left as prose:
+///
+/// 1. If this case ever starts being *refused*, OpenMLS wired up its own cap
+///    and the shortened lifetime became load-bearing for interop after all.
+/// 2. Because the phone applies no cap, the SDK admits a key package from any
+///    peer with an arbitrarily long lifetime. That is a gap in
+///    `MlsManager::import_key_package`, not in this harness, and it is recorded
+///    in ADR 0021 rather than quietly fixed from here.
+fn the_lifetime_cap_is_policy_not_enforcement() {
+    let (provider, _, _) = phone();
+    let (client, _) = leaf_client(MLS_RS_DEFAULT_LIFETIME);
+    let bytes = leaf_key_package(&client, unix_now() - NOT_BEFORE_BACKDATE);
 
     match phone_admits(&provider, &bytes) {
-        Err(e) => println!("  0. uncorrected defaults are refused by the phone ({e})"),
-        Ok(_) => panic!(
-            "the uncorrected leaf key package was ACCEPTED.\n\
-             One of the two stacks changed its lifetime rules. Re-derive whether \
-             KEY_PACKAGE_LIFETIME and NOT_BEFORE_BACKDATE are still needed before \
-             touching them."
+        Ok(_) => println!(
+            "  0.3 mls-rs's one-year lifetime is ACCEPTED: OpenMLS defines a cap \
+             and never applies it"
+        ),
+        Err(e) => panic!(
+            "the phone REFUSED a year-long key package lifetime ({e}).\n\
+             OpenMLS now enforces MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS. That makes \
+             KEY_PACKAGE_LIFETIME load-bearing for interop, and ADR 0021's account \
+             of it as leaf-side policy needs updating."
         ),
     }
 }
@@ -199,13 +299,14 @@ fn step(n: u32, what: &str) {
 fn main() {
     println!("OpenMLS 0.7.4 (phone) <-> mls-rs 0.56.0 (leaf), ciphersuite 3\n");
 
-    default_configuration_is_rejected();
+    corrections_are_load_bearing();
+    the_lifetime_cap_is_policy_not_enforcement();
 
     // ---- The leaf builds an identity and a pairing artifact ---------------
     let (leaf, leaf_address) = leaf_client(KEY_PACKAGE_LIFETIME);
     step(1, &format!("leaf identity derives to {leaf_address}"));
 
-    let key_package_bytes = leaf_key_package(&leaf, NOT_BEFORE_BACKDATE);
+    let key_package_bytes = leaf_key_package(&leaf, unix_now() - NOT_BEFORE_BACKDATE);
     step(
         2,
         &format!("leaf key package, {} bytes", key_package_bytes.len()),
@@ -217,16 +318,35 @@ fn main() {
         .expect("phone parses and validates the leaf's key package");
     step(3, "phone parsed and validated it");
 
-    let credential_content = leaf_key_package
-        .leaf_node()
-        .credential()
-        .serialized_content();
+    // `MlsManager::verify_address_binding` derives from the signature key in the
+    // package that *arrived*, not from one the process already holds, and this
+    // check is written the same way for the same reason. Comparing a credential
+    // against the locally-generated address would hold by construction: it
+    // would pass even if mls-rs and OpenMLS disagreed about where the signature
+    // key sits in the encoding, which is exactly the disagreement an interop
+    // harness exists to catch.
+    let presented_key = leaf_key_package.leaf_node().signature_key().as_slice();
+    let claimed = std::str::from_utf8(
+        leaf_key_package
+            .leaf_node()
+            .credential()
+            .serialized_content(),
+    )
+    .expect("utf8 credential");
+
     assert_eq!(
-        std::str::from_utf8(credential_content).expect("utf8 credential"),
-        leaf_address,
-        "a leaf credential must be the address its own signature key derives to"
+        derive_address(presented_key).to_string(),
+        claimed,
+        "derive(presented_key) must equal the address the credential claims"
     );
-    step(4, "leaf credential satisfies the SDK's identity binding");
+    assert_eq!(
+        claimed, leaf_address,
+        "and the address the phone recovered must be the leaf's own"
+    );
+    step(
+        4,
+        "derive(presented_key) == claimed address, on the phone's copy",
+    );
 
     // ---- The phone creates the group and adds the leaf -------------------
     let group_config = MlsGroupCreateConfig::builder()

--- a/tools/mls-interop/src/main.rs
+++ b/tools/mls-interop/src/main.rs
@@ -1,0 +1,359 @@
+//! Does the leaf's MLS stack talk to the phone's?
+//!
+//! ADR 0020 left a leaf node's payload cryptography open, on the grounds that
+//! MLS does not fit on the part. That is true of OpenMLS and of large groups,
+//! and a phone paired with one device is neither: two members, a three-node
+//! ratchet tree. `tools/embedded-footprint` answers whether the leaf's stack
+//! fits. This answers the other half, which no amount of flash measurement can:
+//! whether it is talking to the phone or only to itself.
+//!
+//! The phone side is OpenMLS 0.7.4 configured the way the SDK configures it
+//! (`crates/offline-protocol-mls/src/group.rs`): ciphersuite 3, the ratchet
+//! tree carried as an extension, the SDK's sender-ratchet tolerance. The leaf
+//! side is mls-rs 0.56 on the RustCrypto provider, the configuration the
+//! footprint harness measures. Both versions are pinned with `=`, because an
+//! interop result is a statement about two specific versions and means nothing
+//! if either floats.
+//!
+//! The flow is a never-committing member's whole life: pair, join, hear,
+//! answer, survive a commit, hear again. Everything asserts, so a disagreement
+//! between the two stacks exits non-zero rather than printing a warning.
+//!
+//! # The part worth reading
+//!
+//! Getting this to pass took three corrections, all of them on the leaf's key
+//! package and none of them obvious. [`leaf_key_package`] documents each, and
+//! [`default_configuration_is_rejected`] runs the uncorrected version and
+//! requires it to *fail*. That negative control is the point: every correction
+//! is a default that someone will eventually "simplify" back, and without a
+//! test that fails when they do, the next person to hit these spends their time
+//! on a hardware bring-up bench instead of here.
+
+use openmls::prelude::tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize};
+use openmls::prelude::*;
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::OpenMlsProvider;
+
+use mls_rs::client_builder::MlsConfig;
+use mls_rs::identity::basic::{BasicCredential, BasicIdentityProvider};
+use mls_rs::identity::SigningIdentity;
+use mls_rs::mls_rs_codec::MlsEncode;
+use mls_rs::time::MlsTime;
+use mls_rs::{CipherSuite, CipherSuiteProvider, Client, CryptoProvider, MlsMessage};
+use mls_rs_crypto_rustcrypto::RustCryptoProvider;
+
+use offline_protocol_core::Address;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// The SDK pins this in exactly one place and never negotiates it.
+const PHONE_SUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+/// The same suite, spelled the way mls-rs spells it.
+const LEAF_SUITE: CipherSuite = CipherSuite::CURVE25519_AES128;
+
+/// Both from `crates/offline-protocol-mls/src/group.rs`.
+const OUT_OF_ORDER_TOLERANCE: u32 = 32;
+const MAXIMUM_FORWARD_DISTANCE: u32 = 1000;
+
+/// How long a leaf's key package claims to be valid.
+///
+/// mls-rs defaults to a year. OpenMLS refuses any leaf node whose total
+/// lifetime range exceeds one hour plus three months
+/// (`MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS`), so the default is refused on
+/// arrival. 28 days sits well inside the cap.
+const KEY_PACKAGE_LIFETIME: Duration = Duration::from_secs(28 * 24 * 3600);
+
+/// How far into the past a key package's validity window has to start.
+///
+/// OpenMLS tests `not_before < now`, strictly. mls-rs's client builder writes
+/// `not_before` as exactly the timestamp it is handed, without the backdating
+/// its own `Lifetime::seconds` helper applies, so a package stamped with the
+/// current second is refused for being not yet valid. This is also the margin
+/// that absorbs clock skew between the two devices.
+const NOT_BEFORE_BACKDATE: u64 = 3600;
+
+/// The SDK's one derivation: an address is the truncated hash of the identity
+/// key, so a credential containing it carries its own proof.
+fn derive_address(public_key: &[u8]) -> Address {
+    use sha2::{Digest, Sha256};
+    assert_eq!(public_key.len(), 32, "Ed25519 public keys are 32 bytes");
+    let hash = Sha256::digest(public_key);
+    let mut truncated = [0u8; 20];
+    truncated.copy_from_slice(&hash[..20]);
+    Address::from_hash_bytes(truncated)
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after 1970")
+        .as_secs()
+}
+
+/// A leaf client and the address its identity key derives to.
+fn leaf_client(lifetime: Duration) -> (Client<impl MlsConfig>, String) {
+    // Only the pinned suite is enabled. On the device this also keeps three
+    // other curves out of the image.
+    let crypto = RustCryptoProvider::with_enabled_cipher_suites(vec![LEAF_SUITE]);
+    let suite = crypto
+        .cipher_suite_provider(LEAF_SUITE)
+        .expect("the RustCrypto provider supports ciphersuite 3");
+    let (secret, public) = suite
+        .signature_key_generate()
+        .expect("signature key generation");
+
+    let address = derive_address(public.as_bytes()).to_string();
+
+    // The credential content *is* the address, which is what the SDK's leaf
+    // identity binding requires of every member of every group.
+    let credential = BasicCredential::new(address.as_bytes().to_vec());
+    let identity = SigningIdentity::new(credential.into_credential(), public);
+
+    let client = Client::builder()
+        .identity_provider(BasicIdentityProvider)
+        .crypto_provider(crypto)
+        .signing_identity(identity, secret, LEAF_SUITE)
+        .key_package_lifetime(lifetime)
+        .build();
+
+    (client, address)
+}
+
+/// The leaf's pairing artifact, with all three corrections applied.
+///
+/// 1. **The lifetime is shortened.** See [`KEY_PACKAGE_LIFETIME`].
+/// 2. **`not_before` is backdated.** See [`NOT_BEFORE_BACKDATE`].
+/// 3. **The timestamp is passed in, not read.** A bare-metal leaf has no
+///    clock, and mls-rs stamps `not_before = 0` when it cannot read one, which
+///    puts the validity window in 1970 and gets the package refused as expired.
+///    Passing it explicitly here is not a test convenience: it is the shape the
+///    device firmware has to have, and it means **a leaf needs a time source at
+///    pairing**, from its radio stack, its commissioner, or the pairing frame
+///    itself. That obligation is real and belongs in the ADR.
+///
+/// The framing correction is separate and smaller: the SDK puts a bare
+/// `KeyPackage` on the wire, while mls-rs's convenience API returns one wrapped
+/// in an `MLSMessage`. Both are legal; they just have to agree.
+fn leaf_key_package(client: &Client<impl MlsConfig>, backdate: u64) -> Vec<u8> {
+    let paired_at = MlsTime::from(unix_now() - backdate);
+
+    client
+        .generate_key_package_message(Default::default(), Default::default(), Some(paired_at))
+        .expect("leaf generates a key package")
+        .into_key_package()
+        .expect("the message is a key package")
+        .mls_encode_to_vec()
+        .expect("re-encode the key package as bare KeyPackage bytes")
+}
+
+/// A phone, configured as `MlsGroupCreateConfig` is configured in the SDK.
+fn phone() -> (OpenMlsRustCrypto, SignatureKeyPair, CredentialWithKey) {
+    let provider = OpenMlsRustCrypto::default();
+    let keys =
+        SignatureKeyPair::new(PHONE_SUITE.signature_algorithm()).expect("phone signature keys");
+    keys.store(provider.storage()).expect("store phone keys");
+
+    let address = derive_address(keys.public()).to_string();
+    let credential = CredentialWithKey {
+        credential: Credential::new(CredentialType::Basic, address.as_bytes().to_vec()),
+        signature_key: keys.public().into(),
+    };
+
+    (provider, keys, credential)
+}
+
+/// Runs the phone's side of key package admission: parse, then validate.
+fn phone_admits(provider: &OpenMlsRustCrypto, bytes: &[u8]) -> Result<KeyPackage, String> {
+    KeyPackageIn::tls_deserialize_exact(bytes)
+        .map_err(|e| format!("parse: {e}"))?
+        .validate(provider.crypto(), ProtocolVersion::Mls10)
+        .map_err(|e| format!("{e:?}"))
+}
+
+/// The negative control.
+///
+/// mls-rs's defaults produce a key package the phone refuses. If this ever
+/// stops failing, one of the two libraries changed its mind and the
+/// corrections above may no longer be load-bearing, which is worth knowing
+/// deliberately rather than discovering by deleting them.
+fn default_configuration_is_rejected() {
+    let (client, _) = leaf_client(Duration::from_secs(365 * 24 * 3600));
+    let bytes = leaf_key_package(&client, 0);
+    let (provider, _, _) = phone();
+
+    match phone_admits(&provider, &bytes) {
+        Err(e) => println!("  0. uncorrected defaults are refused by the phone ({e})"),
+        Ok(_) => panic!(
+            "the uncorrected leaf key package was ACCEPTED.\n\
+             One of the two stacks changed its lifetime rules. Re-derive whether \
+             KEY_PACKAGE_LIFETIME and NOT_BEFORE_BACKDATE are still needed before \
+             touching them."
+        ),
+    }
+}
+
+fn step(n: u32, what: &str) {
+    println!("  {n}. {what}");
+}
+
+fn main() {
+    println!("OpenMLS 0.7.4 (phone) <-> mls-rs 0.56.0 (leaf), ciphersuite 3\n");
+
+    default_configuration_is_rejected();
+
+    // ---- The leaf builds an identity and a pairing artifact ---------------
+    let (leaf, leaf_address) = leaf_client(KEY_PACKAGE_LIFETIME);
+    step(1, &format!("leaf identity derives to {leaf_address}"));
+
+    let key_package_bytes = leaf_key_package(&leaf, NOT_BEFORE_BACKDATE);
+    step(
+        2,
+        &format!("leaf key package, {} bytes", key_package_bytes.len()),
+    );
+
+    // ---- The phone admits it, exactly as `import_key_package` does --------
+    let (provider, phone_keys, phone_credential) = phone();
+    let leaf_key_package = phone_admits(&provider, &key_package_bytes)
+        .expect("phone parses and validates the leaf's key package");
+    step(3, "phone parsed and validated it");
+
+    let credential_content = leaf_key_package
+        .leaf_node()
+        .credential()
+        .serialized_content();
+    assert_eq!(
+        std::str::from_utf8(credential_content).expect("utf8 credential"),
+        leaf_address,
+        "a leaf credential must be the address its own signature key derives to"
+    );
+    step(4, "leaf credential satisfies the SDK's identity binding");
+
+    // ---- The phone creates the group and adds the leaf -------------------
+    let group_config = MlsGroupCreateConfig::builder()
+        .ciphersuite(PHONE_SUITE)
+        .use_ratchet_tree_extension(true)
+        .sender_ratchet_configuration(SenderRatchetConfiguration::new(
+            OUT_OF_ORDER_TOLERANCE,
+            MAXIMUM_FORWARD_DISTANCE,
+        ))
+        .build();
+
+    let mut phone_group = MlsGroup::new(&provider, &phone_keys, &group_config, phone_credential)
+        .expect("phone creates the group");
+
+    let (_commit, welcome, _group_info) = phone_group
+        .add_members(&provider, &phone_keys, &[leaf_key_package])
+        .expect("phone commits the Add");
+    phone_group
+        .merge_pending_commit(&provider)
+        .expect("phone merges its own commit");
+    step(5, "phone created the group and committed the Add");
+
+    // ---- The leaf joins from the Welcome ---------------------------------
+    let welcome_bytes = welcome.tls_serialize_detached().expect("serialize welcome");
+    let welcome_message =
+        MlsMessage::from_bytes(&welcome_bytes).expect("leaf parses the phone's Welcome");
+
+    // `tree_data` is None on purpose: the SDK sets `use_ratchet_tree_extension`,
+    // so the tree rides inside the Welcome. A device that had to fetch the tree
+    // out of band would need a side channel it does not have.
+    let (mut leaf_group, _info) = leaf
+        .join_group(None, &welcome_message, None)
+        .expect("leaf joins from the Welcome");
+    step(6, "leaf joined from the Welcome with no out-of-band tree");
+
+    assert_eq!(
+        leaf_group.current_epoch(),
+        phone_group.epoch().as_u64(),
+        "both sides must agree on the epoch after the join"
+    );
+
+    // ---- Phone speaks, leaf hears ----------------------------------------
+    let phone_msg = phone_group
+        .create_message(&provider, &phone_keys, b"unlock the door")
+        .expect("phone encrypts")
+        .tls_serialize_detached()
+        .expect("serialize");
+
+    match leaf_group
+        .process_incoming_message(MlsMessage::from_bytes(&phone_msg).expect("leaf parses"))
+        .expect("leaf decrypts the phone's message")
+    {
+        mls_rs::group::ReceivedMessage::ApplicationMessage(app) => {
+            assert_eq!(app.data(), b"unlock the door");
+            step(7, "leaf decrypted the phone's application message");
+        }
+        other => panic!("expected an application message, got {other:?}"),
+    }
+
+    // ---- Leaf answers, phone hears ---------------------------------------
+    let leaf_answer = leaf_group
+        .encrypt_application_message(b"unlocked", Vec::new())
+        .expect("leaf encrypts its answer")
+        .to_bytes()
+        .expect("serialize the answer");
+
+    let inbound = MlsMessageIn::tls_deserialize_exact(&leaf_answer)
+        .expect("phone parses the leaf's answer")
+        .try_into_protocol_message()
+        .expect("the answer is a protocol message");
+
+    match phone_group
+        .process_message(&provider, inbound)
+        .expect("phone decrypts the leaf's answer")
+        .into_content()
+    {
+        ProcessedMessageContent::ApplicationMessage(app) => {
+            assert_eq!(app.into_bytes(), b"unlocked");
+            step(8, "phone decrypted the leaf's answer");
+        }
+        _ => panic!("expected an application message from the leaf"),
+    }
+
+    // ---- The phone commits; the leaf has to survive it -------------------
+    let (commit, _welcome, _gi) = phone_group
+        .self_update(&provider, &phone_keys, LeafNodeParameters::default())
+        .expect("phone self-updates")
+        .into_contents();
+    phone_group
+        .merge_pending_commit(&provider)
+        .expect("phone merges the update");
+
+    let commit_bytes = commit
+        .tls_serialize_detached()
+        .expect("serialize the commit");
+    match leaf_group
+        .process_incoming_message(MlsMessage::from_bytes(&commit_bytes).expect("leaf parses"))
+        .expect("leaf processes the phone's commit")
+    {
+        mls_rs::group::ReceivedMessage::Commit(_) => step(9, "leaf processed the phone's commit"),
+        other => panic!("expected a commit, got {other:?}"),
+    }
+
+    assert_eq!(
+        leaf_group.current_epoch(),
+        phone_group.epoch().as_u64(),
+        "both sides must agree on the epoch after the commit"
+    );
+
+    // ---- And still hears in the new epoch --------------------------------
+    let after = phone_group
+        .create_message(&provider, &phone_keys, b"post-commit")
+        .expect("phone encrypts in the new epoch")
+        .tls_serialize_detached()
+        .expect("serialize");
+
+    match leaf_group
+        .process_incoming_message(MlsMessage::from_bytes(&after).expect("leaf parses"))
+        .expect("leaf decrypts in the new epoch")
+    {
+        mls_rs::group::ReceivedMessage::ApplicationMessage(app) => {
+            assert_eq!(app.data(), b"post-commit");
+            step(10, "leaf decrypted in the new epoch");
+        }
+        other => panic!("expected an application message, got {other:?}"),
+    }
+
+    println!("\nPASS: the leaf stack interoperates with the phone's, both directions,");
+    println!("across a commit, with the SDK's ciphersuite and credential shape.");
+}


### PR DESCRIPTION
Phase 1 of the embedded work, and the answer to the question
[ADR 0020](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/adr/0020-core-compiles-without-std.md)
left open:

> A leaf node's payload cryptography is a separate decision, still open.

It is closed, and not in the direction the ADR expected. **A leaf node runs
real MLS.** Nothing on the wire changes, the engine keeps its single sealing
path, and there is no weaker second protocol to design, deploy, or defend.

## Why the premise was wrong

ADR 0020 said MLS key-schedule and ratchet-tree state does not fit beside a
vendor radio stack in 256 KB. That is true of OpenMLS, and true of large
groups. A phone paired with one device is neither: **two members, a three-node
ratchet tree**, roughly 2 KB of logical state. The frightening numbers attached
to MLS state are O(N) numbers, and N here is 2.

And RFC 9420 exists in `no_std` Rust. `mls-rs` carries `no_std` as a CI-gated
configuration built for `thumbv6m-none-eabi`, a weaker part than our M33, and
its RustCrypto provider supports `CURVE25519_AES128`, which is exactly the one
ciphersuite this SDK pins and never negotiates.

So the question stopped being "what weaker thing does a leaf speak" and became
"does the same thing fit". Two harnesses answer that, and both ship here,
because a decision resting on numbers should ship the thing that reproduces
them.

## It fits

| Configuration | Flash | vs baseline |
|---|--:|--:|
| Application messages only, not shippable | 361.7 KiB | 360.6 KiB |
| **Never-committing leaf, the candidate** | **391.3 KiB** | **390.2 KiB** |
| `rfc_compliant`, X.509 included, upper bound | 403.8 KiB | 402.7 KiB |

About a quarter of an xG24's flash for a whole leaf image, protocol layer
included, against a budget that also holds a radio stack and an application.

Roughly **111 KiB of that is P-384 and P-256 arithmetic nothing here uses**,
linked because `mls-rs-crypto-rustcrypto` keeps all four curves in one
`EcPrivateKey` enum with no feature gating; enabling a suite is a runtime
filter, not a compile-time one. A curve-gated provider is worth about 28% of
the image and is not needed to clear the bar. That figure is symbol
attribution from the real image, not an estimate.

The protocol-layer number is **unchanged at 94.9 KiB** (97,152 bytes), so ADR
0020's "about 95 KB" still holds. The new binary was written to leave it alone,
and that was verified by measuring with the new sources stashed.

## It interoperates, and that is the gate that mattered

New `tools/mls-interop` runs OpenMLS 0.7.4 against mls-rs 0.56.0, both pinned
with `=`, with this SDK's ciphersuite, group configuration, and credential
shape. A never-committing member's whole life: pair, join from a Welcome with
no out-of-band tree, an application message each way, a commit from the phone,
a message after it. Nothing published covered that pair before this.

```
  0.1 a leaf whose clock leads the phone's is refused (InvalidLifetime)
  0.2 a leaf with no clock at all, stamping 1970 is refused (InvalidLifetime)
  0.3 mls-rs's one-year lifetime is ACCEPTED: OpenMLS defines a cap and never applies it
  1. leaf identity derives to off1qxlh2y9vz72x4lmwjsknr98mwprdgnz9ysafxwzy
  2. leaf key package, 312 bytes
  3. phone parsed and validated it
  4. derive(presented_key) == claimed address, on the phone's copy
  5. phone created the group and committed the Add
  6. leaf joined from the Welcome with no out-of-band tree
  7. leaf decrypted the phone's application message
  8. phone decrypted the leaf's answer
  9. leaf processed the phone's commit
 10. leaf decrypted in the new epoch
```

### Two corrections, none signposted by either library

Every one produces a key package the phone refuses, and every one would
otherwise have surfaced on a bring-up bench.

**`not_before` must be backdated.** OpenMLS tests `not_before < now`, strictly,
while mls-rs's client builder writes `not_before` as exactly the timestamp it
is handed, without the backdating its own `Lifetime::seconds` helper applies.
A package stamped with the current second is refused for being not yet valid.

**The timestamp must be supplied, not read.** This one has consequences past
the call site. A bare-metal leaf has no clock, and mls-rs stamps
`not_before = 0` when it cannot read one, with a source comment saying the
value exists so tests can run. A device shipping that way emits a validity
window in 1970 and is refused as expired. **A leaf therefore needs a time
source at pairing.** It costs availability rather than security, since key
package validity is a freshness bound and not an authentication mechanism, but
it has to be designed rather than discovered.

There is also a framing difference, smaller and not a correction to either
side: the SDK puts a bare `KeyPackage` on the wire while mls-rs's convenience
API returns one wrapped in an `MLSMessage`. Both legal. They have to agree.

### A third one that turned out to be imaginary

This PR originally claimed a third correction: shorten mls-rs's one-year key
package lifetime, because "OpenMLS refuses any leaf node whose total lifetime
range exceeds one hour plus three months". **That is not true of OpenMLS
0.7.4.** It declares the bound (`MAX_LEAF_NODE_LIFETIME_RANGE_SECONDS`) and the
predicate that tests it (`Lifetime::has_acceptable_range`), and nothing in the
crate calls the predicate. `KeyPackageIn::validate` checks only the
`not_before < now < not_after` window and names that failure `InvalidLifetime`,
which is what made a year-long lifetime look like it was refused for its range
when it was really refused for its `not_before`.

The original negative control broke all three defaults at once, so it could not
tell those apart. Restoring them one at a time surfaced it on the first run.
The 28-day lifetime stays, because RFC 9420 asks an application to define a
maximum and it bounds how long an unused init key is usable, but it is
**leaf-side policy, not an interop requirement**, and it is now documented as
policy. Step 0.3 pins the behaviour and fails if OpenMLS wires its cap up.

**This also says something about the phone.** Because no cap is applied,
`MlsManager::import_key_package` admits a key package from any peer with an
arbitrarily long lifetime, where RFC 9420 asks an implementation to reject it.
It is a freshness bound rather than an authentication one, so it is not urgent,
but it is ours to enforce and no library is doing it for us. Recorded in ADR
0021 and deliberately **not** fixed here, so that this PR keeps touching
nothing in `crates/`. Worth its own issue.

## What this buys, and how it compares

Not a smaller compromise: the absence of one. Forward secrecy,
post-compromise security, replay defence, sender authentication, the three
`derive(presented_key) == claimed_address` gates, and ADR 0010's unconditional
leaf identity binding apply to a leaf exactly as to a phone, because it is the
same protocol and the same checks.

For this device class that is not merely adequate. Continuous ratcheting is
something no shipped smart-home protocol provides: Z-Wave S2 distributes static
network-lifetime keys and its own specification argues against ever rotating
them, while Matter and Aliro do an ephemeral exchange at establishment and then
run a non-forward-secret fast path for most sessions. No regulation requires
better; "forward secrecy" does not appear in ETSI EN 303 645 at all.

It also removes a problem rather than solving it. A device with no MLS has no
way to advertise a capability, because advertisement rides in a key package and
nothing else, so every frame sent to it would fall to the JSON floor forever. A
device that does MLS mints a signed key package like any peer.

## Negative controls

Both harnesses can fail, and I checked that they do rather than assuming it.

**Footprint.** The leaf images are fed bytes that are deliberately not a valid
Welcome, so "it stopped parsing" is not a signal there the way it is for
`protocol`. `measure.sh` counts `mls_rs` symbols per image and fails below
fifty. Gutting `mls_workload` produces `FAIL: only 0 mls-rs symbols`, then the
file was restored from a copy rather than with `git checkout`, since it is
untracked.

**Interop.** The step 0 lines restore one default each and require the phone to
refuse the result. Each correction is a default someone will eventually tidy
back, and a harness that only proves the corrected path works cannot tell them
they broke it.

Restoring them **one at a time** rather than all at once is what corrected this
PR's own account of itself, and is the change reviewers should look at first.
See below.

## What is deliberately not proven

**The RAM figure.** MLS group state is heap-allocated, so `.bss` barely moves
and the working set is simply not in a link-time measurement. It needs a
running device. Called out in the ADR and both READMEs rather than papered
over.

**The 111 KiB curve saving** is symbol attribution, not a build with the curves
removed.

**Anything past the MLS boundary.** No radio, no fragmentation, no flash
persistence across a power cut, no timing on the part, and no exercise of the
SDK's envelope layer.

Two risks are accepted with open eyes and written into the ADR: mls-rs has had
no third-party security audit and its only `no_std` crypto provider is the one
its own authors label experimental, and an interop result covers exactly the
two versions it pinned.

## Changes

- **`docs/adr/0021-a-leaf-node-speaks-mls.md`** (new). The decision, the
  numbers, the three key package corrections, the obligations a device picks up
  (a time source at pairing, durable state before emission, a real entropy
  source), and a "what would undo this" naming a second sealing path.
- **ADR 0020** closing paragraph now points at 0021 instead of leaving the
  question open; ADR index updated.
- **`tools/mls-interop/`** (new, own workspace, pinned versions).
- **`tools/embedded-footprint/`**: third image behind optional features, a
  custom `getrandom` backend for linking, symbol guard, `--core-only`, README.
- **CI**: new `mls-interop` job. The footprint job needs no change; `measure.sh`
  picks up the new images itself.

Nothing in `crates/` is touched, which is why the workspace is untouched by
construction.

## Verification

`cargo clippy --workspace --locked -- -D warnings`; `cargo fmt --all --check`;
`cargo test --workspace --lib` (**2,459 passed, 0 failed**);
`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`;
`cargo clippy -p offline-protocol-core --no-default-features --target
thumbv8m.main-none-eabihf -- -D warnings`; both harnesses green with
`--locked`; both negative controls confirmed firing.

## Next

Stage 2 is a relocation PR with no behaviour change: `EncryptedMessage`'s
compact codec, `derive_address`, and the control-plane signing payload move to
a home reachable from both the engine and a `no_std` leaf. One open question
for that PR: whether that home is a **new crate between core and mls**, or a
**feature on core**. Core's documented doctrine is that it "never touches key
material", which argues for the new crate. Stage 3 is the `offline-protocol-leaf`
crate itself.

