### PR TITLE
fix(bindings): skip setNotifyValue on a live message characteristic subscription

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,6 +636,7 @@ jobs:
             mesh/Mesh.swift ble/MeshConnectionRegistry.swift \
             ble/BleDiscoveryBootstrapPolicy.swift \
             PeripheralRestorationAgeOutPolicy.swift \
+            BleMessageNotificationPolicy.swift \
             Generated/offline_protocol.swift ForcedPresenceCheckQueue.swift \
             AddressDeclarationPolicy.swift \
             GatewayAttachPolicy.swift GatewayVerdictTracker.swift \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ archived by series under [docs/changelog/](docs/changelog/); see the
 
 ### Fixed
 
+- **Re-discovering an established iOS BLE link no longer repeats the work that
+  set it up.** `BleManager`'s characteristic-discovery callback is not a
+  first-contact callback: the connection monitor re-runs characteristic
+  discovery every five seconds on any peripheral missing from the connection
+  registry, and CoreBluetooth replays the callback from its cache when it does,
+  so a live connection reaches it indefinitely. Every arrival re-subscribed to
+  the message characteristic and re-read both halves of the peer handshake.
+
+  The subscribe now runs only when the characteristic reports that it is not
+  already notifying. A redundant one re-emitted the bridge's own subscribe
+  diagnostic, so a link that subscribed once read in the logs as one
+  re-subscribing every sweep, and where the write reached the peer it re-ran
+  that peer's inbound admission decision, which can evict a different peer.
+  The handshake reads now stop once the peer is announced, which also drops a
+  signature verification and an address derivation that ran on the main thread
+  on every sweep and whose result was discarded. A disconnect still resets both
+  gates, so a reconnect re-subscribes and re-proves the peer from scratch.
+
 - **iOS state restoration no longer chases peripherals whose owners are gone.**
   `BleManager.centralManager(_:willRestoreState:)` re-issued `connect(...)` on
   every peripheral iOS handed back. The OS keeps servicing those connect

--- a/bindings/react-native/MeshSdk.podspec
+++ b/bindings/react-native/MeshSdk.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
     "ios/InboundFragmentBuffer.swift",
     "ios/OutboundFragmentQueue.swift",
     "ios/AddressDeclarationPolicy.swift",
+    "ios/BleMessageNotificationPolicy.swift",
     "ios/PeerIdentityBinding.swift",
     "ios/RelayAnswerPrefixes.swift",
     "ios/RelayControlOpTranslator.swift",

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -3108,10 +3108,20 @@ extension BleManager: CBPeripheralDelegate {
         // method for why the identity is no longer optional.
         for characteristic in characteristics {
             if characteristic.uuid == MESSAGE_CHAR_UUID {
-                // Enable notifications for message characteristic
-                peripheral.setNotifyValue(true, for: characteristic)
-                print("[BleManager] Enabled notifications for message characteristic")
-                emitDiagnostic("info", "Enabled notifications for message characteristic", context: ["peripheral": peripheral.identifier.uuidString])
+                // The connection monitor re-invokes discoverCharacteristics on
+                // peripherals it does not see in the connection registry, and
+                // characteristic discovery replays from CoreBluetooth's cache
+                // when it does. Both paths land here with a characteristic
+                // that is already subscribed; iOS re-emits
+                // didUpdateNotificationStateFor on every setNotifyValue call
+                // regardless, so a redundant call produces a runaway
+                // subscribed=YES stream on a still-live subscription. Skip
+                // the call entirely when the characteristic already notifies.
+                if BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: characteristic.isNotifying) {
+                    peripheral.setNotifyValue(true, for: characteristic)
+                    print("[BleManager] Enabled notifications for message characteristic")
+                    emitDiagnostic("info", "Enabled notifications for message characteristic", context: ["peripheral": peripheral.identifier.uuidString])
+                }
             } else if characteristic.uuid == DEVICE_ID_CHAR_UUID {
                 // Read device ID
                 peripheral.readValue(for: characteristic)

--- a/bindings/react-native/ios/BleManager.swift
+++ b/bindings/react-native/ios/BleManager.swift
@@ -3102,27 +3102,57 @@ extension BleManager: CBPeripheralDelegate {
         
         guard let characteristics = service.characteristics else { return }
 
+        // This callback fires more than once per link without an intervening
+        // disconnect. The connection monitor re-invokes
+        // `discoverCharacteristics` every CONNECTION_MONITOR_INTERVAL on any
+        // peripheral it does not find in the connection registry, and
+        // characteristic discovery replays from CoreBluetooth's cache when it
+        // does, so a still-live link can arrive here indefinitely. Everything
+        // below therefore has to be safe to reach on an established
+        // connection, which is two separate questions: the subscription is
+        // judged on the characteristic, and the join is judged on whether it
+        // already finished.
+        //
+        // Subscribing asks the characteristic, because `isNotifying` is
+        // present-tense evidence about the link. A real disconnect resets it,
+        // and so would a service invalidation handing back fresh
+        // characteristic objects on a peer we still consider announced, so
+        // asking here keeps the subscription self-healing in both cases where
+        // our own bookkeeping would not. There is no
+        // `didUpdateNotificationStateFor` in this file, so the redundant call
+        // was visible from two other places: it re-emitted the diagnostic
+        // below, which made one link that subscribed once read as a link
+        // re-subscribing every sweep, and, if CoreBluetooth forwards the CCCD
+        // write rather than swallowing it, the peer's `didSubscribeTo` re-runs
+        // its whole inbound admission path once per sweep —
+        // `shouldAcceptInboundConnection`, which may evict a *different* peer
+        // as an inbound_swap, and then `maybeHandleRebalance`.
+        if let messageCharacteristic = characteristics.first(where: { $0.uuid == MESSAGE_CHAR_UUID }),
+           BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: messageCharacteristic.isNotifying) {
+            peripheral.setNotifyValue(true, for: messageCharacteristic)
+            print("[BleManager] Enabled notifications for message characteristic")
+            emitDiagnostic("info", "Enabled notifications for message characteristic", context: ["peripheral": peripheral.identifier.uuidString])
+        }
+
+        // The join below is one-shot per connection, and for an announced peer
+        // it is finished. Re-reading DEVICE_ID and IDENTITY costs a GATT round
+        // trip each, then a signature verification and an address derivation on
+        // the main thread in `handleReceivedIdentity`, and ends at
+        // `completePeerHandshake`'s own `announcedPeripherals` guard having
+        // changed nothing. `didDisconnectPeripheral` clears the set, so a
+        // reconnect still re-reads both halves and re-proves the peer from
+        // scratch; within a single connection an identity that changed under us
+        // is something to refuse, not to adopt. Returning here also keeps the
+        // absence checks below from judging an established link on a cache
+        // replay that came back partial.
+        guard !announcedPeripherals.contains(peripheral.identifier) else { return }
+
         // Both reads are issued here and complete in either order; the peer is
         // announced by whichever one lands second, through
         // `completePeerHandshake`. Neither is sufficient alone — see that
         // method for why the identity is no longer optional.
         for characteristic in characteristics {
-            if characteristic.uuid == MESSAGE_CHAR_UUID {
-                // The connection monitor re-invokes discoverCharacteristics on
-                // peripherals it does not see in the connection registry, and
-                // characteristic discovery replays from CoreBluetooth's cache
-                // when it does. Both paths land here with a characteristic
-                // that is already subscribed; iOS re-emits
-                // didUpdateNotificationStateFor on every setNotifyValue call
-                // regardless, so a redundant call produces a runaway
-                // subscribed=YES stream on a still-live subscription. Skip
-                // the call entirely when the characteristic already notifies.
-                if BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: characteristic.isNotifying) {
-                    peripheral.setNotifyValue(true, for: characteristic)
-                    print("[BleManager] Enabled notifications for message characteristic")
-                    emitDiagnostic("info", "Enabled notifications for message characteristic", context: ["peripheral": peripheral.identifier.uuidString])
-                }
-            } else if characteristic.uuid == DEVICE_ID_CHAR_UUID {
+            if characteristic.uuid == DEVICE_ID_CHAR_UUID {
                 // Read device ID
                 peripheral.readValue(for: characteristic)
             } else if characteristic.uuid == IDENTITY_CHAR_UUID {

--- a/bindings/react-native/ios/BleMessageNotificationPolicy.swift
+++ b/bindings/react-native/ios/BleMessageNotificationPolicy.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Decision helper for enabling GATT notifications on the message
+/// characteristic during characteristic discovery.
+///
+/// The characteristic-discovery callback can fire more than once for the same
+/// peripheral without an intervening disconnect: the connection monitor's
+/// periodic sweep re-invokes `discoverCharacteristics` on peripherals it
+/// believes are unclaimed, and iOS state-restoration paths call it again on
+/// relaunch. iOS emits `didUpdateNotificationStateFor` on every
+/// `setNotifyValue` call, even when the subscription is unchanged, so
+/// unconditionally re-enabling notifications on an already-subscribed
+/// characteristic produces a runaway stream of redundant notification-state
+/// events (observed in the field: 146 subscribed=YES events at ~5s cadence on
+/// a single live subscription).
+///
+/// This helper factors the decision out of the delegate method so the guard
+/// is testable in isolation without a live `CBCharacteristic`.
+internal enum BleMessageNotificationPolicy {
+    /// Whether the app should issue `setNotifyValue(true, ...)` for the
+    /// message characteristic given its current subscription state.
+    ///
+    /// Callers pass `isNotifying` from `CBCharacteristic.isNotifying` so the
+    /// decision stays a pure function of the observed state and this file
+    /// never has to import CoreBluetooth. Returns `true` only when the
+    /// characteristic is not already subscribed; a live subscription is left
+    /// alone.
+    static func shouldEnableNotifications(isNotifying: Bool) -> Bool {
+        return !isNotifying
+    }
+}

--- a/bindings/react-native/ios/BleMessageNotificationPolicy.swift
+++ b/bindings/react-native/ios/BleMessageNotificationPolicy.swift
@@ -3,19 +3,36 @@ import Foundation
 /// Decision helper for enabling GATT notifications on the message
 /// characteristic during characteristic discovery.
 ///
-/// The characteristic-discovery callback can fire more than once for the same
-/// peripheral without an intervening disconnect: the connection monitor's
-/// periodic sweep re-invokes `discoverCharacteristics` on peripherals it
-/// believes are unclaimed, and iOS state-restoration paths call it again on
-/// relaunch. iOS emits `didUpdateNotificationStateFor` on every
-/// `setNotifyValue` call, even when the subscription is unchanged, so
-/// unconditionally re-enabling notifications on an already-subscribed
-/// characteristic produces a runaway stream of redundant notification-state
-/// events (observed in the field: 146 subscribed=YES events at ~5s cadence on
-/// a single live subscription).
+/// The characteristic-discovery callback fires more than once for the same
+/// peripheral without an intervening disconnect: the connection monitor
+/// re-invokes `discoverCharacteristics` on peripherals it does not find in the
+/// connection registry, and iOS state-restoration paths call it again on
+/// relaunch. Both land on a characteristic that is often already subscribed.
 ///
-/// This helper factors the decision out of the delegate method so the guard
-/// is testable in isolation without a live `CBCharacteristic`.
+/// A redundant `setNotifyValue(true, ...)` is not a silent no-op. `BleManager`
+/// implements no `didUpdateNotificationStateFor`, so the call is not observed
+/// there, but it is observed twice elsewhere: it re-emits the "Enabled
+/// notifications for message characteristic" diagnostic, so a link that
+/// subscribed once reads in the field logs as a link that re-subscribes on
+/// every sweep (146 such events at roughly a 5 s cadence on one live
+/// subscription is what surfaced this); and if CoreBluetooth forwards the CCCD
+/// write rather than swallowing it, the *peer* runs `didSubscribeTo` again,
+/// which re-enters its whole inbound admission path — a
+/// `shouldAcceptInboundConnection` decision that can evict a different peer,
+/// then a rebalance — once per sweep for as long as the link is up.
+///
+/// The decision is `isNotifying` rather than any bookkeeping this file could
+/// consult, because `isNotifying` is present-tense evidence about the link
+/// itself: a real disconnect resets it, and so does a service invalidation that
+/// hands back fresh characteristic objects on a peer the app still considers
+/// established. Both cases re-subscribe on the next discovery pass without
+/// anything having to remember them.
+///
+/// This helper factors the decision out of the delegate method so the guard is
+/// testable in isolation without a live `CBCharacteristic`. That the delegate
+/// actually routes through it is pinned separately, by
+/// `react_native_ios_ble_discovery_is_idempotent_on_a_live_link` in the uniffi
+/// crate, because no Swift test can reach `BleManager`.
 internal enum BleMessageNotificationPolicy {
     /// Whether the app should issue `setNotifyValue(true, ...)` for the
     /// message characteristic given its current subscription state.

--- a/bindings/react-native/ios/Package.swift
+++ b/bindings/react-native/ios/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
             ],
             sources: [
                 "AddressDeclarationPolicy.swift",
+                "BleMessageNotificationPolicy.swift",
                 "EncryptionConfigReader.swift",
                 "ForcedPresenceCheckQueue.swift",
                 "ForegroundReconnectPolicy.swift",
@@ -101,6 +102,7 @@ let package = Package(
             ],
             sources: [
                 "AddressDeclarationPolicyTests.swift",
+                "BleMessageNotificationPolicyTests.swift",
                 "EncryptionConfigReaderTests.swift",
                 "ForcedPresenceCheckQueueTests.swift",
                 "GatewayAttachPolicyTests.swift",

--- a/bindings/react-native/ios/tests/BleMessageNotificationPolicyTests.swift
+++ b/bindings/react-native/ios/tests/BleMessageNotificationPolicyTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import OfflineProtocol
+
+final class BleMessageNotificationPolicyTests: XCTestCase {
+
+    /// A freshly-discovered characteristic reports `isNotifying == false`.
+    /// The first discovery pass must enable notifications so message
+    /// fragments start reaching the reassembly buffer.
+    func testEnablesNotificationsOnAFreshCharacteristic() {
+        XCTAssertTrue(BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: false))
+    }
+
+    /// A characteristic surfaced from CoreBluetooth's cache during a
+    /// re-discovery reports `isNotifying == true` when the subscription is
+    /// still live. Calling `setNotifyValue(true, ...)` on it would produce
+    /// another redundant `didUpdateNotificationStateFor` event without any
+    /// change in wire behaviour, so the policy declines.
+    func testSuppressesNotificationsWhenAlreadySubscribed() {
+        XCTAssertFalse(BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: true))
+    }
+
+    /// Successive discovery callbacks on the same live characteristic must
+    /// produce exactly one `setNotifyValue` call: the first (fresh discovery)
+    /// enables notifications, subsequent re-discoveries against the now-live
+    /// subscription are no-ops. This pins the invariant the delegate loop
+    /// relies on — one `setNotifyValue` per subscription cycle, not one per
+    /// characteristic-discovery event.
+    func testSecondDiscoveryOnALiveSubscriptionIsANoOp() {
+        var setNotifyCallCount = 0
+        var isNotifying = false
+
+        let simulateDiscovery: () -> Void = {
+            if BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: isNotifying) {
+                setNotifyCallCount += 1
+                // CoreBluetooth flips isNotifying after the delegate accepts
+                // the subscription; the simulation reflects that so a second
+                // discovery observes the live state.
+                isNotifying = true
+            }
+        }
+
+        simulateDiscovery()
+        simulateDiscovery()
+        simulateDiscovery()
+
+        XCTAssertEqual(setNotifyCallCount, 1)
+        XCTAssertTrue(isNotifying)
+    }
+
+    /// After a real disconnect and reconnect the characteristic returns to
+    /// `isNotifying == false` (CoreBluetooth resets it on link teardown).
+    /// The next discovery must re-enable notifications so message reception
+    /// resumes.
+    func testReEnablesNotificationsAfterADisconnect() {
+        // First subscription cycle.
+        var isNotifying = false
+        XCTAssertTrue(BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: isNotifying))
+        isNotifying = true
+
+        // A live re-discovery observes the still-live subscription.
+        XCTAssertFalse(BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: isNotifying))
+
+        // Simulated disconnect: CoreBluetooth resets the flag.
+        isNotifying = false
+
+        // A discovery after the reconnect must re-subscribe.
+        XCTAssertTrue(BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: isNotifying))
+    }
+}

--- a/bindings/react-native/ios/tests/BleMessageNotificationPolicyTests.swift
+++ b/bindings/react-native/ios/tests/BleMessageNotificationPolicyTests.swift
@@ -1,6 +1,19 @@
 import XCTest
 @testable import OfflineProtocol
 
+/// Covers `BleMessageNotificationPolicy` only.
+///
+/// The two cases below are the whole input domain; the two after them replay
+/// that decision across a scripted sequence of discovery callbacks. Those two
+/// drive their own `isNotifying` local, so they document how the flag moves
+/// under CoreBluetooth rather than proving anything the first two do not — the
+/// simulation is the fixture, not the subject.
+///
+/// That `BleManager` routes its one `setNotifyValue` call through this policy,
+/// and that the handshake reads sit behind the announce gate, is pinned in
+/// `react_native_ios_ble_discovery_is_idempotent_on_a_live_link` in the uniffi
+/// crate. Nothing here can reach the delegate: it sits behind CoreBluetooth and
+/// CI only typechecks it.
 final class BleMessageNotificationPolicyTests: XCTestCase {
 
     /// A freshly-discovered characteristic reports `isNotifying == false`.
@@ -12,19 +25,20 @@ final class BleMessageNotificationPolicyTests: XCTestCase {
 
     /// A characteristic surfaced from CoreBluetooth's cache during a
     /// re-discovery reports `isNotifying == true` when the subscription is
-    /// still live. Calling `setNotifyValue(true, ...)` on it would produce
-    /// another redundant `didUpdateNotificationStateFor` event without any
+    /// still live. Calling `setNotifyValue(true, ...)` on it re-emits the
+    /// central's own subscribe diagnostic and, if CoreBluetooth forwards the
+    /// CCCD write, re-runs the peer's inbound admission path — all without any
     /// change in wire behaviour, so the policy declines.
     func testSuppressesNotificationsWhenAlreadySubscribed() {
         XCTAssertFalse(BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: true))
     }
 
-    /// Successive discovery callbacks on the same live characteristic must
-    /// produce exactly one `setNotifyValue` call: the first (fresh discovery)
-    /// enables notifications, subsequent re-discoveries against the now-live
-    /// subscription are no-ops. This pins the invariant the delegate loop
-    /// relies on — one `setNotifyValue` per subscription cycle, not one per
-    /// characteristic-discovery event.
+    /// Successive discovery callbacks on one subscription cycle yield exactly
+    /// one `setNotifyValue`. The fixture moves `isNotifying` the way
+    /// CoreBluetooth does — set once the subscription is accepted, and left
+    /// alone thereafter — to show that the policy's own answer is what makes
+    /// repeated discovery cheap, one call per subscription cycle rather than
+    /// one per discovery event.
     func testSecondDiscoveryOnALiveSubscriptionIsANoOp() {
         var setNotifyCallCount = 0
         var isNotifying = false
@@ -33,7 +47,7 @@ final class BleMessageNotificationPolicyTests: XCTestCase {
             if BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: isNotifying) {
                 setNotifyCallCount += 1
                 // CoreBluetooth flips isNotifying after the delegate accepts
-                // the subscription; the simulation reflects that so a second
+                // the subscription; the fixture reflects that so a second
                 // discovery observes the live state.
                 isNotifying = true
             }
@@ -50,7 +64,10 @@ final class BleMessageNotificationPolicyTests: XCTestCase {
     /// After a real disconnect and reconnect the characteristic returns to
     /// `isNotifying == false` (CoreBluetooth resets it on link teardown).
     /// The next discovery must re-enable notifications so message reception
-    /// resumes.
+    /// resumes. This is why the delegate asks the characteristic rather than
+    /// asking whether the peer is already announced: the reset is what makes
+    /// the subscription self-healing, and no bookkeeping in the bridge
+    /// observes it.
     func testReEnablesNotificationsAfterADisconnect() {
         // First subscription cycle.
         var isNotifying = false

--- a/crates/offline-protocol-uniffi/src/lib.rs
+++ b/crates/offline-protocol-uniffi/src/lib.rs
@@ -12681,6 +12681,119 @@ mod tests {
         );
     }
 
+    /// Re-discovering the characteristics of a live link changes nothing.
+    ///
+    /// `didDiscoverCharacteristicsFor` is not a first-contact callback. The
+    /// connection monitor re-invokes `discoverCharacteristics` every
+    /// `CONNECTION_MONITOR_INTERVAL` on any peripheral missing from the
+    /// connection registry, and characteristic discovery replays from
+    /// CoreBluetooth's cache when it does, so an established connection can
+    /// arrive there indefinitely. Everything the delegate does on arrival has
+    /// to be safe to repeat, and the two halves are safe for different
+    /// reasons — which is exactly what a later reader is likely to collapse.
+    ///
+    /// 1. **The subscribe is guarded by the characteristic, not by us.**
+    ///    Unconditionally re-issuing `setNotifyValue(true, ...)` on an
+    ///    already-notifying characteristic re-emits the central's own
+    ///    subscribe diagnostic, so one link that subscribed once reads in the
+    ///    logs as a link re-subscribing every sweep; and if CoreBluetooth
+    ///    forwards the CCCD write rather than swallowing it, the peer runs
+    ///    `didSubscribeTo` again, re-entering the inbound admission path that
+    ///    can evict a *different* peer as an inbound_swap and then rebalance.
+    ///    Nothing in the bridge observes the redundancy directly: there is no
+    ///    `didUpdateNotificationStateFor` in `BleManager` to notice it.
+    /// 2. **The subscribe must NOT move behind the announce gate.**
+    ///    `isNotifying` is present-tense evidence about the link. A disconnect
+    ///    resets it, and so does a service invalidation handing back fresh
+    ///    characteristic objects on a peer the bridge still considers
+    ///    announced; in that second case a gate keyed on `announcedPeripherals`
+    ///    would decline forever and leave an announced peer with a dead
+    ///    subscription — a silent one-way link, since egress keeps working.
+    ///    Hence the positional assertion: subscribe first, gate after.
+    /// 3. **The handshake reads sit behind the announce gate.** They are
+    ///    one-shot per connection. Re-reading DEVICE_ID and IDENTITY on an
+    ///    announced peer spends a GATT round trip each and then a signature
+    ///    verification plus an address derivation on the main thread in
+    ///    `handleReceivedIdentity`, only for `completePeerHandshake` to bail at
+    ///    its own `announcedPeripherals` guard. `didDisconnectPeripheral`
+    ///    clears the set, so a reconnect still re-proves the peer.
+    ///
+    /// No Swift test reaches any of this: `BleManager` sits behind
+    /// CoreBluetooth and CI only typechecks it. `BleMessageNotificationPolicy`
+    /// is unit-tested, but a policy nobody calls passes its own tests.
+    #[test]
+    fn react_native_ios_ble_discovery_is_idempotent_on_a_live_link() {
+        let swift = rn_source_code_only("ios/BleManager.swift");
+
+        let body_start = swift
+            .find(
+                "public func peripheral(_ peripheral: CBPeripheral, \
+                 didDiscoverCharacteristicsFor service: CBService, error: Error?) {",
+            )
+            .expect("BleManager.swift must implement didDiscoverCharacteristicsFor");
+        let body_end = swift
+            .find(
+                "public func peripheral(_ peripheral: CBPeripheral, \
+                 didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {",
+            )
+            .expect("BleManager.swift must implement didUpdateValueFor");
+        assert!(
+            body_start < body_end,
+            "didUpdateValueFor must follow didDiscoverCharacteristicsFor so the slice below is \
+             exactly the discovery delegate body"
+        );
+        let body = &swift[body_start..body_end];
+
+        // --- 1. The one subscribe runs only through the policy ---------------
+        assert_eq!(
+            swift.matches("setNotifyValue(").count(),
+            1,
+            "BleManager.swift may contain exactly one setNotifyValue call. A second call site is \
+             how the unconditional re-subscribe grows back while this guard still passes"
+        );
+        assert!(
+            body.contains(
+                "if let messageCharacteristic = characteristics.first(where: { $0.uuid == \
+                 MESSAGE_CHAR_UUID }), \
+                 BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying: \
+                 messageCharacteristic.isNotifying) { \
+                 peripheral.setNotifyValue(true, for: messageCharacteristic)"
+            ),
+            "the message-characteristic subscribe must be gated on \
+             BleMessageNotificationPolicy.shouldEnableNotifications(isNotifying:) reading the \
+             characteristic's own isNotifying. Re-subscribing a live subscription re-emits the \
+             subscribe diagnostic and re-runs the peer's inbound admission path once per sweep"
+        );
+
+        // --- 2 & 3. Subscribe, then gate, then the one-shot reads ------------
+        let subscribe = body
+            .find("peripheral.setNotifyValue(true, for: messageCharacteristic)")
+            .expect("the subscribe must live in the discovery delegate body");
+        let announce_gate = body
+            .find("guard !announcedPeripherals.contains(peripheral.identifier) else { return }")
+            .expect(
+                "the discovery delegate must return early for an already-announced peer, so a \
+                 re-discovery does not re-issue the one-shot handshake reads",
+            );
+        let first_read = body
+            .find("peripheral.readValue(for: characteristic)")
+            .expect("the discovery delegate must issue the DEVICE_ID and IDENTITY reads");
+        assert!(
+            subscribe < announce_gate,
+            "the subscribe must sit ABOVE the announce gate. Behind it, a service invalidation \
+             that hands back fresh characteristic objects on an announced peer would never \
+             re-subscribe, leaving a live connection that can send and never receive — and \
+             nothing resets announcedPeripherals without a disconnect"
+        );
+        assert!(
+            announce_gate < first_read,
+            "the DEVICE_ID and IDENTITY reads must sit BELOW the announce gate. They are one-shot \
+             per connection; repeating them on an announced peer costs two GATT round trips plus \
+             a signature verification and an address derivation on the main thread, and \
+             completePeerHandshake discards the result"
+        );
+    }
+
     /// State restoration must not issue CoreBluetooth commands where iOS hands
     /// it the restored list.
     ///


### PR DESCRIPTION
## Summary
Make `BleManager`'s characteristic-discovery callback idempotent on a link that
is already established. It is not a first-contact callback: the connection
monitor re-runs `discoverCharacteristics` every `CONNECTION_MONITOR_INTERVAL`
on any peripheral missing from the connection registry, and CoreBluetooth
replays the callback from its cache when it does, so a live connection reaches
it indefinitely. Every arrival re-subscribed to the message characteristic and
re-read both halves of the peer handshake.

## What a redundant pass actually cost

**The subscribe.** `setNotifyValue(true, ...)` was issued unconditionally.
`BleManager` implements no `didUpdateNotificationStateFor`, so the redundancy
was not observable there; it was observable in two other places. It re-emitted
the bridge's own "Enabled notifications for message characteristic" diagnostic,
so a link that subscribed once read in the field logs as a link re-subscribing
every sweep (146 events at roughly 5s cadence on one live subscription is what
surfaced this). And if CoreBluetooth forwards the CCCD write rather than
swallowing it, the peer runs `didSubscribeTo` again, re-entering its whole
inbound admission path: a `shouldAcceptInboundConnection` decision that can
evict a *different* peer as an `inbound_swap`, then `maybeHandleRebalance`.

**The handshake reads.** The same pass re-read `DEVICE_ID` and `IDENTITY` on a
peer announced long ago. That is two GATT round trips, then a signature
verification and an address derivation on the main thread in
`handleReceivedIdentity`, after which `completePeerHandshake` discards the
result at its own `announcedPeripherals` guard. Per peripheral, per sweep.

## Approach

The subscribe is gated on the characteristic's own `isNotifying`, through a
pure-Foundation `BleMessageNotificationPolicy` so the decision is testable
without a live `CBCharacteristic`. The handshake reads are gated on
`announcedPeripherals`, which `didDisconnectPeripheral` clears, so a reconnect
still re-reads both halves and re-proves the peer from scratch.

The two gates are deliberately different, and the subscribe deliberately sits
**above** the announce gate. `isNotifying` is present-tense evidence about the
link: a disconnect resets it, and so does a service invalidation that hands
back fresh characteristic objects on a peer the bridge still considers
announced. Keying the subscribe on our own bookkeeping instead would leave that
peer announced with a dead subscription, sending fine and receiving nothing,
with nothing to reset it short of a disconnect.

## Test plan
- `bindings/react-native/ios/tests/BleMessageNotificationPolicyTests.swift`
  covers the policy. 340 Swift tests pass locally.
- `react_native_ios_ble_discovery_is_idempotent_on_a_live_link` in the uniffi
  crate pins what no Swift test can reach: the single `setNotifyValue` routes
  through the policy, the reads sit below the announce gate, and the subscribe
  sits above it. Negative-controlled four ways (policy call removed, gate
  hoisted above the subscribe, gate deleted, subscribe moved below the reads);
  each mutation fails the guard. `cargo test -p offline-protocol-uniffi --lib`
  is 144/144.
- `cargo test --workspace --lib` 2,612 pass; `cargo clippy --workspace -- -D
  warnings` and `cargo fmt --all -- --check` clean.
- The `ci.yml` iOS bridge typecheck invocation, run verbatim, exits 0 with zero
  errors. The three warnings it prints are pre-existing in untouched code.
- Rebased onto `main` after #429; the only conflict was the adjacent typecheck
  file list in `ci.yml`, and both entries are kept.

## Still open, not fixed here
The reason the connection monitor sees live peripherals as unclaimed and
re-triggers discovery at all. Two candidates worth checking against the field
log before picking one: a `cancelPeripheralConnection` that produced no state
change, or a reconnect-and-reject loop on fresh links, since
`rejectPeerHandshake` clears the registry entry but leaves `discoveredPeripherals`
and `CONNECTION_MONITOR_INTERVAL` equals `MIN_RECONNECT_INTERVAL`, so the
cooldown never gates the sweep. If "Connected to BLE peripheral" events
interleave with the 146, it is the second, and these gates do not fire on it.
This PR makes the redundant pass cheap either way.

## Refs
- OFF-2789
- Related: OFF-2787 (#429, merged)
