### PR TITLE
docs(transport,spec): stop saying no gateway daemon exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,18 @@ archived by series under [docs/changelog/](docs/changelog/); see the
   native layers. See
   [docs/configuration.md](docs/configuration.md#reliability-configuration).
 
+### Documentation
+
+- **The Reticulum transport's counterpart exists.** `docs/reticulum.md` and
+  the gateway contract said no daemon existed anywhere and nothing answered
+  the mobile managers' `daemonAddress`. The reference gateway daemon
+  (`Offline-Protocol/offline-gateway-daemon`) implements contract v1,
+  attaches to `rnsd` as a local client, and is the Python binding's Reticulum
+  transport. Both documents now say so, and still say what has not changed:
+  the mobile managers confirm a send on the socket write and ignore the
+  daemon's verdicts until the transport work that teaches them to settle on
+  its answer.
+
 ## [0.24.1] — 2026-08-26
 
 > **Every fix here is the same defect found four ways: the iOS React Native

--- a/docs/reticulum.md
+++ b/docs/reticulum.md
@@ -6,7 +6,7 @@ The Reticulum transport provides long-range, resilient mesh networking via the [
 
 Reticulum is one of five transports in the Offline Protocol SDK, alongside BLE, Wi-Fi Direct, Internet and Nostr. It is disabled by default because it requires external infrastructure (a running Reticulum instance, an RNode radio, or a gateway).
 
-> **No counterpart daemon ships yet.** The Rust transport opens no Reticulum link of its own: it manages queues, metrics and the send-confirmation loop, and expects the platform to bridge to a real Reticulum stack. Both mobile managers speak the protocol below to a configurable address, and nothing in this repository or any companion repository answers on the other end. Until a daemon exists, enabling Reticulum gives you a transport that queues and never drains. See [the gateway contract](spec/gateway-contract.md), which specifies what that daemon has to be.
+> **The counterpart daemon lives in a sibling repository.** The Rust transport opens no Reticulum link of its own: it manages queues, metrics and the send-confirmation loop, and expects the platform to bridge to a real Reticulum stack. Both mobile managers speak the protocol below to a configurable address. What answers on the other end is the reference gateway daemon, `Offline-Protocol/offline-gateway-daemon`, built to [the gateway contract](spec/gateway-contract.md) and not shipped by this repository. With no daemon at `daemonAddress`, enabling Reticulum gives you a transport that queues and never drains. The Python binding has no Reticulum manager of its own; the daemon repository's `ReticulumBridge` is it.
 
 ## When to Use Reticulum
 
@@ -200,11 +200,13 @@ Regardless of which integration strategy you choose, the platform bridge interac
 > correctly gets no verdict handling from today's bridges. Teaching them to
 > settle on the daemon's answer is part of the transport work, not the daemon's.
 >
-> Note what this section used to imply and does not: **no Reticulum daemon
-> speaks this protocol.** `rnsd`'s own shared-instance IPC is HDLC-framed
-> Reticulum packets over a Unix domain socket (Strategy 3 above), not this. This
-> is a bespoke protocol whose counterpart has never existed, which is why the
-> gateway contract promotes it rather than inventing a third one.
+> Note what this section used to imply and does not: **`rnsd` does not speak
+> this protocol.** Its shared-instance IPC is HDLC-framed Reticulum packets
+> over a Unix domain socket (Strategy 3 above), not this. The counterpart is
+> the reference gateway daemon (`Offline-Protocol/offline-gateway-daemon`),
+> which attaches to `rnsd` as a local client and speaks contract v1 to
+> devices. No daemon existed when the contract was written, which is why it
+> promotes this protocol rather than inventing a third one.
 
 The built-in `ReticulumManager` (iOS and Android) speaks a newline-delimited JSON protocol over TCP to a configurable `daemonAddress` (default `localhost:4242`). Both platforms implement the same message types to stay in sync.
 

--- a/docs/spec/gateway-contract.md
+++ b/docs/spec/gateway-contract.md
@@ -91,8 +91,10 @@ local IP (venue Wi-Fi, or a hotspot the gateway box provides).
 
 This promotes the protocol both mobile bridges already speak to a configurable
 `daemonAddress` (default `localhost:4242`), rather than designing a fresh one:
-the client side is already implemented twice, and no daemon exists anywhere yet,
-so extending it breaks nobody.
+the client side was already implemented twice, and no daemon existed anywhere
+when this contract was written, so extending it broke nobody. The reference
+daemon (`Offline-Protocol/offline-gateway-daemon`) was then built to this
+document.
 
 ### Framing
 


### PR DESCRIPTION
Three passages still described the Reticulum transport as a client with no server anywhere:

- `docs/reticulum.md`, the opening callout: "No counterpart daemon ships yet ... nothing in this repository or any companion repository answers on the other end."
- `docs/reticulum.md`, the protocol section: "a bespoke protocol whose counterpart has never existed."
- `docs/spec/gateway-contract.md`, the promotion rationale: "no daemon exists anywhere yet, so extending it breaks nobody."

The reference gateway daemon (`Offline-Protocol/offline-gateway-daemon`) has implemented contract v1 end to end since 2026-09-02: address-proven attach, one verdict per submit, presence, capabilities, a Reticulum backbone between gateways, and a Python `ReticulumBridge` that two real SDK instances exchange an acknowledged DM through. All three passages now say so.

What they deliberately keep, because it is still true on `main`:

- Both mobile managers send `Identify` alone, confirm a send on the socket write, and ignore `MessageSent` / `DeliveryError`. Settling on the daemon's answer is still transport work.
- `rnsd`'s shared-instance IPC is not this protocol.
- With nothing at `daemonAddress`, enabling Reticulum queues and never drains.
- The Python binding has no Reticulum manager of its own; the daemon repository's bridge is it.

Prose only. No normative change to the contract: the `message_id` amendment and the `offline-gateway-addr-v1` Reserved-to-Live flip the daemon's plan lists as owed are not in this PR.