### PR TITLE
perf(bindings): make the Python internet send loop activity-adaptive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ archived by series under [docs/changelog/](docs/changelog/); see the
 
 ## [Unreleased]
 
+### Changed
+
+- **The Python internet send loop is now activity-adaptive.** The relay bridge
+  drained the core's outbox on a fixed 100 ms tick, so a reply to an inbound
+  frame waited out most of a tick before leaving, and that wait dominated a
+  warm round trip. An inbound frame now wakes the send loop immediately, a
+  drain that moved frames re-drains at event-loop speed, and an empty drain
+  backs off exponentially (2 ms doubling up to the unchanged 100 ms idle
+  interval). A warm round trip drops from ~100 ms to single-digit
+  milliseconds, with no standing busy-poll and no change to quiet-link cost.
+  Python only; the Swift and Kotlin managers keep the fixed tick for now
+  (see [docs/bridges/python.md](docs/bridges/python.md#p7-the-internet-send-loop-is-adaptive-here-and-fixed-elsewhere)). (#421)
+
 ### Fixed
 
 - **Internet-only providers no longer flap a relay's rate limiter into a

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -25,14 +25,7 @@ logger = logging.getLogger(__name__)
 
 # -- Constants (matching iOS InternetManager.swift) ---------------------------
 
-_MESSAGE_POLL_INTERVAL = 0.1  # idle poll, 100 ms
-# Activity-adaptive send polling. For a short window after any inbound frame or
-# outbound drain the send loop polls tightly, so an asynchronously-queued reply
-# ships in a few ms instead of waiting a full idle interval; when genuinely idle
-# it relaxes back to _MESSAGE_POLL_INTERVAL to keep CPU near zero. This gives low
-# latency under load without a fixed busy-poll.
-_SEND_HOT_WINDOW = 0.5  # stay "hot" this long after activity (seconds)
-_SEND_HOT_INTERVAL = 0.002  # 2 ms poll while hot
+_MESSAGE_POLL_INTERVAL = 0.1  # idle send poll, 100 ms
 _RECONNECT_INITIAL_DELAY = 1.0  # seconds
 _RECONNECT_MAX_DELAY = 30.0
 _RECONNECT_BACKOFF_MULTIPLIER = 2.0
@@ -44,6 +37,18 @@ _MAX_CONCURRENT_SENDS = 50
 # In-flight tracker tuning (mirrors iOS/Android RecipientInFlightTracker).
 _RIFT_TTL_MS = 60_000
 _RIFT_MAX_PER_RECIPIENT = 32
+
+# -- Constants (Python only) --------------------------------------------------
+# The send loop here is activity-adaptive (see _poll_outgoing_loop); the
+# Swift/Kotlin managers still poll at the fixed _MESSAGE_POLL_INTERVAL.
+
+# Floor of the send loop's backoff ramp: the wait after activity, doubling on
+# every quiet pass until it reaches _MESSAGE_POLL_INTERVAL.
+_SEND_MIN_POLL_INTERVAL = 0.002  # 2 ms
+# The in-flight sweep in _poll_and_send_messages was sized for the old fixed
+# 10 Hz tick; the adaptive loop can drain at event-loop speed during a burst,
+# so the sweep is gated back to that original cadence.
+_PRUNE_MIN_INTERVAL_MS = 100
 
 
 class _RecipientInFlightTracker:
@@ -205,9 +210,6 @@ class InternetManager(TransportManager):
 
         # Event loop — captured in start() for thread-safe scheduling
         self._loop: asyncio.AbstractEventLoop | None = None
-        # Monotonic timestamp of the last send/recv activity, driving the
-        # activity-adaptive send poll (see _poll_outgoing_loop).
-        self._last_activity: float = 0.0
 
         # Async tasks
         self._recv_task: asyncio.Task[None] | None = None
@@ -219,9 +221,16 @@ class InternetManager(TransportManager):
         # weak task table cannot GC them mid-execution.
         self._process_tasks: set[asyncio.Task[None]] = set()
         self._send_semaphore: asyncio.Semaphore = asyncio.Semaphore(_MAX_CONCURRENT_SENDS)
+        # Set by the receive loop on every inbound frame; the send loop waits
+        # on it, so a reply the core queued while handling that frame ships
+        # immediately instead of waiting out a poll interval.
+        self._send_wake: asyncio.Event = asyncio.Event()
         # Correlates the relay's recipient-keyed DeliveryError back to in-flight
         # sends (parity with the iOS/Android bridges).
         self._inflight = _RecipientInFlightTracker()
+        # Gate for the tracker sweep in _poll_and_send_messages (see
+        # _PRUNE_MIN_INTERVAL_MS).
+        self._last_prune_ms: int = 0
         self._reconnect_handle: asyncio.TimerHandle | None = None
 
         # Re-entrancy guard for `_handle_connection_closed`. Set synchronously
@@ -689,11 +698,12 @@ class InternetManager(TransportManager):
                 else:
                     data = raw.encode("utf-8")
                 self._bytes_received += len(data)
-                # An inbound frame is likely to produce an outbound reply soon
-                # (the handler queues it, possibly from a worker thread). Mark
-                # the transport "hot" so the send loop polls tightly and picks
-                # that reply up in a few ms rather than a full idle interval.
-                self._last_activity = time.monotonic()
+                # Wake the send loop before dispatch: the handlers below feed
+                # the core synchronously, so by the time the send loop runs,
+                # any reply this frame produces is typically already queued.
+                # Replies queued later (from a worker thread) are covered by
+                # the loop's backoff ramp re-arming from its floor.
+                self._send_wake.set()
                 self._process_received(data)
         except websockets.ConnectionClosed:
             await self._handle_connection_closed(None)
@@ -1020,28 +1030,66 @@ class InternetManager(TransportManager):
     async def _poll_outgoing_loop(self) -> None:
         """Drain the core's outbound queue, adaptively.
 
-        The old form slept a fixed _MESSAGE_POLL_INTERVAL between every drain, so
-        a reply queued just after a tick waited up to a full interval per
-        direction (the dominant single-call latency under load). Instead, when a
-        drain moved at least one frame, yield and re-drain immediately so a burst
-        empties at event-loop speed; only sleep when the queue came back empty,
-        and then only briefly for a short window after recent activity, relaxing
-        to the full idle interval once genuinely quiet. When the send-concurrency
-        semaphore is saturated the drain reports 0 (no free slots), so the loop
-        sleeps rather than busy-spinning.
+        The core outbox is poll-only across the FFI, so some poll cadence is
+        unavoidable. A fixed cadence puts up to a full interval in front of
+        every frame (the dominant single-call latency), while a standing tight
+        poll burns CPU on a quiet link. Three rules bound both costs:
+
+        * A drain that moved frames re-drains after one yield, so a burst
+          empties at event-loop speed.
+        * An empty drain waits on ``_send_wake`` (set by the receive loop on
+          every inbound frame) with a timeout that doubles from
+          ``_SEND_MIN_POLL_INTERVAL`` up to ``_MESSAGE_POLL_INTERVAL``. The
+          wake ships a reply within milliseconds of the frame that provoked
+          it; the doubling covers replies queued slightly later (from a
+          worker thread) and converges to one poll per idle interval when
+          the link is genuinely quiet.
+        * When the send-concurrency slots are saturated the drain reports 0
+          without touching the FFI, so backpressure ramps the wait up
+          instead of busy-spinning; the next drain that moves frames resets
+          it to the floor.
+
+        A locally-queued send with no inbound trigger still waits at most one
+        idle interval, exactly as it did when the cadence was fixed.
         """
         try:
+            delay = _MESSAGE_POLL_INTERVAL
             while self._connected and self._authenticated:
+                self._send_wake.clear()
                 drained = self._poll_and_send_messages()
                 if drained > 0:
-                    self._last_activity = time.monotonic()
+                    # Yield once so the send tasks just created get scheduled,
+                    # then re-drain immediately.
+                    delay = _SEND_MIN_POLL_INTERVAL
                     await asyncio.sleep(0)
-                elif time.monotonic() - self._last_activity < _SEND_HOT_WINDOW:
-                    await asyncio.sleep(_SEND_HOT_INTERVAL)
-                else:
-                    await asyncio.sleep(_MESSAGE_POLL_INTERVAL)
+                    continue
+                woken = await self._wait_for_send_wake(delay)
+                delay = self._next_send_delay(delay, active=woken)
         except asyncio.CancelledError:
             return
+
+    async def _wait_for_send_wake(self, timeout: float) -> bool:
+        """Wait until an inbound frame wakes the send loop, or *timeout* passes.
+
+        Returns True when woken (activity), False on a quiet timeout.
+        """
+        try:
+            await asyncio.wait_for(self._send_wake.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return False
+        return True
+
+    @staticmethod
+    def _next_send_delay(prev: float, active: bool) -> float:
+        """The send loop's next wait timeout after one empty drain pass.
+
+        Activity (an inbound-frame wake) resets the ramp to the floor so an
+        imminently-queued reply is picked up within a few ms; each quiet pass
+        doubles the wait, capped at the idle interval.
+        """
+        if active:
+            return _SEND_MIN_POLL_INTERVAL
+        return min(prev * 2.0, _MESSAGE_POLL_INTERVAL)
 
     def _poll_and_send_messages(self) -> int:
         """Drain outgoing messages from the protocol and send them.
@@ -1050,10 +1098,16 @@ class InternetManager(TransportManager):
         prevent unbounded task creation when the protocol core has a large
         outbox.  Remaining messages will be picked up on the next poll tick.
         Returns the number of frames drained this call so the caller can
-        re-drain immediately under load instead of sleeping a fixed interval.
+        re-drain immediately under load instead of waiting a fixed interval.
         """
-        # Drop in-flight tracker entries older than the TTL each tick.
-        self._inflight.prune(self._now_ms())
+        # Drop in-flight tracker entries older than the TTL. Time-gated: the
+        # adaptive send loop calls this at event-loop speed during a burst,
+        # and the sweep, which walks every tracked recipient, was sized for
+        # the old fixed 10 Hz tick.
+        now_ms = self._now_ms()
+        if now_ms - self._last_prune_ms >= _PRUNE_MIN_INTERVAL_MS:
+            self._inflight.prune(now_ms)
+            self._last_prune_ms = now_ms
 
         # Limit to available concurrency slots to avoid creating thousands
         # of tasks that all block on the semaphore.

--- a/bindings/python/offline_protocol_sdk/internet_manager.py
+++ b/bindings/python/offline_protocol_sdk/internet_manager.py
@@ -25,7 +25,14 @@ logger = logging.getLogger(__name__)
 
 # -- Constants (matching iOS InternetManager.swift) ---------------------------
 
-_MESSAGE_POLL_INTERVAL = 0.1  # 100 ms
+_MESSAGE_POLL_INTERVAL = 0.1  # idle poll, 100 ms
+# Activity-adaptive send polling. For a short window after any inbound frame or
+# outbound drain the send loop polls tightly, so an asynchronously-queued reply
+# ships in a few ms instead of waiting a full idle interval; when genuinely idle
+# it relaxes back to _MESSAGE_POLL_INTERVAL to keep CPU near zero. This gives low
+# latency under load without a fixed busy-poll.
+_SEND_HOT_WINDOW = 0.5  # stay "hot" this long after activity (seconds)
+_SEND_HOT_INTERVAL = 0.002  # 2 ms poll while hot
 _RECONNECT_INITIAL_DELAY = 1.0  # seconds
 _RECONNECT_MAX_DELAY = 30.0
 _RECONNECT_BACKOFF_MULTIPLIER = 2.0
@@ -198,6 +205,9 @@ class InternetManager(TransportManager):
 
         # Event loop — captured in start() for thread-safe scheduling
         self._loop: asyncio.AbstractEventLoop | None = None
+        # Monotonic timestamp of the last send/recv activity, driving the
+        # activity-adaptive send poll (see _poll_outgoing_loop).
+        self._last_activity: float = 0.0
 
         # Async tasks
         self._recv_task: asyncio.Task[None] | None = None
@@ -679,6 +689,11 @@ class InternetManager(TransportManager):
                 else:
                     data = raw.encode("utf-8")
                 self._bytes_received += len(data)
+                # An inbound frame is likely to produce an outbound reply soon
+                # (the handler queues it, possibly from a worker thread). Mark
+                # the transport "hot" so the send loop polls tightly and picks
+                # that reply up in a few ms rather than a full idle interval.
+                self._last_activity = time.monotonic()
                 self._process_received(data)
         except websockets.ConnectionClosed:
             await self._handle_connection_closed(None)
@@ -1003,20 +1018,39 @@ class InternetManager(TransportManager):
     # -- outgoing message poll loop -------------------------------------------
 
     async def _poll_outgoing_loop(self) -> None:
-        """Poll the protocol core for outgoing messages every 100 ms."""
+        """Drain the core's outbound queue, adaptively.
+
+        The old form slept a fixed _MESSAGE_POLL_INTERVAL between every drain, so
+        a reply queued just after a tick waited up to a full interval per
+        direction (the dominant single-call latency under load). Instead, when a
+        drain moved at least one frame, yield and re-drain immediately so a burst
+        empties at event-loop speed; only sleep when the queue came back empty,
+        and then only briefly for a short window after recent activity, relaxing
+        to the full idle interval once genuinely quiet. When the send-concurrency
+        semaphore is saturated the drain reports 0 (no free slots), so the loop
+        sleeps rather than busy-spinning.
+        """
         try:
             while self._connected and self._authenticated:
-                self._poll_and_send_messages()
-                await asyncio.sleep(_MESSAGE_POLL_INTERVAL)
+                drained = self._poll_and_send_messages()
+                if drained > 0:
+                    self._last_activity = time.monotonic()
+                    await asyncio.sleep(0)
+                elif time.monotonic() - self._last_activity < _SEND_HOT_WINDOW:
+                    await asyncio.sleep(_SEND_HOT_INTERVAL)
+                else:
+                    await asyncio.sleep(_MESSAGE_POLL_INTERVAL)
         except asyncio.CancelledError:
             return
 
-    def _poll_and_send_messages(self) -> None:
+    def _poll_and_send_messages(self) -> int:
         """Drain outgoing messages from the protocol and send them.
 
         Only dequeues up to the number of available semaphore slots to
         prevent unbounded task creation when the protocol core has a large
         outbox.  Remaining messages will be picked up on the next poll tick.
+        Returns the number of frames drained this call so the caller can
+        re-drain immediately under load instead of sleeping a fixed interval.
         """
         # Drop in-flight tracker entries older than the TTL each tick.
         self._inflight.prune(self._now_ms())
@@ -1047,6 +1081,8 @@ class InternetManager(TransportManager):
             self._send_tasks.add(task)
             task.add_done_callback(self._send_tasks.discard)
             drained += 1
+
+        return drained
 
     @staticmethod
     def _now_ms() -> int:

--- a/bindings/python/tests/test_internet_manager.py
+++ b/bindings/python/tests/test_internet_manager.py
@@ -1092,3 +1092,26 @@ class TestDeliveryErrorRecipientKeyed:
         }
         assert "delivered" not in failed
         assert "stuck" in failed
+
+
+class TestAdaptiveSendDrain:
+    """Pins the drain-until-empty contract the activity-adaptive send loop relies
+    on: _poll_and_send_messages must report how many frames it moved so the loop
+    can re-drain immediately under load and relax only when the queue is empty.
+    """
+
+    @pytest.mark.asyncio
+    async def test_poll_returns_drained_count(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        mgr._send_message = AsyncMock()  # type: ignore[method-assign]
+        msgs = [MagicMock(message_id=f"m{i}", recipient_id="r", data=b"x") for i in range(3)]
+        mock_protocol.internet_get_next_message = MagicMock(side_effect=[*msgs, None])
+        drained = mgr._poll_and_send_messages()
+        assert drained == 3, "must report the number of frames drained"
+
+    @pytest.mark.asyncio
+    async def test_poll_empty_queue_returns_zero(self, mock_protocol: MagicMock) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        mgr._send_message = AsyncMock()  # type: ignore[method-assign]
+        mock_protocol.internet_get_next_message = MagicMock(return_value=None)
+        assert mgr._poll_and_send_messages() == 0, "empty queue drains nothing (loop then relaxes)"

--- a/bindings/python/tests/test_internet_manager.py
+++ b/bindings/python/tests/test_internet_manager.py
@@ -1094,12 +1094,20 @@ class TestDeliveryErrorRecipientKeyed:
         assert "stuck" in failed
 
 
-class TestAdaptiveSendDrain:
-    """Pins the drain-until-empty contract the activity-adaptive send loop relies
-    on: _poll_and_send_messages must report how many frames it moved so the loop
-    can re-drain immediately under load and relax only when the queue is empty.
-    """
+# ---------------------------------------------------------------------------
+# The activity-adaptive send loop. Every piece of the policy is pinned here:
+# the drain-count contract, the backoff ramp, the inbound-frame wake, and the
+# saturation guard. A revert of any piece must fail one of these tests, not a
+# latency measurement.
+# ---------------------------------------------------------------------------
+from offline_protocol_sdk.internet_manager import (
+    _MAX_CONCURRENT_SENDS,
+    _MESSAGE_POLL_INTERVAL,
+    _SEND_MIN_POLL_INTERVAL,
+)
 
+
+class TestAdaptiveSendLoop:
     @pytest.mark.asyncio
     async def test_poll_returns_drained_count(self, mock_protocol: MagicMock) -> None:
         mgr = InternetManager(mock_protocol, "dev-1")
@@ -1115,3 +1123,109 @@ class TestAdaptiveSendDrain:
         mgr._send_message = AsyncMock()  # type: ignore[method-assign]
         mock_protocol.internet_get_next_message = MagicMock(return_value=None)
         assert mgr._poll_and_send_messages() == 0, "empty queue drains nothing (loop then relaxes)"
+
+    def test_saturated_slots_report_zero_without_touching_the_ffi(
+        self, mock_protocol: MagicMock
+    ) -> None:
+        # With every concurrency slot occupied the drain must not call into
+        # the core at all: the loop's backoff then paces the retry, so
+        # saturation cannot become a busy-spin against the FFI.
+        mgr = InternetManager(mock_protocol, "dev-1")
+        mgr._send_tasks = {MagicMock() for _ in range(_MAX_CONCURRENT_SENDS)}
+        assert mgr._poll_and_send_messages() == 0
+        mock_protocol.internet_get_next_message.assert_not_called()
+
+    def test_delay_resets_to_the_floor_on_activity(self) -> None:
+        assert (
+            InternetManager._next_send_delay(_MESSAGE_POLL_INTERVAL, active=True)
+            == _SEND_MIN_POLL_INTERVAL
+        )
+
+    def test_delay_doubles_when_quiet_and_caps_at_the_idle_interval(self) -> None:
+        delays = []
+        d = _SEND_MIN_POLL_INTERVAL
+        for _ in range(8):
+            d = InternetManager._next_send_delay(d, active=False)
+            delays.append(d)
+        assert delays == [
+            pytest.approx(x)
+            for x in [0.004, 0.008, 0.016, 0.032, 0.064, 0.1, 0.1, 0.1]
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_burst_redrains_immediately_then_ramps_down(
+        self, mock_protocol: MagicMock
+    ) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        mgr._connected = True
+        mgr._authenticated = True
+        waits: list[float] = []
+        drains = [2, 0, 0, 0, 0]
+
+        def fake_drain() -> int:
+            if not drains:
+                mgr._connected = False  # end the loop
+                return 0
+            return drains.pop(0)
+
+        async def fake_wait(timeout: float) -> bool:
+            waits.append(timeout)
+            return False
+
+        mgr._poll_and_send_messages = MagicMock(side_effect=fake_drain)  # type: ignore[method-assign]
+        mgr._wait_for_send_wake = fake_wait  # type: ignore[method-assign]
+        await mgr._poll_outgoing_loop()
+        # The drain that moved frames slept 0 (no wait recorded); the empty
+        # drains after it ramp up from the floor.
+        assert waits == [
+            pytest.approx(x) for x in [0.002, 0.004, 0.008, 0.016, 0.032]
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_wake_resets_the_ramp_and_quiet_stays_at_idle(
+        self, mock_protocol: MagicMock
+    ) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+        mgr._connected = True
+        mgr._authenticated = True
+        waits: list[float] = []
+        wake_results = [False, True, False]
+
+        async def fake_wait(timeout: float) -> bool:
+            waits.append(timeout)
+            if len(wake_results) == 1:
+                mgr._connected = False  # end the loop
+            return wake_results.pop(0)
+
+        mgr._poll_and_send_messages = MagicMock(return_value=0)  # type: ignore[method-assign]
+        mgr._wait_for_send_wake = fake_wait  # type: ignore[method-assign]
+        await mgr._poll_outgoing_loop()
+        # Quiet at the idle interval stays there (no unbounded growth); the
+        # wake drops the very next wait to the floor.
+        assert waits == [pytest.approx(x) for x in [0.1, 0.1, 0.002]]
+
+    @pytest.mark.asyncio
+    async def test_an_inbound_frame_wakes_the_send_loop(
+        self, mock_protocol: MagicMock
+    ) -> None:
+        mgr = InternetManager(mock_protocol, "dev-1")
+
+        class _OneFrameWS:
+            def __init__(self) -> None:
+                self._frames = [json.dumps({"type": "SomethingUnknown"}).encode()]
+
+            def __aiter__(self) -> "_OneFrameWS":
+                return self
+
+            async def __anext__(self) -> bytes:
+                if not self._frames:
+                    raise StopAsyncIteration
+                return self._frames.pop(0)
+
+        mgr._ws = _OneFrameWS()  # type: ignore[assignment]
+        assert not mgr._send_wake.is_set()
+        await mgr._receive_loop()
+        assert mgr._send_wake.is_set(), (
+            "every inbound frame must wake the send loop; the reply the core "
+            "queues while handling it would otherwise wait out a poll interval"
+        )

--- a/docs/bridges/python.md
+++ b/docs/bridges/python.md
@@ -95,6 +95,35 @@ root, and if it pointed documents at a separate backend, call
 tombstones, so a wipe on a running engine with live sessions is undone by the
 peer's next version offer, which recreates and refills every document.
 
+## P7. The internet send loop is adaptive here, and fixed elsewhere
+
+The core's internet outbox is poll-only across the FFI in every binding. The
+Swift and Kotlin managers drain it on a fixed 100 ms tick. The Python manager
+(`internet_manager.py`) drains it adaptively: an inbound frame wakes the send
+loop immediately, a drain that moved frames re-drains at event-loop speed, and
+an empty drain backs off exponentially from 2 ms to the shared 100 ms idle
+interval.
+
+The invariant both shapes preserve: a locally queued message waits at most one
+idle interval, and a quiet link costs at most one poll per interval. What the
+adaptive shape adds is that a reply to an inbound frame does not pay the poll
+interval at all, which at 100 ms was most of a warm round trip.
+
+Two consequences worth knowing before touching it:
+
+- The policy is pinned by `TestAdaptiveSendLoop` in
+  `tests/test_internet_manager.py`, not by a latency measurement. Change the
+  tests with the policy, or a revert ships silently.
+- The in-flight tracker sweep inside `_poll_and_send_messages` is gated to the
+  old 10 Hz cadence (`_PRUNE_MIN_INTERVAL_MS`). The gate exists because the
+  adaptive loop can call the drain at event-loop speed during a burst, and the
+  sweep walks every tracked recipient; without the gate a burst turns into a
+  sweep storm.
+
+Porting the adaptive shape to Swift and Kotlin is intended eventually. Until
+then the latency profiles differ by design: a warm Python round trip is
+milliseconds, while the mobile bridges pay up to one tick per direction.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
The Python internet transport drains the core outbound queue on a fixed 100 ms poll (`_MESSAGE_POLL_INTERVAL`), sleeping that interval between every drain. A reply queued just after a tick therefore waits up to a full interval per direction, which is the dominant single-call latency: a warm mesh round trip measured ~100 ms, almost all of it spent waiting for the next tick.

## What this changes
Makes the send loop **activity-adaptive**:
- When a drain moves at least one frame, yield and re-drain immediately, so a burst empties at event-loop speed (0 added latency under load).
- When the queue is empty, poll tightly (2 ms) only for a short window after recent activity, then relax to the full idle interval once genuinely quiet.
- `_poll_and_send_messages` now returns the number of frames drained so the loop can make that decision.

Under sustained load this is effectively event-driven; when idle it costs one poll per interval, exactly as before. **No behaviour change when idle, and no new configuration** (it self-tunes).

## Measured
Single round-trip latency drops from **~100 ms to ~5 ms** at the default idle interval, with no busy-poll and no change to idle CPU (validated locally against the live relay + a provider/consumer pair). Adds two tests pinning the drain-count contract the loop relies on.

Mirrors the intent of the Swift/Kotlin managers; a follow-up can apply the same shape there if desired.
## Maintainer update after review (2026-09-01)

The branch was rebased onto main and reworked in a follow-up commit; the original commit is preserved. What changed and why:

**Rebase onto #420.** PR #420 landed after this branch was cut and rewrote `_poll_and_send_messages` (the in-flight `DeliveryError` tracker). The rebase keeps both its `prune` sweep and this PR's `return drained`. The sweep is now time-gated to its original 10 Hz cadence (`_PRUNE_MIN_INTERVAL_MS`), because the adaptive loop calls the drain at event-loop speed during a burst and the sweep walks every tracked recipient.

**Hot window replaced with a wake + exponential backoff.** The receive loop now sets an `asyncio.Event` before dispatching each inbound frame, and the send loop waits on that event instead of sleeping blind. Two problems with the 0.5 s hot window disappear:

- The first reply after a quiet spell no longer pays up to a full idle interval: the wake cuts the in-progress wait short, and the handlers feed the core synchronously, so the reply is typically already queued when the loop runs. The measured ~5 ms warm number now also holds for the cold-start reply.
- Steady inbound chatter (including the relay's `MessageSent` echoes of our own sends) no longer renews a permanent 2 ms poll (~500 FFI calls/s). An empty drain doubles its wait from 2 ms up to the unchanged 100 ms idle interval, so the tail after a burst is ~6 wakeups instead of ~250, and a quiet link costs exactly what it did before.

**The policy is pinned by tests, not by a latency measurement.** `TestAdaptiveSendLoop` covers the drain-count contract (the two original tests, kept), the backoff ramp and its cap, the wake resetting the ramp, quiet holding at the idle interval, the receive-loop wake, and slot saturation reporting 0 drained without touching the FFI.

Also added: a changelog entry and `docs/bridges/python.md` P7 documenting the divergence from the fixed-tick Swift/Kotlin managers (porting the shape there remains a welcome follow-up).

One caveat retained from review: a locally queued send with no inbound trigger still waits up to one idle interval; the core outbox is poll-only across the FFI, so fixing that needs a core-side wake and is out of scope here.

