### PR TITLE
fix(bindings): name the NDK C compiler for Android release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,20 @@ jobs:
           export ${{ matrix.linker_env }}="$NDK_TOOLCHAIN/${{ matrix.linker_bin }}"
           export AR="$NDK_TOOLCHAIN/llvm-ar"
 
+          # The linker setting above is cargo's; cc-rs, which `ring` (the
+          # telemetry uploader's TLS, via rustls) uses for its C and assembly,
+          # never reads it and resolves a compiler on its own. Left to itself
+          # it probes PATH for `<triple>-clang`, and setup-ndk puts the NDK
+          # root on PATH, not the toolchain bin, so on every ABI the probe
+          # fails inside ring's build script. Its fallback list does not help
+          # either: it names armv7a-linux-androideabi16-clang and
+          # i686-linux-android16-clang, API levels r26b no longer ships. So
+          # name the compiler outright: the same versioned clang the linker
+          # uses. cc-rs reads CC_<triple> with the dashes made underscores.
+          TARGET_VAR="$(printf '%s' '${{ matrix.target }}' | tr '-' '_')"
+          export "CC_${TARGET_VAR}=$NDK_TOOLCHAIN/${{ matrix.linker_bin }}"
+          export "CXX_${TARGET_VAR}=$NDK_TOOLCHAIN/${{ matrix.linker_bin }}++"
+
           cargo build --release --locked --target ${{ matrix.target }} --package offline-protocol-uniffi
 
           mkdir -p jniLibs/${{ matrix.abi }}

--- a/bindings/react-native/scripts/build-uniffi-android.sh
+++ b/bindings/react-native/scripts/build-uniffi-android.sh
@@ -117,6 +117,23 @@ export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$NDK_TOOLCHAIN/x86_64-linux-and
 export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$NDK_TOOLCHAIN/i686-linux-android21-clang"
 export AR="$NDK_TOOLCHAIN/llvm-ar"
 
+# The linker settings above are cargo's; cc-rs, which `ring` (the telemetry
+# uploader's TLS, via rustls) uses for its C and assembly, never reads them
+# and resolves a compiler on its own. It probes PATH for `<triple>-clang`,
+# a name no NDK ships, then a fixed list of versioned names, two of which
+# (armv7a-linux-androideabi16-clang and i686-linux-android16-clang) are API
+# levels that NDK r24 and later no longer carry. So with the toolchain on
+# PATH the 64-bit ABIs happen to build and the 32-bit ones fail in ring's
+# build script. Name each compiler outright, the same clang the linker uses.
+export CC_aarch64_linux_android="$CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER"
+export CXX_aarch64_linux_android="${CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER}++"
+export CC_armv7_linux_androideabi="$CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER"
+export CXX_armv7_linux_androideabi="${CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER}++"
+export CC_x86_64_linux_android="$CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER"
+export CXX_x86_64_linux_android="${CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER}++"
+export CC_i686_linux_android="$CARGO_TARGET_I686_LINUX_ANDROID_LINKER"
+export CXX_i686_linux_android="${CARGO_TARGET_I686_LINUX_ANDROID_LINKER}++"
+
 for linker in \
   "$CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER" \
   "$CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER" \


### PR DESCRIPTION
## What broke

The `v0.26.0` Release & Publish run (34696833375) failed in all four `Build Android` jobs, in `ring`'s build script:

```
error occurred in cc-rs: failed to find tool "aarch64-linux-android-clang": No such file or directory
```

Nothing published: both `release` and `publish-crates` depend on `build-android`.

## Why

0.26.0 added `ring` to the mobile cdylib via the telemetry uploader (`ureq` -> `rustls`). It is the first dependency in the Android build that compiles C, and it does so through cc-rs, which never reads cargo's linker setting. The workflow set only the linker and `AR`. cc-rs probes PATH for a versioned clang and then `<triple>-clang`; `setup-ndk` puts the NDK root on PATH, not the toolchain bin, so every ABI came up empty.

`build-uniffi-android.sh` has the same gap. It does put the toolchain on PATH, so cc-rs's fallback list finds `aarch64-linux-android21-clang` and `x86_64-linux-android21-clang`, but the list names `armv7a-linux-androideabi16-clang` and `i686-linux-android16-clang`, API levels NDK r24+ no longer ship, so the 32-bit ABIs fail locally too.

## Fix

Both paths export `CC_<triple>` and `CXX_<triple>` pointing at the same versioned clang the linker uses. The workflow derives the variable name from the matrix target, so no new matrix fields.

## Verification

Local, NDK r27, the locked cc 1.2.43:

- `ring` alone under the exact CI env (linker + AR, toolchain off PATH): fails with the CI error. With `CC_aarch64_linux_android` set: builds.
- `ring` alone under the script's env (toolchain on PATH) for armv7: fails with `arm-linux-androideabi-clang` not found. With `CC_armv7_linux_androideabi` set: builds.
- Full `cargo build --release --locked --target armv7-linux-androideabi -p offline-protocol-uniffi`: builds, and `check-elf-alignment.py` reports 16 KB PT_LOAD alignment.

A `workflow_dispatch` dry run of the release workflow on this branch (version `0.26.0`) is the CI-side proof; link in the comments.

## After merge

Per the `version-gate` note and CONTRIBUTING, the tag can be deleted and re-pushed because nothing shipped:

```
git tag -d v0.26.0
git push origin :refs/tags/v0.26.0
git tag v0.26.0 <merge commit>
git push origin v0.26.0
```
