### PR TITLE
docs(spec,security): specify what a leaf node owes at pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,46 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   copies come back. See
   [ADR 0022](./docs/adr/0022-one-sealed-layer-shared-with-the-leaf.md).
 
+- **What a leaf node owes at pairing is specified** in
+  [docs/spec/leaf-provisioning.md](./docs/spec/leaf-provisioning.md). A leaf is
+  a peer rather than a class of peer: same frames, same envelope, same trust
+  gates, no second sealing path. What is genuinely different is four
+  obligations that a passing build does not reveal, and each is stated with the
+  failure it prevents. A static artifact carries `{address, pubkey}` and never
+  a key package, because an init key is single use and a sticker is not. A key
+  package is minted from a **supplied** time, because an implementation that
+  cannot read a clock stamps a validity window at the Unix epoch and the peer
+  refuses it as expired, so a device that ships that way never pairs at all.
+  State is persisted **before** a frame that advanced it is emitted, because a
+  device that answers and then loses power comes back and reuses an AEAD nonce.
+  Entropy comes from real hardware, because MLS key generation is exactly as
+  strong as what that source returns.
+
+  The chapter also specifies the never-committing profile (what a leaf emits,
+  what it accepts, and what it must never emit), and states that a phone-driven
+  rekey reaches a device as a key package with `session_reset` set rather than
+  as an unsolicited Welcome, which is the sequence a device has to survive for
+  post-compromise security to arrive at all.
+
+- **The leaf profile in [capability
+  negotiation](./docs/spec/capability-negotiation.md)**: what a minimal device
+  advertises, and the two rules that are easy to get backwards on a part where
+  every kilobyte is argued over. A device that advertises nothing still
+  interoperates, because empty lists select the floor and the floor is a
+  complete conversation. And parsing stays unconditional on a device too: a
+  leaf that decodes only the envelope form it advertised drops frames from a
+  peer that legitimately believed it capable.
+
+- **Two threat-model entries for the device class**:
+  [A8, the provisioning-time adversary](./docs/security/threat-model.md), who
+  handles a device or its label before its owner does, and has no
+  cryptographic answer because every cryptographic check passes (the key on the
+  swapped label does derive to the address on that label); and R12, which says
+  plainly that boundary 3's "platform secure storage holds" assumption means an
+  OS keystore on a phone and whatever the part provides on a microcontroller.
+  One device, one key: a fleet sharing an identity key turns one extraction in
+  a laboratory into every unit's identity.
+
 ### Changed
 
 - **The envelope codec and `GroupId::new` now return `SealedError`** rather

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ implementation written against these documents should interoperate.
 | [Encryption envelopes](spec/encryption-envelopes.md) | MLS envelope forms, media chunk envelope, sealed rich payload |
 | [Group protocol](spec/group-protocol.md) | Group frames, membership commits, leaf identity binding, relay broadcast |
 | [Capability negotiation](spec/capability-negotiation.md) | What peers advertise, what it gates, what absence means |
+| [Leaf node provisioning](spec/leaf-provisioning.md) | What a constrained device owes at pairing, the never-committing profile |
 
 ## Security
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -34,11 +34,20 @@ reduces but does not eliminate what that reveals.
 | **A5. Malicious application** | Runs above the SDK on the same device | Full access to the SDK's public API |
 | **A6. Device compromise** | Root or equivalent on the device | Everything |
 | **A7. Hostile gateway** | Operates or has compromised a gateway a device attached to | Everything A3 has, at a zone's bridge to the wider network: originates verdicts and presence answers, and observes attach sessions |
+| **A8. Provisioning-time adversary** | Handles a leaf node, or its labelling, before its owner does | Chooses which key the device's pairing artifact names, and what the device pairs with first |
 
 A6 is out of scope. The protocol assumes platform secure storage holds. A5 is
 partly in scope: the SDK refuses control-frame injection through public send
 surfaces and refuses to hand back attacker-chosen identifiers, but it does not
 defend an application against itself.
+
+A8 arrives with leaf nodes and has no cryptographic answer, because every
+cryptographic check passes: the key on the swapped label does derive to the
+address on that label. Its anchor is the one an invite already relies on, the
+out-of-band human context in which the artifact was obtained, and what the
+protocol adds is that the substitution is detectable afterwards, because an
+address is stable and self-certifying. See
+[Leaf node provisioning](../spec/leaf-provisioning.md#the-provisioning-time-adversary).
 
 ## Trust boundaries
 
@@ -446,6 +455,24 @@ accepted, which is why it is recorded here rather than raised as a residual of
 its own.
 
 This shrinks when the engine's import hardening reaches its Rust release.
+
+### R12. A leaf node's identity key is only as protected as the part
+
+Boundary 3 assumes platform secure storage. A phone has an OS-backed keystore
+behind that assumption; a microcontroller has whatever the part provides, and
+an attacker holding the device has physical access rather than the remote
+access A6 describes.
+
+**Why it stands:** it is an integration property, not a protocol one. A leaf
+SHOULD hold its identity key in the part's secure key storage, reachable
+through the same storage seam the SDK already uses for key material, and a
+device that keeps the key in general flash yields it to anyone who holds the
+device.
+
+**What bounds it:** one device, one key. A fleet provisioned with a shared
+identity key turns one extraction into every unit's identity, and the address
+that names one device names all of them. See
+[Leaf node provisioning](../spec/leaf-provisioning.md#identity-and-key-storage).
 
 ## The telemetry producer rule
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -20,6 +20,7 @@ document says which reading is normative for the wire.
 | [Encryption envelopes](encryption-envelopes.md) | The `__MLS_ENC__` envelope forms, the media chunk envelope, and the sealed rich payload |
 | [Group protocol](group-protocol.md) | Group frames, membership commits, leaf identity binding, relay broadcast and the delivery report |
 | [Capability negotiation](capability-negotiation.md) | What peers advertise, what each capability gates, and what happens on absence |
+| [Leaf node provisioning](leaf-provisioning.md) | What a constrained device owes at pairing, the never-committing profile, and the provisioning-time adversary |
 | [Username discovery and invites](username-discovery.md) | The self-certifying invite payload, and the non-authoritative username directory |
 | [The gateway contract](gateway-contract.md) | What a gateway is, the five verbs it implements, the gateway-daemon wire protocol, and the backbone |
 

--- a/docs/spec/capability-negotiation.md
+++ b/docs/spec/capability-negotiation.md
@@ -153,6 +153,43 @@ and MUST NOT feed envelope selection. It is a second-hand claim, adequate for
 deciding whether to include optional context in a group message, not adequate
 for anything else.
 
+## The leaf profile
+
+A constrained device negotiates through the same key package as any other peer.
+This is the reason a leaf node runs MLS at all: capability advertisement rides
+in a key package and nowhere else, so a device with no key package to mint has
+no channel to advertise anything, and every frame sent to it falls to the floor
+forever. See [ADR 0021](../adr/0021-a-leaf-node-speaks-mls.md) for the decision
+and [Leaf node provisioning](leaf-provisioning.md) for what a device owes at
+pairing.
+
+A minimal leaf advertises little and works fully:
+
+| Field | A minimal leaf | Effect |
+|-------|----------------|--------|
+| `wire_versions` | `[1]` if it decodes the binary hop encoding, else empty | Empty means peers send it JSON, which every conforming receiver parses anyway |
+| `env_versions` | `[1]` if it decodes the compact envelope, else empty | Empty means peers send the JSON envelope, which is the permanent floor |
+| `rich_versions` | Empty | Peers send plain text and drop extras rather than sending them in a weaker form |
+| `data_versions` | Empty | No document replication with this peer |
+| `nostr_pubkey` | Absent unless the device is reachable over that carrier | Peers seal to the publicly computable key |
+
+Two consequences follow from the universal rules above, and both are easy to
+get backwards on a device where every kilobyte is argued over.
+
+**A device that advertises nothing still interoperates.** Empty lists select
+the floor, and the floor is a complete conversation: a JSON-encoded `Message`
+carrying a JSON `__MLS_ENC__` envelope. Advertising a capability buys smaller
+frames, never a feature the peer would otherwise withhold.
+
+**Parsing is unconditional on a device too.** A leaf MUST accept every
+historical form of everything it receives regardless of what it advertised,
+which for the envelope means all three inbound forms described in
+[Encryption envelopes](encryption-envelopes.md). A device that decodes only the
+form it advertises drops frames from a peer that legitimately believed it
+capable, and the shipping order in [Adding a capability](#adding-a-capability)
+exists precisely to keep that from happening in a fleet where firmware updates
+slowly.
+
 ## Adding a capability
 
 1. Decide the layer. Hop-local capabilities are in-memory and re-exchanged;

--- a/docs/spec/leaf-provisioning.md
+++ b/docs/spec/leaf-provisioning.md
@@ -1,0 +1,223 @@
+# Leaf node provisioning
+
+## What a leaf node is
+
+A leaf node is a constrained device that speaks this protocol as a peer: a
+door lock, a sensor, a mains-powered relay. It parses frames, validates
+addressing, runs MLS, and holds an end-to-end encrypted conversation with a
+phone under the same guarantees a phone gets.
+
+**A leaf is a peer, not a class of peer.** It sends and receives the frames in
+[Control messages](control-messages.md), seals with the envelope in
+[Encryption envelopes](encryption-envelopes.md), derives and checks addresses by
+[Identity and addressing](identity.md), and advertises capabilities the way
+[Capability negotiation](capability-negotiation.md) describes. There is no
+second sealing path, no leaf-only prefix, and no reduced guarantee. A device
+that cannot meet the obligations in this chapter is not a leaf node with fewer
+properties; it is a relay that forwards ciphertext it cannot read.
+
+The decision behind this, and the measurements that justified it, are in
+[ADR 0021](../adr/0021-a-leaf-node-speaks-mls.md). The pieces both ends share
+rather than implement twice are in
+[ADR 0022](../adr/0022-one-sealed-layer-shared-with-the-leaf.md).
+
+## Four obligations
+
+These hold before any mechanism below makes sense. Three of them are invisible
+in a passing build and expensive to discover on a bench.
+
+### 1. A static artifact carries an address and a key, never a key package
+
+The artifact a person scans or a label carries MUST contain `{address,
+pubkey}`, in the `InviteV1` form specified in
+[Username discovery and invites](username-discovery.md#the-invite-payload). It
+MUST NOT contain an MLS key package.
+
+An MLS init key is single use and a sticker is not. The second person to scan a
+key package printed on a label gets a collision, and the failure surfaces as an
+establishment that silently does not converge rather than as a refusal. That is
+the same collision [ADR 0012](../adr/0012-one-key-package-per-peer.md) removed
+from the push path, where one package advertised to every peer left every peer
+after the first unable to establish. A fresh key package flows over the pairing
+radio instead, one per pairing.
+
+### 2. A key package is minted from a supplied time, not a read clock
+
+A leaf MUST obtain a wall-clock time at pairing and pass it into key package
+generation. It MUST NOT rely on its MLS implementation to read one.
+
+A bare-metal device has no clock, and an implementation that cannot read one
+stamps a validity window beginning at the Unix epoch. The peer refuses that
+package as expired, so a device that ships this way never pairs at all. The
+time may come from the radio stack, from the commissioner, or from the pairing
+exchange itself; this specification does not choose among them, and requires
+only that one of them supplies it.
+
+Key package validity is a **freshness bound, not an authentication mechanism**.
+A wrong clock costs availability, never confidentiality. It still has to be
+designed rather than discovered.
+
+### 3. State is durable before a frame is emitted
+
+A leaf MUST persist its MLS state before emitting any frame whose production
+advanced that state, and MUST NOT emit the frame if the write fails.
+
+The failure this prevents is not a delivery hiccup. A device that answers and
+then loses power before its ratchet state reaches flash comes back and reuses an
+AEAD nonce, which is a confidentiality failure in a protocol whose whole claim
+is the AEAD boundary. Ordering the persist before the emit is the requirement.
+The write SHOULD be atomic, so that a power cut during the write leaves either
+the old state or the new one and never a torn record.
+
+### 4. Entropy is real
+
+A leaf MUST source randomness from a hardware entropy source. MLS key
+generation is exactly as strong as what that source returns, and nothing else
+in the protocol compensates for a weak one.
+
+Randomness is the integrator's obligation because it is the integrator's part
+that has it: an MLS implementation built for bare metal reaches a symbol the
+firmware supplies. Measurement harnesses in this repository register a counter
+in that slot so an image that never executes can be linked and sized. That stub
+must never reach firmware, and it is documented as such where it appears.
+
+## The pairing exchange
+
+Pairing is the ordinary session establishment described in
+[Session lifecycle](../state-machines/session-lifecycle.md), carried over
+whatever radio the device and the phone share. Nothing about it is leaf
+specific except where the time in step 2 comes from.
+
+1. **Out-of-band anchor.** The person scans the device's `InviteV1` artifact,
+   or the commissioner supplies the same `{address, pubkey}` pair. The verifier
+   MUST run the full verification order in
+   [Username discovery and invites](username-discovery.md#verification),
+   ending in `derive_address(pubkey) == address`. Any failure means refuse.
+
+2. **The device mints a key package** from a supplied timestamp and sends it as
+   a signed `__MLS_KEY_PKG__` frame.
+
+3. **The phone establishes the session**: it imports the package, creates the
+   two-member group, and sends a signed `__MLS_WELCOME__`.
+
+4. **The device joins** from the Welcome and confirms, by sealing an
+   `__MLS_ENC_CONFIRM__` marker inside an ordinary `__MLS_ENC__` envelope. A
+   group-aware decrypt is the only proof that converges a peer which created a
+   session of its own, so a device that answers only the plaintext probe leaves
+   that peer unconfirmed.
+
+From step 4 the pair is an ordinary 1:1 session. Every later message is an
+`__MLS_ENC__` envelope in both directions.
+
+### What the anchor is, and is not
+
+The out-of-band artifact is the whole of first-contact trust, exactly as it is
+for two phones. It carries no key package, so it grants no session by itself;
+what it grants is the address to compare a presented key against. Everything
+after it is `derive(presented_key) == claimed_address`, unconditionally, at
+every site that accepts an identity claim.
+
+A leaf MUST apply that comparison at each of them, and MUST refuse an identifier
+that does not parse as an address rather than skipping the check. Answering
+"acceptable" for an unparseable identifier is the bypass, not a lenience: a
+claim that cannot be checked is the one an attacker makes.
+
+## The key package a leaf mints
+
+Three properties are load bearing. Each is a default that produces a package
+the peer refuses, or a policy this protocol asks an application to set.
+
+| Property | Requirement | Why |
+|----------|-------------|-----|
+| `not_before` | MUST be backdated below the supplied time | Receivers test `not_before < now` strictly, so a package stamped with the current second is refused as not yet valid. The backdate is also the margin that absorbs clock skew between the two devices |
+| Total lifetime | SHOULD be bounded to weeks rather than a year | RFC 9420 asks an application to define a maximum. A shorter window bounds how long an unused init key stays usable. This is leaf-side policy, not something the peer enforces |
+| Framing | The frame body carries a **bare** key package | An implementation whose convenience API returns one wrapped in an `MLSMessage` MUST unwrap it before encoding. Both forms are legal MLS; only one is this protocol's wire |
+
+The reference values for the backdate and the lifetime are constants in
+`offline-protocol-sealed`, shared by both ends rather than restated.
+
+## The never-committing profile
+
+A leaf joins a two-member group and never commits to it. The phone creates the
+group, adds the device, and issues every commit; the device joins, opens what
+arrives, answers, and persists.
+
+A conforming leaf:
+
+- **emits** `__MLS_KEY_PKG__`, `__MLS_ENC__`, and `__MLS_CONFIRM_ACK__`;
+- **accepts** `__MLS_KEY_PKG__` (including one that sets `session_reset`),
+  `__MLS_WELCOME__`, `__MLS_ENC__` carrying either an application message or a
+  commit, and `__MLS_CONFIRM_PROBE__`;
+- **never emits** a Welcome, a commit, a proposal, or any group, rich, document
+  or relay frame.
+
+Per-commit cost on the device is two elliptic-curve operations. Per-message
+cost is symmetric only.
+
+### Post-compromise security arrives on the phone's cadence
+
+Healing happens when a commit rotates the device's leaf in the ratchet tree. A
+device that never commits does not originate those, so the phone's session
+rekey path drives recovery and its interval bounds the window.
+
+A phone-driven rekey reaches the device as a `__MLS_KEY_PKG__` frame with
+`session_reset` set, not as an unsolicited Welcome. A leaf MUST, on receiving
+it, discard the existing session and mint a fresh key package, so that the
+exchange begins again from step 2 above. A leaf that treats `session_reset` as
+an ordinary key package refresh keeps a session the phone has already discarded,
+and every later frame from it decrypts to nothing.
+
+Letting a device originate Update proposals would make it self-healing on its
+own schedule. That is deliberately outside this version.
+
+## Identity and key storage
+
+A leaf holds one long-term identity keypair, generated at provisioning, with
+the properties [Identity and addressing](identity.md#the-identity-key) requires
+of every install: it signs control frames, it derives the address, and it is
+the signature key inside the MLS credential.
+
+**One device, one key.** A fleet provisioned with a shared identity key is one
+identity on many devices, which this protocol neither prevents nor supports
+([Identity and addressing](identity.md#what-an-address-does-not-tell-you)). For
+devices the consequence is sharper than for installs: extracting the key from
+one unit in a laboratory yields every unit's identity, and the address that
+names one lock names all of them.
+
+The key SHOULD live in the part's secure key storage rather than in general
+flash. A device that stores it in the clear is a device whose identity is
+recoverable by anyone who holds it.
+
+## The provisioning-time adversary
+
+Pairing anchors on an artifact a person handles. That admits an adversary the
+phone-to-phone paths do not face in the same form: someone who controls the
+device, or its label, before the owner does.
+
+- **Sticker swap.** An attacker replaces the artifact on the box with one
+  naming a key they hold. The scan then pairs the owner's phone with the
+  attacker's device, and every check passes, because the check is that the key
+  derives to the address on the label and it does.
+- **Malicious installer.** Whoever commissions the device chooses what it
+  pairs with, and may pair it with themselves first.
+
+**Neither is a cryptographic failure and neither has a cryptographic fix.** The
+anchor for a leaf is the same anchor as for an invite: the out-of-band human
+context in which the artifact was obtained. A label on a device in a sealed box
+from a trusted supplier carries that context; one photographed and re-printed
+does not.
+
+What the protocol does provide is that the compromise is **detectable and
+bounded**. The address a device presents is stable and self-certifying, so a
+substituted device has a different address, and an owner who records the
+address at first pairing sees the substitution on any later re-pair. An
+implementation SHOULD surface the address at pairing rather than only a
+petname, because a petname is chosen by whoever made the artifact and the
+address is not.
+
+## What this chapter does not decide
+
+The storage backend, the radio, the pairing user experience, whether a device
+ever joins a group space rather than a pair, and where the time in obligation 2
+comes from. Each is an integration choice, and none of them changes a frame on
+the wire.


### PR DESCRIPTION
Stage 3 of the leaf payload crypto work, part A of three. This is the docs-only part, and it closes a gap found while planning the crate: **Stage 1's spec half never shipped.** [ADR 0021](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/adr/0021-a-leaf-node-speaks-mls.md) landed with #394, but neither #394 nor #395 touched `docs/spec/` at all, so the leaf profile and the provisioning chapter that ADR called for do not exist. An ADR is the record of a decision; it is not the contract an implementer builds against.

No code changes.

## What lands

**`docs/spec/leaf-provisioning.md`** (new chapter). The framing is that a leaf is a peer rather than a class of peer: same frames, same envelope, same trust gates, no second sealing path. That is the whole reason ADR 0021 was affordable, and it is the first thing an implementer should read.

What is genuinely different is four obligations, each stated with the failure it prevents, because all four are invisible in a passing build and expensive on a bench:

| Obligation | The failure it prevents |
|---|---|
| A static artifact carries `{address, pubkey}`, never a key package | An init key is single use and a sticker is not. The second scan surfaces as an establishment that silently does not converge, which is the collision [ADR 0012](https://github.com/Offline-Protocol/offline-protocol-sdk/blob/main/docs/adr/0012-one-key-package-per-peer.md) removed from the push path |
| A key package is minted from a **supplied** time | An implementation that cannot read a clock stamps a validity window at the Unix epoch, so the peer refuses it as expired and a device shipping that way never pairs at all |
| State is persisted **before** a frame that advanced it is emitted | A device that answers and then loses power comes back and reuses an AEAD nonce |
| Entropy is real hardware | MLS key generation is exactly as strong as what that symbol returns, and the measurement harnesses in this tree register a counter in that slot |

The chapter also specifies the never-committing profile (what a leaf emits, what it accepts, what it must never emit) and one sequence a device has to survive for post-compromise security to arrive at all: **a phone-driven rekey reaches a device as a `__MLS_KEY_PKG__` with `session_reset` set, not as an unsolicited Welcome.** A device that treats it as an ordinary key package refresh keeps a session the phone has already discarded, and every later frame from it decrypts to nothing.

**The leaf profile in `capability-negotiation.md`.** What a minimal device advertises, plus two rules that are easy to get backwards on a part where every kilobyte is argued over: a device that advertises nothing still interoperates (empty selects the floor, and the floor is a complete conversation), and parsing stays unconditional on a device too (a leaf that decodes only the form it advertised drops frames from a peer that legitimately believed it capable).

**Two threat-model entries for the device class.** `A8`, the provisioning-time adversary who handles a device or its label before its owner does, which has no cryptographic answer because every cryptographic check passes: the key on the swapped label does derive to the address on that label. Its anchor is the one an invite already relies on, and what the protocol adds is that the substitution is detectable afterwards, because an address is stable and self-certifying. And `R12`, which says plainly that boundary 3's "platform secure storage holds" assumption means an OS keystore on a phone and whatever the part provides on a microcontroller. One device, one key: a fleet sharing an identity key turns one laboratory extraction into every unit's identity.
