### PR TITLE
diag(bindings): add iOS BLE receive-path trace logs for OFF-2781 fragment-loss investigation

### DIFF
--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -258,7 +258,19 @@ public class BleManager: NSObject, TransportManager {
     private var scanStateMonitor: DispatchSourceTimer?
     private var lastDiscoveryDate: Date?
     private var scanStartDate: Date?
-    
+
+    // Diagnostic sampling for the BLE receive path — running per-peripheral
+    // tally of `didUpdateValueFor` (i.e. every notify frame that arrives on the
+    // message characteristic), flushed on a 5-second window boundary. Used to
+    // localize fragment loss to either the wire (few notifies arrive between
+    // two subscription cycles) or downstream (many notifies arrive but
+    // reassembly never completes). Guarded by its own lock — this is polled
+    // from CoreBluetooth's delegate queue, but cleared on flush, so it never
+    // holds unbounded state per peer.
+    private let notifyRateLock = NSLock()
+    private var notifyValueCounts: [UUID: Int] = [:]
+    private var notifyRateWindowStart: [UUID: Date] = [:]
+
     // Adaptive scan state
     /// Timestamps of recent peripheral discoveries for density estimation
     private var recentDiscoveryTimestamps: [Date] = []
@@ -1895,7 +1907,32 @@ public class BleManager: NSObject, TransportManager {
                     "senderId": senderId,
                     "fragmentSize": data.count
                 ])
-                
+
+                // Parse the OP fragment header for diagnostic logging.
+                // Wire format (from the Rust core BleTransport, mirrored in
+                // the mesh-node shim's fragmentation): 2-byte magic "OP",
+                // 1-byte version, 1-byte messageId length N, N-byte messageId
+                // (UTF-8), then u16 LE fragmentIndex, u16 LE totalFragments,
+                // u16 LE dataLength. Emit ONE line per notify with the parsed
+                // (msgId, idx, total) so a run-log grep can confirm whether
+                // reassembly ever reaches `idx == total - 1` for a given
+                // messageId, which is the direct symptom of a mid-transfer
+                // subscription drop.
+                var traceMessageId = "?"
+                var traceFragIdx = -1
+                var traceFragTotal = -1
+                if bytes.count >= 10, bytes[0] == 0x4F, bytes[1] == 0x50, bytes[2] == 0x01 {
+                    let idLen = Int(bytes[3])
+                    if bytes.count >= 4 + idLen + 6 {
+                        traceMessageId = String(bytes: bytes[4..<(4 + idLen)], encoding: .utf8) ?? "?"
+                        let idxOff = 4 + idLen
+                        traceFragIdx = Int(bytes[idxOff]) | (Int(bytes[idxOff + 1]) << 8)
+                        traceFragTotal = Int(bytes[idxOff + 2]) | (Int(bytes[idxOff + 3]) << 8)
+                    }
+                }
+                NSLog("[BleManager] FRAG recv msgId=%@ idx=%d/%d senderId=%@ size=%d",
+                      traceMessageId, traceFragIdx, traceFragTotal, senderId, data.count)
+
                 try self.protocolInstance.bleFragmentReceived(senderId: senderId, fragment: bytes)
                 print("[BleManager] ✅ Fragment processed successfully for sender: \(senderId)")
                 
@@ -1904,6 +1941,14 @@ public class BleManager: NSObject, TransportManager {
                 var messageCount = 0
                 while let completedMessage = self.protocolInstance.receiveMessage() {
                     messageCount += 1
+                    // Distinct tag from the pretty-printed lines below so a
+                    // run-log grep can pick out exactly the reassembled JSON
+                    // without emoji chrome. Truncated at 400 chars because
+                    // training_cluster payloads are ~6 KB but the JSON header
+                    // (type/sender/recipient/messageId) is what localizes a
+                    // routing or dispatch failure downstream of reassembly.
+                    let fullPreview = String(completedMessage.prefix(400))
+                    NSLog("[BleManager] FULL_MSG %@", fullPreview)
                     print("[BleManager] 🎉 COMPLETE MESSAGE #\(messageCount) ASSEMBLED FROM FRAGMENTS!")
                     print("[BleManager] 📬 Received message: \(completedMessage)")
                     self.emitDiagnostic("info", "Complete message assembled from fragments", context: [
@@ -2944,6 +2989,33 @@ extension BleManager: CBPeripheralDelegate {
     }
     
     public func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        // Diagnostic sample of per-peripheral notify rate on the message
+        // characteristic. Every FRAG log below is one notify; this running
+        // tally catches the case where notifies simply stop arriving (silent
+        // unsubscribe, iOS backpressure, GATT reset) with no other log line
+        // signalling it. Flushed on a 5-second window boundary so the log
+        // lines are read-once-per-window, not per-fragment.
+        if error == nil, characteristic.uuid == MESSAGE_CHAR_UUID {
+            let key = peripheral.identifier
+            let now = Date()
+            var flushed: (count: Int, elapsed: TimeInterval)? = nil
+            notifyRateLock.lock()
+            notifyValueCounts[key, default: 0] += 1
+            if notifyRateWindowStart[key] == nil {
+                notifyRateWindowStart[key] = now
+            }
+            let elapsed = now.timeIntervalSince(notifyRateWindowStart[key] ?? now)
+            if elapsed >= 5.0 {
+                flushed = (notifyValueCounts[key] ?? 0, elapsed)
+                notifyValueCounts[key] = 0
+                notifyRateWindowStart[key] = now
+            }
+            notifyRateLock.unlock()
+            if let f = flushed {
+                NSLog("[BleManager] NOTIFY_RATE peer=%@ count=%d window=%.1fs",
+                      key.uuidString, f.count, f.elapsed)
+            }
+        }
         if let error = error {
             print("[BleManager] Error reading characteristic: \(error)")
             emitDiagnostic("error", "Error reading characteristic", context: ["error": error.localizedDescription])
@@ -3282,6 +3354,28 @@ extension BleManager: CBPeripheralDelegate {
             print("[BleManager] Error writing characteristic: \(error)")
             emitDiagnostic("error", "Error writing characteristic", context: ["error": error.localizedDescription])
         }
+    }
+
+    /// Diagnostic: fires whenever the LOCAL central's subscription state on
+    /// `characteristic` changes — either because this side called
+    /// `setNotifyValue(...)` on a live link, or because the remote peripheral
+    /// reported a change. Pairs with the peripheral-side
+    /// CENTRAL SUBSCRIBED / UNSUBSCRIBED logs on the sender to timestamp
+    /// subscription churn from BOTH ends of the same link, which is how the
+    /// fragment-loss hypothesis (mid-transfer unsubscribe) is confirmed or
+    /// refuted in a single trace.
+    public func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        if let error = error {
+            NSLog("[BleManager] NOTIFY_STATE peer=%@ char=%@ error=%@",
+                  peripheral.identifier.uuidString,
+                  characteristic.uuid.uuidString,
+                  error.localizedDescription)
+            return
+        }
+        NSLog("[BleManager] NOTIFY_STATE peer=%@ char=%@ subscribed=%@",
+              peripheral.identifier.uuidString,
+              characteristic.uuid.uuidString,
+              characteristic.isNotifying ? "YES" : "NO")
     }
     
     /// Flow-control signal: the BLE write buffer has drained for this peripheral.

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offline-protocol/mesh-sdk",
-  "version": "0.24.1",
+  "version": "0.24.1-diag.off2785.0",
   "description": "Offline-first mesh networking SDK with intelligent transport switching for React Native",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary

Instruments `bindings/react-native/ios/BleManager.swift` with three cheap trace points so a 2-device DiLoCo run (or any two-phone BLE session where reassembly is suspect) can tell us:

1. Whether a single messageId ever reaches `fragmentIndex == totalFragments - 1` — direct signal for mid-transfer subscription drops.
2. Whether reassembly produces a Message at all — signal for downstream dispatch failure vs BLE-layer loss.
3. Whether subscription state is churning underneath the notifies — signal for the local central or the peripheral being the one that unsubscribes.

Diagnostic only. No behaviour change to the wire protocol, reassembly logic, or delegate plumbing.

## What the trace looks like

```
[BleManager] FRAG recv msgId=48ce…-9fc2 idx=17/44 senderId=off1abc… size=185
[BleManager] FULL_MSG {"type":"training_cluster","messageId":"48ce…","sender":"off1…","recipient":"*",…
[BleManager] NOTIFY_RATE peer=<uuid> count=52 window=5.1s
[BleManager] NOTIFY_STATE peer=<uuid> char=6E400002-… subscribed=YES
```

`FRAG idx` is the 0-based `fragmentIndex` from the OP header; a 44-fragment message shows the last frame as `idx=43/44`.

All four lines are emitted via `NSLog` so they surface in Xcode's device console and Metro's iOS console with a stable, greppable prefix regardless of the app's logger filter.

## Interpretation matrix

| Observed | Root cause |
|---|---|
| `FRAG` `idx` values plateau at ~10–15 per subscription window; `FULL_MSG` never fires | Fragment reassembly never completes — subscription churn is starving a 44-frag transfer. |
| `FRAG` reaches `idx=43/44` for a single msgId but `FULL_MSG` never fires | Reassembly happens but Rust-core dispatch drops the message (recipient / sender-id validation, decrypt). |
| `FULL_MSG` fires but the JS `message_received` listener never runs | Event pump on the JS bridge is broken — SDK-side fan-out ticket. |
| `NOTIFY_STATE subscribed=NO` interleaved with the FRAG stream | Local central is unsubscribing mid-transfer — connection-monitor / GATT-reset trigger. |

## Consumption

`npm pack` at `bindings/react-native/` (with the pre-built XCFramework + Android jniLibs from a matching `0.24.1` install in place) produces a `.tgz` that consumers install via `npm install /path/to/tarball`. Package version is bumped to `0.24.1-diag.off2785.0` so the diag tree is distinguishable from shipped `0.24.1` without colliding with future `0.24.2` semver.

## Test plan

- [ ] Rebuild the phone against a locally-packed `0.24.1-diag.off2785.0` tarball.
- [ ] Run the 2-device DiLoCo baseline (Mac shim + phone) that OFF-2781 was investigating.
- [ ] Grep the Xcode console for `[BleManager] FRAG recv`, `FULL_MSG`, `NOTIFY_RATE`, `NOTIFY_STATE` and apply the interpretation matrix above.
- [ ] Roll back to shipped `0.24.1` before any release build — this is diagnostic, not shippable.

Refs: OFF-2781, OFF-2785